### PR TITLE
Fix channel points for web GQL logins

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/TwitchApiHelper.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/TwitchApiHelper.kt
@@ -259,17 +259,29 @@ object TwitchApiHelper {
                     }
                 }
             } else {
-                context.prefs().getString(C.GQL_CLIENT_ID2, "kd1unb4b3q4t58fwlpcbzcbnm76a8fp")?.let {
-                    if (it.isNotBlank()) {
-                        put(C.HEADER_CLIENT_ID, it)
-                    }
+                val gqlClientId = context.prefs().getString(C.GQL_CLIENT_ID2, "kd1unb4b3q4t58fwlpcbzcbnm76a8fp")
+                val gqlToken = if (includeToken) {
+                    context.tokenPrefs().getString(C.GQL_TOKEN2, null)?.takeIf { it.isNotBlank() }
+                } else {
+                    null
                 }
-                if (includeToken) {
-                    context.tokenPrefs().getString(C.GQL_TOKEN2, null)?.let {
+                val gqlWebToken = if (includeToken) {
+                    context.tokenPrefs().getString(C.GQL_TOKEN_WEB, null)?.takeIf { it.isNotBlank() }
+                } else {
+                    null
+                }
+                if (!gqlClientId.isNullOrBlank()) {
+                    put(C.HEADER_CLIENT_ID, gqlClientId)
+                }
+                if (!gqlToken.isNullOrBlank()) {
+                    put(C.HEADER_TOKEN, addTokenPrefixGQL(gqlToken))
+                } else if (!gqlWebToken.isNullOrBlank()) {
+                    context.prefs().getString(C.GQL_CLIENT_ID_WEB, "kimne78kx3ncx6brgo4mv6wki5h1ko")?.let {
                         if (it.isNotBlank()) {
-                            put(C.HEADER_TOKEN, addTokenPrefixGQL(it))
+                            put(C.HEADER_CLIENT_ID, it)
                         }
                     }
+                    put(C.HEADER_TOKEN, addTokenPrefixGQL(gqlWebToken))
                 }
             }
         }


### PR DESCRIPTION
## Summary

- Fall back to the stored web GQL token when the dedicated GQL token is unavailable.
- Use the matching web GQL client ID with that fallback token.
- Preserve the existing dedicated GQL-token path and unauthenticated client-ID behavior.

This fixes channel points being hidden for users who complete the normal web login flow without the optional TV-login step.

## Verification

- `docker compose -f docker-compose.android.yml run --rm android-build :app:assembleRelease --no-daemon`
- Release build completed successfully with minification and resource shrinking.
- The rebuilt APK retains the channel-points resources.