### PR TITLE
Add modern and AMOLED-friendly themes

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/C.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/C.kt
@@ -69,6 +69,8 @@ object C {
     const val SORT_DEFAULT_FOLLOWED_VIDEOS = "sort_default_followed_videos"
     const val SORT_DEFAULT_FOLLOWED_CHANNELS = "sort_default_followed_channels"
     const val THEME = "theme"
+    const val THEME_MODERN = "7"
+    const val THEME_MODERN_AMOLED = "8"
     const val PORTRAIT_COLUMN_COUNT = "columnsPortrait"
     const val LANDSCAPE_COLUMN_COUNT = "columnsLandscape"
     const val COMPACT_STREAMS = "compactStreamsV2"

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/ContextExtensions.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/ContextExtensions.kt
@@ -41,7 +41,9 @@ fun Activity.applyTheme() {
     } else {
         prefs().getString(C.THEME, "0") ?: "0"
     }
-    if (prefs().getBoolean(C.UI_THEME_MATERIAL3, true)) {
+    if (prefs().getBoolean(C.UI_THEME_MATERIAL3, true) && (theme == "7" || theme == "8")) {
+        setTheme(if (theme == "8") R.style.ModernAmoledTheme else R.style.ModernTheme)
+    } else if (prefs().getBoolean(C.UI_THEME_MATERIAL3, true)) {
         val reducedPadding = prefs().getBoolean(C.UI_THEME_REDUCED_PADDING, false)
         val compactText = prefs().getBoolean(C.UI_THEME_COMPACT_TEXT, false)
         when (prefs().getString(C.UI_THEME_ROUNDED_CORNERS, "0")) {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/ContextExtensions.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/ContextExtensions.kt
@@ -41,9 +41,10 @@ fun Activity.applyTheme() {
     } else {
         prefs().getString(C.THEME, "0") ?: "0"
     }
-    if (prefs().getBoolean(C.UI_THEME_MATERIAL3, true) && (theme == "7" || theme == "8")) {
-        setTheme(if (theme == "8") R.style.ModernAmoledTheme else R.style.ModernTheme)
-    } else if (prefs().getBoolean(C.UI_THEME_MATERIAL3, true)) {
+    val material3 = prefs().getBoolean(C.UI_THEME_MATERIAL3, true)
+    if (material3 && (theme == C.THEME_MODERN || theme == C.THEME_MODERN_AMOLED)) {
+        setTheme(if (theme == C.THEME_MODERN_AMOLED) R.style.ModernAmoledTheme else R.style.ModernTheme)
+    } else if (material3) {
         val reducedPadding = prefs().getBoolean(C.UI_THEME_REDUCED_PADDING, false)
         val compactText = prefs().getBoolean(C.UI_THEME_COMPACT_TEXT, false)
         when (prefs().getString(C.UI_THEME_ROUNDED_CORNERS, "0")) {

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -88,6 +88,8 @@
         <item>@string/amoled</item>
         <item>@string/light</item>
         <item>@string/blue</item>
+        <item>@string/modern</item>
+        <item>@string/modern_amoled</item>
     </string-array>
 
     <string-array name="themeValues">
@@ -98,6 +100,8 @@
         <item>1</item>
         <item>2</item>
         <item>3</item>
+        <item>7</item>
+        <item>8</item>
     </string-array>
 
     <string-array name="themeNoDynamicEntries">
@@ -105,6 +109,8 @@
         <item>@string/amoled</item>
         <item>@string/light</item>
         <item>@string/blue</item>
+        <item>@string/modern</item>
+        <item>@string/modern_amoled</item>
     </string-array>
 
     <string-array name="themeNoDynamicValues">
@@ -112,6 +118,8 @@
         <item>1</item>
         <item>2</item>
         <item>3</item>
+        <item>7</item>
+        <item>8</item>
     </string-array>
 
     <string-array name="roundedCornerEntries">

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -33,4 +33,26 @@
     <color name="watchStreakOrange">#FFB31A</color>
     <color name="watchStreakProgress">#00D395</color>
     <color name="channel_points_reward_default">#9146FF</color>
+    <color name="modernPrimary">#D0BCFF</color>
+    <color name="modernOnPrimary">#381E72</color>
+    <color name="modernPrimaryContainer">#4F378B</color>
+    <color name="modernOnPrimaryContainer">#EADDFF</color>
+    <color name="modernSecondary">#C4C6D0</color>
+    <color name="modernSecondaryContainer">#42454F</color>
+    <color name="modernOnSecondaryContainer">#E1E2EC</color>
+    <color name="modernSurface">#111318</color>
+    <color name="modernSurfaceContainerLowest">#0C0E13</color>
+    <color name="modernSurfaceContainerLow">#191B22</color>
+    <color name="modernSurfaceContainer">#1D2028</color>
+    <color name="modernSurfaceContainerHigh">#272A33</color>
+    <color name="modernSurfaceContainerHighest">#32353E</color>
+    <color name="modernOnSurface">#E3E2E9</color>
+    <color name="modernOnSurfaceVariant">#C5C6D0</color>
+    <color name="modernOutline">#8F9099</color>
+    <color name="modernAmoledSurface">#000000</color>
+    <color name="modernAmoledSurfaceContainerLowest">#000000</color>
+    <color name="modernAmoledSurfaceContainerLow">#08090C</color>
+    <color name="modernAmoledSurfaceContainer">#0E0F13</color>
+    <color name="modernAmoledSurfaceContainerHigh">#16171C</color>
+    <color name="modernAmoledSurfaceContainerHighest">#202126</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -76,6 +76,8 @@
     <string name="dark">Dark</string>
     <string name="amoled">Black</string>
     <string name="light">Light</string>
+    <string name="modern">Modern</string>
+    <string name="modern_amoled">Modern AMOLED</string>
     <string name="settings">Settings</string>
     <string name="general_settings">General</string>
     <string name="settings_search_prompt">Search settings</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -109,6 +109,102 @@
         <item name="android:statusBarColor">@android:color/transparent</item>
     </style>
 
+    <style name="ModernTheme" parent="BaseDarkTheme">
+        <item name="colorPrimary">@color/modernPrimary</item>
+        <item name="colorOnPrimary">@color/modernOnPrimary</item>
+        <item name="colorPrimaryContainer">@color/modernPrimaryContainer</item>
+        <item name="colorOnPrimaryContainer">@color/modernOnPrimaryContainer</item>
+        <item name="colorSecondary">@color/modernSecondary</item>
+        <item name="colorSecondaryContainer">@color/modernSecondaryContainer</item>
+        <item name="colorOnSecondaryContainer">@color/modernOnSecondaryContainer</item>
+        <item name="colorSurface">@color/modernSurface</item>
+        <item name="android:colorBackground">@color/modernSurface</item>
+        <item name="colorSurfaceContainerLowest">@color/modernSurfaceContainerLowest</item>
+        <item name="colorSurfaceContainerLow">@color/modernSurfaceContainerLow</item>
+        <item name="colorSurfaceContainer">@color/modernSurfaceContainer</item>
+        <item name="colorSurfaceContainerHigh">@color/modernSurfaceContainerHigh</item>
+        <item name="colorSurfaceContainerHighest">@color/modernSurfaceContainerHighest</item>
+        <item name="colorOnSurface">@color/modernOnSurface</item>
+        <item name="colorOnSurfaceVariant">@color/modernOnSurfaceVariant</item>
+        <item name="colorOutline">@color/modernOutline</item>
+        <item name="actionBarSize">56dp</item>
+        <item name="toolbarStyle">@style/ModernToolbar</item>
+        <item name="tabLayoutHeight">44dp</item>
+        <item name="bottomNavigationHeight">64dp</item>
+        <item name="bottomNavigationStyle">@style/ModernBottomNavigation</item>
+        <item name="cardStyle">@style/ModernCard</item>
+        <item name="materialSwitchStyle">@style/SwitchModern</item>
+        <item name="sliderStyle">@style/SliderModern</item>
+        <item name="preferenceTheme">@style/ModernPreferenceTheme</item>
+        <item name="android:navigationBarColor">@color/modernSurface</item>
+    </style>
+
+    <style name="ModernAmoledTheme" parent="ModernTheme">
+        <item name="colorSurface">@color/modernAmoledSurface</item>
+        <item name="android:colorBackground">@color/modernAmoledSurface</item>
+        <item name="colorSurfaceContainerLowest">@color/modernAmoledSurfaceContainerLowest</item>
+        <item name="colorSurfaceContainerLow">@color/modernAmoledSurfaceContainerLow</item>
+        <item name="colorSurfaceContainer">@color/modernAmoledSurfaceContainer</item>
+        <item name="colorSurfaceContainerHigh">@color/modernAmoledSurfaceContainerHigh</item>
+        <item name="colorSurfaceContainerHighest">@color/modernAmoledSurfaceContainerHighest</item>
+        <item name="android:navigationBarColor">@color/modernAmoledSurface</item>
+    </style>
+
+    <style name="ModernToolbar" parent="Widget.Material3.Toolbar">
+        <item name="maxButtonHeight">48dp</item>
+    </style>
+
+    <style name="ModernBottomNavigation" parent="Widget.Material3.BottomNavigationView">
+        <item name="materialThemeOverlay">@style/ModernBottomNavigationOverlay</item>
+        <item name="itemPaddingTop">2dp</item>
+        <item name="itemPaddingBottom">2dp</item>
+        <item name="activeIndicatorLabelPadding">0dp</item>
+        <item name="itemActiveIndicatorStyle">@style/ModernActiveIndicator</item>
+        <item name="elevation">0dp</item>
+    </style>
+
+    <style name="ModernBottomNavigationOverlay">
+        <item name="colorSurfaceContainer">?attr/colorSurface</item>
+        <item name="colorSecondaryContainer">@color/modernPrimaryContainer</item>
+    </style>
+
+    <style name="ModernActiveIndicator" parent="Widget.Material3.BottomNavigationView.ActiveIndicator">
+        <item name="android:height">30dp</item>
+    </style>
+
+    <style name="ModernCard" parent="Widget.Material3.CardView.Elevated">
+        <item name="android:layout_margin">4dp</item>
+        <item name="android:elevation">0dp</item>
+        <item name="cardElevation">0dp</item>
+        <item name="cardBackgroundColor">?attr/colorSurfaceContainerLow</item>
+        <item name="strokeWidth">0dp</item>
+        <item name="shapeAppearanceOverlay">@style/ModernCardShape</item>
+    </style>
+
+    <style name="ModernCardShape" parent="ShapeAppearance.Material3.MediumComponent">
+        <item name="cornerSize">12dp</item>
+    </style>
+
+    <style name="SwitchModern" parent="Widget.Material3.CompoundButton.MaterialSwitch">
+        <item name="materialThemeOverlay">@style/SwitchOverlayModern</item>
+    </style>
+
+    <style name="SwitchOverlayModern">
+        <item name="colorPrimary">@color/modernPrimary</item>
+        <item name="colorOnPrimary">@color/modernOnPrimary</item>
+        <item name="colorPrimaryContainer">@color/modernPrimaryContainer</item>
+    </style>
+
+    <style name="SliderModern" parent="Widget.Material3.Slider">
+        <item name="trackColorInactive">@color/modernSurfaceContainerHighest</item>
+    </style>
+
+    <style name="ModernPreferenceTheme" parent="@style/PreferenceTheme">
+        <item name="android:listPreferredItemHeightSmall">56dp</item>
+        <item name="android:listPreferredItemHeight">64dp</item>
+        <item name="preferenceCategoryTitleTextColor">@color/modernPrimary</item>
+    </style>
+
     <style name="BaseDarkThemeReducedPadding" parent="BaseDarkTheme">
         <item name="actionBarSize">42dp</item>
         <item name="toolbarStyle">@style/CompactToolbar</item>


### PR DESCRIPTION
## What changed
- Add a compact Modern Material 3 visual theme.
- Add a separate Modern AMOLED option with true-black base surfaces and near-black containers.
- Keep the theme choices available in both dynamic and non-dynamic theme selectors.
- Preserve the existing theme behavior when Material 3 is disabled.

## Verification
- Built with Docker: docker compose -f docker-compose.android.yml run --rm android-build :app:assembleDebug --no-daemon
- Installed and exercised on a connected Android device.
- Verified Modern AMOLED selection in Appearance > Theme and checked the settings/feed surfaces.
- Checked logcat for fatal exceptions.