### PR TITLE
Add channel point rewards and searchable emote picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,27 @@
 # Xtra for Twitch
 
-<img src="https://github.com/AndreyAsadchy/Xtra/blob/197ba90cac879abd2a5645393ce361847f12fa0b/app/src/main/ic_launcher-web.png" align="left" width="100"/>
+<p align="center">
+  <img src="https://github.com/thiscallnet/Xtra/raw/master/app/src/main/ic_launcher-web.png" width="96" alt="Xtra logo">
+</p>
 
-Xtra is a Twitch player and browser for Android.
+<p align="center">
+  A community-maintained fork of <a href="https://github.com/crackededed/Xtra">Xtra</a>,<br>
+  focused on practical fixes and Twitch features that are useful in everyday viewing.
+</p>
 
-</br>
-</br>
+## What this fork adds
+
+Compared with the upstream project, this fork currently includes:
+
+- More reliable live notifications with persisted follow IDs and Helix fallback.
+- Channel Points in chat: balances, custom icons, watch streaks, rewards, voting, and redemption.
+- Searchable emote pickers limited to emotes belonging to the active channel.
+- Fork-hosted releases and update links for existing Xtra installs.
+
+<p align="center">
+  <img src="https://github.com/thiscallnet/Xtra/releases/download/latest/channel-points-rewards.jpg" width="320" alt="Channel Points rewards and watch streaks">
+  <img src="https://github.com/thiscallnet/Xtra/releases/download/latest/channel-points-navigation.jpg" width="620" alt="Channel Points balance in the navigation bar">
+</p>
 
 ## Download
 

