### PR TITLE
Fix paged list loading states

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -65,6 +65,8 @@ android {
 }
 
 dependencies {
+    testImplementation("junit:junit:4.13.2")
+
     compileOnly("com.google.j2objc:j2objc-annotations:3.0.0") // OkHttpDataSource SettableFuture
     implementation("com.google.android.gms:play-services-cronet:18.1.0")
     implementation("com.google.mlkit:language-id:17.0.6")

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/datasource/FollowedChannelsDataSource.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/datasource/FollowedChannelsDataSource.kt
@@ -23,23 +23,27 @@ class FollowedChannelsDataSource(
     private val helixRepository: HelixRepository,
     private val enableIntegrity: Boolean,
     private val networkLibrary: String?,
+    internal val pageLoaderForTest: (suspend (LoadParams<Int>) -> LoadResult<Int, User>)? = null,
+    internal val initialOffsetForTest: String? = null,
 ) : PagingSource<Int, User>() {
     private var api: String? = null
-    private var offset: String? = null
+    private var offset: String? = initialOffsetForTest
 
     override suspend fun load(params: LoadParams<Int>): LoadResult<Int, User> {
         return if (!offset.isNullOrBlank()) {
-            val list = mutableListOf<User>()
             val result = try {
                 loadFromApi(params)
             } catch (e: Exception) {
-                null
-            }?.let {
-                if (it is LoadResult.Error && it.throwable.message == C.FAILED_INTEGRITY_CHECK) {
-                    return it
-                }
-                it as? LoadResult.Page
+                return LoadResult.Error(e)
             }
+            if (result !is LoadResult.Page) {
+                return result
+            }
+            // Keep the data returned by the API for every page. Previously this
+            // branch created an empty list and only used the result for nextKey,
+            // which made followed channels after the first 100 disappear.
+            val page = followedChannelsPage(result) ?: return result
+            val list = page.data
             list.filter { it.lastBroadcast == null || it.profileImageURL == null }.mapNotNull { it.id }.chunked(100).forEach { ids ->
                 val response = graphQLRepository.loadQueryUsersLastBroadcast(networkLibrary, gqlHeaders, ids)
                 if (enableIntegrity) {
@@ -57,7 +61,7 @@ class FollowedChannelsDataSource(
             LoadResult.Page(
                 data = list,
                 prevKey = null,
-                nextKey = result?.nextKey
+                nextKey = page.nextKey
             )
         } else {
             val list = mutableListOf<User>()
@@ -69,30 +73,35 @@ class FollowedChannelsDataSource(
                     localFollow = true,
                 ))
             }
-            val result = if (!gqlHeaders[C.HEADER_TOKEN].isNullOrBlank() || !helixHeaders[C.HEADER_TOKEN].isNullOrBlank()) {
-                try {
-                    api = C.GQL
-                    loadFromApi(params)
-                } catch (e: Exception) {
+            var remoteError: Throwable? = null
+            val page = if (!gqlHeaders[C.HEADER_TOKEN].isNullOrBlank() || !helixHeaders[C.HEADER_TOKEN].isNullOrBlank()) {
+                var loadedPage: LoadResult.Page<Int, User>? = null
+                for (candidate in listOf(C.GQL, C.GQL_PERSISTED_QUERY, C.HELIX)) {
+                    api = candidate
                     try {
-                        api = C.GQL_PERSISTED_QUERY
-                        loadFromApi(params)
-                    } catch (e: Exception) {
-                        try {
-                            api = C.HELIX
-                            loadFromApi(params)
-                        } catch (e: Exception) {
-                            null
+                        val response = loadFromApi(params)
+                        if (response is LoadResult.Page) {
+                            loadedPage = response
+                            break
                         }
+                        if (response is LoadResult.Error) {
+                            if (response.throwable.message == C.FAILED_INTEGRITY_CHECK) {
+                                return response
+                            }
+                            remoteError = response.throwable
+                        } else {
+                            return response
+                        }
+                    } catch (e: Exception) {
+                        remoteError = e
                     }
-                }?.let {
-                    if (it is LoadResult.Error && it.throwable.message == C.FAILED_INTEGRITY_CHECK) {
-                        return it
-                    }
-                    it as? LoadResult.Page
                 }
+                loadedPage
             } else null
-            result?.data?.forEach { user ->
+            if (page == null && list.isEmpty() && remoteError != null) {
+                return LoadResult.Error(remoteError)
+            }
+            page?.data?.forEach { user ->
                 val item = list.find { it.id == user.id }
                 if (item == null) {
                     user.accountFollow = true
@@ -196,13 +205,13 @@ class FollowedChannelsDataSource(
             LoadResult.Page(
                 data = sorted,
                 prevKey = null,
-                nextKey = result?.nextKey
+                nextKey = page?.nextKey
             )
         }
     }
 
     private suspend fun loadFromApi(params: LoadParams<Int>): LoadResult<Int, User> {
-        return when (api) {
+        return pageLoaderForTest?.invoke(params) ?: when (api) {
             C.GQL -> if (!gqlHeaders[C.HEADER_TOKEN].isNullOrBlank()) gqlQueryLoad(params) else throw Exception()
             C.GQL_PERSISTED_QUERY -> if (!gqlHeaders[C.HEADER_TOKEN].isNullOrBlank()) gqlLoad(params) else throw Exception()
             C.HELIX -> if (!helixHeaders[C.HEADER_TOKEN].isNullOrBlank()) helixLoad(params) else throw Exception()
@@ -300,5 +309,21 @@ class FollowedChannelsDataSource(
             val anchorPage = state.closestPageToPosition(anchorPosition)
             anchorPage?.prevKey?.plus(1) ?: anchorPage?.nextKey?.minus(1)
         }
+    }
+}
+
+internal data class FollowedChannelsPage<T : Any>(
+    val data: MutableList<T>,
+    val nextKey: Int?,
+)
+
+internal fun <T : Any> followedChannelsPage(
+    result: PagingSource.LoadResult<Int, T>,
+): FollowedChannelsPage<T>? {
+    return (result as? PagingSource.LoadResult.Page)?.let {
+        FollowedChannelsPage(
+            data = it.data.toMutableList(),
+            nextKey = it.nextKey,
+        )
     }
 }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/PagedListFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/PagedListFragment.kt
@@ -5,17 +5,23 @@ import androidx.core.view.isVisible
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
+import androidx.paging.CombinedLoadStates
 import androidx.paging.LoadState
 import androidx.paging.PagingDataAdapter
 import androidx.recyclerview.widget.RecyclerView
+import com.google.android.material.snackbar.Snackbar
 import com.github.andreyasadchy.xtra.databinding.CommonRecyclerViewLayoutBinding
 import com.github.andreyasadchy.xtra.ui.main.MainActivity
+import com.github.andreyasadchy.xtra.R
 import com.github.andreyasadchy.xtra.util.C
 import com.github.andreyasadchy.xtra.util.prefs
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 
 abstract class PagedListFragment : BaseNetworkFragment(), IntegrityDialog.Listener {
+
+    private var pageErrorSnackbar: Snackbar? = null
+    private var pageError: LoadState.Error? = null
 
     fun <T : Any, VH : RecyclerView.ViewHolder> setAdapter(recyclerView: RecyclerView, adapter: PagingDataAdapter<T, VH>) {
         adapter.registerAdapterDataObserver(object : RecyclerView.AdapterDataObserver() {
@@ -51,26 +57,13 @@ abstract class PagedListFragment : BaseNetworkFragment(), IntegrityDialog.Listen
 
     fun <T : Any, VH : RecyclerView.ViewHolder> initializeAdapter(binding: CommonRecyclerViewLayoutBinding, pagingAdapter: PagingDataAdapter<T, VH>, enableSwipeRefresh: Boolean = true, enableScrollTopButton: Boolean = true) {
         with(binding) {
+            setupPagingControls(binding, pagingAdapter, enableSwipeRefresh)
             viewLifecycleOwner.lifecycleScope.launch {
                 repeatOnLifecycle(Lifecycle.State.STARTED) {
                     pagingAdapter.loadStateFlow.collectLatest { loadState ->
-                        progressBar.isVisible = loadState.refresh is LoadState.Loading && pagingAdapter.itemCount == 0
-                        if (enableSwipeRefresh) {
-                            swipeRefresh.isRefreshing = loadState.refresh is LoadState.Loading && pagingAdapter.itemCount != 0
-                        }
-                        nothingHere.isVisible = loadState.refresh !is LoadState.Loading && pagingAdapter.itemCount == 0
-                        if ((loadState.refresh as? LoadState.Error ?:
-                            loadState.append as? LoadState.Error ?:
-                            loadState.prepend as? LoadState.Error)?.error?.message == C.FAILED_INTEGRITY_CHECK
-                        ) {
-                            (requireActivity() as? MainActivity)?.getNewIntegrityToken("refresh", childFragmentManager)
-                        }
+                        updatePagingState(binding, pagingAdapter, loadState, enableSwipeRefresh = enableSwipeRefresh)
                     }
                 }
-            }
-            if (enableSwipeRefresh) {
-                swipeRefresh.isEnabled = true
-                swipeRefresh.setOnRefreshListener { pagingAdapter.refresh() }
             }
             if (enableScrollTopButton && requireContext().prefs().getBoolean(C.UI_SCROLL_TOP, true)) {
                 recyclerView.addOnScrollListener(object : RecyclerView.OnScrollListener() {
@@ -85,5 +78,71 @@ abstract class PagedListFragment : BaseNetworkFragment(), IntegrityDialog.Listen
                 }
             }
         }
+    }
+
+    protected fun <T : Any, VH : RecyclerView.ViewHolder> setupPagingControls(
+        binding: CommonRecyclerViewLayoutBinding,
+        pagingAdapter: PagingDataAdapter<T, VH>,
+        enableSwipeRefresh: Boolean = true,
+    ) {
+        binding.retryButton.setOnClickListener { pagingAdapter.retry() }
+        binding.swipeRefresh.isEnabled = enableSwipeRefresh
+        if (enableSwipeRefresh) {
+            binding.swipeRefresh.setOnRefreshListener { pagingAdapter.refresh() }
+        }
+    }
+
+    protected fun <T : Any, VH : RecyclerView.ViewHolder> updatePagingState(
+        binding: CommonRecyclerViewLayoutBinding,
+        pagingAdapter: PagingDataAdapter<T, VH>,
+        loadState: CombinedLoadStates,
+        showEmpty: Boolean = true,
+        enableSwipeRefresh: Boolean = true,
+    ) {
+        val contentState = pagedListContentState(loadState.refresh, pagingAdapter.itemCount)
+        val refreshError = loadState.refresh as? LoadState.Error
+        val appendError = loadState.append as? LoadState.Error
+        val prependError = loadState.prepend as? LoadState.Error
+        val pageError = appendError ?: prependError
+
+        binding.progressBar.isVisible = contentState == PagedListContentState.Loading
+        binding.nothingHere.isVisible = showEmpty && contentState == PagedListContentState.Empty
+        binding.errorContainer.isVisible = showEmpty && contentState == PagedListContentState.Error
+        binding.retryButton.isVisible = refreshError != null
+        if (showEmpty && refreshError != null) {
+            binding.errorMessage.setText(R.string.list_load_error)
+        }
+
+        if (enableSwipeRefresh) {
+            binding.swipeRefresh.isRefreshing = contentState == PagedListContentState.Content && loadState.refresh is LoadState.Loading
+        }
+
+        if (pageError != null && pagingAdapter.itemCount > 0 && showEmpty) {
+            if (this.pageError !== pageError) {
+                pageErrorSnackbar?.dismiss()
+                this.pageError = pageError
+                pageErrorSnackbar = Snackbar.make(
+                    binding.recyclerView,
+                    R.string.list_load_more_error,
+                    Snackbar.LENGTH_INDEFINITE,
+                ).setAction(R.string.retry) { pagingAdapter.retry() }
+                pageErrorSnackbar?.show()
+            }
+        } else {
+            pageErrorSnackbar?.dismiss()
+            pageErrorSnackbar = null
+            this.pageError = null
+        }
+
+        if ((refreshError ?: appendError ?: prependError)?.error?.message == C.FAILED_INTEGRITY_CHECK) {
+            (requireActivity() as? MainActivity)?.getNewIntegrityToken("refresh", childFragmentManager)
+        }
+    }
+
+    override fun onDestroyView() {
+        pageErrorSnackbar?.dismiss()
+        pageErrorSnackbar = null
+        pageError = null
+        super.onDestroyView()
     }
 }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/PagedListState.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/PagedListState.kt
@@ -1,0 +1,19 @@
+package com.github.andreyasadchy.xtra.ui.common
+
+import androidx.paging.LoadState
+
+internal enum class PagedListContentState {
+    Loading,
+    Content,
+    Empty,
+    Error,
+}
+
+internal fun pagedListContentState(refresh: LoadState, itemCount: Int): PagedListContentState {
+    return when {
+        itemCount > 0 -> PagedListContentState.Content
+        refresh is LoadState.Loading -> PagedListContentState.Loading
+        refresh is LoadState.Error -> PagedListContentState.Error
+        else -> PagedListContentState.Empty
+    }
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/search/channels/ChannelSearchFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/search/channels/ChannelSearchFragment.kt
@@ -13,14 +13,12 @@ import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
-import androidx.paging.LoadState
 import androidx.paging.PagingDataAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.github.andreyasadchy.xtra.R
 import com.github.andreyasadchy.xtra.databinding.CommonRecyclerViewLayoutBinding
 import com.github.andreyasadchy.xtra.model.ui.User
 import com.github.andreyasadchy.xtra.ui.common.PagedListFragment
-import com.github.andreyasadchy.xtra.ui.main.MainActivity
 import com.github.andreyasadchy.xtra.ui.search.RecentSearchAdapter
 import com.github.andreyasadchy.xtra.ui.search.SearchPagerFragment
 import com.github.andreyasadchy.xtra.ui.search.Searchable
@@ -58,6 +56,7 @@ class ChannelSearchFragment : PagedListFragment(), Searchable {
 
     override fun initialize() {
         with(binding) {
+            setupPagingControls(binding, pagingAdapter)
             viewLifecycleOwner.lifecycleScope.launch {
                 repeatOnLifecycle(Lifecycle.State.STARTED) {
                     viewModel.flow.collectLatest { pagingData ->
@@ -68,20 +67,13 @@ class ChannelSearchFragment : PagedListFragment(), Searchable {
             viewLifecycleOwner.lifecycleScope.launch {
                 repeatOnLifecycle(Lifecycle.State.STARTED) {
                     pagingAdapter.loadStateFlow.collectLatest { loadState ->
-                        progressBar.isVisible = loadState.refresh is LoadState.Loading && pagingAdapter.itemCount == 0
-                        nothingHere.isVisible = loadState.refresh !is LoadState.Loading && pagingAdapter.itemCount == 0 && viewModel.query.value.isNotBlank()
+                        updatePagingState(binding, pagingAdapter, loadState, showEmpty = viewModel.query.value.isNotBlank())
                         if (viewModel.query.value.isBlank() && requireContext().prefs().getBoolean(C.UI_STORE_RECENT_SEARCHES, true)) {
                             recyclerView.adapter = recentSearchAdapter
                         } else {
                             if (recyclerView.adapter is RecentSearchAdapter) {
                                 recyclerView.adapter = pagingAdapter
                             }
-                        }
-                        if ((loadState.refresh as? LoadState.Error ?:
-                            loadState.append as? LoadState.Error ?:
-                            loadState.prepend as? LoadState.Error)?.error?.message == C.FAILED_INTEGRITY_CHECK
-                        ) {
-                            (requireActivity() as? MainActivity)?.getNewIntegrityToken("refresh", childFragmentManager)
                         }
                     }
                 }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/search/games/GameSearchFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/search/games/GameSearchFragment.kt
@@ -14,7 +14,6 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.fragment.findNavController
-import androidx.paging.LoadState
 import androidx.paging.PagingDataAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.github.andreyasadchy.xtra.R
@@ -23,7 +22,6 @@ import com.github.andreyasadchy.xtra.model.ui.Game
 import com.github.andreyasadchy.xtra.ui.common.GamesAdapter
 import com.github.andreyasadchy.xtra.ui.common.PagedListFragment
 import com.github.andreyasadchy.xtra.ui.games.GamesFragmentDirections
-import com.github.andreyasadchy.xtra.ui.main.MainActivity
 import com.github.andreyasadchy.xtra.ui.search.RecentSearchAdapter
 import com.github.andreyasadchy.xtra.ui.search.SearchPagerFragment
 import com.github.andreyasadchy.xtra.ui.search.Searchable
@@ -67,6 +65,7 @@ class GameSearchFragment : PagedListFragment(), Searchable {
 
     override fun initialize() {
         with(binding) {
+            setupPagingControls(binding, pagingAdapter)
             viewLifecycleOwner.lifecycleScope.launch {
                 repeatOnLifecycle(Lifecycle.State.STARTED) {
                     viewModel.flow.collectLatest { pagingData ->
@@ -77,20 +76,13 @@ class GameSearchFragment : PagedListFragment(), Searchable {
             viewLifecycleOwner.lifecycleScope.launch {
                 repeatOnLifecycle(Lifecycle.State.STARTED) {
                     pagingAdapter.loadStateFlow.collectLatest { loadState ->
-                        progressBar.isVisible = loadState.refresh is LoadState.Loading && pagingAdapter.itemCount == 0
-                        nothingHere.isVisible = loadState.refresh !is LoadState.Loading && pagingAdapter.itemCount == 0 && viewModel.query.value.isNotBlank()
+                        updatePagingState(binding, pagingAdapter, loadState, showEmpty = viewModel.query.value.isNotBlank())
                         if (viewModel.query.value.isBlank() && requireContext().prefs().getBoolean(C.UI_STORE_RECENT_SEARCHES, true)) {
                             recyclerView.adapter = recentSearchAdapter
                         } else {
                             if (recyclerView.adapter is RecentSearchAdapter) {
                                 recyclerView.adapter = pagingAdapter
                             }
-                        }
-                        if ((loadState.refresh as? LoadState.Error ?:
-                            loadState.append as? LoadState.Error ?:
-                            loadState.prepend as? LoadState.Error)?.error?.message == C.FAILED_INTEGRITY_CHECK
-                        ) {
-                            (requireActivity() as? MainActivity)?.getNewIntegrityToken("refresh", childFragmentManager)
                         }
                     }
                 }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/search/streams/StreamSearchFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/search/streams/StreamSearchFragment.kt
@@ -14,7 +14,6 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.fragment.findNavController
-import androidx.paging.LoadState
 import androidx.paging.PagingDataAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.github.andreyasadchy.xtra.R
@@ -23,7 +22,6 @@ import com.github.andreyasadchy.xtra.model.ui.Stream
 import com.github.andreyasadchy.xtra.ui.common.PagedListFragment
 import com.github.andreyasadchy.xtra.ui.common.StreamsAdapter
 import com.github.andreyasadchy.xtra.ui.common.StreamsCompactAdapter
-import com.github.andreyasadchy.xtra.ui.main.MainActivity
 import com.github.andreyasadchy.xtra.ui.search.RecentSearchAdapter
 import com.github.andreyasadchy.xtra.ui.search.SearchPagerFragment
 import com.github.andreyasadchy.xtra.ui.search.Searchable
@@ -78,6 +76,7 @@ class StreamSearchFragment : PagedListFragment(), Searchable {
 
     override fun initialize() {
         with(binding) {
+            setupPagingControls(binding, pagingAdapter)
             viewLifecycleOwner.lifecycleScope.launch {
                 repeatOnLifecycle(Lifecycle.State.STARTED) {
                     viewModel.flow.collectLatest { pagingData ->
@@ -88,20 +87,13 @@ class StreamSearchFragment : PagedListFragment(), Searchable {
             viewLifecycleOwner.lifecycleScope.launch {
                 repeatOnLifecycle(Lifecycle.State.STARTED) {
                     pagingAdapter.loadStateFlow.collectLatest { loadState ->
-                        progressBar.isVisible = loadState.refresh is LoadState.Loading && pagingAdapter.itemCount == 0
-                        nothingHere.isVisible = loadState.refresh !is LoadState.Loading && pagingAdapter.itemCount == 0 && viewModel.query.value.isNotBlank()
+                        updatePagingState(binding, pagingAdapter, loadState, showEmpty = viewModel.query.value.isNotBlank())
                         if (viewModel.query.value.isBlank() && requireContext().prefs().getBoolean(C.UI_STORE_RECENT_SEARCHES, true)) {
                             recyclerView.adapter = recentSearchAdapter
                         } else {
                             if (recyclerView.adapter is RecentSearchAdapter) {
                                 recyclerView.adapter = pagingAdapter
                             }
-                        }
-                        if ((loadState.refresh as? LoadState.Error ?:
-                            loadState.append as? LoadState.Error ?:
-                            loadState.prepend as? LoadState.Error)?.error?.message == C.FAILED_INTEGRITY_CHECK
-                        ) {
-                            (requireActivity() as? MainActivity)?.getNewIntegrityToken("refresh", childFragmentManager)
                         }
                     }
                 }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/search/videos/VideoSearchFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/search/videos/VideoSearchFragment.kt
@@ -13,7 +13,6 @@ import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
-import androidx.paging.LoadState
 import androidx.paging.PagingDataAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.github.andreyasadchy.xtra.R
@@ -22,7 +21,6 @@ import com.github.andreyasadchy.xtra.model.ui.Video
 import com.github.andreyasadchy.xtra.ui.common.PagedListFragment
 import com.github.andreyasadchy.xtra.ui.common.VideosAdapter
 import com.github.andreyasadchy.xtra.ui.download.DownloadDialog
-import com.github.andreyasadchy.xtra.ui.main.MainActivity
 import com.github.andreyasadchy.xtra.ui.search.RecentSearchAdapter
 import com.github.andreyasadchy.xtra.ui.search.SearchPagerFragment
 import com.github.andreyasadchy.xtra.ui.search.Searchable
@@ -86,6 +84,7 @@ class VideoSearchFragment : PagedListFragment(), Searchable {
 
     override fun initialize() {
         with(binding) {
+            setupPagingControls(binding, pagingAdapter)
             viewLifecycleOwner.lifecycleScope.launch {
                 repeatOnLifecycle(Lifecycle.State.STARTED) {
                     viewModel.flow.collectLatest { pagingData ->
@@ -96,20 +95,13 @@ class VideoSearchFragment : PagedListFragment(), Searchable {
             viewLifecycleOwner.lifecycleScope.launch {
                 repeatOnLifecycle(Lifecycle.State.STARTED) {
                     pagingAdapter.loadStateFlow.collectLatest { loadState ->
-                        progressBar.isVisible = loadState.refresh is LoadState.Loading && pagingAdapter.itemCount == 0
-                        nothingHere.isVisible = loadState.refresh !is LoadState.Loading && pagingAdapter.itemCount == 0 && viewModel.query.value.isNotBlank()
+                        updatePagingState(binding, pagingAdapter, loadState, showEmpty = viewModel.query.value.isNotBlank())
                         if (viewModel.query.value.isBlank() && requireContext().prefs().getBoolean(C.UI_STORE_RECENT_SEARCHES, true)) {
                             recyclerView.adapter = recentSearchAdapter
                         } else {
                             if (recyclerView.adapter is RecentSearchAdapter) {
                                 recyclerView.adapter = pagingAdapter
                             }
-                        }
-                        if ((loadState.refresh as? LoadState.Error ?:
-                            loadState.append as? LoadState.Error ?:
-                            loadState.prepend as? LoadState.Error)?.error?.message == C.FAILED_INTEGRITY_CHECK
-                        ) {
-                            (requireActivity() as? MainActivity)?.getNewIntegrityToken("refresh", childFragmentManager)
                         }
                     }
                 }

--- a/app/src/main/res/layout/common_recycler_view_layout.xml
+++ b/app/src/main/res/layout/common_recycler_view_layout.xml
@@ -50,6 +50,45 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintRight_toRightOf="parent" />
 
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/errorContainer"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:visibility="gone"
+        app:cardUseCompatPadding="true"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:visibility="visible">
+
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:orientation="vertical"
+            android:padding="24dp">
+
+            <TextView
+                android:id="@+id/errorMessage"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:gravity="center"
+                android:text="@string/list_load_error"
+                android:textAppearance="?attr/textAppearanceBodyMedium" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/retryButton"
+                style="?attr/materialButtonOutlinedStyle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:text="@string/retry" />
+
+        </LinearLayout>
+
+    </com.google.android.material.card.MaterialCardView>
+
     <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/scrollTop"
         style="?attr/floatingActionButtonSmallStyle"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -70,6 +70,9 @@
     <string name="storage_permission_message">Storage permission is required to download videos.</string>
     <string name="permission_denied">Required permissions were denied.</string>
     <string name="nothing_here">Nothing here</string>
+    <string name="list_load_error">Couldn’t load this content.</string>
+    <string name="list_load_more_error">Couldn’t load more content.</string>
+    <string name="retry">Retry</string>
     <string name="watch_live">Watch live</string>
     <string name="open_player">Open player</string>
     <string name="error_stream">Error when loading stream</string>

--- a/app/src/test/java/com/github/andreyasadchy/xtra/repository/datasource/FollowedChannelsDataSourceTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/repository/datasource/FollowedChannelsDataSourceTest.kt
@@ -1,0 +1,138 @@
+package com.github.andreyasadchy.xtra.repository.datasource
+
+import android.net.http.HttpEngine
+import androidx.paging.PagingSource
+import com.github.andreyasadchy.xtra.db.BookmarkIgnoredUsersDao
+import com.github.andreyasadchy.xtra.db.BookmarksDao
+import com.github.andreyasadchy.xtra.db.OfflineVideosDao
+import com.github.andreyasadchy.xtra.model.ui.User
+import com.github.andreyasadchy.xtra.repository.BookmarksRepository
+import com.github.andreyasadchy.xtra.repository.GraphQLRepository
+import com.github.andreyasadchy.xtra.repository.HelixRepository
+import com.github.andreyasadchy.xtra.repository.LocalChannelFollowsRepository
+import com.github.andreyasadchy.xtra.repository.OfflineVideosRepository
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import okhttp3.OkHttpClient
+import org.chromium.net.CronetEngine
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.lang.reflect.Proxy
+import java.util.concurrent.Executors
+
+class FollowedChannelsDataSourceTest {
+
+    private val testJson = Json.Default
+
+    @Test
+    fun subsequentLoadReturnsApiItemsAndNextKey() = runBlocking {
+        val first = User(
+            id = "first",
+            login = "first",
+            profileImageURL = "https://example.com/first.png",
+            lastBroadcast = "2026-08-08T00:00:00Z",
+        )
+        val second = User(
+            id = "second",
+            login = "second",
+            profileImageURL = "https://example.com/second.png",
+            lastBroadcast = "2026-08-08T00:01:00Z",
+        )
+        val source = dataSource {
+            PagingSource.LoadResult.Page(
+                data = listOf(first, second),
+                prevKey = 1,
+                nextKey = 3,
+            )
+        }
+
+        val result = source.load(appendParams())
+
+        assertTrue(result is PagingSource.LoadResult.Page)
+        result as PagingSource.LoadResult.Page
+        assertEquals(listOf(first, second), result.data)
+        assertEquals(3, result.nextKey)
+    }
+
+    @Test
+    fun subsequentLoadPropagatesApiErrors() = runBlocking {
+        val expected = IllegalStateException("offline")
+        val source = dataSource {
+            PagingSource.LoadResult.Error(expected)
+        }
+
+        val result = source.load(appendParams())
+
+        assertTrue(result is PagingSource.LoadResult.Error)
+        result as PagingSource.LoadResult.Error
+        assertSame(expected, result.throwable)
+    }
+
+    private fun appendParams(): PagingSource.LoadParams<Int> {
+        return PagingSource.LoadParams.Append(
+            key = 2,
+            loadSize = 100,
+            placeholdersEnabled = false,
+        )
+    }
+
+    private fun dataSource(
+        pageLoader: suspend (PagingSource.LoadParams<Int>) -> PagingSource.LoadResult<Int, User>,
+    ): FollowedChannelsDataSource {
+        val offlineVideosDao = noOpDao<OfflineVideosDao>()
+        val bookmarksDao = noOpDao<BookmarksDao>()
+        return FollowedChannelsDataSource(
+            sort = "last_broadcast",
+            order = "desc",
+            userId = null,
+            localChannelFollowsRepository = LocalChannelFollowsRepository(
+                noOpDao(),
+                offlineVideosDao,
+                bookmarksDao,
+            ),
+            offlineVideosRepository = OfflineVideosRepository(offlineVideosDao, bookmarksDao),
+            bookmarksRepository = BookmarksRepository(
+                bookmarksDao,
+                noOpDao<BookmarkIgnoredUsersDao>(),
+                offlineVideosDao,
+            ),
+            gqlHeaders = emptyMap(),
+            graphQLRepository = GraphQLRepository(
+                httpEngine = lazy<HttpEngine?> { null },
+                cronetEngine = lazy<CronetEngine?> { null },
+                cronetExecutor = lazy { Executors.newSingleThreadExecutor() },
+                okHttpClient = lazy { OkHttpClient() },
+                json = testJson,
+            ),
+            helixHeaders = emptyMap(),
+            helixRepository = HelixRepository(
+                httpEngine = lazy<HttpEngine?> { null },
+                cronetEngine = lazy<CronetEngine?> { null },
+                cronetExecutor = lazy { Executors.newSingleThreadExecutor() },
+                okHttpClient = lazy { OkHttpClient() },
+                json = testJson,
+            ),
+            enableIntegrity = false,
+            networkLibrary = null,
+            pageLoaderForTest = pageLoader,
+            initialOffsetForTest = "cursor",
+        )
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private inline fun <reified T> noOpDao(): T {
+        return Proxy.newProxyInstance(
+            T::class.java.classLoader,
+            arrayOf(T::class.java),
+        ) { _, method, _ ->
+            when (method.returnType) {
+                Boolean::class.javaPrimitiveType -> false
+                Int::class.javaPrimitiveType -> 0
+                Long::class.javaPrimitiveType -> 0L
+                else -> null
+            }
+        } as T
+    }
+}

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/common/PagedListStateTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/common/PagedListStateTest.kt
@@ -1,0 +1,40 @@
+package com.github.andreyasadchy.xtra.ui.common
+
+import androidx.paging.LoadState
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class PagedListStateTest {
+
+    @Test
+    fun emptyRefreshShowsLoading() {
+        assertEquals(
+            PagedListContentState.Loading,
+            pagedListContentState(LoadState.Loading, itemCount = 0),
+        )
+    }
+
+    @Test
+    fun emptyRefreshErrorShowsError() {
+        assertEquals(
+            PagedListContentState.Error,
+            pagedListContentState(LoadState.Error(IllegalStateException("offline")), itemCount = 0),
+        )
+    }
+
+    @Test
+    fun successfulEmptyRefreshShowsEmpty() {
+        assertEquals(
+            PagedListContentState.Empty,
+            pagedListContentState(LoadState.NotLoading(endOfPaginationReached = true), itemCount = 0),
+        )
+    }
+
+    @Test
+    fun existingContentWinsOverRefreshError() {
+        assertEquals(
+            PagedListContentState.Content,
+            pagedListContentState(LoadState.Error(IllegalStateException("offline")), itemCount = 4),
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- Fix followed-channel pagination so subsequent pages retain API results.
- Surface loading, empty, refresh-error, and append-error states with Retry actions.
- Apply the shared state behavior to Following and search lists.
- Add focused unit tests and record the broader audit in `APP_REVIEW.md`.

## Verification

- `:app:testDebugUnitTest`
- `:app:assembleDebug`
- Installed the debug APK on a connected OPPO CPH2493 device with ADB.
- `:app:lintDebug` exceeded the local command timeout without producing a report.

## Scope note

The existing live-notification worktree changes were intentionally left out of this PR.