### PR TITLE
Make sensible features default-on

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatFragment.kt
@@ -501,7 +501,7 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
                                 if (raid != null) {
                                     if (!viewModel.raidClosed) {
                                         if (raid.openStream) {
-                                            if (requireContext().prefs().getBoolean(C.CHAT_RAIDS_AUTO_SWITCH, true) && (parentFragment is Media3PlayerFragment || parentFragment is PlayerFragment)) {
+                                            if (requireContext().prefs().getBoolean(C.CHAT_RAIDS_AUTO_SWITCH, false) && (parentFragment is Media3PlayerFragment || parentFragment is PlayerFragment)) {
                                                 (requireActivity() as? MainActivity)?.startStream(
                                                     Stream(
                                                         channelId = raid.targetId,

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/main/MainActivity.kt
@@ -1412,5 +1412,18 @@ class MainActivity : AppCompatActivity() {
                 putInt(C.SETTINGS_VERSION, 13)
             }
         }
+        if (version < 14) {
+            prefs.edit {
+                when {
+                    prefs.contains(C.PLAYER_AVOID_ADS) && !prefs.contains(C.PLAYER_HIDE_ADS) -> {
+                        putBoolean(C.PLAYER_HIDE_ADS, prefs.getBoolean(C.PLAYER_AVOID_ADS, false))
+                    }
+                    !prefs.contains(C.PLAYER_AVOID_ADS) && prefs.contains(C.PLAYER_HIDE_ADS) -> {
+                        putBoolean(C.PLAYER_AVOID_ADS, prefs.getBoolean(C.PLAYER_HIDE_ADS, false))
+                    }
+                }
+                putInt(C.SETTINGS_VERSION, 14)
+            }
+        }
     }
 }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/main/MainActivity.kt
@@ -1273,8 +1273,8 @@ class MainActivity : AppCompatActivity() {
                     putString(C.PORTRAIT_COLUMN_COUNT, "2")
                     putString(C.LANDSCAPE_COLUMN_COUNT, "3")
                 }
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-                    putString(C.THEME, "4")
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && !prefs.contains(C.THEME)) {
+                    putString(C.THEME, C.THEME_MODERN)
                 }
             }
         }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/ExoPlayerService.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/ExoPlayerService.kt
@@ -77,6 +77,7 @@ import com.github.andreyasadchy.xtra.util.TwitchApiHelper
 import com.github.andreyasadchy.xtra.util.m3u8.PlaylistUtils
 import com.github.andreyasadchy.xtra.util.m3u8.TwitchAdDetector
 import com.github.andreyasadchy.xtra.util.prefs
+import com.github.andreyasadchy.xtra.util.shouldAvoidTwitchAds
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -240,8 +241,7 @@ class ExoPlayerService : BasePlaybackService() {
                         }
                     }
                     if (type == STREAM) {
-                        val avoidAds = prefs().getBoolean(C.PLAYER_AVOID_ADS, false)
-                                || prefs().getBoolean(C.PLAYER_HIDE_ADS, false)
+                        val avoidAds = prefs().shouldAvoidTwitchAds()
                         val suppressAds = avoidAds
                         val useProxy = prefs().getBoolean(C.PROXY_MEDIA_PLAYLIST, true)
                                 && !prefs().getString(C.PROXY_HOST, null).isNullOrBlank()

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/Media3Fragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/Media3Fragment.kt
@@ -47,6 +47,7 @@ import com.github.andreyasadchy.xtra.ui.main.MainActivity
 import com.github.andreyasadchy.xtra.util.C
 import com.github.andreyasadchy.xtra.util.getAlertDialogBuilder
 import com.github.andreyasadchy.xtra.util.prefs
+import com.github.andreyasadchy.xtra.util.shouldAvoidTwitchAds
 import com.google.common.util.concurrent.ListenableFuture
 import com.google.common.util.concurrent.MoreExecutors
 import kotlinx.coroutines.CancellationException
@@ -272,8 +273,7 @@ class Media3Fragment : Media3PlayerFragment() {
                         }
                     }
                     if (videoType == STREAM) {
-                        val avoidAds = requireContext().prefs().getBoolean(C.PLAYER_AVOID_ADS, false)
-                                || requireContext().prefs().getBoolean(C.PLAYER_HIDE_ADS, false)
+                        val avoidAds = requireContext().prefs().shouldAvoidTwitchAds()
                         val suppressAds = avoidAds
                         val useProxy = requireContext().prefs().getBoolean(C.PROXY_MEDIA_PLAYLIST, true)
                                 && !requireContext().prefs().getString(C.PROXY_HOST, null).isNullOrBlank()

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/ContextExtensions.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/ContextExtensions.kt
@@ -21,6 +21,17 @@ fun Context.prefs(): SharedPreferences = PreferenceManager.getDefaultSharedPrefe
 
 fun Context.tokenPrefs(): SharedPreferences = getSharedPreferences("prefs2", Context.MODE_PRIVATE)
 
+/**
+ * Enables ad handling for new installs while preserving an explicit opt-out
+ * from either of the legacy ad switches.
+ */
+fun SharedPreferences.shouldAvoidTwitchAds(): Boolean {
+    if (!contains(C.PLAYER_AVOID_ADS) && !contains(C.PLAYER_HIDE_ADS)) {
+        return true
+    }
+    return getBoolean(C.PLAYER_AVOID_ADS, false) || getBoolean(C.PLAYER_HIDE_ADS, false)
+}
+
 fun Activity.applyTheme() {
     // On Android 15, wrong language is used when multiple languages are set in device settings
     if (Build.VERSION.SDK_INT == Build.VERSION_CODES.VANILLA_ICE_CREAM) {
@@ -35,11 +46,11 @@ fun Activity.applyTheme() {
     }
     val theme = if (prefs().getBoolean(C.UI_THEME_FOLLOW_SYSTEM, false)) {
         when (resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK) {
-            Configuration.UI_MODE_NIGHT_YES -> prefs().getString(C.UI_THEME_DARK_ON, "0") ?: "0"
+            Configuration.UI_MODE_NIGHT_YES -> prefs().getString(C.UI_THEME_DARK_ON, C.THEME_MODERN) ?: C.THEME_MODERN
             else -> prefs().getString(C.UI_THEME_DARK_OFF, "2") ?: "2"
         }
     } else {
-        prefs().getString(C.THEME, "0") ?: "0"
+        prefs().getString(C.THEME, C.THEME_MODERN) ?: C.THEME_MODERN
     }
     val material3 = prefs().getBoolean(C.UI_THEME_MATERIAL3, true)
     if (material3 && (theme == C.THEME_MODERN || theme == C.THEME_MODERN_AMOLED)) {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/ContextExtensions.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/ContextExtensions.kt
@@ -26,10 +26,14 @@ fun Context.tokenPrefs(): SharedPreferences = getSharedPreferences("prefs2", Con
  * from either of the legacy ad switches.
  */
 fun SharedPreferences.shouldAvoidTwitchAds(): Boolean {
-    if (!contains(C.PLAYER_AVOID_ADS) && !contains(C.PLAYER_HIDE_ADS)) {
-        return true
+    val hasAvoidAds = contains(C.PLAYER_AVOID_ADS)
+    val hasHideAds = contains(C.PLAYER_HIDE_ADS)
+    return when {
+        !hasAvoidAds && !hasHideAds -> true
+        hasAvoidAds && !hasHideAds -> getBoolean(C.PLAYER_AVOID_ADS, false)
+        !hasAvoidAds && hasHideAds -> getBoolean(C.PLAYER_HIDE_ADS, false)
+        else -> getBoolean(C.PLAYER_AVOID_ADS, false) || getBoolean(C.PLAYER_HIDE_ADS, false)
     }
-    return getBoolean(C.PLAYER_AVOID_ADS, false) || getBoolean(C.PLAYER_HIDE_ADS, false)
 }
 
 fun Activity.applyTheme() {

--- a/app/src/main/res/xml/chat_preferences.xml
+++ b/app/src/main/res/xml/chat_preferences.xml
@@ -239,7 +239,7 @@
         app:singleLineTitle="false" />
 
     <SwitchPreferenceCompat
-        android:defaultValue="true"
+        android:defaultValue="false"
         android:key="chat_raids_auto_switch"
         android:title="@string/auto_switch_raids"
         app:iconSpaceReserved="false"

--- a/app/src/main/res/xml/playback_preferences.xml
+++ b/app/src/main/res/xml/playback_preferences.xml
@@ -208,7 +208,7 @@
         app:iconSpaceReserved="false" />
 
     <SwitchPreferenceCompat
-        android:defaultValue="false"
+        android:defaultValue="true"
         android:key="player_avoid_ads"
         android:summary="@string/avoid_twitch_ads_summary"
         android:title="@string/avoid_twitch_ads"
@@ -216,7 +216,7 @@
         app:singleLineTitle="false" />
 
     <SwitchPreferenceCompat
-        android:defaultValue="false"
+        android:defaultValue="true"
         android:key="player_hide_ads"
         android:title="@string/hide_during_ads"
         app:iconSpaceReserved="false"

--- a/app/src/main/res/xml/theme_preferences.xml
+++ b/app/src/main/res/xml/theme_preferences.xml
@@ -6,7 +6,7 @@
         app:iconSpaceReserved="false" />
 
     <ListPreference
-        android:defaultValue="0"
+        android:defaultValue="7"
         android:entries="@array/themeEntries"
         android:entryValues="@array/themeValues"
         android:key="theme"
@@ -23,7 +23,7 @@
         app:singleLineTitle="false" />
 
     <ListPreference
-        android:defaultValue="0"
+        android:defaultValue="7"
         android:entries="@array/themeEntries"
         android:entryValues="@array/themeValues"
         android:key="ui_theme_dark_on"


### PR DESCRIPTION
## Summary

- Make Modern the default theme while preserving explicit theme choices.
- Enable Twitch ad avoidance and ad hiding for first-run users.
- Keep channel-point features available by default and disable surprising automatic raid navigation.
- Preserve explicit ad and raid preferences through runtime fallbacks.

## Verification

- Docker: :app:assembleDebug --no-daemon passed.
- git diff --check passed.