### PR TITLE
Fix squished channel points dialog

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChannelPointsDialog.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChannelPointsDialog.kt
@@ -9,6 +9,7 @@ import android.os.Bundle
 import android.text.InputType
 import android.view.Gravity
 import android.view.View
+import android.view.WindowManager
 import android.widget.EditText
 import android.widget.ImageView
 import android.widget.LinearLayout
@@ -115,6 +116,17 @@ class ChannelPointsDialog : DialogFragment() {
             }
         }
         return dialog
+    }
+
+    override fun onStart() {
+        super.onStart()
+        dialog?.window?.let { window ->
+            val density = resources.displayMetrics.density
+            val maxWidth = (640 * density).roundToInt()
+            val screenWidth = resources.displayMetrics.widthPixels
+            val width = (screenWidth * 0.94f).roundToInt().coerceAtMost(maxWidth)
+            window.setLayout(width, WindowManager.LayoutParams.WRAP_CONTENT)
+        }
     }
 
     private fun render(state: DialogState) {


### PR DESCRIPTION
## Summary\n- size the channel points dialog to 94% of the available screen width\n- cap the dialog at 640dp on larger displays\n- preserve the existing scrollable content height\n\n## Verification\n- Docker release build: docker compose -f docker-compose.android.yml run --rm android-build :app:assembleRelease --no-daemon --console=plain\n- BUILD SUCCESSFUL\n- git diff --check clean