### PR TITLE
Fix CI compile error from missing prefs import

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/settings/SettingsViewModel.kt
@@ -37,6 +37,7 @@ import com.github.andreyasadchy.xtra.util.NetworkUtils
 import com.github.andreyasadchy.xtra.util.NetworkUtils.executeAsync
 import com.github.andreyasadchy.xtra.util.m3u8.PlaylistUtils
 import com.github.andreyasadchy.xtra.util.m3u8.Segment
+import com.github.andreyasadchy.xtra.util.prefs
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job


### PR DESCRIPTION
## Fix\n- import the existing Context.prefs() extension used by SettingsViewModel\n\nThe merged master build failed at SettingsViewModel.kt:506 with Unresolved reference: prefs. This PR adds only the missing import.