--- a/app/src/main/java/com/github/andreyasadchy/xtra/model/chat/Emote.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/model/chat/Emote.kt
@@ -11,6 +11,7 @@ class Emote(
     val isAnimated: Boolean = true,
     val isOverlayEmote: Boolean = false,
     val source: Int? = null,
+    val id: String? = null,
 ) {
     val thirdParty = source == PERSONAL_STV || source == CHANNEL_STV || source == CHANNEL_BTTV || source == CHANNEL_FFZ || source == GLOBAL_STV || source == GLOBAL_BTTV || source == GLOBAL_FFZ
 

--- a/app/src/main/java/com/github/andreyasadchy/xtra/model/gql/chat/ChannelPointContextResponse.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/model/gql/chat/ChannelPointContextResponse.kt
@@ -49,9 +49,14 @@ class ChannelPointContextResponse(
 
     @Serializable
     class CustomReward(
+        val id: String? = null,
         val title: String? = null,
         val cost: Int? = null,
         val prompt: String? = null,
+        val isUserInputRequired: Boolean? = null,
+        val backgroundColor: String? = null,
+        val image: RewardImage? = null,
+        val defaultImage: RewardImage? = null,
         val isEnabled: Boolean? = null,
         val isPaused: Boolean? = null,
         val isInStock: Boolean? = null,
@@ -59,10 +64,25 @@ class ChannelPointContextResponse(
 
     @Serializable
     class AutomaticReward(
+        val id: String? = null,
         val type: String? = null,
         val cost: Int? = null,
+        val defaultCost: Int? = null,
+        val pricingType: String? = null,
+        val backgroundColor: String? = null,
+        val defaultBackgroundColor: String? = null,
+        val image: RewardImage? = null,
+        val defaultImage: RewardImage? = null,
         val isEnabled: Boolean? = null,
         val isInStock: Boolean? = null,
+    )
+
+    @Serializable
+    class RewardImage(
+        val url: String? = null,
+        val url1x: String? = null,
+        val url2x: String? = null,
+        val url4x: String? = null,
     )
 
     @Serializable

--- a/app/src/main/java/com/github/andreyasadchy/xtra/model/gql/chat/ChannelPointContextResponse.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/model/gql/chat/ChannelPointContextResponse.kt
@@ -46,6 +46,7 @@ class ChannelPointContextResponse(
         val image: RewardImage? = null,
         val customRewards: List<CustomReward> = emptyList(),
         val automaticRewards: List<AutomaticReward> = emptyList(),
+        val emoteVariants: List<EmoteVariant> = emptyList(),
         val earning: Earning? = null,
     )
 
@@ -54,6 +55,7 @@ class ChannelPointContextResponse(
         val id: String? = null,
         val title: String? = null,
         val cost: Int? = null,
+        val pricingType: String? = null,
         val prompt: String? = null,
         val isUserInputRequired: Boolean? = null,
         val backgroundColor: String? = null,
@@ -85,6 +87,33 @@ class ChannelPointContextResponse(
         val url1x: String? = null,
         val url2x: String? = null,
         val url4x: String? = null,
+    )
+
+    @Serializable
+    class EmoteVariant(
+        val id: String? = null,
+        val isUnlockable: Boolean? = null,
+        val emote: VariantEmote? = null,
+        val modifications: List<EmoteModification> = emptyList(),
+    )
+
+    @Serializable
+    class EmoteModification(
+        val id: String? = null,
+        val title: String? = null,
+        val emote: VariantEmote? = null,
+        val modifier: Modifier? = null,
+    )
+
+    @Serializable
+    class VariantEmote(
+        val id: String? = null,
+        val token: String? = null,
+    )
+
+    @Serializable
+    class Modifier(
+        val id: String? = null,
     )
 
     @Serializable

--- a/app/src/main/java/com/github/andreyasadchy/xtra/model/gql/chat/ChannelPointContextResponse.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/model/gql/chat/ChannelPointContextResponse.kt
@@ -42,6 +42,8 @@ class ChannelPointContextResponse(
 
     @Serializable
     class CommunityPointsSettings(
+        val name: String? = null,
+        val image: RewardImage? = null,
         val customRewards: List<CustomReward> = emptyList(),
         val automaticRewards: List<AutomaticReward> = emptyList(),
         val earning: Earning? = null,

--- a/app/src/main/java/com/github/andreyasadchy/xtra/model/gql/chat/ChannelPointRedemptionResponse.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/model/gql/chat/ChannelPointRedemptionResponse.kt
@@ -11,7 +11,32 @@ class ChannelPointRedemptionResponse(
     @Serializable
     class Data(
         val redeemCommunityPointsCustomReward: Payload? = null,
-    )
+        val unlockRandomSubscriberEmote: Payload? = null,
+        val unlockChosenSubscriberEmote: Payload? = null,
+        val unlockChosenModifiedSubscriberEmote: Payload? = null,
+        val sendChatMessageThroughSubscriberMode: Payload? = null,
+        val sendHighlightedChatMessage: Payload? = null,
+    ) {
+        fun errorCode(): String? {
+            return listOf(
+                redeemCommunityPointsCustomReward,
+                unlockRandomSubscriberEmote,
+                unlockChosenSubscriberEmote,
+                unlockChosenModifiedSubscriberEmote,
+                sendChatMessageThroughSubscriberMode,
+                sendHighlightedChatMessage,
+            ).firstNotNullOfOrNull { it?.error?.code }
+        }
+
+        fun hasPayload(): Boolean {
+            return redeemCommunityPointsCustomReward != null ||
+                    unlockRandomSubscriberEmote != null ||
+                    unlockChosenSubscriberEmote != null ||
+                    unlockChosenModifiedSubscriberEmote != null ||
+                    sendChatMessageThroughSubscriberMode != null ||
+                    sendHighlightedChatMessage != null
+        }
+    }
 
     @Serializable
     class Payload(

--- a/app/src/main/java/com/github/andreyasadchy/xtra/model/gql/chat/ChannelPointRedemptionResponse.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/model/gql/chat/ChannelPointRedemptionResponse.kt
@@ -1,0 +1,25 @@
+package com.github.andreyasadchy.xtra.model.gql.chat
+
+import com.github.andreyasadchy.xtra.model.gql.Error
+import kotlinx.serialization.Serializable
+
+@Serializable
+class ChannelPointRedemptionResponse(
+    val errors: List<Error>? = null,
+    val data: Data? = null,
+) {
+    @Serializable
+    class Data(
+        val redeemCommunityPointsCustomReward: Payload? = null,
+    )
+
+    @Serializable
+    class Payload(
+        val error: RedemptionError? = null,
+    )
+
+    @Serializable
+    class RedemptionError(
+        val code: String? = null,
+    )
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/model/ui/ChannelPoints.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/model/ui/ChannelPoints.kt
@@ -15,12 +15,22 @@ data class ChannelPointReward(
     val imageUrl: String? = null,
     val backgroundColor: String? = null,
     val inputType: ChannelPointRewardInput = ChannelPointRewardInput.NONE,
+    val redemptionType: ChannelPointRewardRedemption = ChannelPointRewardRedemption.CUSTOM,
 )
 
 enum class ChannelPointRewardInput {
     NONE,
     TEXT,
     EMOTE,
+}
+
+enum class ChannelPointRewardRedemption {
+    CUSTOM,
+    RANDOM_SUB_EMOTE,
+    CHOSEN_SUB_EMOTE,
+    CHOSEN_MODIFIED_SUB_EMOTE,
+    SUBSCRIBER_MODE_MESSAGE,
+    HIGHLIGHTED_MESSAGE,
 }
 
 data class ChannelPointRedemptionResult(

--- a/app/src/main/java/com/github/andreyasadchy/xtra/model/ui/ChannelPoints.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/model/ui/ChannelPoints.kt
@@ -7,9 +7,25 @@ data class ChannelPoints(
 )
 
 data class ChannelPointReward(
+    val id: String,
     val title: String,
     val cost: Int,
     val prompt: String? = null,
+    val imageUrl: String? = null,
+    val backgroundColor: String? = null,
+    val inputType: ChannelPointRewardInput = ChannelPointRewardInput.NONE,
+)
+
+enum class ChannelPointRewardInput {
+    NONE,
+    TEXT,
+    EMOTE,
+}
+
+data class ChannelPointRedemptionResult(
+    val rewardTitle: String,
+    val success: Boolean,
+    val message: String? = null,
 )
 
 data class WatchStreakReward(

--- a/app/src/main/java/com/github/andreyasadchy/xtra/model/ui/ChannelPoints.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/model/ui/ChannelPoints.kt
@@ -2,6 +2,7 @@ package com.github.andreyasadchy.xtra.model.ui
 
 data class ChannelPoints(
     val balance: Int,
+    val iconUrl: String? = null,
     val rewards: List<ChannelPointReward> = emptyList(),
     val watchStreakRewards: List<WatchStreakReward> = emptyList(),
 )

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/GraphQLRepository.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/GraphQLRepository.kt
@@ -1527,13 +1527,17 @@ class GraphQLRepository(
         val body = buildJsonObject {
             putJsonObject("extensions") {
                 putJsonObject("persistedQuery") {
-                    put("sha256Hash", "374314de591e69925fce3ddc2bcf085796f56ebb8cad67a0daa3165c03adc345")
+                    put("sha256Hash", "7fe050e3761eb2cf258d70ee1a21cbd76fa8cf3d7e7b12fc437e7029d446b5e3")
                     put("version", 1)
                 }
             }
             put("operationName", "ChannelPointsContext")
             putJsonObject("variables") {
                 put("channelLogin", channelLogin)
+                putJsonArray("includeGoalTypes") {
+                    add("CREATOR")
+                    add("BOOST")
+                }
             }
         }.toString()
         json.decodeFromString<ChannelPointContextResponse>(sendPersistedQuery(networkLibrary, headers, body))

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/GraphQLRepository.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/GraphQLRepository.kt
@@ -71,6 +71,7 @@ import com.github.andreyasadchy.xtra.model.gql.channel.ChannelViewerListResponse
 import com.github.andreyasadchy.xtra.model.gql.chat.BadgesResponse
 import com.github.andreyasadchy.xtra.model.gql.chat.ChannelCheerEmotesResponse
 import com.github.andreyasadchy.xtra.model.gql.chat.ChannelPointContextResponse
+import com.github.andreyasadchy.xtra.model.gql.chat.ChannelPointRedemptionResponse
 import com.github.andreyasadchy.xtra.model.gql.chat.EmoteCardResponse
 import com.github.andreyasadchy.xtra.model.gql.chat.GlobalCheerEmotesResponse
 import com.github.andreyasadchy.xtra.model.gql.chat.ModeratorsResponse
@@ -141,6 +142,17 @@ class GraphQLRepository(
                         watchStreakThreshold
                         watchStreakCopoBonus
                     }
+                }
+            }
+        }
+    """.trimIndent()
+
+    private val channelPointRedemptionMutation = """
+        mutation RedeemCommunityPointsCustomReward(${'$'}input: RedeemCommunityPointsCustomRewardInput!) {
+            redeemCommunityPointsCustomReward(input: ${'$'}input) {
+                error {
+                    __typename
+                    code
                 }
             }
         }
@@ -1499,6 +1511,34 @@ class GraphQLRepository(
             }
         }.toString()
         json.decodeFromString<WatchStreakResponse>(sendPersistedQuery(networkLibrary, headers, body))
+    }
+
+    suspend fun redeemChannelPointReward(
+        networkLibrary: String?,
+        headers: Map<String, String>,
+        channelId: String,
+        rewardId: String,
+        title: String,
+        cost: Int,
+        prompt: String?,
+        textInput: String?,
+    ): ChannelPointRedemptionResponse = withContext(Dispatchers.IO) {
+        val body = buildJsonObject {
+            put("operationName", "RedeemCommunityPointsCustomReward")
+            put("query", channelPointRedemptionMutation)
+            putJsonObject("variables") {
+                putJsonObject("input") {
+                    put("channelID", channelId)
+                    put("cost", cost)
+                    put("prompt", prompt)
+                    put("rewardID", rewardId)
+                    put("textInput", textInput)
+                    put("title", title)
+                    put("transactionID", Uuid.random().toString())
+                }
+            }
+        }.toString()
+        json.decodeFromString<ChannelPointRedemptionResponse>(sendPersistedQuery(networkLibrary, headers, body))
     }
 
     suspend fun loadClaimPoints(networkLibrary: String?, headers: Map<String, String>, channelId: String?, claimId: String?): ErrorResponse = withContext(Dispatchers.IO) {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/GraphQLRepository.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/GraphQLRepository.kt
@@ -100,6 +100,7 @@ import com.github.andreyasadchy.xtra.model.gql.stream.ViewerCountResponse
 import com.github.andreyasadchy.xtra.model.gql.tag.TagResponse
 import com.github.andreyasadchy.xtra.model.gql.video.VideoGamesResponse
 import com.github.andreyasadchy.xtra.model.gql.video.VideoMessagesResponse
+import com.github.andreyasadchy.xtra.model.ui.ChannelPointRewardRedemption
 import com.github.andreyasadchy.xtra.util.C
 import com.github.andreyasadchy.xtra.util.NetworkUtils
 import com.github.andreyasadchy.xtra.util.NetworkUtils.executeAsync
@@ -150,10 +151,47 @@ class GraphQLRepository(
     private val channelPointRedemptionMutation = """
         mutation RedeemCommunityPointsCustomReward(${'$'}input: RedeemCommunityPointsCustomRewardInput!) {
             redeemCommunityPointsCustomReward(input: ${'$'}input) {
-                error {
-                    __typename
-                    code
-                }
+                error { code }
+            }
+        }
+    """.trimIndent()
+
+    private val randomSubscriberEmoteRedemptionMutation = """
+        mutation UnlockRandomSubscriberEmote(${'$'}input: UnlockRandomSubscriberEmoteInput!) {
+            unlockRandomSubscriberEmote(input: ${'$'}input) {
+                error { code }
+            }
+        }
+    """.trimIndent()
+
+    private val chosenSubscriberEmoteRedemptionMutation = """
+        mutation UnlockChosenSubscriberEmote(${'$'}input: UnlockChosenSubscriberEmoteInput!) {
+            unlockChosenSubscriberEmote(input: ${'$'}input) {
+                error { code }
+            }
+        }
+    """.trimIndent()
+
+    private val chosenModifiedSubscriberEmoteRedemptionMutation = """
+        mutation UnlockChosenModifiedSubscriberEmote(${'$'}input: UnlockChosenModifiedSubscriberEmoteInput!) {
+            unlockChosenModifiedSubscriberEmote(input: ${'$'}input) {
+                error { code }
+            }
+        }
+    """.trimIndent()
+
+    private val subscriberModeMessageRedemptionMutation = """
+        mutation SendChatMessageThroughSubscriberMode(${'$'}input: SendChatMessageThroughSubscriberModeInput!) {
+            sendChatMessageThroughSubscriberMode(input: ${'$'}input) {
+                error { code }
+            }
+        }
+    """.trimIndent()
+
+    private val highlightedMessageRedemptionMutation = """
+        mutation SendHighlightedChatMessage(${'$'}input: SendHighlightedChatMessageInput!) {
+            sendHighlightedChatMessage(input: ${'$'}input) {
+                error { code }
             }
         }
     """.trimIndent()
@@ -1522,19 +1560,44 @@ class GraphQLRepository(
         cost: Int,
         prompt: String?,
         textInput: String?,
+        emoteId: String?,
+        redemptionType: ChannelPointRewardRedemption,
     ): ChannelPointRedemptionResponse = withContext(Dispatchers.IO) {
+        val (operationName, mutation) = when (redemptionType) {
+            ChannelPointRewardRedemption.CUSTOM -> "RedeemCommunityPointsCustomReward" to channelPointRedemptionMutation
+            ChannelPointRewardRedemption.RANDOM_SUB_EMOTE -> "UnlockRandomSubscriberEmote" to randomSubscriberEmoteRedemptionMutation
+            ChannelPointRewardRedemption.CHOSEN_SUB_EMOTE -> "UnlockChosenSubscriberEmote" to chosenSubscriberEmoteRedemptionMutation
+            ChannelPointRewardRedemption.CHOSEN_MODIFIED_SUB_EMOTE -> "UnlockChosenModifiedSubscriberEmote" to chosenModifiedSubscriberEmoteRedemptionMutation
+            ChannelPointRewardRedemption.SUBSCRIBER_MODE_MESSAGE -> "SendChatMessageThroughSubscriberMode" to subscriberModeMessageRedemptionMutation
+            ChannelPointRewardRedemption.HIGHLIGHTED_MESSAGE -> "SendHighlightedChatMessage" to highlightedMessageRedemptionMutation
+        }
         val body = buildJsonObject {
-            put("operationName", "RedeemCommunityPointsCustomReward")
-            put("query", channelPointRedemptionMutation)
+            put("operationName", operationName)
+            put("query", mutation)
             putJsonObject("variables") {
                 putJsonObject("input") {
                     put("channelID", channelId)
                     put("cost", cost)
-                    put("prompt", prompt)
-                    put("rewardID", rewardId)
-                    put("textInput", textInput)
-                    put("title", title)
                     put("transactionID", Uuid.random().toString())
+                    when (redemptionType) {
+                        ChannelPointRewardRedemption.CUSTOM -> {
+                            put("prompt", prompt)
+                            put("rewardID", rewardId)
+                            put("textInput", textInput)
+                            put("title", title)
+                        }
+                        ChannelPointRewardRedemption.RANDOM_SUB_EMOTE -> Unit
+                        ChannelPointRewardRedemption.CHOSEN_SUB_EMOTE,
+                        ChannelPointRewardRedemption.CHOSEN_MODIFIED_SUB_EMOTE -> {
+                            require(!emoteId.isNullOrBlank()) { "Emote id is required" }
+                            put("emoteID", emoteId)
+                        }
+                        ChannelPointRewardRedemption.SUBSCRIBER_MODE_MESSAGE,
+                        ChannelPointRewardRedemption.HIGHLIGHTED_MESSAGE -> {
+                            require(!textInput.isNullOrBlank()) { "Message is required" }
+                            put("message", textInput)
+                        }
+                    }
                 }
             }
         }.toString()

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/PlayerRepository.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/PlayerRepository.kt
@@ -1873,6 +1873,7 @@ class PlayerRepository(
                                     .replaceFirst("{{format}}", format)
                                     .replaceFirst("{{theme_mode}}", theme)
                                 TwitchEmote(
+                                    id = id,
                                     name = if (emote.type == "smilies") {
                                         name.replace("\\", "").replace("?", "")
                                             .replace("&lt;", "<").replace("&gt;", ">")
@@ -1916,6 +1917,7 @@ class PlayerRepository(
                         .replaceFirst("{{format}}", format)
                         .replaceFirst("{{theme_mode}}", theme)
                     TwitchEmote(
+                        id = id,
                         name = if (emote.type == "smilies") {
                             name.replace("\\", "").replace("?", "")
                                 .replace("&lt;", "<").replace("&gt;", ">")

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChannelPointsDialog.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChannelPointsDialog.kt
@@ -2,21 +2,42 @@ package com.github.andreyasadchy.xtra.ui.chat
 
 import android.app.Dialog
 import android.content.Context
+import android.graphics.Color
 import android.os.Bundle
+import android.text.InputType
+import android.view.Gravity
+import android.view.View
+import android.widget.EditText
+import android.widget.ImageView
 import android.widget.LinearLayout
 import android.widget.TextView
+import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
+import androidx.core.widget.addTextChangedListener
 import androidx.fragment.app.DialogFragment
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
+import androidx.recyclerview.widget.RecyclerView
+import coil3.imageLoader
+import coil3.request.ImageRequest
+import coil3.request.crossfade
+import coil3.request.target
 import com.github.andreyasadchy.xtra.R
 import com.github.andreyasadchy.xtra.databinding.DialogChannelPointsBinding
+import com.github.andreyasadchy.xtra.model.chat.Emote
 import com.github.andreyasadchy.xtra.model.chat.Poll
 import com.github.andreyasadchy.xtra.model.chat.Prediction
 import com.github.andreyasadchy.xtra.model.ui.ChannelPoints
+import com.github.andreyasadchy.xtra.model.ui.ChannelPointReward
+import com.github.andreyasadchy.xtra.model.ui.ChannelPointRewardInput
+import com.github.andreyasadchy.xtra.model.ui.ChannelPointRedemptionResult
 import com.github.andreyasadchy.xtra.model.ui.WatchStreak
+import com.github.andreyasadchy.xtra.ui.view.GridAutofitLayoutManager
+import com.github.andreyasadchy.xtra.util.C
 import com.github.andreyasadchy.xtra.util.getAlertDialogBuilder
+import com.github.andreyasadchy.xtra.util.prefs
+import com.google.android.material.card.MaterialCardView
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
@@ -32,15 +53,25 @@ class ChannelPointsDialog : DialogFragment() {
         fun watchStreakFlow(): StateFlow<WatchStreak?>
         fun activePollFlow(): StateFlow<Poll?>
         fun activePredictionFlow(): StateFlow<Prediction?>
+        fun channelName(): String?
+        fun emotePickerItems(): List<Emote>
+        fun redeemChannelPointReward(reward: ChannelPointReward, textInput: String?)
+        fun channelPointRedemptionFlow(): kotlinx.coroutines.flow.SharedFlow<ChannelPointRedemptionResult>
     }
 
     companion object {
         const val TAG = "channelPointsDialog"
+        private const val REWARD_COLUMNS = 3
     }
 
     private var _binding: DialogChannelPointsBinding? = null
     private val binding get() = _binding!!
     private lateinit var listener: Listener
+
+    private data class RewardInputContent(
+        val input: EditText,
+        val view: View,
+    )
 
     override fun onAttach(context: Context) {
         super.onAttach(context)
@@ -66,12 +97,20 @@ class ChannelPointsDialog : DialogFragment() {
                 }.collectLatest(::render)
             }
         }
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                listener.channelPointRedemptionFlow().collectLatest(::showRedemptionResult)
+            }
+        }
         return dialog
     }
 
     private fun render(state: DialogState) {
         val numberFormat = NumberFormat.getInstance()
         val points = state.channelPoints
+        binding.headerTitle.text = listener.channelName()?.let {
+            getString(R.string.channel_points_rewards_for, it)
+        } ?: getString(R.string.channel_points_watch_streak)
         binding.balance.text = points?.let {
             getString(R.string.channel_points_current_balance, numberFormat.format(it.balance))
         } ?: getString(R.string.channel_points_unavailable)
@@ -162,17 +201,188 @@ class ChannelPointsDialog : DialogFragment() {
         binding.rewardsTitle.isVisible = rewards.isNotEmpty()
         binding.rewardsList.isVisible = rewards.isNotEmpty()
         binding.rewardsList.removeAllViews()
-        rewards.forEach { reward ->
-            addRow(
-                binding.rewardsList,
-                buildString {
-                    append(getString(R.string.channel_points_reward, reward.title, numberFormat.format(reward.cost)))
-                    if (!reward.prompt.isNullOrBlank()) {
-                        append('\n')
-                        append(getString(R.string.channel_points_reward_prompt, reward.prompt))
-                    }
-                },
+        rewards.forEachIndexed { index, reward ->
+            addRewardCard(index, reward, numberFormat)
+        }
+    }
+
+    private fun addRewardCard(index: Int, reward: ChannelPointReward, numberFormat: NumberFormat) {
+        val density = resources.displayMetrics.density
+        val card = MaterialCardView(requireContext()).apply {
+            radius = 4 * density
+            strokeWidth = 0
+            setCardBackgroundColor(parseColor(reward.backgroundColor, R.color.channel_points_reward_default))
+            isClickable = true
+            isFocusable = true
+            contentDescription = reward.title
+            setOnClickListener { showRewardRedemptionDialog(reward) }
+        }
+        val content = LinearLayout(requireContext()).apply {
+            gravity = Gravity.CENTER
+            orientation = LinearLayout.VERTICAL
+            setPadding(dp(6), dp(6), dp(6), dp(6))
+        }
+        val image = ImageView(requireContext()).apply {
+            layoutParams = LinearLayout.LayoutParams(dp(42), dp(42))
+            scaleType = ImageView.ScaleType.CENTER_INSIDE
+            setImageResource(R.drawable.ic_channel_points)
+            imageTintList = android.content.res.ColorStateList.valueOf(Color.WHITE)
+        }
+        reward.imageUrl?.let { imageUrl ->
+            requireContext().imageLoader.enqueue(
+                ImageRequest.Builder(requireContext())
+                    .data(imageUrl)
+                    .crossfade(true)
+                    .target(image)
+                    .build(),
             )
+        }
+        content.addView(image)
+        content.addView(TextView(requireContext()).apply {
+            layoutParams = LinearLayout.LayoutParams(
+                LinearLayout.LayoutParams.MATCH_PARENT,
+                dp(36),
+            ).apply {
+                topMargin = dp(2)
+            }
+            gravity = Gravity.CENTER
+            maxLines = 2
+            ellipsize = android.text.TextUtils.TruncateAt.END
+            setTextColor(Color.WHITE)
+            text = reward.title
+            textSize = 12f
+        })
+        val cost = LinearLayout(requireContext()).apply {
+            background = ContextCompat.getDrawable(requireContext(), R.drawable.bg_channel_points_pill)
+            gravity = Gravity.CENTER
+            setPadding(dp(6), dp(2), dp(6), dp(2))
+        }
+        cost.addView(ImageView(requireContext()).apply {
+            layoutParams = LinearLayout.LayoutParams(dp(14), dp(14))
+            setImageResource(R.drawable.ic_channel_points)
+            imageTintList = android.content.res.ColorStateList.valueOf(Color.WHITE)
+        })
+        cost.addView(TextView(requireContext()).apply {
+            layoutParams = LinearLayout.LayoutParams(
+                LinearLayout.LayoutParams.WRAP_CONTENT,
+                LinearLayout.LayoutParams.WRAP_CONTENT,
+            ).apply {
+                marginStart = dp(3)
+            }
+            setTextColor(Color.WHITE)
+            text = numberFormat.format(reward.cost)
+            textSize = 12f
+            setTypeface(typeface, android.graphics.Typeface.BOLD)
+        })
+        content.addView(cost)
+        card.addView(content)
+        binding.rewardsList.addView(card, android.widget.GridLayout.LayoutParams().apply {
+            width = 0
+            height = dp(132)
+            rowSpec = android.widget.GridLayout.spec(index / REWARD_COLUMNS)
+            columnSpec = android.widget.GridLayout.spec(index % REWARD_COLUMNS, 1f)
+            setMargins(dp(2), dp(2), dp(2), dp(2))
+        })
+    }
+
+    private fun showRewardRedemptionDialog(reward: ChannelPointReward) {
+        val inputContent = createRewardInputContent(reward)
+        requireContext().getAlertDialogBuilder()
+            .setTitle(reward.title)
+            .setMessage(reward.prompt ?: getString(R.string.channel_points_reward_confirm))
+            .apply { inputContent?.let { setView(it.view) } }
+            .setNegativeButton(android.R.string.cancel, null)
+            .setPositiveButton(R.string.channel_points_reward_redeem) { _, _ ->
+                listener.redeemChannelPointReward(reward, inputContent?.input?.text?.toString())
+            }
+            .show()
+    }
+
+    private fun createRewardInputContent(reward: ChannelPointReward): RewardInputContent? {
+        return when (reward.inputType) {
+            ChannelPointRewardInput.NONE -> null
+            ChannelPointRewardInput.TEXT -> {
+                val input = EditText(requireContext()).apply {
+                    hint = getString(R.string.channel_points_reward_text_hint)
+                    inputType = InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_FLAG_MULTI_LINE
+                    minLines = 2
+                    maxLines = 4
+                    gravity = Gravity.TOP or Gravity.START
+                }
+                RewardInputContent(
+                    input = input,
+                    view = LinearLayout(requireContext()).apply {
+                        setPadding(dp(24), 0, dp(24), 0)
+                        addView(input, LinearLayout.LayoutParams(
+                            LinearLayout.LayoutParams.MATCH_PARENT,
+                            LinearLayout.LayoutParams.WRAP_CONTENT,
+                        ))
+                    },
+                )
+            }
+            ChannelPointRewardInput.EMOTE -> {
+                val input = EditText(requireContext()).apply {
+                    hint = getString(R.string.channel_points_reward_emote_hint)
+                    inputType = InputType.TYPE_CLASS_TEXT
+                    setSingleLine(true)
+                }
+                val allEmotes = listener.emotePickerItems()
+                val adapter = EmotesAdapter(
+                    this,
+                    { emote ->
+                        input.setText(emote.name.orEmpty())
+                        input.setSelection(input.text.length)
+                    },
+                    requireContext().prefs().getString(C.CHAT_IMAGE_QUALITY, "4") ?: "4",
+                    requireContext().prefs().getString(C.CHAT_IMAGE_LIBRARY, "0"),
+                )
+                val picker = RecyclerView(requireContext()).apply {
+                    itemAnimator = null
+                    this.adapter = adapter
+                    layoutManager = GridAutofitLayoutManager(requireContext(), dp(50))
+                }
+                fun updatePicker(query: String) {
+                    adapter.submitList(
+                        allEmotes.filter { it.name.orEmpty().contains(query, ignoreCase = true) },
+                    )
+                }
+                input.addTextChangedListener { updatePicker(it?.toString().orEmpty()) }
+                updatePicker("")
+                RewardInputContent(
+                    input = input,
+                    view = LinearLayout(requireContext()).apply {
+                        orientation = LinearLayout.VERTICAL
+                        setPadding(dp(24), 0, dp(24), 0)
+                        addView(input, LinearLayout.LayoutParams(
+                            LinearLayout.LayoutParams.MATCH_PARENT,
+                            LinearLayout.LayoutParams.WRAP_CONTENT,
+                        ))
+                        addView(picker, LinearLayout.LayoutParams(
+                            LinearLayout.LayoutParams.MATCH_PARENT,
+                            dp(180),
+                        ).apply {
+                            topMargin = dp(8)
+                        })
+                    },
+                )
+            }
+        }
+    }
+
+    private fun showRedemptionResult(result: ChannelPointRedemptionResult) {
+        val message = if (result.success) {
+            getString(R.string.channel_points_reward_redeemed, result.rewardTitle)
+        } else {
+            getString(R.string.channel_points_reward_failed, result.rewardTitle, result.message.orEmpty())
+        }
+        android.widget.Toast.makeText(requireContext(), message, android.widget.Toast.LENGTH_LONG).show()
+    }
+
+    private fun dp(value: Int): Int = (value * resources.displayMetrics.density).roundToInt()
+
+    private fun parseColor(value: String?, fallback: Int): Int {
+        return runCatching { Color.parseColor(value ?: "") }.getOrElse {
+            ContextCompat.getColor(requireContext(), fallback)
         }
     }
 
@@ -242,4 +452,5 @@ class ChannelPointsDialog : DialogFragment() {
         val poll: Poll?,
         val prediction: Prediction?,
     )
+
 }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChannelPointsDialog.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChannelPointsDialog.kt
@@ -2,6 +2,7 @@ package com.github.andreyasadchy.xtra.ui.chat
 
 import android.app.Dialog
 import android.content.Context
+import android.content.res.ColorStateList
 import android.graphics.Color
 import android.os.Bundle
 import android.text.InputType
@@ -38,6 +39,9 @@ import com.github.andreyasadchy.xtra.util.C
 import com.github.andreyasadchy.xtra.util.getAlertDialogBuilder
 import com.github.andreyasadchy.xtra.util.prefs
 import com.google.android.material.card.MaterialCardView
+import com.google.android.material.color.MaterialColors
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
@@ -54,9 +58,10 @@ class ChannelPointsDialog : DialogFragment() {
         fun activePollFlow(): StateFlow<Poll?>
         fun activePredictionFlow(): StateFlow<Prediction?>
         fun channelName(): String?
-        fun emotePickerItems(): List<Emote>
+        fun channelEmotePickerItems(): List<Emote>
+        fun channelEmotePickerUpdates(): Flow<Unit>
         fun redeemChannelPointReward(reward: ChannelPointReward, textInput: String?)
-        fun channelPointRedemptionFlow(): kotlinx.coroutines.flow.SharedFlow<ChannelPointRedemptionResult>
+        fun channelPointRedemptionFlow(): Flow<ChannelPointRedemptionResult>
     }
 
     companion object {
@@ -71,6 +76,8 @@ class ChannelPointsDialog : DialogFragment() {
     private data class RewardInputContent(
         val input: EditText,
         val view: View,
+        val pickerUpdates: Flow<Unit>? = null,
+        val refreshPicker: (() -> Unit)? = null,
     )
 
     override fun onAttach(context: Context) {
@@ -114,6 +121,11 @@ class ChannelPointsDialog : DialogFragment() {
         binding.balance.text = points?.let {
             getString(R.string.channel_points_current_balance, numberFormat.format(it.balance))
         } ?: getString(R.string.channel_points_unavailable)
+        setChannelPointsIcon(
+            binding.balanceIcon,
+            points?.iconUrl,
+            MaterialColors.getColor(binding.balanceIcon, androidx.appcompat.R.attr.colorControlNormal),
+        )
 
         renderWatchStreak(state.watchStreak, points, numberFormat)
         renderRewards(points, numberFormat)
@@ -202,11 +214,16 @@ class ChannelPointsDialog : DialogFragment() {
         binding.rewardsList.isVisible = rewards.isNotEmpty()
         binding.rewardsList.removeAllViews()
         rewards.forEachIndexed { index, reward ->
-            addRewardCard(index, reward, numberFormat)
+            addRewardCard(index, reward, numberFormat, points?.iconUrl)
         }
     }
 
-    private fun addRewardCard(index: Int, reward: ChannelPointReward, numberFormat: NumberFormat) {
+    private fun addRewardCard(
+        index: Int,
+        reward: ChannelPointReward,
+        numberFormat: NumberFormat,
+        pointsIconUrl: String?,
+    ) {
         val density = resources.displayMetrics.density
         val card = MaterialCardView(requireContext()).apply {
             radius = 4 * density
@@ -226,9 +243,10 @@ class ChannelPointsDialog : DialogFragment() {
             layoutParams = LinearLayout.LayoutParams(dp(42), dp(42))
             scaleType = ImageView.ScaleType.CENTER_INSIDE
             setImageResource(R.drawable.ic_channel_points)
-            imageTintList = android.content.res.ColorStateList.valueOf(Color.WHITE)
+            imageTintList = ColorStateList.valueOf(Color.WHITE)
         }
         reward.imageUrl?.let { imageUrl ->
+            image.imageTintList = null
             requireContext().imageLoader.enqueue(
                 ImageRequest.Builder(requireContext())
                     .data(imageUrl)
@@ -259,8 +277,7 @@ class ChannelPointsDialog : DialogFragment() {
         }
         cost.addView(ImageView(requireContext()).apply {
             layoutParams = LinearLayout.LayoutParams(dp(14), dp(14))
-            setImageResource(R.drawable.ic_channel_points)
-            imageTintList = android.content.res.ColorStateList.valueOf(Color.WHITE)
+            setChannelPointsIcon(this, pointsIconUrl, Color.WHITE)
         })
         cost.addView(TextView(requireContext()).apply {
             layoutParams = LinearLayout.LayoutParams(
@@ -287,7 +304,7 @@ class ChannelPointsDialog : DialogFragment() {
 
     private fun showRewardRedemptionDialog(reward: ChannelPointReward) {
         val inputContent = createRewardInputContent(reward)
-        requireContext().getAlertDialogBuilder()
+        val dialog = requireContext().getAlertDialogBuilder()
             .setTitle(reward.title)
             .setMessage(reward.prompt ?: getString(R.string.channel_points_reward_confirm))
             .apply { inputContent?.let { setView(it.view) } }
@@ -295,7 +312,18 @@ class ChannelPointsDialog : DialogFragment() {
             .setPositiveButton(R.string.channel_points_reward_redeem) { _, _ ->
                 listener.redeemChannelPointReward(reward, inputContent?.input?.text?.toString())
             }
-            .show()
+            .create()
+        val pickerUpdatesJob: Job? = inputContent?.let { content ->
+            content.pickerUpdates?.let { updates ->
+                lifecycleScope.launch {
+                    repeatOnLifecycle(Lifecycle.State.STARTED) {
+                        updates.collectLatest { content.refreshPicker?.invoke() }
+                    }
+                }
+            }
+        }
+        dialog.setOnDismissListener { pickerUpdatesJob?.cancel() }
+        dialog.show()
     }
 
     private fun createRewardInputContent(reward: ChannelPointReward): RewardInputContent? {
@@ -326,7 +354,7 @@ class ChannelPointsDialog : DialogFragment() {
                     inputType = InputType.TYPE_CLASS_TEXT
                     setSingleLine(true)
                 }
-                val allEmotes = listener.emotePickerItems()
+                var allEmotes = listener.channelEmotePickerItems()
                 val adapter = EmotesAdapter(
                     this,
                     { emote ->
@@ -341,13 +369,18 @@ class ChannelPointsDialog : DialogFragment() {
                     this.adapter = adapter
                     layoutManager = GridAutofitLayoutManager(requireContext(), dp(50))
                 }
-                fun updatePicker(query: String) {
+                fun updatePicker() {
+                    val query = input.text.toString()
                     adapter.submitList(
                         allEmotes.filter { it.name.orEmpty().contains(query, ignoreCase = true) },
                     )
                 }
-                input.addTextChangedListener { updatePicker(it?.toString().orEmpty()) }
-                updatePicker("")
+                val refreshPicker: () -> Unit = {
+                    allEmotes = listener.channelEmotePickerItems()
+                    updatePicker()
+                }
+                input.addTextChangedListener { updatePicker() }
+                updatePicker()
                 RewardInputContent(
                     input = input,
                     view = LinearLayout(requireContext()).apply {
@@ -364,8 +397,25 @@ class ChannelPointsDialog : DialogFragment() {
                             topMargin = dp(8)
                         })
                     },
+                    pickerUpdates = listener.channelEmotePickerUpdates(),
+                    refreshPicker = refreshPicker,
                 )
             }
+        }
+    }
+
+    private fun setChannelPointsIcon(image: ImageView, imageUrl: String?, fallbackTint: Int) {
+        image.setImageResource(R.drawable.ic_channel_points)
+        image.imageTintList = ColorStateList.valueOf(fallbackTint)
+        if (!imageUrl.isNullOrBlank()) {
+            image.imageTintList = null
+            requireContext().imageLoader.enqueue(
+                ImageRequest.Builder(requireContext())
+                    .data(imageUrl)
+                    .crossfade(true)
+                    .target(image)
+                    .build(),
+            )
         }
     }
 

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChannelPointsDialog.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChannelPointsDialog.kt
@@ -2,6 +2,7 @@ package com.github.andreyasadchy.xtra.ui.chat
 
 import android.app.Dialog
 import android.content.Context
+import android.content.DialogInterface
 import android.content.res.ColorStateList
 import android.graphics.Color
 import android.os.Bundle
@@ -60,7 +61,7 @@ class ChannelPointsDialog : DialogFragment() {
         fun channelName(): String?
         fun channelEmotePickerItems(): List<Emote>
         fun channelEmotePickerUpdates(): Flow<Unit>
-        fun redeemChannelPointReward(reward: ChannelPointReward, textInput: String?)
+        fun redeemChannelPointReward(reward: ChannelPointReward, textInput: String?, emoteId: String?)
         fun channelPointRedemptionFlow(): Flow<ChannelPointRedemptionResult>
     }
 
@@ -78,6 +79,7 @@ class ChannelPointsDialog : DialogFragment() {
         val view: View,
         val pickerUpdates: Flow<Unit>? = null,
         val refreshPicker: (() -> Unit)? = null,
+        val selectedEmoteId: (() -> String?)? = null,
     )
 
     override fun onAttach(context: Context) {
@@ -310,7 +312,13 @@ class ChannelPointsDialog : DialogFragment() {
             .apply { inputContent?.let { setView(it.view) } }
             .setNegativeButton(android.R.string.cancel, null)
             .setPositiveButton(R.string.channel_points_reward_redeem) { _, _ ->
-                listener.redeemChannelPointReward(reward, inputContent?.input?.text?.toString())
+                val textInput = inputContent?.input?.text?.toString()
+                    ?.takeIf { reward.inputType == ChannelPointRewardInput.TEXT }
+                listener.redeemChannelPointReward(
+                    reward,
+                    textInput,
+                    inputContent?.selectedEmoteId?.invoke(),
+                )
             }
             .create()
         val pickerUpdatesJob: Job? = inputContent?.let { content ->
@@ -324,6 +332,18 @@ class ChannelPointsDialog : DialogFragment() {
         }
         dialog.setOnDismissListener { pickerUpdatesJob?.cancel() }
         dialog.show()
+        inputContent?.let { content ->
+            val redeemButton = dialog.getButton(DialogInterface.BUTTON_POSITIVE)
+            fun updateRedeemButton() {
+                redeemButton.isEnabled = when (reward.inputType) {
+                    ChannelPointRewardInput.NONE -> true
+                    ChannelPointRewardInput.TEXT -> content.input.text.isNotBlank()
+                    ChannelPointRewardInput.EMOTE -> content.selectedEmoteId?.invoke()?.isNotBlank() == true
+                }
+            }
+            content.input.addTextChangedListener { updateRedeemButton() }
+            updateRedeemButton()
+        }
     }
 
     private fun createRewardInputContent(reward: ChannelPointReward): RewardInputContent? {
@@ -349,6 +369,7 @@ class ChannelPointsDialog : DialogFragment() {
                 )
             }
             ChannelPointRewardInput.EMOTE -> {
+                var selectedEmoteId: String? = null
                 val input = EditText(requireContext()).apply {
                     hint = getString(R.string.channel_points_reward_emote_hint)
                     inputType = InputType.TYPE_CLASS_TEXT
@@ -358,6 +379,7 @@ class ChannelPointsDialog : DialogFragment() {
                 val adapter = EmotesAdapter(
                     this,
                     { emote ->
+                        selectedEmoteId = emote.id
                         input.setText(emote.name.orEmpty())
                         input.setSelection(input.text.length)
                     },
@@ -379,7 +401,12 @@ class ChannelPointsDialog : DialogFragment() {
                     allEmotes = listener.channelEmotePickerItems()
                     updatePicker()
                 }
-                input.addTextChangedListener { updatePicker() }
+                input.addTextChangedListener { text ->
+                    selectedEmoteId = allEmotes.firstOrNull {
+                        it.name.equals(text?.toString(), ignoreCase = true)
+                    }?.id
+                    updatePicker()
+                }
                 updatePicker()
                 RewardInputContent(
                     input = input,
@@ -399,6 +426,7 @@ class ChannelPointsDialog : DialogFragment() {
                     },
                     pickerUpdates = listener.channelEmotePickerUpdates(),
                     refreshPicker = refreshPicker,
+                    selectedEmoteId = { selectedEmoteId },
                 )
             }
         }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChannelPointsDialog.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChannelPointsDialog.kt
@@ -33,6 +33,7 @@ import com.github.andreyasadchy.xtra.model.chat.Prediction
 import com.github.andreyasadchy.xtra.model.ui.ChannelPoints
 import com.github.andreyasadchy.xtra.model.ui.ChannelPointReward
 import com.github.andreyasadchy.xtra.model.ui.ChannelPointRewardInput
+import com.github.andreyasadchy.xtra.model.ui.ChannelPointRewardRedemption
 import com.github.andreyasadchy.xtra.model.ui.ChannelPointRedemptionResult
 import com.github.andreyasadchy.xtra.model.ui.WatchStreak
 import com.github.andreyasadchy.xtra.ui.view.GridAutofitLayoutManager
@@ -61,6 +62,8 @@ class ChannelPointsDialog : DialogFragment() {
         fun channelName(): String?
         fun channelEmotePickerItems(): List<Emote>
         fun channelEmotePickerUpdates(): Flow<Unit>
+        fun channelPointModifiedEmotePickerItems(): List<Emote>
+        fun channelPointModifiedEmotePickerUpdates(): Flow<Unit>
         fun redeemChannelPointReward(reward: ChannelPointReward, textInput: String?, emoteId: String?)
         fun channelPointRedemptionFlow(): Flow<ChannelPointRedemptionResult>
     }
@@ -370,12 +373,17 @@ class ChannelPointsDialog : DialogFragment() {
             }
             ChannelPointRewardInput.EMOTE -> {
                 var selectedEmoteId: String? = null
+                val modified = reward.redemptionType == ChannelPointRewardRedemption.CHOSEN_MODIFIED_SUB_EMOTE
                 val input = EditText(requireContext()).apply {
                     hint = getString(R.string.channel_points_reward_emote_hint)
                     inputType = InputType.TYPE_CLASS_TEXT
                     setSingleLine(true)
                 }
-                var allEmotes = listener.channelEmotePickerItems()
+                var allEmotes = if (modified) {
+                    listener.channelPointModifiedEmotePickerItems()
+                } else {
+                    listener.channelEmotePickerItems()
+                }
                 val adapter = EmotesAdapter(
                     this,
                     { emote ->
@@ -398,7 +406,11 @@ class ChannelPointsDialog : DialogFragment() {
                     )
                 }
                 val refreshPicker: () -> Unit = {
-                    allEmotes = listener.channelEmotePickerItems()
+                    allEmotes = if (modified) {
+                        listener.channelPointModifiedEmotePickerItems()
+                    } else {
+                        listener.channelEmotePickerItems()
+                    }
                     updatePicker()
                 }
                 input.addTextChangedListener { text ->
@@ -424,7 +436,11 @@ class ChannelPointsDialog : DialogFragment() {
                             topMargin = dp(8)
                         })
                     },
-                    pickerUpdates = listener.channelEmotePickerUpdates(),
+                    pickerUpdates = if (modified) {
+                        listener.channelPointModifiedEmotePickerUpdates()
+                    } else {
+                        listener.channelEmotePickerUpdates()
+                    },
                     refreshPicker = refreshPicker,
                     selectedEmoteId = { selectedEmoteId },
                 )

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatFragment.kt
@@ -44,6 +44,8 @@ import com.github.andreyasadchy.xtra.model.chat.Emote
 import com.github.andreyasadchy.xtra.model.chat.Poll
 import com.github.andreyasadchy.xtra.model.chat.Prediction
 import com.github.andreyasadchy.xtra.model.ui.ChannelPoints
+import com.github.andreyasadchy.xtra.model.ui.ChannelPointReward
+import com.github.andreyasadchy.xtra.model.ui.ChannelPointRedemptionResult
 import com.github.andreyasadchy.xtra.model.ui.Stream
 import com.github.andreyasadchy.xtra.model.ui.WatchStreak
 import com.github.andreyasadchy.xtra.ui.channel.ChannelPagerFragmentDirections
@@ -68,6 +70,7 @@ import com.google.mlkit.nl.translate.Translation
 import com.google.mlkit.nl.translate.Translator
 import com.google.mlkit.nl.translate.TranslatorOptions
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import java.text.NumberFormat
@@ -111,6 +114,19 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
     override fun activePollFlow(): StateFlow<Poll?> = viewModel.activePoll
 
     override fun activePredictionFlow(): StateFlow<Prediction?> = viewModel.activePrediction
+
+    override fun channelName(): String? {
+        return arguments?.getString(KEY_CHANNEL_NAME)?.takeIf { it.isNotBlank() }
+            ?: arguments?.getString(KEY_CHANNEL_LOGIN)
+    }
+
+    override fun emotePickerItems(): List<Emote> = viewModel.emotePickerItems()
+
+    override fun redeemChannelPointReward(reward: ChannelPointReward, textInput: String?) {
+        viewModel.redeemChannelPointReward(reward, textInput)
+    }
+
+    override fun channelPointRedemptionFlow(): SharedFlow<ChannelPointRedemptionResult> = viewModel.channelPointRedemption
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         _binding = FragmentChatBinding.inflate(inflater, container, false)

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatFragment.kt
@@ -126,8 +126,8 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
 
     override fun channelEmotePickerUpdates(): Flow<Unit> = viewModel.channelEmotePickerUpdates()
 
-    override fun redeemChannelPointReward(reward: ChannelPointReward, textInput: String?) {
-        viewModel.redeemChannelPointReward(reward, textInput)
+    override fun redeemChannelPointReward(reward: ChannelPointReward, textInput: String?, emoteId: String?) {
+        viewModel.redeemChannelPointReward(reward, textInput, emoteId)
     }
 
     override fun channelPointRedemptionFlow(): Flow<ChannelPointRedemptionResult> = viewModel.channelPointRedemption

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatFragment.kt
@@ -1,6 +1,7 @@
 package com.github.andreyasadchy.xtra.ui.chat
 
 import android.content.Context
+import android.content.res.ColorStateList
 import android.os.Build
 import android.os.Bundle
 import android.text.format.DateUtils
@@ -70,7 +71,7 @@ import com.google.mlkit.nl.translate.Translation
 import com.google.mlkit.nl.translate.Translator
 import com.google.mlkit.nl.translate.TranslatorOptions
 import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import java.text.NumberFormat
@@ -89,6 +90,7 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
     private var showChatStatus = false
     private var hasRecentEmotes = false
     private var messagingEnabled = false
+    private var channelPointsIconUrl: String? = null
 
     private var autoCompleteAdapter: AutoCompleteAdapter<Any>? = null
 
@@ -120,13 +122,15 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
             ?: arguments?.getString(KEY_CHANNEL_LOGIN)
     }
 
-    override fun emotePickerItems(): List<Emote> = viewModel.emotePickerItems()
+    override fun channelEmotePickerItems(): List<Emote> = viewModel.channelEmotePickerItems()
+
+    override fun channelEmotePickerUpdates(): Flow<Unit> = viewModel.channelEmotePickerUpdates()
 
     override fun redeemChannelPointReward(reward: ChannelPointReward, textInput: String?) {
         viewModel.redeemChannelPointReward(reward, textInput)
     }
 
-    override fun channelPointRedemptionFlow(): SharedFlow<ChannelPointRedemptionResult> = viewModel.channelPointRedemption
+    override fun channelPointRedemptionFlow(): Flow<ChannelPointRedemptionResult> = viewModel.channelPointRedemption
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         _binding = FragmentChatBinding.inflate(inflater, container, false)
@@ -274,10 +278,12 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
                                 viewModel.channelPoints.collectLatest { points ->
                                     if (points != null) {
                                         val balance = NumberFormat.getInstance().format(points.balance)
-                                        channelPoints.text = balance
+                                        channelPointsText.text = balance
                                         channelPoints.contentDescription = getString(R.string.channel_points_balance, balance)
+                                        updateChannelPointsIcon(points.iconUrl)
                                         channelPoints.visibility = View.VISIBLE
                                     } else {
+                                        updateChannelPointsIcon(null)
                                         channelPoints.visibility = View.GONE
                                     }
                                 }
@@ -1290,8 +1296,30 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
     }
 
     override fun onDestroyView() {
+        channelPointsIconUrl = null
         super.onDestroyView()
         _binding = null
+    }
+
+    private fun updateChannelPointsIcon(url: String?) {
+        val icon = binding.channelPointsIcon
+        if (channelPointsIconUrl == url) return
+        channelPointsIconUrl = url
+        icon.setImageResource(R.drawable.ic_channel_points)
+        if (url.isNullOrBlank()) {
+            icon.imageTintList = ColorStateList.valueOf(
+                MaterialColors.getColor(icon, androidx.appcompat.R.attr.colorControlNormal),
+            )
+        } else {
+            icon.imageTintList = null
+            requireContext().imageLoader.enqueue(
+                ImageRequest.Builder(requireContext())
+                    .data(url)
+                    .crossfade(true)
+                    .target(icon)
+                    .build(),
+            )
+        }
     }
 
     override fun onDestroy() {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatFragment.kt
@@ -126,6 +126,10 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
 
     override fun channelEmotePickerUpdates(): Flow<Unit> = viewModel.channelEmotePickerUpdates()
 
+    override fun channelPointModifiedEmotePickerItems(): List<Emote> = viewModel.channelPointModifiedEmotePickerItems()
+
+    override fun channelPointModifiedEmotePickerUpdates(): Flow<Unit> = viewModel.channelPointModifiedEmotePickerUpdates()
+
     override fun redeemChannelPointReward(reward: ChannelPointReward, textInput: String?, emoteId: String?) {
         viewModel.redeemChannelPointReward(reward, textInput, emoteId)
     }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatViewModel.kt
@@ -36,6 +36,7 @@ import com.github.andreyasadchy.xtra.model.gql.chat.WatchStreakResponse
 import com.github.andreyasadchy.xtra.model.ui.ChannelPoints
 import com.github.andreyasadchy.xtra.model.ui.ChannelPointReward as ChannelPointRewardInfo
 import com.github.andreyasadchy.xtra.model.ui.ChannelPointRewardInput
+import com.github.andreyasadchy.xtra.model.ui.ChannelPointRewardRedemption
 import com.github.andreyasadchy.xtra.model.ui.ChannelPointRedemptionResult
 import com.github.andreyasadchy.xtra.model.ui.TranslatedChannel
 import com.github.andreyasadchy.xtra.model.ui.WatchStreak
@@ -787,7 +788,9 @@ class ChatViewModel(
     }
 
     private fun loadUserEmotes(channelId: String?) {
-        val saved = savedUserEmotes
+        val saved = channelId?.let { id ->
+            synchronized(savedUserEmotes) { savedUserEmotes[id] }
+        }
         if (!saved.isNullOrEmpty()) {
             updateChannelEmotes(saved, channelId)
             synchronized(userEmotes) {
@@ -813,13 +816,17 @@ class ChatViewModel(
                         val animateGifs =  applicationContext.prefs().getBoolean(C.ANIMATED_EMOTES, true)
                         val enableIntegrity = applicationContext.prefs().getBoolean(C.ENABLE_INTEGRITY, false)
                         val emotes = playerRepository.loadUserEmotes(networkLibrary, helixHeaders, gqlHeaders, channelId, accountId, animateGifs, enableIntegrity)
-                        if (emotes.isNotEmpty()) {
+                        val currentChannelId = channelId?.takeIf { it == activeChannelId && it.isNotBlank() }
+                        if (emotes.isNotEmpty() && currentChannelId != null) {
                             val sorted = emotes.sortedByDescending { it.setId }
-                            updateChannelEmotes(sorted, channelId)
+                            synchronized(savedUserEmotes) {
+                                savedUserEmotes[currentChannelId] = sorted
+                            }
+                            updateChannelEmotes(sorted, currentChannelId)
                             synchronized(userEmotes) {
                                 userEmotes.clear()
                                 userEmotes.addAll(
-                                    sorted.sortedByDescending { it.ownerId == channelId }.map { it.toPickerEmote() },
+                                    sorted.sortedByDescending { it.ownerId == currentChannelId }.map { it.toPickerEmote() },
                                 )
                             }
                             userEmotesUpdated.emit(Unit)
@@ -1026,12 +1033,13 @@ class ChatViewModel(
             }
         val automaticRewards = settings?.automaticRewards.orEmpty()
             .asSequence()
-            .filter { it.pricingType.equals(POINTS_PRICING_TYPE, true) && it.isEnabled != false && it.isInStock != false }
+            .filter { it.isEnabled != false && it.isInStock != false }
             .mapNotNull { reward ->
                 val id = reward.id
                 val type = reward.type
                 val cost = reward.cost ?: reward.defaultCost
-                if (!id.isNullOrBlank() && !type.isNullOrBlank() && cost != null) {
+                val redemptionType = type?.let(::automaticRewardRedemption)
+                if (!id.isNullOrBlank() && !type.isNullOrBlank() && cost != null && redemptionType != null) {
                     ChannelPointRewardInfo(
                         id = id,
                         title = automaticRewardTitle(type),
@@ -1040,7 +1048,8 @@ class ChatViewModel(
                         backgroundColor = reward.backgroundColor
                             ?: reward.defaultBackgroundColor
                             ?: automaticRewardColor(type),
-                        inputType = automaticRewardInput(type),
+                        inputType = redemptionType.inputType(),
+                        redemptionType = redemptionType,
                     )
                 } else null
             }
@@ -1099,13 +1108,22 @@ class ChatViewModel(
         else -> DEFAULT_REWARD_COLOR
     }
 
-    private fun automaticRewardInput(type: String): ChannelPointRewardInput = when (type.uppercase()) {
-        "CHOSEN_SUB_EMOTE_UNLOCK", "CHOSEN_MODIFIED_SUB_EMOTE_UNLOCK",
-        "SEND_GIGANTIFIED_EMOTE", "GIGANTIFY_AN_EMOTE",
-        "CELEBRATION", "ON_SCREEN_CELEBRATION" -> ChannelPointRewardInput.EMOTE
-        "SINGLE_MESSAGE_BYPASS_SUB_MODE", "SEND_HIGHLIGHTED_MESSAGE",
-        "SEND_ANIMATED_MESSAGE", "MESSAGE_EFFECT" -> ChannelPointRewardInput.TEXT
-        else -> ChannelPointRewardInput.NONE
+    private fun automaticRewardRedemption(type: String): ChannelPointRewardRedemption? = when (type.uppercase()) {
+        "RANDOM_SUB_EMOTE_UNLOCK" -> ChannelPointRewardRedemption.RANDOM_SUB_EMOTE
+        "CHOSEN_SUB_EMOTE_UNLOCK" -> ChannelPointRewardRedemption.CHOSEN_SUB_EMOTE
+        "CHOSEN_MODIFIED_SUB_EMOTE_UNLOCK" -> ChannelPointRewardRedemption.CHOSEN_MODIFIED_SUB_EMOTE
+        "SINGLE_MESSAGE_BYPASS_SUB_MODE" -> ChannelPointRewardRedemption.SUBSCRIBER_MODE_MESSAGE
+        "SEND_HIGHLIGHTED_MESSAGE" -> ChannelPointRewardRedemption.HIGHLIGHTED_MESSAGE
+        else -> null
+    }
+
+    private fun ChannelPointRewardRedemption.inputType(): ChannelPointRewardInput = when (this) {
+        ChannelPointRewardRedemption.CUSTOM,
+        ChannelPointRewardRedemption.RANDOM_SUB_EMOTE -> ChannelPointRewardInput.NONE
+        ChannelPointRewardRedemption.CHOSEN_SUB_EMOTE,
+        ChannelPointRewardRedemption.CHOSEN_MODIFIED_SUB_EMOTE -> ChannelPointRewardInput.EMOTE
+        ChannelPointRewardRedemption.SUBSCRIBER_MODE_MESSAGE,
+        ChannelPointRewardRedemption.HIGHLIGHTED_MESSAGE -> ChannelPointRewardInput.TEXT
     }
 
     private fun updateWatchStreak(streakCount: Int?, pointsAwarded: Int? = null) {
@@ -1172,12 +1190,32 @@ class ChatViewModel(
         }
     }
 
-    fun redeemChannelPointReward(reward: ChannelPointRewardInfo, textInput: String?) {
+    fun redeemChannelPointReward(reward: ChannelPointRewardInfo, textInput: String?, emoteId: String?) {
         val channelId = activeChannelId
         val channelLogin = activeChannelLogin
         if (channelId.isNullOrBlank() || channelLogin.isNullOrBlank()) {
             channelPointRedemptionEvents.trySend(
                 ChannelPointRedemptionResult(reward.title, success = false, message = "Chat is not connected"),
+            )
+            return
+        }
+        if (reward.inputType == ChannelPointRewardInput.TEXT && textInput.isNullOrBlank()) {
+            channelPointRedemptionEvents.trySend(
+                ChannelPointRedemptionResult(
+                    reward.title,
+                    success = false,
+                    message = applicationContext.getString(R.string.channel_points_reward_input_required),
+                ),
+            )
+            return
+        }
+        if (reward.inputType == ChannelPointRewardInput.EMOTE && emoteId.isNullOrBlank()) {
+            channelPointRedemptionEvents.trySend(
+                ChannelPointRedemptionResult(
+                    reward.title,
+                    success = false,
+                    message = applicationContext.getString(R.string.channel_points_reward_input_required),
+                ),
             )
             return
         }
@@ -1201,12 +1239,21 @@ class ChatViewModel(
                     cost = reward.cost,
                     prompt = reward.prompt,
                     textInput = textInput?.takeIf { it.isNotBlank() },
+                    emoteId = emoteId?.takeIf { it.isNotBlank() },
+                    redemptionType = reward.redemptionType,
                 )
+                if (activeChannelId != channelId || activeChannelLogin != channelLogin) {
+                    return@launch
+                }
                 val error = response.errors?.firstOrNull()?.message
-                    ?: response.data?.redeemCommunityPointsCustomReward?.error?.code
-                if (error != null) {
+                    ?: response.data?.errorCode()
+                if (error != null || response.data?.hasPayload() != true) {
                     channelPointRedemptionEvents.send(
-                        ChannelPointRedemptionResult(reward.title, success = false, message = error),
+                        ChannelPointRedemptionResult(
+                            reward.title,
+                            success = false,
+                            message = error ?: "Request failed",
+                        ),
                     )
                 } else {
                     channelPointRedemptionEvents.send(ChannelPointRedemptionResult(reward.title, success = true))
@@ -1215,13 +1262,15 @@ class ChatViewModel(
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
-                channelPointRedemptionEvents.send(
-                    ChannelPointRedemptionResult(
-                        reward.title,
-                        success = false,
-                        message = e.message ?: "Request failed",
-                    ),
-                )
+                if (activeChannelId == channelId && activeChannelLogin == channelLogin) {
+                    channelPointRedemptionEvents.send(
+                        ChannelPointRedemptionResult(
+                            reward.title,
+                            success = false,
+                            message = e.message ?: "Request failed",
+                        ),
+                    )
+                }
             }
         }
     }
@@ -1237,6 +1286,7 @@ class ChatViewModel(
 
     private fun TwitchEmote.toPickerEmote(): Emote = Emote(
         name = name,
+        id = id,
         url1x = url1x,
         url2x = url2x,
         url3x = url3x,
@@ -1245,13 +1295,14 @@ class ChatViewModel(
     )
 
     private fun updateChannelEmotes(emotes: List<TwitchEmote>, channelId: String?) {
+        if (channelId.isNullOrBlank() || channelId != activeChannelId) {
+            return
+        }
         synchronized(channelEmotes) {
             channelEmotes.clear()
-            if (!channelId.isNullOrBlank()) {
-                channelEmotes.addAll(
-                    emotes.filter { it.ownerId == channelId }.map { it.toPickerEmote() },
-                )
-            }
+            channelEmotes.addAll(
+                emotes.filter { it.ownerId == channelId }.map { it.toPickerEmote() },
+            )
         }
     }
 
@@ -2180,14 +2231,17 @@ class ChatViewModel(
                     savedEmoteSets?.chunked(25)?.forEach { list ->
                         playerRepository.loadEmotesFromSet(networkLibrary, helixHeaders, list, animateGifs).let { emotes.addAll(it) }
                     }
-                    if (emotes.isNotEmpty()) {
+                    val currentChannelId = channelId?.takeIf { it == activeChannelId && it.isNotBlank() }
+                    if (emotes.isNotEmpty() && currentChannelId != null) {
                         val sorted = emotes.sortedByDescending { it.setId }
-                        savedUserEmotes = sorted
-                        updateChannelEmotes(sorted, channelId)
+                        synchronized(savedUserEmotes) {
+                            savedUserEmotes[currentChannelId] = sorted
+                        }
+                        updateChannelEmotes(sorted, currentChannelId)
                         synchronized(userEmotes) {
                             userEmotes.clear()
                             userEmotes.addAll(
-                                sorted.sortedByDescending { it.ownerId == channelId }.map { it.toPickerEmote() },
+                                sorted.sortedByDescending { it.ownerId == currentChannelId }.map { it.toPickerEmote() },
                             )
                         }
                         userEmotesUpdated.emit(Unit)
@@ -3466,10 +3520,9 @@ class ChatViewModel(
     }
 
     companion object {
-        private const val POINTS_PRICING_TYPE = "POINTS"
         private const val DEFAULT_REWARD_COLOR = "#9146FF"
         private var savedEmoteSets: List<String>? = null
-        private var savedUserEmotes: List<TwitchEmote>? = null
+        private val savedUserEmotes = mutableMapOf<String, List<TwitchEmote>>()
         private var savedGlobalBadges: List<TwitchBadge>? = null
         private var savedGlobalSTVEmotes: List<Emote>? = null
         private var savedGlobalBTTVEmotes: List<Emote>? = null

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatViewModel.kt
@@ -35,6 +35,8 @@ import com.github.andreyasadchy.xtra.model.gql.chat.ChannelPointContextResponse
 import com.github.andreyasadchy.xtra.model.gql.chat.WatchStreakResponse
 import com.github.andreyasadchy.xtra.model.ui.ChannelPoints
 import com.github.andreyasadchy.xtra.model.ui.ChannelPointReward as ChannelPointRewardInfo
+import com.github.andreyasadchy.xtra.model.ui.ChannelPointRewardInput
+import com.github.andreyasadchy.xtra.model.ui.ChannelPointRedemptionResult
 import com.github.andreyasadchy.xtra.model.ui.TranslatedChannel
 import com.github.andreyasadchy.xtra.model.ui.WatchStreak
 import com.github.andreyasadchy.xtra.model.ui.WatchStreakReward
@@ -114,6 +116,8 @@ class ChatViewModel(
     private var usedPredictionId: String? = null
     private var predictionTimeoutJob: Job? = null
     private var started = false
+    private var activeChannelId: String? = null
+    private var activeChannelLogin: String? = null
     var autoReconnect = true
 
     private var chatReplayManager: ChatReplayManager? = null
@@ -158,6 +162,7 @@ class ChatViewModel(
     val translateAllMessages = MutableStateFlow<Boolean?>(null)
     val channelPoints = MutableStateFlow<ChannelPoints?>(null)
     val watchStreak = MutableStateFlow<WatchStreak?>(null)
+    val channelPointRedemption = MutableSharedFlow<ChannelPointRedemptionResult>(extraBufferCapacity = 1)
 
     val reloadMessages = MutableStateFlow(false)
     val hideRaid = MutableStateFlow(false)
@@ -1010,28 +1015,47 @@ class ChatViewModel(
             .asSequence()
             .filter { it.isEnabled != false && it.isPaused != true && it.isInStock != false }
             .mapNotNull { reward ->
+                val id = reward.id
                 val title = reward.title
                 val cost = reward.cost
-                if (!title.isNullOrBlank() && cost != null) {
-                    ChannelPointRewardInfo(title = title, cost = cost, prompt = reward.prompt)
+                if (!id.isNullOrBlank() && !title.isNullOrBlank() && cost != null) {
+                    ChannelPointRewardInfo(
+                        id = id,
+                        title = title,
+                        cost = cost,
+                        prompt = reward.prompt,
+                        imageUrl = reward.rewardImageUrl(),
+                        backgroundColor = reward.backgroundColor ?: DEFAULT_REWARD_COLOR,
+                        inputType = if (reward.isUserInputRequired == true) {
+                            ChannelPointRewardInput.TEXT
+                        } else {
+                            ChannelPointRewardInput.NONE
+                        },
+                    )
                 } else null
             }
         val automaticRewards = settings?.automaticRewards.orEmpty()
             .asSequence()
-            .filter { it.isEnabled != false && it.isInStock != false }
+            .filter { it.pricingType.equals(POINTS_PRICING_TYPE, true) && it.isEnabled != false && it.isInStock != false }
             .mapNotNull { reward ->
+                val id = reward.id
                 val type = reward.type
-                val cost = reward.cost
-                if (!type.isNullOrBlank() && cost != null) {
+                val cost = reward.cost ?: reward.defaultCost
+                if (!id.isNullOrBlank() && !type.isNullOrBlank() && cost != null) {
                     ChannelPointRewardInfo(
-                        title = type.replace('_', ' ').lowercase().replaceFirstChar { it.uppercase() },
+                        id = id,
+                        title = automaticRewardTitle(type),
                         cost = cost,
+                        imageUrl = reward.rewardImageUrl(),
+                        backgroundColor = reward.backgroundColor
+                            ?: reward.defaultBackgroundColor
+                            ?: automaticRewardColor(type),
+                        inputType = automaticRewardInput(type),
                     )
                 } else null
             }
         val rewards = (customRewards + automaticRewards)
-            .sortedBy { it.cost }
-            .take(8)
+            .sortedWith(compareBy<ChannelPointRewardInfo> { it.cost }.thenBy { it.title })
             .toList()
         val watchStreakRewards = settings?.earning?.watchStreakPoints.orEmpty()
             .mapIndexedNotNull { index, reward ->
@@ -1044,6 +1068,42 @@ class ChatViewModel(
             rewards = rewards,
             watchStreakRewards = watchStreakRewards,
         )
+    }
+
+    private fun ChannelPointContextResponse.CustomReward.rewardImageUrl(): String? {
+        return image?.url4x ?: image?.url2x ?: image?.url1x ?: image?.url
+            ?: defaultImage?.url4x ?: defaultImage?.url2x ?: defaultImage?.url1x ?: defaultImage?.url
+    }
+
+    private fun ChannelPointContextResponse.AutomaticReward.rewardImageUrl(): String? {
+        return image?.url4x ?: image?.url2x ?: image?.url1x ?: image?.url
+            ?: defaultImage?.url4x ?: defaultImage?.url2x ?: defaultImage?.url1x ?: defaultImage?.url
+    }
+
+    private fun automaticRewardTitle(type: String): String = when (type) {
+        "RANDOM_SUB_EMOTE_UNLOCK" -> "Unlock a Random Sub Emote"
+        "SINGLE_MESSAGE_BYPASS_SUB_MODE" -> "Send a Message in Sub-Only Mode"
+        "CHOSEN_SUB_EMOTE_UNLOCK" -> "Choose an Emote to Unlock"
+        "CHOSEN_MODIFIED_SUB_EMOTE_UNLOCK" -> "Modify a Single Emote"
+        "SEND_HIGHLIGHTED_MESSAGE" -> "Highlight My Message"
+        "SEND_ANIMATED_MESSAGE" -> "Message Effects"
+        "SEND_GIGANTIFIED_EMOTE" -> "Gigantify an Emote"
+        else -> type.replace('_', ' ').lowercase().replaceFirstChar { it.uppercase() }
+    }
+
+    private fun automaticRewardColor(type: String): String = when (type) {
+        "RANDOM_SUB_EMOTE_UNLOCK" -> "#8205B4"
+        "SINGLE_MESSAGE_BYPASS_SUB_MODE" -> "#9146FF"
+        "CHOSEN_SUB_EMOTE_UNLOCK" -> "#00C8AF"
+        "CHOSEN_MODIFIED_SUB_EMOTE_UNLOCK" -> "#00FA05"
+        "SEND_HIGHLIGHTED_MESSAGE" -> "#FF6905"
+        else -> DEFAULT_REWARD_COLOR
+    }
+
+    private fun automaticRewardInput(type: String): ChannelPointRewardInput = when (type) {
+        "CHOSEN_SUB_EMOTE_UNLOCK", "CHOSEN_MODIFIED_SUB_EMOTE_UNLOCK" -> ChannelPointRewardInput.EMOTE
+        "SINGLE_MESSAGE_BYPASS_SUB_MODE", "SEND_HIGHLIGHTED_MESSAGE" -> ChannelPointRewardInput.TEXT
+        else -> ChannelPointRewardInput.NONE
     }
 
     private fun updateWatchStreak(streakCount: Int?, pointsAwarded: Int? = null) {
@@ -1110,9 +1170,75 @@ class ChatViewModel(
         }
     }
 
+    fun redeemChannelPointReward(reward: ChannelPointRewardInfo, textInput: String?) {
+        val channelId = activeChannelId
+        val channelLogin = activeChannelLogin
+        if (channelId.isNullOrBlank() || channelLogin.isNullOrBlank()) {
+            channelPointRedemption.tryEmit(
+                ChannelPointRedemptionResult(reward.title, success = false, message = "Chat is not connected"),
+            )
+            return
+        }
+        val gqlHeaders = TwitchApiHelper.getGQLHeaders(applicationContext, true)
+        if (gqlHeaders[C.HEADER_TOKEN].isNullOrBlank()) {
+            channelPointRedemption.tryEmit(
+                ChannelPointRedemptionResult(reward.title, success = false, message = "Login is required"),
+            )
+            return
+        }
+        val networkLibrary = applicationContext.prefs().getString(C.NETWORK_LIBRARY, C.OKHTTP)
+        val enableIntegrity = applicationContext.prefs().getBoolean(C.ENABLE_INTEGRITY, false)
+        viewModelScope.launch {
+            try {
+                val response = graphQLRepository.redeemChannelPointReward(
+                    networkLibrary = networkLibrary,
+                    headers = gqlHeaders,
+                    channelId = channelId,
+                    rewardId = reward.id,
+                    title = reward.title,
+                    cost = reward.cost,
+                    prompt = reward.prompt,
+                    textInput = textInput?.takeIf { it.isNotBlank() },
+                )
+                val error = response.errors?.firstOrNull()?.message
+                    ?: response.data?.redeemCommunityPointsCustomReward?.error?.code
+                if (error != null) {
+                    channelPointRedemption.emit(
+                        ChannelPointRedemptionResult(reward.title, success = false, message = error),
+                    )
+                } else {
+                    channelPointRedemption.emit(ChannelPointRedemptionResult(reward.title, success = true))
+                    loadChannelPoints(networkLibrary, gqlHeaders, channelLogin, enableIntegrity)
+                }
+            } catch (e: Exception) {
+                channelPointRedemption.emit(
+                    ChannelPointRedemptionResult(
+                        reward.title,
+                        success = false,
+                        message = e.message ?: "Request failed",
+                    ),
+                )
+            }
+        }
+    }
+
+    fun emotePickerItems(): List<Emote> {
+        val personalEmotes = userSTVEmoteSetId?.let { setId ->
+            synchronized(personalEmoteSets) { personalEmoteSets[setId].orEmpty() }
+        }.orEmpty()
+        return (synchronized(userEmotes) { userEmotes.toList() } +
+                personalEmotes +
+                synchronized(thirdPartyEmotes) { thirdPartyEmotes.toList() })
+            .filter { !it.name.isNullOrBlank() }
+            .distinctBy { it.name }
+            .sortedBy { it.name.orEmpty().lowercase() }
+    }
+
     fun startLiveChat(channelId: String?, channelLogin: String) {
         stopLiveChat()
         started = true
+        activeChannelId = channelId
+        activeChannelLogin = channelLogin
         val gqlHeaders = TwitchApiHelper.getGQLHeaders(applicationContext, true)
         val helixHeaders = TwitchApiHelper.getHelixHeaders(applicationContext)
         val networkLibrary = applicationContext.prefs().getString(C.NETWORK_LIBRARY, C.OKHTTP)
@@ -1229,6 +1355,8 @@ class ChatViewModel(
     }
 
     fun stopLiveChat() {
+        activeChannelId = null
+        activeChannelLogin = null
         channelPointsJob?.cancel()
         channelPointsJob = null
         watchStreakJob?.cancel()
@@ -3310,6 +3438,8 @@ class ChatViewModel(
     }
 
     companion object {
+        private const val POINTS_PRICING_TYPE = "POINTS"
+        private const val DEFAULT_REWARD_COLOR = "#9146FF"
         private var savedEmoteSets: List<String>? = null
         private var savedUserEmotes: List<TwitchEmote>? = null
         private var savedGlobalBadges: List<TwitchBadge>? = null

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatViewModel.kt
@@ -132,6 +132,7 @@ class ChatViewModel(
     val hasRecentEmotes = MutableStateFlow(false)
     val userEmotes = mutableListOf<Emote>()
     private val channelEmotes = mutableListOf<Emote>()
+    private val channelPointModifiedEmotes = mutableListOf<Emote>()
     private var loadedUserEmotes = false
     val localTwitchEmotes = mutableListOf<TwitchEmote>()
     val thirdPartyEmotes = mutableListOf<Emote>()
@@ -181,6 +182,7 @@ class ChatViewModel(
     val removeMessages = MutableSharedFlow<Int>()
     val updateUserMessages = MutableSharedFlow<String>()
     val userEmotesUpdated = MutableSharedFlow<Unit>()
+    private val channelPointModifiedEmotesUpdated = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
     val thirdPartyEmotesUpdated = MutableSharedFlow<Unit>()
 
     private var messageLimit = 600
@@ -1008,14 +1010,25 @@ class ChatViewModel(
         val channel = response.data?.community?.channel ?: return
         val balance = channel.self.communityPoints?.balance ?: return
         val settings = channel.communityPointsSettings
+        updateChannelPointModifiedEmotes(settings)
+        val hasModifiedEmotes = synchronized(channelPointModifiedEmotes) {
+            channelPointModifiedEmotes.isNotEmpty()
+        }
         val customRewards = settings?.customRewards.orEmpty()
             .asSequence()
-            .filter { it.isEnabled != false && it.isPaused != true && it.isInStock != false }
+            .filter {
+                it.isEnabled != false &&
+                    it.isPaused != true &&
+                    it.isInStock != false &&
+                    it.cost != null &&
+                    it.cost > 0 &&
+                    (it.pricingType.isNullOrBlank() || it.pricingType.equals("POINTS", true))
+            }
             .mapNotNull { reward ->
                 val id = reward.id
                 val title = reward.title
                 val cost = reward.cost
-                if (!id.isNullOrBlank() && !title.isNullOrBlank() && cost != null) {
+                if (!id.isNullOrBlank() && !title.isNullOrBlank() && cost != null && cost > 0) {
                     ChannelPointRewardInfo(
                         id = id,
                         title = title,
@@ -1033,13 +1046,25 @@ class ChatViewModel(
             }
         val automaticRewards = settings?.automaticRewards.orEmpty()
             .asSequence()
-            .filter { it.isEnabled != false && it.isInStock != false }
+            .filter {
+                val type = it.type
+                it.isEnabled != false &&
+                    it.isInStock != false &&
+                    (type?.equals("CHOSEN_MODIFIED_SUB_EMOTE_UNLOCK", true) != true || hasModifiedEmotes)
+            }
             .mapNotNull { reward ->
                 val id = reward.id
                 val type = reward.type
                 val cost = reward.cost ?: reward.defaultCost
                 val redemptionType = type?.let(::automaticRewardRedemption)
-                if (!id.isNullOrBlank() && !type.isNullOrBlank() && cost != null && redemptionType != null) {
+                if (
+                    !id.isNullOrBlank() &&
+                    !type.isNullOrBlank() &&
+                    cost != null &&
+                    cost > 0 &&
+                    (reward.pricingType.isNullOrBlank() || reward.pricingType.equals("POINTS", true)) &&
+                    redemptionType != null
+                ) {
                     ChannelPointRewardInfo(
                         id = id,
                         title = automaticRewardTitle(type),
@@ -1082,6 +1107,35 @@ class ChatViewModel(
     private fun ChannelPointContextResponse.AutomaticReward.rewardImageUrl(): String? {
         return image?.url4x ?: image?.url2x ?: image?.url1x ?: image?.url
             ?: defaultImage?.url4x ?: defaultImage?.url2x ?: defaultImage?.url1x ?: defaultImage?.url
+    }
+
+    private fun updateChannelPointModifiedEmotes(
+        settings: ChannelPointContextResponse.CommunityPointsSettings?,
+    ) {
+        val emotes = settings?.emoteVariants.orEmpty()
+            .asSequence()
+            .filter { it.isUnlockable != false }
+            .flatMap { variant ->
+                variant.modifications.asSequence().mapNotNull { modification ->
+                    val id = modification.emote?.id ?: modification.id
+                    val name = modification.emote?.token
+                        ?: modification.title
+                        ?: modification.id
+                    if (id.isNullOrBlank() || name.isNullOrBlank()) {
+                        null
+                    } else {
+                        TwitchEmote(id = id, name = name).toPickerEmote()
+                    }
+                }
+            }
+            .distinctBy { it.id ?: it.name }
+            .sortedBy { it.name.orEmpty().lowercase() }
+            .toList()
+        synchronized(channelPointModifiedEmotes) {
+            channelPointModifiedEmotes.clear()
+            channelPointModifiedEmotes.addAll(emotes)
+        }
+        channelPointModifiedEmotesUpdated.tryEmit(Unit)
     }
 
     private fun automaticRewardTitle(type: String): String = when (type.uppercase()) {
@@ -1176,10 +1230,14 @@ class ChatViewModel(
         if (channelLogin.isNullOrBlank() || gqlHeaders[C.HEADER_TOKEN].isNullOrBlank()) {
             return
         }
+        val expectedChannelId = activeChannelId
         channelPointsJob?.cancel()
         channelPointsJob = viewModelScope.launch {
             try {
                 val response = graphQLRepository.loadChannelPointsContext(networkLibrary, gqlHeaders, channelLogin)
+                if (activeChannelId != expectedChannelId || activeChannelLogin != channelLogin) {
+                    return@launch
+                }
                 if (enableIntegrity && response.errors?.any { it.message == C.FAILED_INTEGRITY_CHECK } == true) {
                     integrity.emit("refresh")
                     return@launch
@@ -1281,6 +1339,14 @@ class ChatViewModel(
         .filter { !it.name.isNullOrBlank() }
         .distinctBy { it.name }
         .sortedBy { it.name.orEmpty().lowercase() }
+
+    fun channelPointModifiedEmotePickerItems(): List<Emote> = synchronized(channelPointModifiedEmotes) {
+        channelPointModifiedEmotes.toList()
+    }
+        .filter { !it.name.isNullOrBlank() && !it.id.isNullOrBlank() }
+        .sortedBy { it.name.orEmpty().lowercase() }
+
+    fun channelPointModifiedEmotePickerUpdates(): Flow<Unit> = channelPointModifiedEmotesUpdated
 
     fun channelEmotePickerUpdates(): Flow<Unit> = userEmotesUpdated
 
@@ -1443,6 +1509,9 @@ class ChatViewModel(
         activeChannelLogin = null
         synchronized(channelEmotes) {
             channelEmotes.clear()
+        }
+        synchronized(channelPointModifiedEmotes) {
+            channelPointModifiedEmotes.clear()
         }
         channelPointsJob?.cancel()
         channelPointsJob = null

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatViewModel.kt
@@ -58,13 +58,17 @@ import com.github.andreyasadchy.xtra.util.chat.STVEventApiUtils
 import com.github.andreyasadchy.xtra.util.chat.STVEventApiWebSocket
 import com.github.andreyasadchy.xtra.util.prefs
 import com.github.andreyasadchy.xtra.util.tokenPrefs
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
@@ -126,6 +130,7 @@ class ChatViewModel(
     val recentEmotes by lazy { playerRepository.loadRecentEmotesFlow() }
     val hasRecentEmotes = MutableStateFlow(false)
     val userEmotes = mutableListOf<Emote>()
+    private val channelEmotes = mutableListOf<Emote>()
     private var loadedUserEmotes = false
     val localTwitchEmotes = mutableListOf<TwitchEmote>()
     val thirdPartyEmotes = mutableListOf<Emote>()
@@ -162,7 +167,8 @@ class ChatViewModel(
     val translateAllMessages = MutableStateFlow<Boolean?>(null)
     val channelPoints = MutableStateFlow<ChannelPoints?>(null)
     val watchStreak = MutableStateFlow<WatchStreak?>(null)
-    val channelPointRedemption = MutableSharedFlow<ChannelPointRedemptionResult>(extraBufferCapacity = 1)
+    private val channelPointRedemptionEvents = Channel<ChannelPointRedemptionResult>(Channel.BUFFERED)
+    val channelPointRedemption: Flow<ChannelPointRedemptionResult> = channelPointRedemptionEvents.receiveAsFlow()
 
     val reloadMessages = MutableStateFlow(false)
     val hideRaid = MutableStateFlow(false)
@@ -783,19 +789,11 @@ class ChatViewModel(
     private fun loadUserEmotes(channelId: String?) {
         val saved = savedUserEmotes
         if (!saved.isNullOrEmpty()) {
+            updateChannelEmotes(saved, channelId)
             synchronized(userEmotes) {
                 userEmotes.clear()
                 userEmotes.addAll(
-                    saved.sortedByDescending { it.ownerId == channelId }.map {
-                        Emote(
-                            name = it.name,
-                            url1x = it.url1x,
-                            url2x = it.url2x,
-                            url3x = it.url3x,
-                            url4x = it.url4x,
-                            format = it.format
-                        )
-                    }
+                    saved.sortedByDescending { it.ownerId == channelId }.map { it.toPickerEmote() },
                 )
             }
             viewModelScope.launch {
@@ -817,19 +815,11 @@ class ChatViewModel(
                         val emotes = playerRepository.loadUserEmotes(networkLibrary, helixHeaders, gqlHeaders, channelId, accountId, animateGifs, enableIntegrity)
                         if (emotes.isNotEmpty()) {
                             val sorted = emotes.sortedByDescending { it.setId }
+                            updateChannelEmotes(sorted, channelId)
                             synchronized(userEmotes) {
                                 userEmotes.clear()
                                 userEmotes.addAll(
-                                    sorted.sortedByDescending { it.ownerId == channelId }.map {
-                                        Emote(
-                                            name = it.name,
-                                            url1x = it.url1x,
-                                            url2x = it.url2x,
-                                            url3x = it.url3x,
-                                            url4x = it.url4x,
-                                            format = it.format
-                                        )
-                                    }
+                                    sorted.sortedByDescending { it.ownerId == channelId }.map { it.toPickerEmote() },
                                 )
                             }
                             userEmotesUpdated.emit(Unit)
@@ -1057,6 +1047,10 @@ class ChatViewModel(
         val rewards = (customRewards + automaticRewards)
             .sortedWith(compareBy<ChannelPointRewardInfo> { it.cost }.thenBy { it.title })
             .toList()
+        val iconUrl = settings?.image?.url4x
+            ?: settings?.image?.url2x
+            ?: settings?.image?.url1x
+            ?: settings?.image?.url
         val watchStreakRewards = settings?.earning?.watchStreakPoints.orEmpty()
             .mapIndexedNotNull { index, reward ->
                 reward.points?.takeIf { it > 0 }?.let { points ->
@@ -1065,6 +1059,7 @@ class ChatViewModel(
             }
         channelPoints.value = ChannelPoints(
             balance = balance,
+            iconUrl = iconUrl,
             rewards = rewards,
             watchStreakRewards = watchStreakRewards,
         )
@@ -1080,29 +1075,36 @@ class ChatViewModel(
             ?: defaultImage?.url4x ?: defaultImage?.url2x ?: defaultImage?.url1x ?: defaultImage?.url
     }
 
-    private fun automaticRewardTitle(type: String): String = when (type) {
+    private fun automaticRewardTitle(type: String): String = when (type.uppercase()) {
         "RANDOM_SUB_EMOTE_UNLOCK" -> "Unlock a Random Sub Emote"
         "SINGLE_MESSAGE_BYPASS_SUB_MODE" -> "Send a Message in Sub-Only Mode"
         "CHOSEN_SUB_EMOTE_UNLOCK" -> "Choose an Emote to Unlock"
         "CHOSEN_MODIFIED_SUB_EMOTE_UNLOCK" -> "Modify a Single Emote"
         "SEND_HIGHLIGHTED_MESSAGE" -> "Highlight My Message"
-        "SEND_ANIMATED_MESSAGE" -> "Message Effects"
-        "SEND_GIGANTIFIED_EMOTE" -> "Gigantify an Emote"
+        "SEND_ANIMATED_MESSAGE", "MESSAGE_EFFECT" -> "Message Effects"
+        "SEND_GIGANTIFIED_EMOTE", "GIGANTIFY_AN_EMOTE" -> "Gigantify an Emote"
+        "CELEBRATION", "ON_SCREEN_CELEBRATION" -> "On-Screen Celebration"
         else -> type.replace('_', ' ').lowercase().replaceFirstChar { it.uppercase() }
     }
 
-    private fun automaticRewardColor(type: String): String = when (type) {
+    private fun automaticRewardColor(type: String): String = when (type.uppercase()) {
         "RANDOM_SUB_EMOTE_UNLOCK" -> "#8205B4"
         "SINGLE_MESSAGE_BYPASS_SUB_MODE" -> "#9146FF"
         "CHOSEN_SUB_EMOTE_UNLOCK" -> "#00C8AF"
         "CHOSEN_MODIFIED_SUB_EMOTE_UNLOCK" -> "#00FA05"
         "SEND_HIGHLIGHTED_MESSAGE" -> "#FF6905"
+        "SEND_ANIMATED_MESSAGE", "MESSAGE_EFFECT" -> "#8205B4"
+        "SEND_GIGANTIFIED_EMOTE", "GIGANTIFY_AN_EMOTE" -> "#00C8AF"
+        "CELEBRATION", "ON_SCREEN_CELEBRATION" -> "#FFCC00"
         else -> DEFAULT_REWARD_COLOR
     }
 
-    private fun automaticRewardInput(type: String): ChannelPointRewardInput = when (type) {
-        "CHOSEN_SUB_EMOTE_UNLOCK", "CHOSEN_MODIFIED_SUB_EMOTE_UNLOCK" -> ChannelPointRewardInput.EMOTE
-        "SINGLE_MESSAGE_BYPASS_SUB_MODE", "SEND_HIGHLIGHTED_MESSAGE" -> ChannelPointRewardInput.TEXT
+    private fun automaticRewardInput(type: String): ChannelPointRewardInput = when (type.uppercase()) {
+        "CHOSEN_SUB_EMOTE_UNLOCK", "CHOSEN_MODIFIED_SUB_EMOTE_UNLOCK",
+        "SEND_GIGANTIFIED_EMOTE", "GIGANTIFY_AN_EMOTE",
+        "CELEBRATION", "ON_SCREEN_CELEBRATION" -> ChannelPointRewardInput.EMOTE
+        "SINGLE_MESSAGE_BYPASS_SUB_MODE", "SEND_HIGHLIGHTED_MESSAGE",
+        "SEND_ANIMATED_MESSAGE", "MESSAGE_EFFECT" -> ChannelPointRewardInput.TEXT
         else -> ChannelPointRewardInput.NONE
     }
 
@@ -1174,14 +1176,14 @@ class ChatViewModel(
         val channelId = activeChannelId
         val channelLogin = activeChannelLogin
         if (channelId.isNullOrBlank() || channelLogin.isNullOrBlank()) {
-            channelPointRedemption.tryEmit(
+            channelPointRedemptionEvents.trySend(
                 ChannelPointRedemptionResult(reward.title, success = false, message = "Chat is not connected"),
             )
             return
         }
         val gqlHeaders = TwitchApiHelper.getGQLHeaders(applicationContext, true)
         if (gqlHeaders[C.HEADER_TOKEN].isNullOrBlank()) {
-            channelPointRedemption.tryEmit(
+            channelPointRedemptionEvents.trySend(
                 ChannelPointRedemptionResult(reward.title, success = false, message = "Login is required"),
             )
             return
@@ -1203,20 +1205,51 @@ class ChatViewModel(
                 val error = response.errors?.firstOrNull()?.message
                     ?: response.data?.redeemCommunityPointsCustomReward?.error?.code
                 if (error != null) {
-                    channelPointRedemption.emit(
+                    channelPointRedemptionEvents.send(
                         ChannelPointRedemptionResult(reward.title, success = false, message = error),
                     )
                 } else {
-                    channelPointRedemption.emit(ChannelPointRedemptionResult(reward.title, success = true))
+                    channelPointRedemptionEvents.send(ChannelPointRedemptionResult(reward.title, success = true))
                     loadChannelPoints(networkLibrary, gqlHeaders, channelLogin, enableIntegrity)
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
-                channelPointRedemption.emit(
+                channelPointRedemptionEvents.send(
                     ChannelPointRedemptionResult(
                         reward.title,
                         success = false,
                         message = e.message ?: "Request failed",
                     ),
+                )
+            }
+        }
+    }
+
+    fun channelEmotePickerItems(): List<Emote> = synchronized(channelEmotes) {
+        channelEmotes.toList()
+    }
+        .filter { !it.name.isNullOrBlank() }
+        .distinctBy { it.name }
+        .sortedBy { it.name.orEmpty().lowercase() }
+
+    fun channelEmotePickerUpdates(): Flow<Unit> = userEmotesUpdated
+
+    private fun TwitchEmote.toPickerEmote(): Emote = Emote(
+        name = name,
+        url1x = url1x,
+        url2x = url2x,
+        url3x = url3x,
+        url4x = url4x,
+        format = format,
+    )
+
+    private fun updateChannelEmotes(emotes: List<TwitchEmote>, channelId: String?) {
+        synchronized(channelEmotes) {
+            channelEmotes.clear()
+            if (!channelId.isNullOrBlank()) {
+                channelEmotes.addAll(
+                    emotes.filter { it.ownerId == channelId }.map { it.toPickerEmote() },
                 )
             }
         }
@@ -1357,6 +1390,9 @@ class ChatViewModel(
     fun stopLiveChat() {
         activeChannelId = null
         activeChannelLogin = null
+        synchronized(channelEmotes) {
+            channelEmotes.clear()
+        }
         channelPointsJob?.cancel()
         channelPointsJob = null
         watchStreakJob?.cancel()
@@ -2147,19 +2183,11 @@ class ChatViewModel(
                     if (emotes.isNotEmpty()) {
                         val sorted = emotes.sortedByDescending { it.setId }
                         savedUserEmotes = sorted
+                        updateChannelEmotes(sorted, channelId)
                         synchronized(userEmotes) {
                             userEmotes.clear()
                             userEmotes.addAll(
-                                sorted.sortedByDescending { it.ownerId == channelId }.map {
-                                    Emote(
-                                        name = it.name,
-                                        url1x = it.url1x,
-                                        url2x = it.url2x,
-                                        url3x = it.url3x,
-                                        url4x = it.url4x,
-                                        format = it.format
-                                    )
-                                }
+                                sorted.sortedByDescending { it.ownerId == channelId }.map { it.toPickerEmote() },
                             )
                         }
                         userEmotesUpdated.emit(Unit)

--- a/app/src/main/res/layout/dialog_channel_points.xml
+++ b/app/src/main/res/layout/dialog_channel_points.xml
@@ -248,12 +248,13 @@
             android:textStyle="bold"
             android:visibility="gone" />
 
-        <LinearLayout
+        <GridLayout
             android:id="@+id/rewardsList"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="6dp"
-            android:orientation="vertical" />
+            android:columnCount="3"
+            android:useDefaultMargins="false" />
 
         <TextView
             android:id="@+id/votingTitle"

--- a/app/src/main/res/layout/dialog_channel_points.xml
+++ b/app/src/main/res/layout/dialog_channel_points.xml
@@ -53,6 +53,7 @@
             android:paddingBottom="6dp">
 
             <ImageView
+                android:id="@+id/balanceIcon"
                 android:layout_width="18dp"
                 android:layout_height="18dp"
                 android:contentDescription="@string/channel_points"

--- a/app/src/main/res/layout/fragment_chat.xml
+++ b/app/src/main/res/layout/fragment_chat.xml
@@ -111,25 +111,39 @@
                 app:tint="?attr/colorControlNormal"
                 tools:visibility="visible" />
 
-            <TextView
+            <LinearLayout
                 android:id="@+id/channelPoints"
                 android:layout_width="wrap_content"
                 android:layout_height="match_parent"
                 android:contentDescription="@string/channel_points"
-                android:drawableStart="@drawable/ic_channel_points"
-                android:drawablePadding="4dp"
-                android:drawableTint="?attr/colorControlNormal"
-                android:gravity="center"
                 android:background="?android:selectableItemBackground"
                 android:clickable="true"
                 android:focusable="true"
+                android:gravity="center_vertical"
                 android:minWidth="50dp"
+                android:orientation="horizontal"
                 android:paddingStart="8dp"
                 android:paddingEnd="8dp"
-                android:textAppearance="?attr/textAppearanceBodyMedium"
                 android:visibility="gone"
-                tools:text="12,345"
-                tools:visibility="visible" />
+                tools:visibility="visible">
+
+                <ImageView
+                    android:id="@+id/channelPointsIcon"
+                    android:layout_width="18dp"
+                    android:layout_height="18dp"
+                    android:contentDescription="@string/channel_points"
+                    android:src="@drawable/ic_channel_points"
+                    app:tint="?attr/colorControlNormal"
+                    tools:ignore="ContentDescription" />
+
+                <TextView
+                    android:id="@+id/channelPointsText"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="4dp"
+                    android:textAppearance="?attr/textAppearanceBodyMedium"
+                    tools:text="12,345" />
+            </LinearLayout>
 
             <ImageButton
                 android:id="@+id/send"

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -32,4 +32,5 @@
     <color name="liveStreamRed">#DD0000</color>
     <color name="watchStreakOrange">#FFB31A</color>
     <color name="watchStreakProgress">#00D395</color>
+    <color name="channel_points_reward_default">#9146FF</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -316,6 +316,7 @@
     <string name="channel_points_reward_confirm">Redeem this reward?</string>
     <string name="channel_points_reward_emote_hint">Choose an emote</string>
     <string name="channel_points_reward_text_hint">Enter the message</string>
+    <string name="channel_points_reward_input_required">Input is required</string>
     <string name="channel_points_reward_redeem">Redeem</string>
     <string name="channel_points_reward_redeemed">Redeemed %s</string>
     <string name="channel_points_reward_failed">Couldn’t redeem %1$s: %2$s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -310,8 +310,15 @@
     <string name="channel_points_streak_reward">%1$s streams: +%2$s points</string>
     <string name="channel_points_streak_reward_unknown">+%1$s points</string>
     <string name="channel_points_rewards">Rewards</string>
+    <string name="channel_points_rewards_for">%s\'s rewards</string>
     <string name="channel_points_reward">%1$s — %2$s points</string>
     <string name="channel_points_reward_prompt">Requires input: %s</string>
+    <string name="channel_points_reward_confirm">Redeem this reward?</string>
+    <string name="channel_points_reward_emote_hint">Choose an emote</string>
+    <string name="channel_points_reward_text_hint">Enter the message</string>
+    <string name="channel_points_reward_redeem">Redeem</string>
+    <string name="channel_points_reward_redeemed">Redeemed %s</string>
+    <string name="channel_points_reward_failed">Couldn’t redeem %1$s: %2$s</string>
     <string name="channel_points_voting">Voting</string>
     <string name="channel_points_poll">Poll: %s</string>
     <string name="channel_points_prediction">Prediction: %s</string>


### PR DESCRIPTION
## Summary
- expose Twitch channel-point rewards, watch streak details, and active voting data
- make channel-point rewards clickable with redemption support
- add a searchable emote grid for emote-based rewards while keeping manual entry
- limit the picker to Twitch emotes owned by the active channel
- preserve colored reward artwork and use each channel's custom points icon
- document the fork’s differences from upstream in the README

## Validation
- Docker build: `docker compose -f docker-compose.android.yml run --rm android-build :app:assembleDebug --no-daemon --console=plain`
- APK installed and launched on the connected Android device
- No new `FATAL EXCEPTION`/`AndroidRuntime` entries observed
- Verified device rotation remained disabled (`accelerometer_rotation=0`, `user_rotation=0`)
- README screenshot links verified rendering on GitHub

The README screenshots are hosted as assets on the fork’s `latest` GitHub release; the original local image files are intentionally untracked and are not part of the repository commits.

No live-notification logs or personal device data are included.