### PR TITLE
Add opt-in Twitch ad avoidance

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/PlayerRepository.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/PlayerRepository.kt
@@ -39,6 +39,9 @@ import com.github.andreyasadchy.xtra.model.ui.TranslatedChannel
 import com.github.andreyasadchy.xtra.util.C
 import com.github.andreyasadchy.xtra.util.NetworkUtils
 import com.github.andreyasadchy.xtra.util.NetworkUtils.executeAsync
+import com.github.andreyasadchy.xtra.util.m3u8.PlaylistUtils
+import com.github.andreyasadchy.xtra.util.m3u8.TwitchAdDetector
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
@@ -63,6 +66,7 @@ import org.json.JSONException
 import org.json.JSONObject
 import java.net.InetSocketAddress
 import java.net.Proxy
+import java.net.URI
 import java.util.concurrent.ExecutorService
 import kotlin.math.roundToInt
 import kotlin.random.Random
@@ -81,6 +85,11 @@ class PlayerRepository(
     private val graphQLRepository: GraphQLRepository,
     private val helixRepository: HelixRepository,
 ) {
+
+    data class StreamPlaylistCandidate(
+        val playerType: String,
+        val url: String,
+    )
 
     suspend fun loadStreamPlaylistUrl(context: Context, networkLibrary: String?, gqlHeaders: Map<String, String>, channelLogin: String, randomDeviceId: Boolean?, xDeviceId: String?, playerType: String?, supportedCodecs: String?, proxyPlaybackAccessToken: Boolean, proxyHost: String?, proxyPort: Int?, proxyUser: String?, proxyPassword: String?, enableIntegrity: Boolean): String = withContext(Dispatchers.IO) {
         val accessToken = loadStreamPlaybackAccessToken(context, networkLibrary, gqlHeaders, channelLogin, randomDeviceId, xDeviceId, playerType, proxyPlaybackAccessToken, proxyHost, proxyPort, proxyUser, proxyPassword, enableIntegrity).let { token ->
@@ -102,6 +111,96 @@ class PlayerRepository(
             supportedCodecs?.let { appendQueryParameter("supported_codecs", it) }
             token?.let { appendQueryParameter("token", it) }
         }.build().toString()
+    }
+
+    /**
+     * Gets a stream using each alternate Twitch player type and rejects a
+     * candidate when its first media playlist already contains ad markers.
+     * A failed inspection is treated as unknown rather than blocking playback;
+     * the player will run the normal HLS detector once the source is attached.
+     */
+    suspend fun loadCleanStreamPlaylistUrl(
+        context: Context,
+        networkLibrary: String?,
+        gqlHeaders: Map<String, String>,
+        channelLogin: String,
+        randomDeviceId: Boolean?,
+        xDeviceId: String?,
+        playerTypes: List<String>,
+        supportedCodecs: String?,
+        proxyPlaybackAccessToken: Boolean,
+        proxyHost: String?,
+        proxyPort: Int?,
+        proxyUser: String?,
+        proxyPassword: String?,
+        enableIntegrity: Boolean,
+    ): StreamPlaylistCandidate? = withContext(Dispatchers.IO) {
+        playerTypes.forEach { playerType ->
+            val url = try {
+                loadStreamPlaylistUrl(
+                    context = context,
+                    networkLibrary = networkLibrary,
+                    gqlHeaders = gqlHeaders,
+                    channelLogin = channelLogin,
+                    randomDeviceId = randomDeviceId,
+                    xDeviceId = xDeviceId,
+                    playerType = playerType,
+                    supportedCodecs = supportedCodecs,
+                    proxyPlaybackAccessToken = proxyPlaybackAccessToken,
+                    proxyHost = proxyHost,
+                    proxyPort = proxyPort,
+                    proxyUser = proxyUser,
+                    proxyPassword = proxyPassword,
+                    enableIntegrity = enableIntegrity,
+                )
+            } catch (e: CancellationException) {
+                throw e
+            } catch (_: Exception) {
+                null
+            } ?: return@forEach
+
+            if (containsAdMarkers(url) != true) {
+                return@withContext StreamPlaylistCandidate(playerType, url)
+            }
+        }
+        null
+    }
+
+    private suspend fun containsAdMarkers(masterUrl: String): Boolean? = withContext(Dispatchers.IO) {
+        try {
+            val master = okHttpClient.value.newCall(Request.Builder().url(masterUrl).build())
+                .executeAsync().use { response -> response.body.string() }
+            var mediaPath: String? = null
+            var expectMediaPlaylist = false
+            for (line in master.lineSequence()) {
+                val value = line.trim()
+                when {
+                    value.startsWith("#EXT-X-STREAM-INF") -> expectMediaPlaylist = true
+                    expectMediaPlaylist && value.isNotEmpty() && !value.startsWith("#") -> {
+                        mediaPath = value
+                        break
+                    }
+                }
+            }
+            val mediaUrl = mediaPath?.let {
+                runCatching { URI(masterUrl).resolve(it).toString() }.getOrNull() ?: it
+            }
+            if (mediaUrl == null) {
+                return@withContext TwitchAdDetector.isAd(
+                    PlaylistUtils.parseMediaPlaylist(master.byteInputStream())
+                )
+            }
+            okHttpClient.value.newCall(Request.Builder().url(mediaUrl).build())
+                .executeAsync().use { response ->
+                    response.body.byteStream().use { input ->
+                        TwitchAdDetector.isAd(PlaylistUtils.parseMediaPlaylist(input))
+                    }
+                }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (_: Exception) {
+            null
+        }
     }
 
     private suspend fun loadStreamPlaybackAccessToken(context: Context, networkLibrary: String?, gqlHeaders: Map<String, String>, channelLogin: String, randomDeviceId: Boolean?, xDeviceId: String?, playerType: String?, proxyPlaybackAccessToken: Boolean, proxyHost: String?, proxyPort: Int?, proxyUser: String?, proxyPassword: String?, enableIntegrity: Boolean): Pair<String?, String?> = withContext(Dispatchers.IO) {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/ExoPlayerService.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/ExoPlayerService.kt
@@ -75,7 +75,9 @@ import com.github.andreyasadchy.xtra.util.NetworkUtils
 import com.github.andreyasadchy.xtra.util.NetworkUtils.executeAsync
 import com.github.andreyasadchy.xtra.util.TwitchApiHelper
 import com.github.andreyasadchy.xtra.util.m3u8.PlaylistUtils
+import com.github.andreyasadchy.xtra.util.m3u8.TwitchAdDetector
 import com.github.andreyasadchy.xtra.util.prefs
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -102,7 +104,6 @@ import kotlin.concurrent.scheduleAtFixedRate
 import kotlin.math.floor
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
-import kotlin.time.Instant
 
 @OptIn(UnstableApi::class)
 class ExoPlayerService : BasePlaybackService() {
@@ -125,6 +126,8 @@ class ExoPlayerService : BasePlaybackService() {
     private var proxyMediaPlaylist = false
     private var stopProxy = false
     private var hidden = false
+    private val adController = TwitchAdController()
+    private var adAvoidanceJob: Job? = null
     private var backupQualities: List<String>? = null
     private var updateQualities = false
     private var created = false
@@ -237,77 +240,36 @@ class ExoPlayerService : BasePlaybackService() {
                         }
                     }
                     if (type == STREAM) {
-                        val hideAds = prefs().getBoolean(C.PLAYER_HIDE_ADS, false)
+                        val avoidAds = prefs().getBoolean(C.PLAYER_AVOID_ADS, false)
+                                || prefs().getBoolean(C.PLAYER_HIDE_ADS, false)
+                        val suppressAds = avoidAds
                         val useProxy = prefs().getBoolean(C.PROXY_MEDIA_PLAYLIST, true)
                                 && !prefs().getString(C.PROXY_HOST, null).isNullOrBlank()
                                 && prefs().getString(C.PROXY_PORT, null)?.toIntOrNull() != null
-                        if (hideAds || useProxy) {
+                        if (suppressAds || useProxy) {
                             val playlist = (player?.currentManifest as? HlsManifest)?.mediaPlaylist
-                            val ads = playlist?.segments?.lastOrNull()?.let { segment ->
-                                val segmentStartTime = playlist.startTimeUs + segment.relativeStartTimeUs
-                                listOf("Amazon", "Adform", "DCM").any { segment.title.contains(it) } ||
-                                        playlist.interstitials.find {
-                                            val startTime = it.startDateUnixUs
-                                            val endTime = it.endDateUnixUs.takeIf { it != androidx.media3.common.C.TIME_UNSET }
-                                                ?: it.durationUs.takeIf { it != androidx.media3.common.C.TIME_UNSET }?.let { startTime + it }
-                                                ?: it.plannedDurationUs.takeIf { it != androidx.media3.common.C.TIME_UNSET }?.let { startTime + it }
-                                            endTime != null
-                                                    && (it.id.startsWith("stitched-ad-")
-                                                    || it.clientDefinedAttributes.find { it.name == "CLASS" }?.textValue == "twitch-stitched-ad"
-                                                    || it.clientDefinedAttributes.find { it.name.startsWith("X-TV-TWITCH-AD-") } != null)
-                                                    && segmentStartTime in startTime..endTime
-                                        } != null
-                            } == true
+                            val ads = playlist?.let { TwitchAdDetector.isAd(it) } == true
                             val oldValue = playingAds
                             playingAds = ads
                             if (ads) {
-                                if (proxyMediaPlaylist) {
-                                    if (!stopProxy) {
-                                        proxyMediaPlaylist = false
-                                        stopProxy = true
-                                    }
-                                } else {
-                                    if (!oldValue) {
-                                        val playlist = quality?.url
-                                        if (!stopProxy && !playlist.isNullOrBlank() && useProxy) {
-                                            proxyMediaPlaylist = true
-                                            lifecycleScope.launch {
-                                                for (i in 0 until 10) {
-                                                    delay(10.seconds)
-                                                    if (!checkPlaylist(prefs().getString(C.NETWORK_LIBRARY, C.OKHTTP), playlist)) {
-                                                        break
-                                                    }
-                                                }
-                                                proxyMediaPlaylist = false
-                                            }
+                                if (avoidAds) {
+                                    if (adAvoidanceJob?.isActive != true) {
+                                        val playerTypes = adController.playerTypesForAd(
+                                            prefs().getString(C.TOKEN_PLAYER_TYPE, "site")
+                                        )
+                                        if (playerTypes.isNotEmpty()) {
+                                            suppressAdPlayback()
+                                            tryAlternateStream(playerTypes, useProxy)
                                         } else {
-                                            if (hideAds) {
-                                                hidden = true
-                                                player?.let { player ->
-                                                    if (quality?.name != AUDIO_ONLY_QUALITY) {
-                                                        player.trackSelectionParameters = player.trackSelectionParameters.buildUpon().apply {
-                                                            setTrackTypeDisabled(androidx.media3.common.C.TRACK_TYPE_VIDEO, true)
-                                                        }.build()
-                                                    }
-                                                    player.volume = 0f
-                                                }
-                                                serviceListener?.toast(R.string.waiting_ads, Toast.LENGTH_LONG)
-                                            }
+                                            fallbackFromAd(useProxy, suppressAds)
                                         }
                                     }
+                                } else if (!oldValue) {
+                                    fallbackFromAd(useProxy, suppressAds)
                                 }
                             } else {
-                                if (hideAds && hidden) {
-                                    hidden = false
-                                    player?.let { player ->
-                                        if (quality?.name != AUDIO_ONLY_QUALITY) {
-                                            player.trackSelectionParameters = player.trackSelectionParameters.buildUpon().apply {
-                                                setTrackTypeDisabled(androidx.media3.common.C.TRACK_TYPE_VIDEO, false)
-                                            }.build()
-                                        }
-                                        player.volume = prefs().getInt(C.PLAYER_VOLUME, 100) / 100f
-                                    }
-                                }
+                                adController.onCleanPlaylist()
+                                restoreAdPlayback()
                             }
                         }
                     }
@@ -762,9 +724,113 @@ class ExoPlayerService : BasePlaybackService() {
         }
     }
 
-    private suspend fun loadStream(restorePauseState: Boolean = false, restart: Boolean = false) {
+    private fun suppressAdPlayback() {
+        if (!hidden) {
+            hidden = true
+            player?.let { player ->
+                if (quality?.name != AUDIO_ONLY_QUALITY) {
+                    player.trackSelectionParameters = player.trackSelectionParameters.buildUpon().apply {
+                        setTrackTypeDisabled(androidx.media3.common.C.TRACK_TYPE_VIDEO, true)
+                    }.build()
+                }
+                player.volume = 0f
+            }
+            serviceListener?.toast(R.string.waiting_ads, Toast.LENGTH_LONG)
+        }
+    }
+
+    private fun restoreAdPlayback() {
+        if (hidden) {
+            hidden = false
+            player?.let { player ->
+                if (quality?.name != AUDIO_ONLY_QUALITY) {
+                    player.trackSelectionParameters = player.trackSelectionParameters.buildUpon().apply {
+                        setTrackTypeDisabled(androidx.media3.common.C.TRACK_TYPE_VIDEO, false)
+                    }.build()
+                }
+                player.volume = prefs().getInt(C.PLAYER_VOLUME, 100) / 100f
+            }
+        }
+    }
+
+    private fun fallbackFromAd(useProxy: Boolean, suppressAds: Boolean) {
+        if (proxyMediaPlaylist) {
+            if (!stopProxy) {
+                proxyMediaPlaylist = false
+                stopProxy = true
+            }
+            return
+        }
+        val playlist = quality?.url
+        if (!stopProxy && !playlist.isNullOrBlank() && useProxy) {
+            proxyMediaPlaylist = true
+            lifecycleScope.launch {
+                for (i in 0 until 10) {
+                    delay(10.seconds)
+                    if (!checkPlaylist(prefs().getString(C.NETWORK_LIBRARY, C.OKHTTP), playlist)) {
+                        break
+                    }
+                }
+                proxyMediaPlaylist = false
+            }
+        } else if (suppressAds) {
+            suppressAdPlayback()
+        }
+    }
+
+    private fun tryAlternateStream(playerTypes: List<String>, useProxy: Boolean) {
+        val channelLogin = channelLogin ?: return
+        adAvoidanceJob = lifecycleScope.launch {
+            val candidate = try {
+                xtraModule.playerRepository.loadCleanStreamPlaylistUrl(
+                    context = this@ExoPlayerService,
+                    networkLibrary = prefs().getString(C.NETWORK_LIBRARY, C.OKHTTP),
+                    gqlHeaders = TwitchApiHelper.getGQLHeaders(this@ExoPlayerService, prefs().getBoolean(C.TOKEN_INCLUDE_TOKEN_STREAM, true)),
+                    channelLogin = channelLogin,
+                    randomDeviceId = prefs().getBoolean(C.TOKEN_RANDOM_DEVICE_ID, true),
+                    xDeviceId = prefs().getString(C.TOKEN_X_DEVICE_ID, "twitch-web-wall-mason"),
+                    playerTypes = playerTypes,
+                    supportedCodecs = prefs().getString(C.TOKEN_SUPPORTED_CODECS, "av1,h265,h264"),
+                    proxyPlaybackAccessToken = prefs().getBoolean(C.PROXY_PLAYBACK_ACCESS_TOKEN, false),
+                    proxyHost = prefs().getString(C.PROXY_HOST, null),
+                    proxyPort = prefs().getString(C.PROXY_PORT, null)?.toIntOrNull(),
+                    proxyUser = prefs().getString(C.PROXY_USER, null),
+                    proxyPassword = prefs().getString(C.PROXY_PASSWORD, null),
+                    enableIntegrity = prefs().getBoolean(C.ENABLE_INTEGRITY, false),
+                )
+            } catch (e: CancellationException) {
+                throw e
+            } catch (_: Exception) {
+                null
+            }
+            if (candidate != null && type == STREAM) {
+                try {
+                    loadStream(restorePauseState = true, playlistUrlOverride = candidate.url)
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (_: Exception) {
+                    fallbackFromAd(useProxy, suppressAds = true)
+                }
+            } else {
+                fallbackFromAd(useProxy, suppressAds = true)
+            }
+        }
+    }
+
+    private suspend fun loadStream(
+        restorePauseState: Boolean = false,
+        restart: Boolean = false,
+        playlistUrlOverride: String? = null,
+    ) {
         channelLogin?.let { channelLogin ->
-            if (restart || qualities.isNullOrEmpty()) {
+            if (!playlistUrlOverride.isNullOrBlank()) {
+                playlistUrl = playlistUrlOverride
+                qualities = null
+                updateQualities = true
+            } else if (restart || qualities.isNullOrEmpty()) {
+                adAvoidanceJob?.cancel()
+                adController.reset()
+                stopProxy = false
                 val proxyUrl = prefs().getString(C.PLAYER_PROXY_URL, "")
                 if (useCustomProxy && !proxyUrl.isNullOrBlank()) {
                     playlistUrl = proxyUrl.replace("\$channel", channelLogin)
@@ -1501,22 +1567,7 @@ class ExoPlayerService : BasePlaybackService() {
                     }
                 }
             }
-            playlist.segments.lastOrNull()?.let { segment ->
-                segment.title?.let { it.contains("Amazon") || it.contains("Adform") || it.contains("DCM") } == true ||
-                        segment.programDateTime?.let { Instant.parseOrNull(it)?.toEpochMilliseconds()?.takeIf { ms -> ms > 0 } }?.let { segmentStartTime ->
-                            playlist.dateRanges.find { dateRange ->
-                                (dateRange.id.startsWith("stitched-ad-") || dateRange.rangeClass == "twitch-stitched-ad" || dateRange.ad) &&
-                                        dateRange.endDate?.let { Instant.parseOrNull(it)?.toEpochMilliseconds()?.takeIf { ms -> ms > 0 } }?.let { endTime ->
-                                            segmentStartTime < endTime
-                                        } == true ||
-                                        dateRange.startDate.let { Instant.parseOrNull(it)?.toEpochMilliseconds()?.takeIf { ms -> ms > 0 } }?.let { startTime ->
-                                            (dateRange.duration ?: dateRange.plannedDuration)?.let { (it * 1000f).toLong() }?.let { duration ->
-                                                segmentStartTime < (startTime + duration)
-                                            } == true
-                                        } == true
-                            } != null
-                        } == true
-            } == true
+            TwitchAdDetector.isAd(playlist)
         } catch (e: Exception) {
             false
         }
@@ -2185,6 +2236,9 @@ class ExoPlayerService : BasePlaybackService() {
         super.onDestroy()
         streamRecoveryJob?.cancel()
         streamRecoveryJob = null
+        adAvoidanceJob?.cancel()
+        adAvoidanceJob = null
+        adController.reset()
         backgroundVideoDisabled = false
         player?.release()
         session?.release()

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/ExoPlayerService.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/ExoPlayerService.kt
@@ -779,7 +779,10 @@ class ExoPlayerService : BasePlaybackService() {
     }
 
     private fun tryAlternateStream(playerTypes: List<String>, useProxy: Boolean) {
-        val channelLogin = channelLogin ?: return
+        val channelLogin = channelLogin ?: run {
+            fallbackFromAd(useProxy, suppressAds = true)
+            return
+        }
         adAvoidanceJob = lifecycleScope.launch {
             val candidate = try {
                 xtraModule.playerRepository.loadCleanStreamPlaylistUrl(

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/Media3Fragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/Media3Fragment.kt
@@ -594,7 +594,10 @@ class Media3Fragment : Media3PlayerFragment() {
     }
 
     private fun tryAlternateStream(playerTypes: List<String>, useProxy: Boolean) {
-        val channelLogin = requireArguments().getString(KEY_CHANNEL_LOGIN) ?: return
+        val channelLogin = requireArguments().getString(KEY_CHANNEL_LOGIN) ?: run {
+            fallbackFromAd(useProxy, suppressAds = true)
+            return
+        }
         adAvoidanceJob = viewLifecycleOwner.lifecycleScope.launch {
             val candidate = try {
                 viewModel.loadCleanStreamPlaylistUrl(channelLogin, playerTypes)
@@ -608,7 +611,7 @@ class Media3Fragment : Media3PlayerFragment() {
                 viewModel.updateQualities = true
                 viewModel.usingProxy = false
                 try {
-                    sendStreamToService(candidate.url)
+                    sendStreamToService(candidate.url, player?.playWhenReady)
                 } catch (e: CancellationException) {
                     throw e
                 } catch (_: Exception) {
@@ -628,11 +631,12 @@ class Media3Fragment : Media3PlayerFragment() {
         sendStreamToService(url)
     }
 
-    private fun sendStreamToService(url: String?) {
+    private fun sendStreamToService(url: String?, playWhenReady: Boolean? = null) {
         player?.sendCustomCommand(
             SessionCommand(
                 PlaybackService.START_STREAM, Bundle().apply {
                     putString(PlaybackService.URI, url)
+                    playWhenReady?.let { putBoolean(PlaybackService.PLAY_WHEN_READY, it) }
                     putString(PlaybackService.TITLE, requireArguments().getString(KEY_TITLE))
                     putString(PlaybackService.CHANNEL_NAME, requireArguments().getString(KEY_CHANNEL_NAME))
                     putString(PlaybackService.CHANNEL_LOGO, requireArguments().getString(KEY_CHANNEL_IMAGE))

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/Media3Fragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/Media3Fragment.kt
@@ -49,6 +49,7 @@ import com.github.andreyasadchy.xtra.util.getAlertDialogBuilder
 import com.github.andreyasadchy.xtra.util.prefs
 import com.google.common.util.concurrent.ListenableFuture
 import com.google.common.util.concurrent.MoreExecutors
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -71,6 +72,7 @@ class Media3Fragment : Media3PlayerFragment() {
     private var playerListener: Player.Listener? = null
     private var streamRecoveryJob: Job? = null
     private var streamRecoveryAttempt = 0
+    private var adAvoidanceJob: Job? = null
     private val updateProgressAction = Runnable { if (view != null) updateProgress() }
 
     override fun onStart() {
@@ -270,11 +272,13 @@ class Media3Fragment : Media3PlayerFragment() {
                         }
                     }
                     if (videoType == STREAM) {
-                        val hideAds = requireContext().prefs().getBoolean(C.PLAYER_HIDE_ADS, false)
+                        val avoidAds = requireContext().prefs().getBoolean(C.PLAYER_AVOID_ADS, false)
+                                || requireContext().prefs().getBoolean(C.PLAYER_HIDE_ADS, false)
+                        val suppressAds = avoidAds
                         val useProxy = requireContext().prefs().getBoolean(C.PROXY_MEDIA_PLAYLIST, true)
                                 && !requireContext().prefs().getString(C.PROXY_HOST, null).isNullOrBlank()
                                 && requireContext().prefs().getString(C.PROXY_PORT, null)?.toIntOrNull() != null
-                        if (hideAds || useProxy) {
+                        if (suppressAds || useProxy) {
                             player?.sendCustomCommand(
                                 SessionCommand(PlaybackService.CHECK_ADS, Bundle.EMPTY),
                                 Bundle.EMPTY
@@ -288,76 +292,24 @@ class Media3Fragment : Media3PlayerFragment() {
                                         val oldValue = viewModel.playingAds
                                         viewModel.playingAds = playingAds
                                         if (playingAds) {
-                                            if (viewModel.usingProxy) {
-                                                if (!viewModel.stopProxy) {
-                                                    player?.sendCustomCommand(
-                                                        SessionCommand(
-                                                            PlaybackService.TOGGLE_PROXY, Bundle().apply {
-                                                                putBoolean(PlaybackService.USING_PROXY, false)
-                                                            }
-                                                        ), Bundle.EMPTY
+                                            if (avoidAds) {
+                                                if (adAvoidanceJob?.isActive != true) {
+                                                    val playerTypes = viewModel.playerTypesForAd(
+                                                        requireContext().prefs().getString(C.TOKEN_PLAYER_TYPE, "site")
                                                     )
-                                                    viewModel.usingProxy = false
-                                                    viewModel.stopProxy = true
-                                                }
-                                            } else {
-                                                if (!oldValue) {
-                                                    val playlist = viewModel.quality?.url
-                                                    if (!viewModel.stopProxy && !playlist.isNullOrBlank() && useProxy) {
-                                                        player?.sendCustomCommand(
-                                                            SessionCommand(
-                                                                PlaybackService.TOGGLE_PROXY, Bundle().apply {
-                                                                    putBoolean(PlaybackService.USING_PROXY, true)
-                                                                }
-                                                            ), Bundle.EMPTY
-                                                        )
-                                                        viewModel.usingProxy = true
-                                                        viewLifecycleOwner.lifecycleScope.launch {
-                                                            for (i in 0 until 10) {
-                                                                delay(10.seconds)
-                                                                if (!viewModel.checkPlaylist(requireContext().prefs().getString(C.NETWORK_LIBRARY, C.OKHTTP), playlist)) {
-                                                                    break
-                                                                }
-                                                            }
-                                                            player?.sendCustomCommand(
-                                                                SessionCommand(
-                                                                    PlaybackService.TOGGLE_PROXY, Bundle().apply {
-                                                                        putBoolean(PlaybackService.USING_PROXY, false)
-                                                                    }
-                                                                ), Bundle.EMPTY
-                                                            )
-                                                            viewModel.usingProxy = false
-                                                        }
+                                                    if (playerTypes.isNotEmpty()) {
+                                                        suppressAdPlayback()
+                                                        tryAlternateStream(playerTypes, useProxy)
                                                     } else {
-                                                        if (hideAds) {
-                                                            viewModel.hidden = true
-                                                            player?.let { player ->
-                                                                if (viewModel.quality?.name != AUDIO_ONLY_QUALITY) {
-                                                                    player.trackSelectionParameters = player.trackSelectionParameters.buildUpon().apply {
-                                                                        setTrackTypeDisabled(androidx.media3.common.C.TRACK_TYPE_VIDEO, true)
-                                                                    }.build()
-                                                                    binding.playerSurface.visibility = View.GONE
-                                                                }
-                                                                player.volume = 0f
-                                                            }
-                                                            Toast.makeText(requireContext(), R.string.waiting_ads, Toast.LENGTH_LONG).show()
-                                                        }
+                                                        fallbackFromAd(useProxy, suppressAds)
                                                     }
                                                 }
+                                            } else if (!oldValue) {
+                                                fallbackFromAd(useProxy, suppressAds)
                                             }
                                         } else {
-                                            if (hideAds && viewModel.hidden) {
-                                                viewModel.hidden = false
-                                                player?.let { player ->
-                                                    if (viewModel.quality?.name != AUDIO_ONLY_QUALITY) {
-                                                        player.trackSelectionParameters = player.trackSelectionParameters.buildUpon().apply {
-                                                            setTrackTypeDisabled(androidx.media3.common.C.TRACK_TYPE_VIDEO, false)
-                                                        }.build()
-                                                        binding.playerSurface.visibility = View.VISIBLE
-                                                    }
-                                                    player.volume = requireContext().prefs().getInt(C.PLAYER_VOLUME, 100) / 100f
-                                                }
-                                            }
+                                            viewModel.onCleanAdPlaylist()
+                                            restoreAdPlayback()
                                         }
                                     }
                                 }, ContextCompat.getMainExecutor(requireContext()))
@@ -566,7 +518,117 @@ class Media3Fragment : Media3PlayerFragment() {
         super.initialize()
     }
 
+    private fun suppressAdPlayback() {
+        if (!viewModel.hidden) {
+            viewModel.hidden = true
+            player?.let { player ->
+                if (viewModel.quality?.name != AUDIO_ONLY_QUALITY) {
+                    player.trackSelectionParameters = player.trackSelectionParameters.buildUpon().apply {
+                        setTrackTypeDisabled(androidx.media3.common.C.TRACK_TYPE_VIDEO, true)
+                    }.build()
+                    binding.playerSurface.visibility = View.GONE
+                }
+                player.volume = 0f
+            }
+            Toast.makeText(requireContext(), R.string.waiting_ads, Toast.LENGTH_LONG).show()
+        }
+    }
+
+    private fun restoreAdPlayback() {
+        if (viewModel.hidden) {
+            viewModel.hidden = false
+            player?.let { player ->
+                if (viewModel.quality?.name != AUDIO_ONLY_QUALITY) {
+                    player.trackSelectionParameters = player.trackSelectionParameters.buildUpon().apply {
+                        setTrackTypeDisabled(androidx.media3.common.C.TRACK_TYPE_VIDEO, false)
+                    }.build()
+                    binding.playerSurface.visibility = View.VISIBLE
+                }
+                player.volume = requireContext().prefs().getInt(C.PLAYER_VOLUME, 100) / 100f
+            }
+        }
+    }
+
+    private fun fallbackFromAd(useProxy: Boolean, suppressAds: Boolean) {
+        if (viewModel.usingProxy) {
+            player?.sendCustomCommand(
+                SessionCommand(
+                    PlaybackService.TOGGLE_PROXY, Bundle().apply {
+                        putBoolean(PlaybackService.USING_PROXY, false)
+                    }
+                ), Bundle.EMPTY
+            )
+            viewModel.usingProxy = false
+            viewModel.stopProxy = true
+            return
+        }
+        val playlist = viewModel.quality?.url
+        if (!viewModel.stopProxy && !playlist.isNullOrBlank() && useProxy) {
+            player?.sendCustomCommand(
+                SessionCommand(
+                    PlaybackService.TOGGLE_PROXY, Bundle().apply {
+                        putBoolean(PlaybackService.USING_PROXY, true)
+                    }
+                ), Bundle.EMPTY
+            )
+            viewModel.usingProxy = true
+            viewLifecycleOwner.lifecycleScope.launch {
+                for (i in 0 until 10) {
+                    delay(10.seconds)
+                    if (!viewModel.checkPlaylist(requireContext().prefs().getString(C.NETWORK_LIBRARY, C.OKHTTP), playlist)) {
+                        break
+                    }
+                }
+                player?.sendCustomCommand(
+                    SessionCommand(
+                        PlaybackService.TOGGLE_PROXY, Bundle().apply {
+                            putBoolean(PlaybackService.USING_PROXY, false)
+                        }
+                    ), Bundle.EMPTY
+                )
+                viewModel.usingProxy = false
+            }
+        } else if (suppressAds) {
+            suppressAdPlayback()
+        }
+    }
+
+    private fun tryAlternateStream(playerTypes: List<String>, useProxy: Boolean) {
+        val channelLogin = requireArguments().getString(KEY_CHANNEL_LOGIN) ?: return
+        adAvoidanceJob = viewLifecycleOwner.lifecycleScope.launch {
+            val candidate = try {
+                viewModel.loadCleanStreamPlaylistUrl(channelLogin, playerTypes)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (_: Exception) {
+                null
+            }
+            if (candidate != null && isAdded && view != null) {
+                viewModel.qualities = null
+                viewModel.updateQualities = true
+                viewModel.usingProxy = false
+                try {
+                    sendStreamToService(candidate.url)
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (_: Exception) {
+                    fallbackFromAd(useProxy, suppressAds = true)
+                }
+            } else {
+                fallbackFromAd(useProxy, suppressAds = true)
+            }
+        }
+    }
+
     override fun startStream(url: String?) {
+        adAvoidanceJob?.cancel()
+        adAvoidanceJob = null
+        viewModel.resetAdController()
+        viewModel.playingAds = false
+        sendStreamToService(url)
+    }
+
+    private fun sendStreamToService(url: String?) {
         player?.sendCustomCommand(
             SessionCommand(
                 PlaybackService.START_STREAM, Bundle().apply {
@@ -1056,6 +1118,8 @@ class Media3Fragment : Media3PlayerFragment() {
         streamRecoveryJob?.cancel()
         streamRecoveryJob = null
         streamRecoveryAttempt = 0
+        adAvoidanceJob?.cancel()
+        adAvoidanceJob = null
         if (view != null) {
             controller?.clearVideoSurfaceView(binding.playerSurface)
         }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/Media3PlayerViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/Media3PlayerViewModel.kt
@@ -29,7 +29,10 @@ import com.github.andreyasadchy.xtra.repository.PlayerRepository
 import com.github.andreyasadchy.xtra.util.C
 import com.github.andreyasadchy.xtra.util.NetworkUtils
 import com.github.andreyasadchy.xtra.util.NetworkUtils.executeAsync
+import com.github.andreyasadchy.xtra.util.TwitchApiHelper
 import com.github.andreyasadchy.xtra.util.m3u8.PlaylistUtils
+import com.github.andreyasadchy.xtra.util.m3u8.TwitchAdDetector
+import com.github.andreyasadchy.xtra.util.prefs
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -73,6 +76,7 @@ class Media3PlayerViewModel(
     var playingAds = false
     var usingProxy = false
     var stopProxy = false
+    private val adController = TwitchAdController()
 
     val videoResult = MutableStateFlow<String?>(null)
     var backupQualities: List<String>? = null
@@ -150,25 +154,48 @@ class Media3PlayerViewModel(
                     }
                 }
             }
-            playlist.segments.lastOrNull()?.let { segment ->
-                segment.title?.let { it.contains("Amazon") || it.contains("Adform") || it.contains("DCM") } == true ||
-                        segment.programDateTime?.let { Instant.parseOrNull(it)?.toEpochMilliseconds()?.takeIf { ms -> ms > 0 } }?.let { segmentStartTime ->
-                            playlist.dateRanges.find { dateRange ->
-                                (dateRange.id.startsWith("stitched-ad-") || dateRange.rangeClass == "twitch-stitched-ad" || dateRange.ad) &&
-                                        dateRange.endDate?.let { Instant.parseOrNull(it)?.toEpochMilliseconds()?.takeIf { ms -> ms > 0 } }?.let { endTime ->
-                                            segmentStartTime < endTime
-                                        } == true ||
-                                        dateRange.startDate.let { Instant.parseOrNull(it)?.toEpochMilliseconds()?.takeIf { ms -> ms > 0 } }?.let { startTime ->
-                                            (dateRange.duration ?: dateRange.plannedDuration)?.let { (it * 1000f).toLong() }?.let { duration ->
-                                                segmentStartTime < (startTime + duration)
-                                            } == true
-                                        } == true
-                            } != null
-                        } == true
-            } == true
+            TwitchAdDetector.isAd(playlist)
         } catch (e: Exception) {
             false
         }
+    }
+
+    fun playerTypesForAd(currentPlayerType: String?): List<String> {
+        return adController.playerTypesForAd(currentPlayerType)
+    }
+
+    fun onCleanAdPlaylist() {
+        adController.onCleanPlaylist()
+    }
+
+    fun resetAdController() {
+        adController.reset()
+    }
+
+    suspend fun loadCleanStreamPlaylistUrl(
+        channelLogin: String,
+        playerTypes: List<String>,
+    ): PlayerRepository.StreamPlaylistCandidate? {
+        val preferences = applicationContext.prefs()
+        return playerRepository.loadCleanStreamPlaylistUrl(
+            context = applicationContext,
+            networkLibrary = preferences.getString(C.NETWORK_LIBRARY, C.OKHTTP),
+            gqlHeaders = TwitchApiHelper.getGQLHeaders(
+                applicationContext,
+                preferences.getBoolean(C.TOKEN_INCLUDE_TOKEN_STREAM, true),
+            ),
+            channelLogin = channelLogin,
+            randomDeviceId = preferences.getBoolean(C.TOKEN_RANDOM_DEVICE_ID, true),
+            xDeviceId = preferences.getString(C.TOKEN_X_DEVICE_ID, "twitch-web-wall-mason"),
+            playerTypes = playerTypes,
+            supportedCodecs = preferences.getString(C.TOKEN_SUPPORTED_CODECS, "av1,h265,h264"),
+            proxyPlaybackAccessToken = preferences.getBoolean(C.PROXY_PLAYBACK_ACCESS_TOKEN, false),
+            proxyHost = preferences.getString(C.PROXY_HOST, null),
+            proxyPort = preferences.getString(C.PROXY_PORT, null)?.toIntOrNull(),
+            proxyUser = preferences.getString(C.PROXY_USER, null),
+            proxyPassword = preferences.getString(C.PROXY_PASSWORD, null),
+            enableIntegrity = preferences.getBoolean(C.ENABLE_INTEGRITY, false),
+        )
     }
 
     fun loadStreamResult(networkLibrary: String?, gqlHeaders: Map<String, String>, channelLogin: String, randomDeviceId: Boolean?, xDeviceId: String?, playerType: String?, supportedCodecs: String?, proxyPlaybackAccessToken: Boolean, proxyHost: String?, proxyPort: Int?, proxyUser: String?, proxyPassword: String?, enableIntegrity: Boolean) {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/PlaybackService.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/PlaybackService.kt
@@ -46,6 +46,7 @@ import com.github.andreyasadchy.xtra.ui.main.MainActivity
 import com.github.andreyasadchy.xtra.ui.player.ExoPlayerService.Companion.MEDIA_PLAYLIST_REGEX
 import com.github.andreyasadchy.xtra.ui.player.ExoPlayerService.Companion.MULTIVARIANT_PLAYLIST_REGEX
 import com.github.andreyasadchy.xtra.util.C
+import com.github.andreyasadchy.xtra.util.m3u8.TwitchAdDetector
 import com.github.andreyasadchy.xtra.util.prefs
 import com.google.common.util.concurrent.Futures
 import com.google.common.util.concurrent.ListenableFuture
@@ -688,20 +689,7 @@ class PlaybackService : MediaSessionService() {
                             }
                             CHECK_ADS -> {
                                 val playlist = (session.player.currentManifest as? HlsManifest)?.mediaPlaylist
-                                val adSegment = playlist?.segments?.lastOrNull()?.let { segment ->
-                                    val segmentStartTime = playlist.startTimeUs + segment.relativeStartTimeUs
-                                    listOf("Amazon", "Adform", "DCM").any { segment.title.contains(it) } ||
-                                            playlist.interstitials.find {
-                                                val startTime = it.startDateUnixUs
-                                                val endTime = it.endDateUnixUs.takeIf { it != androidx.media3.common.C.TIME_UNSET }
-                                                    ?: it.durationUs.takeIf { it != androidx.media3.common.C.TIME_UNSET }?.let { startTime + it }
-                                                    ?: it.plannedDurationUs.takeIf { it != androidx.media3.common.C.TIME_UNSET }?.let { startTime + it }
-                                                endTime != null && (it.id.startsWith("stitched-ad-") ||
-                                                        it.clientDefinedAttributes.find { it.name == "CLASS" }?.textValue == "twitch-stitched-ad" ||
-                                                        it.clientDefinedAttributes.find { it.name.startsWith("X-TV-TWITCH-AD-") } != null)
-                                                        && segmentStartTime in startTime..endTime
-                                            } != null
-                                } == true
+                                val adSegment = playlist?.let { TwitchAdDetector.isAd(it) } == true
                                 Futures.immediateFuture(SessionResult(SessionResult.RESULT_SUCCESS, Bundle().apply {
                                     putBoolean(RESULT, adSegment)
                                 }))

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/PlaybackService.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/PlaybackService.kt
@@ -504,7 +504,7 @@ class PlaybackService : MediaSessionService() {
                                 session.player.volume = prefs().getInt(C.PLAYER_VOLUME, 100) / 100f
                                 session.player.setPlaybackSpeed(1f)
                                 session.player.prepare()
-                                session.player.playWhenReady = true
+                                session.player.playWhenReady = customCommand.customExtras.getBoolean(PLAY_WHEN_READY, true)
                                 Futures.immediateFuture(SessionResult(SessionResult.RESULT_SUCCESS))
                             }
                             START_VIDEO -> {
@@ -884,6 +884,7 @@ class PlaybackService : MediaSessionService() {
         const val CHANNEL_NAME = "channelName"
         const val CHANNEL_LOGO = "channelLogo"
         const val USING_PROXY = "usingProxy"
+        const val PLAY_WHEN_READY = "playWhenReady"
         const val BACKGROUND_PLAYBACK = "backgroundPlayback"
         const val DURATION = "duration"
         const val NAMES = "names"

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/TwitchAdController.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/TwitchAdController.kt
@@ -1,0 +1,39 @@
+package com.github.andreyasadchy.xtra.ui.player
+
+/**
+ * Coordinates alternate Twitch player types for one live ad window.
+ *
+ * A source is allowed to be tried once per ad window. When a clean playlist is
+ * observed, the controller resets so a later ad can get a fresh set of tokens.
+ */
+class TwitchAdController {
+
+    private var adWindowActive = false
+    private val attemptedPlayerTypes = linkedSetOf<String>()
+
+    fun playerTypesForAd(currentPlayerType: String?): List<String> {
+        if (!adWindowActive) {
+            adWindowActive = true
+            attemptedPlayerTypes.clear()
+        }
+        return ALTERNATE_PLAYER_TYPES.filter { playerType ->
+            playerType != currentPlayerType && attemptedPlayerTypes.add(playerType)
+        }
+    }
+
+    fun onCleanPlaylist() {
+        if (adWindowActive) {
+            adWindowActive = false
+            attemptedPlayerTypes.clear()
+        }
+    }
+
+    fun reset() {
+        adWindowActive = false
+        attemptedPlayerTypes.clear()
+    }
+
+    companion object {
+        val ALTERNATE_PLAYER_TYPES = listOf("popout", "embed", "autoplay")
+    }
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/TwitchAdController.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/TwitchAdController.kt
@@ -16,7 +16,7 @@ class TwitchAdController {
             adWindowActive = true
             attemptedPlayerTypes.clear()
         }
-        return ALTERNATE_PLAYER_TYPES.filter { playerType ->
+        return PLAYER_TYPES.filter { playerType ->
             playerType != currentPlayerType && attemptedPlayerTypes.add(playerType)
         }
     }
@@ -34,6 +34,6 @@ class TwitchAdController {
     }
 
     companion object {
-        val ALTERNATE_PLAYER_TYPES = listOf("popout", "embed", "autoplay")
+        val PLAYER_TYPES = listOf("site", "popout", "embed", "autoplay")
     }
 }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/C.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/C.kt
@@ -185,6 +185,7 @@ object C {
     const val PLAYER_ROUNDED_CORNER_PADDING = "player_rounded_corner_padding"
     const val PLAYER_MOVE_FREELY = "player_move_freely"
     const val PLAYER_KEEP_CHAT_OPEN = "player_keep_chat_open"
+    const val PLAYER_AVOID_ADS = "player_avoid_ads"
     const val PLAYER_HIDE_ADS = "player_hide_ads"
     const val PLAYER_PROXY = "player_proxy"
     const val PLAYER_STREAM_PROXY = "player_stream_proxy"

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/m3u8/TwitchAdDetector.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/m3u8/TwitchAdDetector.kt
@@ -1,0 +1,63 @@
+package com.github.andreyasadchy.xtra.util.m3u8
+
+import androidx.media3.common.C
+import androidx.media3.exoplayer.hls.playlist.HlsMediaPlaylist
+import kotlin.time.Instant
+
+/**
+ * Detects the ad markers Twitch currently exposes in live HLS playlists.
+ *
+ * Keep this separate from the player so all playback implementations make the
+ * same decision when a playlist rolls over to an ad window.
+ */
+@androidx.media3.common.util.UnstableApi
+object TwitchAdDetector {
+
+    private val adTitleMarkers = listOf("Amazon", "Adform", "DCM")
+
+    fun isAd(playlist: HlsMediaPlaylist): Boolean {
+        val segment = playlist.segments.lastOrNull() ?: return false
+        val segmentStartTime = playlist.startTimeUs + segment.relativeStartTimeUs
+        return adTitleMarkers.any { segment.title.contains(it, ignoreCase = true) }
+                || playlist.interstitials.any { interstitial ->
+            val startTime = interstitial.startDateUnixUs
+            val endTime = interstitial.endDateUnixUs.takeIf { it != C.TIME_UNSET }
+                ?: interstitial.durationUs.takeIf { it != C.TIME_UNSET }?.let { startTime + it }
+                ?: interstitial.plannedDurationUs.takeIf { it != C.TIME_UNSET }?.let { startTime + it }
+            endTime != null
+                    && (interstitial.id.startsWith("stitched-ad-")
+                    || interstitial.clientDefinedAttributes.any { attribute ->
+                        (attribute.name == "CLASS" && attribute.textValue == "twitch-stitched-ad")
+                                || attribute.name.startsWith("X-TV-TWITCH-AD-")
+                    })
+                    && segmentStartTime in startTime..endTime
+        }
+    }
+
+    fun isAd(playlist: MediaPlaylist): Boolean {
+        val segment = playlist.segments.lastOrNull() ?: return false
+        if (adTitleMarkers.any { segment.title?.contains(it, ignoreCase = true) == true }) {
+            return true
+        }
+        val segmentStartTime = segment.programDateTime
+            ?.let { Instant.parseOrNull(it)?.toEpochMilliseconds() }
+            ?: return false
+        return playlist.dateRanges.any { dateRange ->
+            if (!isTwitchAd(dateRange.id, dateRange.rangeClass, dateRange.ad)) {
+                return@any false
+            }
+            val startTime = Instant.parseOrNull(dateRange.startDate)?.toEpochMilliseconds()
+                ?: return@any false
+            val endTime = dateRange.endDate
+                ?.let { Instant.parseOrNull(it)?.toEpochMilliseconds() }
+                ?: dateRange.duration?.let { startTime + (it * 1000f).toLong() }
+                ?: dateRange.plannedDuration?.let { startTime + (it * 1000f).toLong() }
+            segmentStartTime >= startTime && (endTime == null || segmentStartTime < endTime)
+        }
+    }
+
+    private fun isTwitchAd(id: String, rangeClass: String?, ad: Boolean = false): Boolean {
+        return ad || id.startsWith("stitched-ad-") || rangeClass == "twitch-stitched-ad"
+    }
+
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -437,6 +437,8 @@
     <string name="enable_ffz">Enable FFZ emotes</string>
     <string name="user_id">User ID</string>
     <string name="user_login">User login</string>
+    <string name="avoid_twitch_ads">Try to avoid Twitch ads</string>
+    <string name="avoid_twitch_ads_summary">Tries clean playback sources and hides playback if Twitch still serves an ad</string>
     <string name="waiting_ads">Waiting for ads to finish</string>
     <string name="show_playlist_tags">Show playlist tags</string>
     <string name="show_media_playlist_tags">Show media playlist tags</string>

--- a/app/src/main/res/xml/playback_preferences.xml
+++ b/app/src/main/res/xml/playback_preferences.xml
@@ -7,6 +7,14 @@
 
     <SwitchPreferenceCompat
         android:defaultValue="false"
+        android:key="player_avoid_ads"
+        android:summary="@string/avoid_twitch_ads_summary"
+        android:title="@string/avoid_twitch_ads"
+        app:iconSpaceReserved="false"
+        app:singleLineTitle="false" />
+
+    <SwitchPreferenceCompat
+        android:defaultValue="false"
         android:key="player_hide_ads"
         android:title="@string/hide_during_ads"
         app:iconSpaceReserved="false"


### PR DESCRIPTION
## Summary
- Add an opt-in Playback setting for Twitch ad avoidance.
- Detect stitched-ad markers in both Media3 and legacy HLS playlists.
- Try alternate Twitch player types and probe candidates before switching playback.
- Preserve the existing proxy and hide-during-ads fallbacks.

## Validation
- Docker :app:compileDebugKotlin --no-daemon
- Docker :app:assembleDebug --no-daemon
- git diff --check

This is best-effort behavior for Twitch's server-side ad stitching; it does not guarantee permanent ad-free playback.