### PR TITLE
Add channel point reward and streak sharing overlays

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/model/gql/chat/WatchStreakResponse.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/model/gql/chat/WatchStreakResponse.kt
@@ -33,6 +33,8 @@ class WatchStreakResponse(
 
     @Serializable
     class MilestoneValue(
+        val id: String? = null,
         val value: JsonElement? = null,
+        val shareStatus: String? = null,
     )
 }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/model/gql/chat/WatchStreakShareResponse.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/model/gql/chat/WatchStreakShareResponse.kt
@@ -1,0 +1,29 @@
+package com.github.andreyasadchy.xtra.model.gql.chat
+
+import com.github.andreyasadchy.xtra.model.gql.Error
+import kotlinx.serialization.Serializable
+
+@Serializable
+class WatchStreakShareResponse(
+    val errors: List<Error>? = null,
+    val data: Data? = null,
+) {
+    @Serializable
+    class Data(
+        val shareViewerMilestone: Payload? = null,
+    ) {
+        fun errorCode(): String? = shareViewerMilestone?.error?.code
+
+        fun hasPayload(): Boolean = shareViewerMilestone != null
+    }
+
+    @Serializable
+    class Payload(
+        val error: ShareError? = null,
+    )
+
+    @Serializable
+    class ShareError(
+        val code: String? = null,
+    )
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/model/ui/ChannelPoints.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/model/ui/ChannelPoints.kt
@@ -37,6 +37,7 @@ data class ChannelPointRedemptionResult(
     val rewardTitle: String,
     val success: Boolean,
     val message: String? = null,
+    val rewardId: String? = null,
 )
 
 data class WatchStreakReward(
@@ -61,4 +62,5 @@ data class WatchStreak(
 data class WatchStreakShareResult(
     val success: Boolean,
     val message: String? = null,
+    val milestoneId: String? = null,
 )

--- a/app/src/main/java/com/github/andreyasadchy/xtra/model/ui/ChannelPoints.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/model/ui/ChannelPoints.kt
@@ -49,4 +49,16 @@ data class WatchStreak(
     val nextMilestone: Int? = null,
     val rewardPoints: Int? = null,
     val pointsAwarded: Int? = null,
+    val milestoneId: String? = null,
+    val shareStatus: String? = null,
+) {
+    companion object {
+        const val SHARE_STATUS_CAN_SHARE = "CAN_SHARE"
+        const val SHARE_STATUS_SHARED = "SHARED"
+    }
+}
+
+data class WatchStreakShareResult(
+    val success: Boolean,
+    val message: String? = null,
 )

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/GraphQLRepository.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/GraphQLRepository.kt
@@ -78,6 +78,7 @@ import com.github.andreyasadchy.xtra.model.gql.chat.ModeratorsResponse
 import com.github.andreyasadchy.xtra.model.gql.chat.UserEmotesResponse
 import com.github.andreyasadchy.xtra.model.gql.chat.VipsResponse
 import com.github.andreyasadchy.xtra.model.gql.chat.WatchStreakResponse
+import com.github.andreyasadchy.xtra.model.gql.chat.WatchStreakShareResponse
 import com.github.andreyasadchy.xtra.model.gql.clip.ClipDataResponse
 import com.github.andreyasadchy.xtra.model.gql.clip.ClipUrlsResponse
 import com.github.andreyasadchy.xtra.model.gql.clip.ClipVideoResponse
@@ -138,7 +139,9 @@ class GraphQLRepository(
                 self {
                     watchStreakMilestone(shouldIncludeAllSuspendedStreaks: ${'$'}shouldIncludeAllSuspendedStreaks) {
                         watchStreakMilestone {
+                            id
                             value
+                            shareStatus
                         }
                         watchStreakThreshold
                         watchStreakCopoBonus
@@ -1553,6 +1556,34 @@ class GraphQLRepository(
             }
         }.toString()
         json.decodeFromString<WatchStreakResponse>(sendPersistedQuery(networkLibrary, headers, body))
+    }
+
+    suspend fun shareWatchStreak(
+        networkLibrary: String?,
+        headers: Map<String, String>,
+        channelId: String,
+        milestoneId: String,
+        message: String?,
+    ): WatchStreakShareResponse = withContext(Dispatchers.IO) {
+        val body = buildJsonObject {
+            putJsonObject("extensions") {
+                putJsonObject("persistedQuery") {
+                    put("sha256Hash", "25d20e60945d10123e8d466e30f21a1f1f578dfdea52c72095030b118eda9f39")
+                    put("version", 1)
+                }
+            }
+            put("operationName", "ShareMilestone")
+            putJsonObject("variables") {
+                putJsonObject("input") {
+                    put("milestoneID", milestoneId)
+                    put("channelID", channelId)
+                    if (!message.isNullOrBlank()) {
+                        put("messageBody", message)
+                    }
+                }
+            }
+        }.toString()
+        json.decodeFromString<WatchStreakShareResponse>(sendPersistedQuery(networkLibrary, headers, body))
     }
 
     suspend fun redeemChannelPointReward(

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChannelPointsDialog.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChannelPointsDialog.kt
@@ -35,7 +35,6 @@ import com.github.andreyasadchy.xtra.model.ui.ChannelPoints
 import com.github.andreyasadchy.xtra.model.ui.ChannelPointReward
 import com.github.andreyasadchy.xtra.model.ui.ChannelPointRewardInput
 import com.github.andreyasadchy.xtra.model.ui.ChannelPointRewardRedemption
-import com.github.andreyasadchy.xtra.model.ui.ChannelPointRedemptionResult
 import com.github.andreyasadchy.xtra.model.ui.WatchStreak
 import com.github.andreyasadchy.xtra.ui.view.GridAutofitLayoutManager
 import com.github.andreyasadchy.xtra.util.C
@@ -66,7 +65,8 @@ class ChannelPointsDialog : DialogFragment() {
         fun channelPointModifiedEmotePickerItems(): List<Emote>
         fun channelPointModifiedEmotePickerUpdates(): Flow<Unit>
         fun redeemChannelPointReward(reward: ChannelPointReward, textInput: String?, emoteId: String?)
-        fun channelPointRedemptionFlow(): Flow<ChannelPointRedemptionResult>
+        fun startChannelPointReward(reward: ChannelPointReward)
+        fun startWatchStreakShare(streak: WatchStreak)
     }
 
     companion object {
@@ -108,11 +108,6 @@ class ChannelPointsDialog : DialogFragment() {
                 ) { channelPoints, watchStreak, poll, prediction ->
                     DialogState(channelPoints, watchStreak, poll, prediction)
                 }.collectLatest(::render)
-            }
-        }
-        lifecycleScope.launch {
-            repeatOnLifecycle(Lifecycle.State.STARTED) {
-                listener.channelPointRedemptionFlow().collectLatest(::showRedemptionResult)
             }
         }
         return dialog
@@ -159,6 +154,8 @@ class ChannelPointsDialog : DialogFragment() {
         binding.streakLabel.isVisible = streak != null
         binding.streakStatusLabel.isVisible = false
         binding.streakProgressCard.isVisible = false
+        binding.streakShare.isVisible = false
+        binding.streakProgressValue.isVisible = true
         binding.streakEmpty.isVisible = streak == null
 
         if (streak != null) {
@@ -185,6 +182,17 @@ class ChannelPointsDialog : DialogFragment() {
                     R.string.channel_points_streak_milestone,
                     next,
                 )
+                val canShare = distance == 0 &&
+                        streak.shareStatus.equals(WatchStreak.SHARE_STATUS_CAN_SHARE, ignoreCase = true) &&
+                        !streak.milestoneId.isNullOrBlank()
+                binding.streakShare.isVisible = canShare
+                binding.streakProgressValue.isVisible = !canShare
+                if (canShare) {
+                    binding.streakShare.setOnClickListener {
+                        listener.startWatchStreakShare(streak)
+                        dismiss()
+                    }
+                }
                 binding.streakProgressValue.text = getString(
                     R.string.channel_points_streak_progress,
                     streak.streakCount.coerceAtMost(next),
@@ -249,7 +257,14 @@ class ChannelPointsDialog : DialogFragment() {
             isClickable = true
             isFocusable = true
             contentDescription = reward.title
-            setOnClickListener { showRewardRedemptionDialog(reward) }
+            setOnClickListener {
+                if (reward.inputType == ChannelPointRewardInput.TEXT) {
+                    listener.startChannelPointReward(reward)
+                    dismiss()
+                } else {
+                    showRewardRedemptionDialog(reward)
+                }
+            }
         }
         val content = LinearLayout(requireContext()).apply {
             gravity = Gravity.CENTER
@@ -473,15 +488,6 @@ class ChannelPointsDialog : DialogFragment() {
                     .build(),
             )
         }
-    }
-
-    private fun showRedemptionResult(result: ChannelPointRedemptionResult) {
-        val message = if (result.success) {
-            getString(R.string.channel_points_reward_redeemed, result.rewardTitle)
-        } else {
-            getString(R.string.channel_points_reward_failed, result.rewardTitle, result.message.orEmpty())
-        }
-        android.widget.Toast.makeText(requireContext(), message, android.widget.Toast.LENGTH_LONG).show()
     }
 
     private fun dp(value: Int): Int = (value * resources.displayMetrics.density).roundToInt()

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatFragment.kt
@@ -49,6 +49,7 @@ import com.github.andreyasadchy.xtra.model.ui.ChannelPointReward
 import com.github.andreyasadchy.xtra.model.ui.ChannelPointRedemptionResult
 import com.github.andreyasadchy.xtra.model.ui.Stream
 import com.github.andreyasadchy.xtra.model.ui.WatchStreak
+import com.github.andreyasadchy.xtra.model.ui.WatchStreakShareResult
 import com.github.andreyasadchy.xtra.ui.channel.ChannelPagerFragmentDirections
 import com.github.andreyasadchy.xtra.ui.chat.ChatViewModel.Companion.ChatViewModelFactory
 import com.github.andreyasadchy.xtra.ui.common.BaseNetworkFragment
@@ -81,6 +82,11 @@ import kotlin.math.roundToInt
 
 class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickListener, ReplyClickedDialog.OnButtonClickListener, ChannelPointsDialog.Listener {
 
+    private sealed interface ComposerOverlayState {
+        data class Reward(val reward: ChannelPointReward) : ComposerOverlayState
+        data class StreakShare(val streak: WatchStreak) : ComposerOverlayState
+    }
+
     private var _binding: FragmentChatBinding? = null
     private val binding get() = _binding!!
     private val viewModel: ChatViewModel by viewModels { ChatViewModelFactory }
@@ -91,6 +97,9 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
     private var hasRecentEmotes = false
     private var messagingEnabled = false
     private var channelPointsIconUrl: String? = null
+    private var composerOverlayState: ComposerOverlayState? = null
+    private var pendingComposerText: String? = null
+    private var composerSubmissionInProgress = false
 
     private var autoCompleteAdapter: AutoCompleteAdapter<Any>? = null
 
@@ -134,7 +143,13 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
         viewModel.redeemChannelPointReward(reward, textInput, emoteId)
     }
 
-    override fun channelPointRedemptionFlow(): Flow<ChannelPointRedemptionResult> = viewModel.channelPointRedemption
+    override fun startChannelPointReward(reward: ChannelPointReward) {
+        showComposerOverlay(ComposerOverlayState.Reward(reward))
+    }
+
+    override fun startWatchStreakShare(streak: WatchStreak) {
+        showComposerOverlay(ComposerOverlayState.StreakShare(streak))
+    }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         _binding = FragmentChatBinding.inflate(inflater, container, false)
@@ -143,6 +158,16 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        viewLifecycleOwner.lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                launch {
+                    viewModel.channelPointRedemption.collectLatest(::handleChannelPointRedemption)
+                }
+                launch {
+                    viewModel.watchStreakShare.collectLatest(::handleWatchStreakShare)
+                }
+            }
+        }
         viewLifecycleOwner.lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.integrity.collect {
@@ -312,13 +337,7 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
                             }
                         }
                         editText.addTextChangedListener(onTextChanged = { text, _, _, _ ->
-                            if (text?.isNotBlank() == true) {
-                                send.visibility = View.VISIBLE
-                                clear.visibility = View.VISIBLE
-                            } else {
-                                send.visibility = View.GONE
-                                clear.visibility = View.GONE
-                            }
+                            updateComposerButtons()
                         })
                         editText.setTokenizer(SpaceTokenizer())
                         editText.setOnKeyListener { _, keyCode, event ->
@@ -1005,11 +1024,8 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
         binding.editText.text.append(emote.name).append(' ')
     }
 
-    private fun sendMessage(replyId: String? = null): Boolean {
+    private fun resetMessageComposerAction() {
         with(binding) {
-            (requireContext().getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager).hideSoftInputFromWindow(editText.windowToken, 0)
-            editText.clearFocus()
-            toggleEmoteMenu(false)
             replyView.visibility = View.GONE
             send.setOnClickListener { sendMessage() }
             editText.setOnKeyListener { _, keyCode, event ->
@@ -1019,6 +1035,150 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
                     false
                 }
             }
+        }
+    }
+
+    private fun updateComposerButtons() {
+        if (_binding == null) return
+        val hasText = binding.editText.text.isNotBlank()
+        val canShareWithoutMessage = composerOverlayState is ComposerOverlayState.StreakShare
+        binding.send.isVisible = !composerSubmissionInProgress && (hasText || canShareWithoutMessage)
+        binding.clear.isVisible = !composerSubmissionInProgress && hasText
+    }
+
+    private fun showComposerOverlay(state: ComposerOverlayState) {
+        composerOverlayState = state
+        pendingComposerText = null
+        composerSubmissionInProgress = false
+        with(binding) {
+            resetMessageComposerAction()
+            channelPointRewardOverlay.isVisible = true
+            when (state) {
+                is ComposerOverlayState.Reward -> {
+                    channelPointRewardTitle.text = state.reward.title
+                    channelPointRewardSubtitle.text = state.reward.prompt
+                        ?.takeIf { it.isNotBlank() }
+                        ?: getString(R.string.channel_points_reward_message_overlay)
+                    updateComposerOverlayIcon(state.reward.imageUrl, R.drawable.ic_channel_points)
+                }
+                is ComposerOverlayState.StreakShare -> {
+                    channelPointRewardTitle.text = getString(
+                        R.string.channel_points_streak_milestone,
+                        state.streak.nextMilestone ?: state.streak.streakCount,
+                    )
+                    channelPointRewardSubtitle.text = getString(R.string.channel_points_streak_share_prompt)
+                    updateComposerOverlayIcon(null, R.drawable.ic_watch_streak)
+                }
+            }
+            channelPointRewardCancel.setOnClickListener { cancelComposerOverlay() }
+            updateComposerButtons()
+            editText.requestFocus()
+            WindowCompat.getInsetsController(this@ChatFragment.requireActivity().window, editText)
+                .show(WindowInsetsCompat.Type.ime())
+        }
+    }
+
+    private fun updateComposerOverlayIcon(url: String?, fallback: Int) {
+        val icon = binding.channelPointRewardIcon
+        icon.setImageResource(fallback)
+        if (url.isNullOrBlank()) {
+            icon.imageTintList = if (fallback == R.drawable.ic_watch_streak) {
+                null
+            } else {
+                ColorStateList.valueOf(MaterialColors.getColor(icon, androidx.appcompat.R.attr.colorControlNormal))
+            }
+        } else {
+            icon.imageTintList = null
+            requireContext().imageLoader.enqueue(
+                ImageRequest.Builder(requireContext())
+                    .data(url)
+                    .crossfade(true)
+                    .target(icon)
+                    .build(),
+            )
+        }
+    }
+
+    private fun cancelComposerOverlay() {
+        composerOverlayState = null
+        pendingComposerText = null
+        composerSubmissionInProgress = false
+        binding.channelPointRewardOverlay.isGone = true
+        updateComposerButtons()
+    }
+
+    private fun restorePendingComposerText() {
+        pendingComposerText?.let { text ->
+            binding.editText.setText(text)
+            binding.editText.setSelection(binding.editText.length())
+        }
+        pendingComposerText = null
+        composerSubmissionInProgress = false
+        updateComposerButtons()
+    }
+
+    private fun handleChannelPointRedemption(result: ChannelPointRedemptionResult) {
+        val overlay = composerOverlayState
+        if (overlay is ComposerOverlayState.Reward && overlay.reward.title == result.rewardTitle) {
+            if (result.success) {
+                cancelComposerOverlay()
+            } else {
+                restorePendingComposerText()
+            }
+        }
+        val message = if (result.success) {
+            getString(R.string.channel_points_reward_redeemed, result.rewardTitle)
+        } else {
+            getString(R.string.channel_points_reward_failed, result.rewardTitle, result.message.orEmpty())
+        }
+        android.widget.Toast.makeText(requireContext(), message, android.widget.Toast.LENGTH_LONG).show()
+    }
+
+    private fun handleWatchStreakShare(result: WatchStreakShareResult) {
+        if (composerOverlayState is ComposerOverlayState.StreakShare) {
+            if (result.success) {
+                cancelComposerOverlay()
+            } else {
+                restorePendingComposerText()
+            }
+        }
+        val message = if (result.success) {
+            getString(R.string.channel_points_streak_shared)
+        } else {
+            getString(R.string.channel_points_streak_share_failed, result.message.orEmpty())
+        }
+        android.widget.Toast.makeText(requireContext(), message, android.widget.Toast.LENGTH_LONG).show()
+    }
+
+    private fun sendMessage(replyId: String? = null): Boolean {
+        with(binding) {
+            val overlay = composerOverlayState
+            if (overlay != null) {
+                if (composerSubmissionInProgress) {
+                    return false
+                }
+                val text = editText.text.trim().toString()
+                if (overlay is ComposerOverlayState.Reward && text.isBlank()) {
+                    return false
+                }
+                pendingComposerText = text
+                composerSubmissionInProgress = true
+                editText.text.clear()
+                (requireContext().getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager)
+                    .hideSoftInputFromWindow(editText.windowToken, 0)
+                editText.clearFocus()
+                toggleEmoteMenu(false)
+                updateComposerButtons()
+                when (overlay) {
+                    is ComposerOverlayState.Reward -> viewModel.redeemChannelPointReward(overlay.reward, text, null)
+                    is ComposerOverlayState.StreakShare -> viewModel.shareWatchStreak(overlay.streak, text)
+                }
+                return true
+            }
+            (requireContext().getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager).hideSoftInputFromWindow(editText.windowToken, 0)
+            editText.clearFocus()
+            toggleEmoteMenu(false)
+            resetMessageComposerAction()
             val text = editText.text.trim()
             editText.text.clear()
             return if (text.isNotEmpty()) {
@@ -1057,6 +1217,7 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
     override fun onReplyClicked(replyId: String?, userLogin: String?, userName: String?, message: String?) {
         with(binding) {
             if (!replyId.isNullOrBlank()) {
+                cancelComposerOverlay()
                 messageDialog?.dismiss()
                 replyView.visibility = View.VISIBLE
                 replyText.text = message?.let {
@@ -1072,15 +1233,7 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
                     getString(R.string.replying_to_message, name, message)
                 }
                 replyClose.setOnClickListener {
-                    replyView.visibility = View.GONE
-                    send.setOnClickListener { sendMessage() }
-                    editText.setOnKeyListener { _, keyCode, event ->
-                        if (event.action == KeyEvent.ACTION_DOWN && keyCode == KeyEvent.KEYCODE_ENTER) {
-                            sendMessage()
-                        } else {
-                            false
-                        }
-                    }
+                    resetMessageComposerAction()
                 }
                 send.setOnClickListener { sendMessage(replyId) }
                 editText.setOnKeyListener { _, keyCode, event ->
@@ -1301,6 +1454,9 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
 
     override fun onDestroyView() {
         channelPointsIconUrl = null
+        composerOverlayState = null
+        pendingComposerText = null
+        composerSubmissionInProgress = false
         super.onDestroyView()
         _binding = null
     }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatFragment.kt
@@ -100,6 +100,9 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
     private var composerOverlayState: ComposerOverlayState? = null
     private var pendingComposerText: String? = null
     private var composerSubmissionInProgress = false
+    private var composerTextBeforeOverlay: String? = null
+    private var composerSelectionBeforeOverlay: Int? = null
+    private var messageViewWasVisibleBeforeOverlay: Boolean? = null
 
     private var autoCompleteAdapter: AutoCompleteAdapter<Any>? = null
 
@@ -1047,11 +1050,19 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
     }
 
     private fun showComposerOverlay(state: ComposerOverlayState) {
+        if (composerOverlayState == null) {
+            composerTextBeforeOverlay = binding.editText.text.toString()
+            composerSelectionBeforeOverlay = binding.editText.selectionStart.takeIf { it >= 0 }
+            messageViewWasVisibleBeforeOverlay = binding.messageView.isVisible
+        }
         composerOverlayState = state
         pendingComposerText = null
         composerSubmissionInProgress = false
         with(binding) {
             resetMessageComposerAction()
+            toggleEmoteMenu(false)
+            messageView.isVisible = true
+            editText.text.clear()
             channelPointRewardOverlay.isVisible = true
             when (state) {
                 is ComposerOverlayState.Reward -> {
@@ -1100,10 +1111,23 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
     }
 
     private fun cancelComposerOverlay() {
+        val textBeforeOverlay = composerTextBeforeOverlay
+        val selectionBeforeOverlay = composerSelectionBeforeOverlay
+        val messageViewWasVisible = messageViewWasVisibleBeforeOverlay
         composerOverlayState = null
         pendingComposerText = null
         composerSubmissionInProgress = false
+        composerTextBeforeOverlay = null
+        composerSelectionBeforeOverlay = null
+        messageViewWasVisibleBeforeOverlay = null
         binding.channelPointRewardOverlay.isGone = true
+        textBeforeOverlay?.let { text ->
+            binding.editText.setText(text)
+            binding.editText.setSelection(
+                (selectionBeforeOverlay ?: binding.editText.length()).coerceIn(0, binding.editText.length()),
+            )
+        }
+        messageViewWasVisible?.let { binding.messageView.isVisible = it }
         updateComposerButtons()
     }
 
@@ -1119,7 +1143,7 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
 
     private fun handleChannelPointRedemption(result: ChannelPointRedemptionResult) {
         val overlay = composerOverlayState
-        if (overlay is ComposerOverlayState.Reward && overlay.reward.title == result.rewardTitle) {
+        if (overlay is ComposerOverlayState.Reward && overlay.reward.id == result.rewardId) {
             if (result.success) {
                 cancelComposerOverlay()
             } else {
@@ -1135,7 +1159,8 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
     }
 
     private fun handleWatchStreakShare(result: WatchStreakShareResult) {
-        if (composerOverlayState is ComposerOverlayState.StreakShare) {
+        val overlay = composerOverlayState
+        if (overlay is ComposerOverlayState.StreakShare && overlay.streak.milestoneId == result.milestoneId) {
             if (result.success) {
                 cancelComposerOverlay()
             } else {
@@ -1457,6 +1482,9 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
         composerOverlayState = null
         pendingComposerText = null
         composerSubmissionInProgress = false
+        composerTextBeforeOverlay = null
+        composerSelectionBeforeOverlay = null
+        messageViewWasVisibleBeforeOverlay = null
         super.onDestroyView()
         _binding = null
     }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatViewModel.kt
@@ -41,6 +41,7 @@ import com.github.andreyasadchy.xtra.model.ui.ChannelPointRedemptionResult
 import com.github.andreyasadchy.xtra.model.ui.TranslatedChannel
 import com.github.andreyasadchy.xtra.model.ui.WatchStreak
 import com.github.andreyasadchy.xtra.model.ui.WatchStreakReward
+import com.github.andreyasadchy.xtra.model.ui.WatchStreakShareResult
 import com.github.andreyasadchy.xtra.repository.GraphQLRepository
 import com.github.andreyasadchy.xtra.repository.HelixRepository
 import com.github.andreyasadchy.xtra.repository.PlayerRepository
@@ -171,6 +172,8 @@ class ChatViewModel(
     val watchStreak = MutableStateFlow<WatchStreak?>(null)
     private val channelPointRedemptionEvents = Channel<ChannelPointRedemptionResult>(Channel.BUFFERED)
     val channelPointRedemption: Flow<ChannelPointRedemptionResult> = channelPointRedemptionEvents.receiveAsFlow()
+    private val watchStreakShareEvents = Channel<WatchStreakShareResult>(Channel.BUFFERED)
+    val watchStreakShare: Flow<WatchStreakShareResult> = watchStreakShareEvents.receiveAsFlow()
 
     val reloadMessages = MutableStateFlow(false)
     val hideRaid = MutableStateFlow(false)
@@ -1188,6 +1191,8 @@ class ChatViewModel(
                 nextMilestone = previous?.nextMilestone,
                 rewardPoints = previous?.rewardPoints,
                 pointsAwarded = pointsAwarded,
+                milestoneId = previous?.milestoneId,
+                shareStatus = previous?.shareStatus,
             )
         }
     }
@@ -1196,11 +1201,14 @@ class ChatViewModel(
 
     private fun updateWatchStreakStatus(response: WatchStreakResponse) {
         val milestone = response.data?.channel?.self?.watchStreakMilestone ?: return
-        val streakCount = milestone.watchStreakMilestone?.value.toIntOrNull() ?: return
+        val milestoneValue = milestone.watchStreakMilestone ?: return
+        val streakCount = milestoneValue.value.toIntOrNull() ?: return
         watchStreak.value = WatchStreak(
             streakCount = streakCount,
             nextMilestone = milestone.watchStreakThreshold.toIntOrNull(),
             rewardPoints = milestone.watchStreakCopoBonus.toIntOrNull(),
+            milestoneId = milestoneValue.id,
+            shareStatus = milestoneValue.shareStatus,
         )
     }
 
@@ -1324,6 +1332,69 @@ class ChatViewModel(
                     channelPointRedemptionEvents.send(
                         ChannelPointRedemptionResult(
                             reward.title,
+                            success = false,
+                            message = e.message ?: "Request failed",
+                        ),
+                    )
+                }
+            }
+        }
+    }
+
+    fun shareWatchStreak(streak: WatchStreak, message: String?) {
+        val channelId = activeChannelId
+        val milestoneId = streak.milestoneId
+        if (channelId.isNullOrBlank() || milestoneId.isNullOrBlank()) {
+            watchStreakShareEvents.trySend(
+                WatchStreakShareResult(
+                    success = false,
+                    message = applicationContext.getString(R.string.channel_points_streak_share_unavailable),
+                ),
+            )
+            return
+        }
+        val gqlHeaders = TwitchApiHelper.getGQLHeaders(applicationContext, true)
+        if (gqlHeaders[C.HEADER_TOKEN].isNullOrBlank()) {
+            watchStreakShareEvents.trySend(
+                WatchStreakShareResult(success = false, message = "Login is required"),
+            )
+            return
+        }
+        val networkLibrary = applicationContext.prefs().getString(C.NETWORK_LIBRARY, C.OKHTTP)
+        viewModelScope.launch {
+            try {
+                val response = graphQLRepository.shareWatchStreak(
+                    networkLibrary = networkLibrary,
+                    headers = gqlHeaders,
+                    channelId = channelId,
+                    milestoneId = milestoneId,
+                    message = message?.takeIf { it.isNotBlank() },
+                )
+                if (activeChannelId != channelId) {
+                    return@launch
+                }
+                val error = response.errors?.firstOrNull()?.message
+                    ?: response.data?.errorCode()
+                if (error != null || response.data?.hasPayload() != true) {
+                    watchStreakShareEvents.send(
+                        WatchStreakShareResult(
+                            success = false,
+                            message = error ?: "Request failed",
+                        ),
+                    )
+                } else {
+                    watchStreak.value?.takeIf { it.milestoneId == milestoneId }?.let {
+                        watchStreak.value = it.copy(shareStatus = WatchStreak.SHARE_STATUS_SHARED)
+                    }
+                    watchStreakShareEvents.send(WatchStreakShareResult(success = true))
+                    loadWatchStreak(networkLibrary, gqlHeaders, channelId)
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                if (activeChannelId == channelId) {
+                    watchStreakShareEvents.send(
+                        WatchStreakShareResult(
                             success = false,
                             message = e.message ?: "Request failed",
                         ),

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatViewModel.kt
@@ -1186,13 +1186,15 @@ class ChatViewModel(
     private fun updateWatchStreak(streakCount: Int?, pointsAwarded: Int? = null) {
         if (streakCount != null && streakCount > 0) {
             val previous = watchStreak.value
+            val milestoneChanged = pointsAwarded != null ||
+                    previous?.nextMilestone?.let { streakCount >= it } == true
             watchStreak.value = WatchStreak(
                 streakCount = streakCount,
                 nextMilestone = previous?.nextMilestone,
                 rewardPoints = previous?.rewardPoints,
                 pointsAwarded = pointsAwarded,
-                milestoneId = previous?.milestoneId,
-                shareStatus = previous?.shareStatus,
+                milestoneId = previous?.milestoneId?.takeUnless { milestoneChanged },
+                shareStatus = previous?.shareStatus?.takeUnless { milestoneChanged },
             )
         }
     }
@@ -1220,10 +1222,16 @@ class ChatViewModel(
         if (channelId.isNullOrBlank() || gqlHeaders[C.HEADER_TOKEN].isNullOrBlank()) {
             return
         }
+        val expectedChannelId = channelId
+        val expectedChannelLogin = activeChannelLogin
         watchStreakJob?.cancel()
         watchStreakJob = viewModelScope.launch {
             try {
-                updateWatchStreakStatus(graphQLRepository.loadWatchStreak(networkLibrary, gqlHeaders, channelId))
+                val response = graphQLRepository.loadWatchStreak(networkLibrary, gqlHeaders, channelId)
+                if (activeChannelId != expectedChannelId || activeChannelLogin != expectedChannelLogin) {
+                    return@launch
+                }
+                updateWatchStreakStatus(response)
             } catch (_: Exception) {
             }
         }
@@ -1261,7 +1269,12 @@ class ChatViewModel(
         val channelLogin = activeChannelLogin
         if (channelId.isNullOrBlank() || channelLogin.isNullOrBlank()) {
             channelPointRedemptionEvents.trySend(
-                ChannelPointRedemptionResult(reward.title, success = false, message = "Chat is not connected"),
+                ChannelPointRedemptionResult(
+                    reward.title,
+                    success = false,
+                    message = "Chat is not connected",
+                    rewardId = reward.id,
+                ),
             )
             return
         }
@@ -1271,6 +1284,7 @@ class ChatViewModel(
                     reward.title,
                     success = false,
                     message = applicationContext.getString(R.string.channel_points_reward_input_required),
+                    rewardId = reward.id,
                 ),
             )
             return
@@ -1281,6 +1295,7 @@ class ChatViewModel(
                     reward.title,
                     success = false,
                     message = applicationContext.getString(R.string.channel_points_reward_input_required),
+                    rewardId = reward.id,
                 ),
             )
             return
@@ -1288,7 +1303,12 @@ class ChatViewModel(
         val gqlHeaders = TwitchApiHelper.getGQLHeaders(applicationContext, true)
         if (gqlHeaders[C.HEADER_TOKEN].isNullOrBlank()) {
             channelPointRedemptionEvents.trySend(
-                ChannelPointRedemptionResult(reward.title, success = false, message = "Login is required"),
+                ChannelPointRedemptionResult(
+                    reward.title,
+                    success = false,
+                    message = "Login is required",
+                    rewardId = reward.id,
+                ),
             )
             return
         }
@@ -1319,10 +1339,17 @@ class ChatViewModel(
                             reward.title,
                             success = false,
                             message = error ?: "Request failed",
+                            rewardId = reward.id,
                         ),
                     )
                 } else {
-                    channelPointRedemptionEvents.send(ChannelPointRedemptionResult(reward.title, success = true))
+                    channelPointRedemptionEvents.send(
+                        ChannelPointRedemptionResult(
+                            reward.title,
+                            success = true,
+                            rewardId = reward.id,
+                        ),
+                    )
                     loadChannelPoints(networkLibrary, gqlHeaders, channelLogin, enableIntegrity)
                 }
             } catch (e: CancellationException) {
@@ -1334,6 +1361,7 @@ class ChatViewModel(
                             reward.title,
                             success = false,
                             message = e.message ?: "Request failed",
+                            rewardId = reward.id,
                         ),
                     )
                 }
@@ -1349,6 +1377,7 @@ class ChatViewModel(
                 WatchStreakShareResult(
                     success = false,
                     message = applicationContext.getString(R.string.channel_points_streak_share_unavailable),
+                    milestoneId = milestoneId,
                 ),
             )
             return
@@ -1356,11 +1385,16 @@ class ChatViewModel(
         val gqlHeaders = TwitchApiHelper.getGQLHeaders(applicationContext, true)
         if (gqlHeaders[C.HEADER_TOKEN].isNullOrBlank()) {
             watchStreakShareEvents.trySend(
-                WatchStreakShareResult(success = false, message = "Login is required"),
+                WatchStreakShareResult(
+                    success = false,
+                    message = "Login is required",
+                    milestoneId = milestoneId,
+                ),
             )
             return
         }
         val networkLibrary = applicationContext.prefs().getString(C.NETWORK_LIBRARY, C.OKHTTP)
+        val channelLogin = activeChannelLogin
         viewModelScope.launch {
             try {
                 val response = graphQLRepository.shareWatchStreak(
@@ -1370,7 +1404,7 @@ class ChatViewModel(
                     milestoneId = milestoneId,
                     message = message?.takeIf { it.isNotBlank() },
                 )
-                if (activeChannelId != channelId) {
+                if (activeChannelId != channelId || activeChannelLogin != channelLogin) {
                     return@launch
                 }
                 val error = response.errors?.firstOrNull()?.message
@@ -1380,23 +1414,30 @@ class ChatViewModel(
                         WatchStreakShareResult(
                             success = false,
                             message = error ?: "Request failed",
+                            milestoneId = milestoneId,
                         ),
                     )
                 } else {
                     watchStreak.value?.takeIf { it.milestoneId == milestoneId }?.let {
                         watchStreak.value = it.copy(shareStatus = WatchStreak.SHARE_STATUS_SHARED)
                     }
-                    watchStreakShareEvents.send(WatchStreakShareResult(success = true))
+                    watchStreakShareEvents.send(
+                        WatchStreakShareResult(
+                            success = true,
+                            milestoneId = milestoneId,
+                        ),
+                    )
                     loadWatchStreak(networkLibrary, gqlHeaders, channelId)
                 }
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
-                if (activeChannelId == channelId) {
+                if (activeChannelId == channelId && activeChannelLogin == channelLogin) {
                     watchStreakShareEvents.send(
                         WatchStreakShareResult(
                             success = false,
                             message = e.message ?: "Request failed",
+                            milestoneId = milestoneId,
                         ),
                     )
                 }

--- a/app/src/main/res/layout/dialog_channel_points.xml
+++ b/app/src/main/res/layout/dialog_channel_points.xml
@@ -186,6 +186,24 @@
                         android:textStyle="bold"
                         tools:text="220-Stream Streak" />
 
+                    <com.google.android.material.button.MaterialButton
+                        android:id="@+id/streakShare"
+                        style="?attr/elevatedButtonStyle"
+                        android:layout_width="wrap_content"
+                        android:layout_height="36dp"
+                        android:layout_marginStart="8dp"
+                        android:minWidth="0dp"
+                        android:minHeight="0dp"
+                        android:paddingStart="14dp"
+                        android:paddingEnd="14dp"
+                        android:text="@string/share"
+                        android:textColor="@android:color/white"
+                        android:textAllCaps="false"
+                        android:visibility="gone"
+                        app:backgroundTint="@color/channel_points_reward_default"
+                        app:cornerRadius="18dp"
+                        tools:visibility="visible" />
+
                     <TextView
                         android:id="@+id/streakProgressValue"
                         android:layout_width="wrap_content"

--- a/app/src/main/res/layout/fragment_chat.xml
+++ b/app/src/main/res/layout/fragment_chat.xml
@@ -71,6 +71,81 @@
         </LinearLayout>
 
         <LinearLayout
+            android:id="@+id/channelPointRewardOverlay"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="?attr/colorSurfaceContainer"
+            android:elevation="2dp"
+            android:orientation="vertical"
+            android:visibility="gone"
+            tools:visibility="visible">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:minHeight="62dp"
+                android:gravity="center_vertical"
+                android:orientation="horizontal"
+                android:paddingStart="8dp"
+                android:paddingTop="6dp"
+                android:paddingEnd="4dp"
+                android:paddingBottom="6dp">
+
+                <ImageView
+                    android:id="@+id/channelPointRewardIcon"
+                    android:layout_width="34dp"
+                    android:layout_height="34dp"
+                    android:contentDescription="@string/channel_points"
+                    android:scaleType="centerInside"
+                    android:src="@drawable/ic_channel_points"
+                    app:tint="?attr/colorControlNormal" />
+
+                <LinearLayout
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="8dp"
+                    android:layout_marginEnd="4dp"
+                    android:layout_weight="1"
+                    android:orientation="vertical">
+
+                    <TextView
+                        android:id="@+id/channelPointRewardTitle"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:ellipsize="end"
+                        android:maxLines="1"
+                        android:textAppearance="?attr/textAppearanceTitleSmall"
+                        android:textStyle="bold"
+                        tools:text="Ticket to ask a stupid question" />
+
+                    <TextView
+                        android:id="@+id/channelPointRewardSubtitle"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:ellipsize="end"
+                        android:maxLines="2"
+                        android:textAppearance="?attr/textAppearanceBodySmall"
+                        tools:text="Free ticket to ask a stupid question" />
+                </LinearLayout>
+
+                <ImageButton
+                    android:id="@+id/channelPointRewardCancel"
+                    android:layout_width="40dp"
+                    android:layout_height="40dp"
+                    android:background="?android:selectableItemBackgroundBorderless"
+                    android:contentDescription="@string/channel_points_composer_cancel"
+                    android:padding="8dp"
+                    android:src="@drawable/baseline_close_black_36"
+                    app:tint="?attr/colorControlNormal" />
+            </LinearLayout>
+
+            <View
+                android:layout_width="match_parent"
+                android:layout_height="1dp"
+                android:background="?attr/colorOutlineVariant" />
+        </LinearLayout>
+
+        <LinearLayout
             android:id="@+id/messageView"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -303,6 +303,10 @@
     <string name="channel_points_streak_notice">You’re %1$d streams away from your %2$d-stream streak reward!</string>
     <string name="channel_points_streak_reached">Streak milestone reached!</string>
     <string name="channel_points_streak_milestone">%1$d-Stream Streak</string>
+    <string name="channel_points_streak_share_prompt">Add a message to share this streak (optional)</string>
+    <string name="channel_points_streak_shared">Watch streak shared</string>
+    <string name="channel_points_streak_share_failed">Couldn’t share your watch streak: %s</string>
+    <string name="channel_points_streak_share_unavailable">Watch streak sharing is unavailable</string>
     <string name="channel_points_streak_progress">%1$d/%2$d</string>
     <string name="channel_points_streak_description">Tune into %1$d consecutive streams to earn %2$s Channel Points and recognition.</string>
     <string name="channel_points_streak_description_no_reward">Tune into %1$d consecutive streams to keep your watch streak going.</string>
@@ -316,6 +320,8 @@
     <string name="channel_points_reward_confirm">Redeem this reward?</string>
     <string name="channel_points_reward_emote_hint">Choose an emote</string>
     <string name="channel_points_reward_text_hint">Enter the message</string>
+    <string name="channel_points_reward_message_overlay">Enter a message to redeem this reward</string>
+    <string name="channel_points_composer_cancel">Cancel</string>
     <string name="channel_points_reward_input_required">Input is required</string>
     <string name="channel_points_reward_redeem">Redeem</string>
     <string name="channel_points_reward_redeemed">Redeemed %s</string>


### PR DESCRIPTION
## Summary
- add a shared cancellable composer overlay for text-entry channel point rewards
- add watch-streak milestone sharing with optional chat message
- expose milestone id/share status and call Twitch's ShareMilestone mutation
- keep emote and one-tap rewards on their existing flows

## Verification
- Docker :app:assembleRelease passed
- Docker clean :app:assembleDebug passed after clearing the stale debug resource-merger cache
- installed the debug APK via ADB and verified on-device: the 140-stream dialog shows Share; tapping it opens the streak overlay; the text reward opens the same overlay
- git diff --check passed