### PR TITLE
Add optional two-stream multiview

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/StreamsAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/StreamsAdapter.kt
@@ -29,6 +29,7 @@ import com.github.andreyasadchy.xtra.ui.channel.ChannelPagerFragmentDirections
 import com.github.andreyasadchy.xtra.ui.game.GameMediaFragmentDirections
 import com.github.andreyasadchy.xtra.ui.game.GamePagerFragmentDirections
 import com.github.andreyasadchy.xtra.ui.main.MainActivity
+import com.github.andreyasadchy.xtra.ui.multiview.MultiviewFragment
 import com.github.andreyasadchy.xtra.util.C
 import com.github.andreyasadchy.xtra.util.TwitchApiHelper
 import com.github.andreyasadchy.xtra.util.prefs
@@ -81,6 +82,13 @@ class StreamsAdapter(
                     }
                     root.setOnClickListener {
                         (fragment.activity as MainActivity).startStream(item)
+                    }
+                    multiview.visibility = if (item.channelLogin.isNullOrBlank()) View.GONE else View.VISIBLE
+                    multiview.setOnClickListener {
+                        (fragment.activity as? MainActivity)?.let { activity ->
+                            if (activity.playerFragment != null) activity.closePlayer()
+                        }
+                        fragment.findNavController().navigate(R.id.multiviewFragment, MultiviewFragment.arguments(item))
                     }
                     if (item.channelImage != null) {
                         userImage.visibility = View.VISIBLE

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/StreamsCompactAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/StreamsCompactAdapter.kt
@@ -27,6 +27,8 @@ import com.github.andreyasadchy.xtra.ui.channel.ChannelPagerFragmentDirections
 import com.github.andreyasadchy.xtra.ui.game.GameMediaFragmentDirections
 import com.github.andreyasadchy.xtra.ui.game.GamePagerFragmentDirections
 import com.github.andreyasadchy.xtra.ui.main.MainActivity
+import com.github.andreyasadchy.xtra.ui.multiview.MultiviewFragment
+import com.github.andreyasadchy.xtra.R
 import com.github.andreyasadchy.xtra.util.C
 import com.github.andreyasadchy.xtra.util.TwitchApiHelper
 import com.github.andreyasadchy.xtra.util.prefs
@@ -79,6 +81,13 @@ class StreamsCompactAdapter(
                     }
                     root.setOnClickListener {
                         (fragment.activity as MainActivity).startStream(item)
+                    }
+                    multiview.visibility = if (item.channelLogin.isNullOrBlank()) View.GONE else View.VISIBLE
+                    multiview.setOnClickListener {
+                        (fragment.activity as? MainActivity)?.let { activity ->
+                            if (activity.playerFragment != null) activity.closePlayer()
+                        }
+                        fragment.findNavController().navigate(R.id.multiviewFragment, MultiviewFragment.arguments(item))
                     }
                     if (item.channelImage != null) {
                         userImage.visibility = View.VISIBLE

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/multiview/MultiviewFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/multiview/MultiviewFragment.kt
@@ -1,0 +1,549 @@
+package com.github.andreyasadchy.xtra.ui.multiview
+
+import android.content.res.ColorStateList
+import android.content.res.Configuration
+import android.graphics.Color
+import android.os.Build
+import android.os.Bundle
+import android.os.Parcelable
+import android.view.Gravity
+import android.view.View
+import android.view.ViewGroup
+import android.widget.FrameLayout
+import android.widget.ImageButton
+import android.widget.LinearLayout
+import android.widget.TextView
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.isVisible
+import androidx.core.view.updateLayoutParams
+import androidx.core.view.updatePadding
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.lifecycleScope
+import androidx.navigation.fragment.findNavController
+import androidx.media3.common.AudioAttributes
+import androidx.media3.common.MediaItem
+import androidx.media3.common.MediaMetadata
+import androidx.media3.common.MimeTypes
+import androidx.media3.common.PlaybackException
+import androidx.media3.common.Player
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.datasource.DataSource
+import androidx.media3.datasource.DefaultDataSource
+import androidx.media3.exoplayer.DefaultLoadControl
+import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.exoplayer.hls.HlsMediaSource
+import androidx.media3.ui.AspectRatioFrameLayout
+import androidx.media3.ui.PlayerView
+import com.github.andreyasadchy.xtra.R
+import com.github.andreyasadchy.xtra.XtraApp
+import com.github.andreyasadchy.xtra.databinding.FragmentMultiviewBinding
+import com.github.andreyasadchy.xtra.model.ui.Stream
+import com.github.andreyasadchy.xtra.ui.chat.ChatFragment
+import com.github.andreyasadchy.xtra.ui.main.MainActivity
+import com.github.andreyasadchy.xtra.ui.player.ExoPlayerService
+import com.github.andreyasadchy.xtra.player.lowlatency.CronetDataSource
+import com.github.andreyasadchy.xtra.player.lowlatency.HttpEngineDataSource
+import com.github.andreyasadchy.xtra.player.lowlatency.OkHttpDataSource
+import com.github.andreyasadchy.xtra.util.C
+import com.github.andreyasadchy.xtra.util.prefs
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import com.google.android.material.textfield.TextInputEditText
+import com.google.android.material.textfield.TextInputLayout
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+@UnstableApi
+class MultiviewFragment : Fragment(R.layout.fragment_multiview) {
+
+    private var _binding: FragmentMultiviewBinding? = null
+    private val binding get() = _binding!!
+    private val viewModel: MultiviewViewModel by viewModels { MultiviewViewModel.MultiviewViewModelFactory }
+
+    private lateinit var firstSlot: Slot
+    private lateinit var secondSlot: Slot
+    private var activeSlot = 0
+    private var chatSlot: Int? = null
+    private var previousNavBarVisibility = View.VISIBLE
+    private var wasPlaying = booleanArrayOf(false, false)
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        _binding = FragmentMultiviewBinding.bind(view)
+
+        val mainActivity = requireActivity() as? MainActivity
+        mainActivity?.findViewById<View>(R.id.navBarContainer)?.let {
+            previousNavBarVisibility = it.visibility
+            it.visibility = View.GONE
+        }
+
+        ViewCompat.setOnApplyWindowInsetsListener(binding.multiviewRoot) { root, insets ->
+            val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+            root.updatePadding(top = systemBars.top, bottom = systemBars.bottom)
+            insets
+        }
+
+        firstSlot = createSlot(binding.streamOneContainer, 0)
+        secondSlot = createSlot(binding.streamTwoContainer, 1)
+        configureGrid()
+
+        binding.addStreamButton.setOnClickListener { showAddStreamDialog() }
+        binding.chatButton.setOnClickListener { toggleChat() }
+        binding.closeButton.setOnClickListener { findNavController().navigateUp() }
+
+        val firstStream = savedInstanceState?.parcelable<Stream>(KEY_FIRST_STREAM)
+            ?: requireArguments().parcelable<Stream>(ARG_STREAM)
+        val secondStream = savedInstanceState?.parcelable<Stream>(KEY_SECOND_STREAM)
+        if (firstStream != null) {
+            startSlot(firstSlot, firstStream)
+        } else {
+            showSlotMessage(firstSlot, getString(R.string.multiview_stream_not_found), error = true)
+        }
+        if (secondStream != null) {
+            startSlot(secondSlot, secondStream)
+        } else {
+            resetSlot(secondSlot)
+        }
+        setActiveSlot(savedInstanceState?.getInt(KEY_ACTIVE_SLOT, 0) ?: 0)
+        updateToolbar()
+    }
+
+    override fun onStart() {
+        super.onStart()
+        firstSlotOrNull()?.player?.let { player ->
+            if (wasPlaying[0]) player.playWhenReady = true
+        }
+        secondSlotOrNull()?.player?.let { player ->
+            if (wasPlaying[1]) player.playWhenReady = true
+        }
+    }
+
+    override fun onStop() {
+        wasPlaying[0] = firstSlotOrNull()?.player?.playWhenReady == true
+        wasPlaying[1] = secondSlotOrNull()?.player?.playWhenReady == true
+        firstSlotOrNull()?.player?.playWhenReady = false
+        secondSlotOrNull()?.player?.playWhenReady = false
+        super.onStop()
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        firstSlotOrNull()?.stream?.let { outState.putParcelable(KEY_FIRST_STREAM, it) }
+        secondSlotOrNull()?.stream?.let { outState.putParcelable(KEY_SECOND_STREAM, it) }
+        outState.putInt(KEY_ACTIVE_SLOT, activeSlot)
+        super.onSaveInstanceState(outState)
+    }
+
+    override fun onDestroyView() {
+        firstSlotOrNull()?.release()
+        secondSlotOrNull()?.release()
+        childFragmentManager.findFragmentByTag(CHAT_TAG)?.let {
+            childFragmentManager.beginTransaction().remove(it).commitAllowingStateLoss()
+        }
+        requireActivity().findViewById<View>(R.id.navBarContainer)?.visibility = previousNavBarVisibility
+        _binding = null
+        super.onDestroyView()
+    }
+
+    private fun configureGrid() {
+        val landscape = resources.configuration.orientation == Configuration.ORIENTATION_LANDSCAPE
+        binding.videoGrid.orientation = if (landscape) LinearLayout.HORIZONTAL else LinearLayout.VERTICAL
+        firstSlotOrNull()?.container?.updateLayoutParams<LinearLayout.LayoutParams> {
+            width = if (landscape) 0 else ViewGroup.LayoutParams.MATCH_PARENT
+            height = if (landscape) ViewGroup.LayoutParams.MATCH_PARENT else 0
+            weight = 1f
+        }
+        secondSlotOrNull()?.container?.updateLayoutParams<LinearLayout.LayoutParams> {
+            width = if (landscape) 0 else ViewGroup.LayoutParams.MATCH_PARENT
+            height = if (landscape) ViewGroup.LayoutParams.MATCH_PARENT else 0
+            weight = 1f
+        }
+        binding.streamDivider.updateLayoutParams<LinearLayout.LayoutParams> {
+            width = if (landscape) 2 else ViewGroup.LayoutParams.MATCH_PARENT
+            height = if (landscape) ViewGroup.LayoutParams.MATCH_PARENT else 2
+            weight = 0f
+        }
+    }
+
+    private fun createSlot(container: FrameLayout, index: Int): Slot {
+        val playerView = PlayerView(requireContext()).apply {
+            useController = false
+            resizeMode = AspectRatioFrameLayout.RESIZE_MODE_FIT
+            setShutterBackgroundColor(Color.BLACK)
+            setKeepContentOnPlayerReset(true)
+        }
+        container.addView(playerView, FrameLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT))
+
+        val topBar = LinearLayout(requireContext()).apply {
+            gravity = Gravity.CENTER_VERTICAL
+            setBackgroundColor(Color.argb(165, 0, 0, 0))
+            setPadding(dp(8), dp(3), dp(3), dp(3))
+        }
+        val channel = TextView(requireContext()).apply {
+            layoutParams = LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f)
+            maxLines = 1
+            ellipsize = android.text.TextUtils.TruncateAt.END
+            setTextColor(Color.WHITE)
+            setTextAppearance(com.google.android.material.R.style.TextAppearance_Material3_BodyMedium)
+        }
+        topBar.addView(channel)
+        val audioButton = createOverlayButton(R.drawable.baseline_volume_off_black_24, R.string.multiview_audio_muted)
+        val chatButton = createOverlayButton(R.drawable.baseline_speaker_notes_black_24, R.string.multiview_chat)
+        val removeButton = createOverlayButton(R.drawable.baseline_close_black_36, R.string.multiview_remove_stream)
+        topBar.addView(audioButton)
+        topBar.addView(chatButton)
+        topBar.addView(removeButton)
+        container.addView(topBar, FrameLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT, Gravity.TOP))
+
+        lateinit var slot: Slot
+        val status = TextView(requireContext()).apply {
+            gravity = Gravity.CENTER
+            setTextColor(Color.WHITE)
+            setPadding(dp(16), dp(8), dp(16), dp(8))
+            setBackgroundColor(Color.argb(180, 0, 0, 0))
+            setOnClickListener { slot.stream?.let { startSlot(slot, it) } }
+        }
+        container.addView(status, FrameLayout.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT, Gravity.CENTER))
+
+        slot = Slot(index, container, playerView, channel, status, audioButton, chatButton, removeButton)
+        container.setOnClickListener { setActiveSlot(index) }
+        playerView.setOnClickListener { setActiveSlot(index) }
+        audioButton.setOnClickListener { setActiveSlot(index) }
+        chatButton.setOnClickListener {
+            setActiveSlot(index)
+            showChatForSlot(index)
+        }
+        removeButton.setOnClickListener { removeSecondStream() }
+        removeButton.isVisible = index == 1
+        audioButton.isVisible = index == 0
+        chatButton.isVisible = false
+        return slot
+    }
+
+    private fun createOverlayButton(icon: Int, description: Int): ImageButton {
+        return ImageButton(requireContext()).apply {
+            layoutParams = LinearLayout.LayoutParams(dp(40), dp(40))
+            setImageResource(icon)
+            imageTintList = ColorStateList.valueOf(Color.WHITE)
+            background = null
+            contentDescription = getString(description)
+        }
+    }
+
+    private fun startSlot(slot: Slot, stream: Stream) {
+        val channelLogin = stream.channelLogin?.trim()?.lowercase()
+        if (channelLogin.isNullOrBlank()) {
+            showSlotMessage(slot, getString(R.string.multiview_stream_not_found), error = true)
+            return
+        }
+        slot.loadJob?.cancel()
+        slot.player?.release()
+        slot.stream = stream
+        slot.channel.text = displayName(stream)
+        slot.audioButton.isVisible = true
+        slot.chatButton.isVisible = !requireContext().prefs().getBoolean(C.CHAT_DISABLE, false)
+        slot.removeButton.isVisible = slot.index == 1
+        showSlotMessage(slot, getString(R.string.multiview_loading), error = false)
+
+        val player = ExoPlayer.Builder(requireContext()).apply {
+            setLoadControl(
+                DefaultLoadControl.Builder().apply {
+                    setBufferDurationsMs(
+                        requireContext().prefs().getString(C.PLAYER_BUFFER_MIN, "15000")?.toIntOrNull() ?: 15000,
+                        requireContext().prefs().getString(C.PLAYER_BUFFER_MAX, "50000")?.toIntOrNull() ?: 50000,
+                        requireContext().prefs().getString(C.PLAYER_BUFFER_PLAYBACK, "2000")?.toIntOrNull() ?: 2000,
+                        requireContext().prefs().getString(C.PLAYER_BUFFER_REBUFFER, "2000")?.toIntOrNull() ?: 2000,
+                    )
+                }.build()
+            )
+            setAudioAttributes(AudioAttributes.DEFAULT, false)
+            setHandleAudioBecomingNoisy(true)
+        }.build()
+        slot.player = player
+        slot.playerView.player = player
+        player.addListener(object : Player.Listener {
+            override fun onPlaybackStateChanged(playbackState: Int) {
+                when (playbackState) {
+                    Player.STATE_READY -> showSlotMessage(slot, null, error = false)
+                    Player.STATE_BUFFERING -> showSlotMessage(slot, getString(R.string.multiview_loading), error = false)
+                    Player.STATE_IDLE, Player.STATE_ENDED -> Unit
+                }
+            }
+
+            override fun onPlayerError(error: PlaybackException) {
+                showSlotMessage(slot, getString(R.string.multiview_playback_error), error = true)
+            }
+        })
+
+        slot.loadJob = viewLifecycleOwner.lifecycleScope.launch {
+            try {
+                val playlistUrl = viewModel.loadStreamPlaylist(channelLogin)
+                if (slot.stream?.channelLogin?.lowercase() != channelLogin) return@launch
+                val mediaItem = MediaItem.Builder()
+                    .setUri(playlistUrl)
+                    .setMimeType(MimeTypes.APPLICATION_M3U8)
+                    .setLiveConfiguration(
+                        MediaItem.LiveConfiguration.Builder()
+                            .setTargetOffsetMs(requireContext().prefs().getString(C.PLAYER_LIVE_TARGET_OFFSET, "2000")?.toLongOrNull() ?: 2000L)
+                            .build()
+                    )
+                    .setMediaMetadata(
+                        MediaMetadata.Builder()
+                            .setTitle(stream.title)
+                            .setArtist(displayName(stream))
+                            .build()
+                    )
+                    .build()
+                val source = HlsMediaSource.Factory(createDataSourceFactory())
+                    .setPlaylistParserFactory(ExoPlayerService.CustomHlsPlaylistParserFactory())
+                    .createMediaSource(mediaItem)
+                player.setMediaSource(source)
+                player.prepare()
+                player.volume = if (slot.index == activeSlot) activeVolume() else 0f
+                player.playWhenReady = true
+                updateToolbar()
+            } catch (_: Exception) {
+                if (slot.stream?.channelLogin?.lowercase() == channelLogin) {
+                    showSlotMessage(slot, getString(R.string.multiview_playback_error), error = true)
+                }
+            }
+        }
+        updateToolbar()
+    }
+
+    private fun showSlotMessage(slot: Slot, message: String?, error: Boolean) {
+        slot.status.text = message
+        slot.status.isVisible = message != null
+        slot.status.isClickable = error
+    }
+
+    private fun resetSlot(slot: Slot) {
+        slot.loadJob?.cancel()
+        slot.loadJob = null
+        slot.playerView.player = null
+        slot.player?.release()
+        slot.player = null
+        slot.stream = null
+        slot.channel.text = null
+        slot.audioButton.isVisible = false
+        slot.chatButton.isVisible = false
+        slot.removeButton.isVisible = false
+        showSlotMessage(slot, getString(R.string.multiview_empty_slot), error = false)
+    }
+
+    private fun removeSecondStream() {
+        if (secondSlot.stream == null) return
+        if (chatSlot == 1) hideChat()
+        resetSlot(secondSlot)
+        setActiveSlot(0)
+        updateToolbar()
+    }
+
+    private fun setActiveSlot(index: Int) {
+        if (index !in 0..1 || (index == 1 && secondSlotOrNull()?.stream == null)) return
+        activeSlot = index
+        val volume = activeVolume()
+        firstSlotOrNull()?.let { slot ->
+            slot.player?.volume = if (slot.index == index) volume else 0f
+            updateAudioButton(slot)
+        }
+        secondSlotOrNull()?.let { slot ->
+            slot.player?.volume = if (slot.index == index) volume else 0f
+            updateAudioButton(slot)
+        }
+        if (binding.chatContainer.isVisible) showChatForSlot(index)
+        updateToolbar()
+    }
+
+    private fun updateAudioButton(slot: Slot) {
+        val isActive = slot.index == activeSlot
+        slot.audioButton.setImageResource(if (isActive) R.drawable.baseline_volume_up_black_24 else R.drawable.baseline_volume_off_black_24)
+        slot.audioButton.contentDescription = getString(
+            if (isActive) R.string.multiview_audio_active else R.string.multiview_audio_muted,
+            displayName(slot.stream),
+        )
+    }
+
+    private fun updateToolbar() {
+        val active = if (activeSlot == 0) firstSlotOrNull()?.stream else secondSlotOrNull()?.stream
+        binding.activeAudio.text = active?.let { getString(R.string.multiview_audio, displayName(it)) }
+        binding.addStreamButton.isVisible = secondSlotOrNull()?.stream == null
+        binding.chatButton.isVisible = active != null && !requireContext().prefs().getBoolean(C.CHAT_DISABLE, false)
+        binding.chatButton.text = getString(if (binding.chatContainer.isVisible) R.string.multiview_hide_chat else R.string.multiview_chat)
+        firstSlotOrNull()?.let(::updateAudioButton)
+        secondSlotOrNull()?.let(::updateAudioButton)
+    }
+
+    private fun toggleChat() {
+        if (binding.chatContainer.isVisible) hideChat() else showChatForSlot(activeSlot)
+    }
+
+    private fun showChatForSlot(index: Int) {
+        val stream = if (index == 0) firstSlotOrNull()?.stream else secondSlotOrNull()?.stream
+        if (stream?.channelLogin.isNullOrBlank()) return
+        chatSlot = index
+        binding.chatContainer.isVisible = true
+        childFragmentManager.beginTransaction()
+            .replace(
+                R.id.chatContainer,
+                ChatFragment.newInstance(stream.channelId, stream.channelLogin, displayName(stream), stream.id),
+                CHAT_TAG,
+            )
+            .commit()
+        updateToolbar()
+    }
+
+    private fun hideChat() {
+        binding.chatContainer.isVisible = false
+        chatSlot = null
+        childFragmentManager.findFragmentByTag(CHAT_TAG)?.let {
+            childFragmentManager.beginTransaction().remove(it).commit()
+        }
+        updateToolbar()
+    }
+
+    private fun showAddStreamDialog() {
+        val input = TextInputEditText(requireContext()).apply {
+            hint = getString(R.string.multiview_channel_hint)
+            setSingleLine(true)
+        }
+        val inputLayout = TextInputLayout(requireContext()).apply {
+            hint = getString(R.string.multiview_channel_hint)
+            addView(input)
+        }
+        val dialog = MaterialAlertDialogBuilder(requireContext())
+            .setTitle(R.string.multiview_add_stream_title)
+            .setMessage(R.string.multiview_add_stream_description)
+            .setView(inputLayout)
+            .setNegativeButton(android.R.string.cancel, null)
+            .setPositiveButton(R.string.multiview_add_stream, null)
+            .create()
+        dialog.setOnShowListener {
+            dialog.getButton(android.app.AlertDialog.BUTTON_POSITIVE).setOnClickListener {
+                val login = input.text?.toString()?.trim()?.removePrefix("@")?.lowercase().orEmpty()
+                if (login.isBlank()) {
+                    inputLayout.error = getString(R.string.multiview_add_stream_empty)
+                    return@setOnClickListener
+                }
+                if (login == firstSlotOrNull()?.stream?.channelLogin?.lowercase()) {
+                    inputLayout.error = getString(R.string.multiview_stream_not_found)
+                    return@setOnClickListener
+                }
+                inputLayout.error = null
+                dialog.getButton(android.app.AlertDialog.BUTTON_POSITIVE).isEnabled = false
+                lifecycleScope.launch {
+                    val stream = viewModel.resolveLiveStream(login)
+                    if (stream == null) {
+                        inputLayout.error = getString(R.string.multiview_stream_not_found)
+                        dialog.getButton(android.app.AlertDialog.BUTTON_POSITIVE).isEnabled = true
+                    } else {
+                        dialog.dismiss()
+                        startSlot(secondSlot, stream)
+                        setActiveSlot(activeSlot)
+                        updateToolbar()
+                    }
+                }
+            }
+        }
+        dialog.show()
+        input.requestFocus()
+        dialog.window?.setSoftInputMode(android.view.WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_VISIBLE)
+        input.post {
+            (requireContext().getSystemService(android.content.Context.INPUT_METHOD_SERVICE) as? android.view.inputmethod.InputMethodManager)
+                ?.showSoftInput(input, 0)
+        }
+    }
+
+    private fun displayName(stream: Stream?): String {
+        return stream?.channelName?.takeIf { it.isNotBlank() }
+            ?: stream?.channelLogin
+            ?: getString(R.string.multiview)
+    }
+
+    private fun activeVolume(): Float {
+        return (requireContext().prefs().getInt(C.PLAYER_VOLUME, 100) / 100f).coerceIn(0f, 1f)
+    }
+
+    @Suppress("NewApi")
+    private fun createDataSourceFactory(): DataSource.Factory {
+        val application = requireContext().applicationContext as XtraApp
+        val module = application.xtraModule
+        val preferences = requireContext().prefs()
+        val networkLibrary = preferences.getString(C.NETWORK_LIBRARY, C.OKHTTP)
+        val upstream = when {
+            networkLibrary == C.HTTP_ENGINE && module.httpEngine.value != null -> {
+                HttpEngineDataSource.Factory(
+                    module.httpEngine.value,
+                    module.cronetExecutor.value,
+                    false,
+                    false,
+                    null,
+                    null,
+                    null,
+                ) { false }
+            }
+            networkLibrary == C.CRONET && module.cronetEngine.value != null -> {
+                CronetDataSource.Factory(
+                    module.cronetEngine.value,
+                    module.cronetExecutor.value,
+                    false,
+                    false,
+                    null,
+                    null,
+                    null,
+                ) { false }
+            }
+            else -> OkHttpDataSource.Factory(module.okHttpClient.value, null) { false }
+        }
+        return DefaultDataSource.Factory(requireContext(), upstream)
+    }
+
+    private fun dp(value: Int): Int = (value * resources.displayMetrics.density).toInt()
+
+    private fun firstSlotOrNull(): Slot? = if (::firstSlot.isInitialized) firstSlot else null
+
+    private fun secondSlotOrNull(): Slot? = if (::secondSlot.isInitialized) secondSlot else null
+
+    private class Slot(
+        val index: Int,
+        val container: FrameLayout,
+        val playerView: PlayerView,
+        val channel: TextView,
+        val status: TextView,
+        val audioButton: ImageButton,
+        val chatButton: ImageButton,
+        val removeButton: ImageButton,
+    ) {
+        var stream: Stream? = null
+        var player: ExoPlayer? = null
+        var loadJob: Job? = null
+
+        fun release() {
+            loadJob?.cancel()
+            loadJob = null
+            playerView.player = null
+            player?.release()
+            player = null
+        }
+    }
+
+    companion object {
+        const val ARG_STREAM = "multiview_stream"
+        private const val KEY_FIRST_STREAM = "multiview_first_stream"
+        private const val KEY_SECOND_STREAM = "multiview_second_stream"
+        private const val KEY_ACTIVE_SLOT = "multiview_active_slot"
+        private const val CHAT_TAG = "multiview_chat"
+
+        fun arguments(stream: Stream): Bundle = Bundle().apply {
+            putParcelable(ARG_STREAM, stream)
+        }
+    }
+}
+
+private inline fun <reified T : Parcelable> Bundle.parcelable(key: String): T? {
+    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        getParcelable(key, T::class.java)
+    } else {
+        @Suppress("DEPRECATION")
+        getParcelable(key)
+    }
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/multiview/MultiviewFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/multiview/MultiviewFragment.kt
@@ -13,6 +13,7 @@ import android.widget.FrameLayout
 import android.widget.ImageButton
 import android.widget.LinearLayout
 import android.widget.TextView
+import androidx.annotation.OptIn
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.isVisible
@@ -53,7 +54,7 @@ import com.google.android.material.textfield.TextInputEditText
 import com.google.android.material.textfield.TextInputLayout
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
-@UnstableApi
+@OptIn(UnstableApi::class)
 class MultiviewFragment : Fragment(R.layout.fragment_multiview) {
 
     private var _binding: FragmentMultiviewBinding? = null

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/multiview/MultiviewViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/multiview/MultiviewViewModel.kt
@@ -1,0 +1,118 @@
+package com.github.andreyasadchy.xtra.ui.multiview
+
+import android.content.Context
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider.AndroidViewModelFactory.Companion.APPLICATION_KEY
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
+import com.github.andreyasadchy.xtra.XtraApp
+import com.github.andreyasadchy.xtra.model.ui.Stream
+import com.github.andreyasadchy.xtra.repository.GraphQLRepository
+import com.github.andreyasadchy.xtra.repository.HelixRepository
+import com.github.andreyasadchy.xtra.repository.PlayerRepository
+import com.github.andreyasadchy.xtra.util.C
+import com.github.andreyasadchy.xtra.util.TwitchApiHelper
+import com.github.andreyasadchy.xtra.util.prefs
+
+class MultiviewViewModel(
+    private val applicationContext: Context,
+    private val graphQLRepository: GraphQLRepository,
+    private val helixRepository: HelixRepository,
+    private val playerRepository: PlayerRepository,
+) : ViewModel() {
+
+    suspend fun resolveLiveStream(channelLogin: String): Stream? {
+        val preferences = applicationContext.prefs()
+        val networkLibrary = preferences.getString(C.NETWORK_LIBRARY, C.OKHTTP)
+        val gqlHeaders = TwitchApiHelper.getGQLHeaders(applicationContext, true)
+        val helixHeaders = TwitchApiHelper.getHelixHeaders(applicationContext)
+
+        try {
+            graphQLRepository.loadQueryUsersStream(
+                networkLibrary = networkLibrary,
+                headers = gqlHeaders,
+                logins = listOf(channelLogin),
+            ).data?.users?.firstOrNull()?.let { user ->
+                user.stream?.let { stream ->
+                    return Stream(
+                        id = stream.id,
+                        channelId = user.id,
+                        channelLogin = user.login,
+                        channelName = user.displayName,
+                        channelImageURL = user.profileImageURL,
+                        gameId = stream.game?.id,
+                        gameSlug = stream.game?.slug,
+                        gameName = stream.game?.displayName,
+                        title = stream.broadcaster?.broadcastSettings?.title,
+                        thumbnailURL = stream.previewImageURL,
+                        createdAt = stream.createdAt?.toString(),
+                        viewerCount = stream.viewersCount,
+                        tags = stream.freeformTags?.mapNotNull { tag -> tag.name },
+                    )
+                }
+            }
+        } catch (_: Exception) {
+            // Helix below is a useful fallback when the persisted GraphQL query is unavailable.
+        }
+
+        return runCatching {
+            helixRepository.getStreams(
+                networkLibrary = networkLibrary,
+                headers = helixHeaders,
+                logins = listOf(channelLogin),
+            ).data.firstOrNull()?.let { stream ->
+                Stream(
+                    id = stream.id,
+                    channelId = stream.channelId,
+                    channelLogin = stream.channelLogin,
+                    channelName = stream.channelName,
+                    gameId = stream.gameId,
+                    gameName = stream.gameName,
+                    title = stream.title,
+                    thumbnailURL = stream.thumbnailURL,
+                    createdAt = stream.startedAt,
+                    viewerCount = stream.viewerCount,
+                    tags = stream.tags,
+                )
+            }
+        }.getOrNull()
+    }
+
+    suspend fun loadStreamPlaylist(channelLogin: String): String {
+        val preferences = applicationContext.prefs()
+        return playerRepository.loadStreamPlaylistUrl(
+            context = applicationContext,
+            networkLibrary = preferences.getString(C.NETWORK_LIBRARY, C.OKHTTP),
+            gqlHeaders = TwitchApiHelper.getGQLHeaders(
+                applicationContext,
+                preferences.getBoolean(C.TOKEN_INCLUDE_TOKEN_STREAM, true),
+            ),
+            channelLogin = channelLogin,
+            randomDeviceId = preferences.getBoolean(C.TOKEN_RANDOM_DEVICE_ID, true),
+            xDeviceId = preferences.getString(C.TOKEN_X_DEVICE_ID, "twitch-web-wall-mason"),
+            playerType = preferences.getString(C.TOKEN_PLAYER_TYPE, "site"),
+            supportedCodecs = preferences.getString(C.TOKEN_SUPPORTED_CODECS, "av1,h265,h264"),
+            proxyPlaybackAccessToken = preferences.getBoolean(C.PROXY_PLAYBACK_ACCESS_TOKEN, false),
+            proxyHost = preferences.getString(C.PROXY_HOST, null),
+            proxyPort = preferences.getString(C.PROXY_PORT, null)?.toIntOrNull(),
+            proxyUser = preferences.getString(C.PROXY_USER, null),
+            proxyPassword = preferences.getString(C.PROXY_PASSWORD, null),
+            enableIntegrity = preferences.getBoolean(C.ENABLE_INTEGRITY, false),
+        )
+    }
+
+    companion object {
+        val MultiviewViewModelFactory = viewModelFactory {
+            initializer {
+                val application = this[APPLICATION_KEY] as XtraApp
+                val xtraModule = application.xtraModule
+                MultiviewViewModel(
+                    application.applicationContext,
+                    xtraModule.graphQLRepository,
+                    xtraModule.helixRepository,
+                    xtraModule.playerRepository,
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/res/layout/fragment_multiview.xml
+++ b/app/src/main/res/layout/fragment_multiview.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/multiviewRoot"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@android:color/black"
+    android:orientation="vertical">
+
+    <LinearLayout
+        android:id="@+id/videoGrid"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:orientation="vertical">
+
+        <FrameLayout
+            android:id="@+id/streamOneContainer"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            android:background="@android:color/black" />
+
+        <View
+            android:id="@+id/streamDivider"
+            android:layout_width="match_parent"
+            android:layout_height="2dp"
+            android:background="?attr/colorOutline" />
+
+        <FrameLayout
+            android:id="@+id/streamTwoContainer"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            android:background="@android:color/black" />
+
+    </LinearLayout>
+
+    <FrameLayout
+        android:id="@+id/chatContainer"
+        android:layout_width="match_parent"
+        android:layout_height="260dp"
+        android:background="?android:colorBackground"
+        android:visibility="gone" />
+
+    <LinearLayout
+        android:id="@+id/multiviewToolbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="?android:colorBackground"
+        android:gravity="center_vertical"
+        android:minHeight="56dp"
+        android:orientation="horizontal"
+        android:paddingStart="8dp"
+        android:paddingTop="4dp"
+        android:paddingEnd="8dp"
+        android:paddingBottom="4dp">
+
+        <TextView
+            android:id="@+id/activeAudio"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:ellipsize="end"
+            android:maxLines="1"
+            android:textAppearance="?attr/textAppearanceBodyMedium"
+            android:textColor="?android:attr/textColorSecondary"
+            tools:text="Audio: channel" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/chatButton"
+            style="?attr/elevatedButtonStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/multiview_chat" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/addStreamButton"
+            style="?attr/materialButtonOutlinedStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="4dp"
+            android:text="@string/multiview_add_stream" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/closeButton"
+            style="?attr/elevatedButtonStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/multiview_close" />
+
+    </LinearLayout>
+</LinearLayout>

--- a/app/src/main/res/layout/fragment_streams_list_item.xml
+++ b/app/src/main/res/layout/fragment_streams_list_item.xml
@@ -47,6 +47,21 @@
                 tools:text="8:21:33 uptime"
                 tools:visibility="visible" />
 
+            <ImageButton
+                android:id="@+id/multiview"
+                android:layout_width="40dp"
+                android:layout_height="40dp"
+                android:layout_marginTop="5dp"
+                android:layout_marginEnd="5dp"
+                android:background="?android:selectableItemBackgroundBorderless"
+                android:contentDescription="@string/watch_in_multiview"
+                android:src="@drawable/baseline_aspect_ratio_black_24"
+                android:visibility="gone"
+                app:tint="@android:color/white"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                tools:visibility="visible" />
+
             <ImageView
                 android:id="@+id/userImage"
                 style="@style/UserPicture"

--- a/app/src/main/res/layout/fragment_streams_list_item_compact.xml
+++ b/app/src/main/res/layout/fragment_streams_list_item_compact.xml
@@ -111,6 +111,17 @@
                     android:visibility="gone"
                     tools:text="8:21:33"
                     tools:visibility="visible" />
+
+                <ImageButton
+                    android:id="@+id/multiview"
+                    android:layout_width="40dp"
+                    android:layout_height="40dp"
+                    android:background="?android:selectableItemBackgroundBorderless"
+                    android:contentDescription="@string/watch_in_multiview"
+                    android:src="@drawable/baseline_aspect_ratio_black_24"
+                    android:visibility="gone"
+                    app:tint="?attr/colorControlNormal"
+                    tools:visibility="visible" />
             </LinearLayout>
 
         </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -204,4 +204,8 @@
     <action
         android:id="@+id/action_global_teamFragment"
         app:destination="@id/teamFragment" />
+
+    <fragment
+        android:id="@+id/multiviewFragment"
+        android:name="com.github.andreyasadchy.xtra.ui.multiview.MultiviewFragment" />
 </navigation>

--- a/app/src/main/res/values-ar/multiview_strings.xml
+++ b/app/src/main/res/values-ar/multiview_strings.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="watch_in_multiview">مشاهدة في العرض المتعدد</string>
+    <string name="multiview">عرض متعدد</string>
+    <string name="multiview_add_stream">إضافة بث</string>
+    <string name="multiview_add_stream_title">إضافة بث ثانٍ</string>
+    <string name="multiview_channel_hint">اسم القناة</string>
+    <string name="multiview_add_stream_description">أدخل اسم قناة مباشرة لإضافتها بجانب البث الحالي.</string>
+    <string name="multiview_add_stream_empty">أدخل اسم قناة.</string>
+    <string name="multiview_stream_not_found">القناة غير متصلة أو تعذر العثور عليها.</string>
+    <string name="multiview_loading">جارٍ تحميل البث…</string>
+    <string name="multiview_playback_error">فشل التشغيل. اضغط لإعادة المحاولة.</string>
+    <string name="multiview_audio">الصوت: %s</string>
+    <string name="multiview_chat">الدردشة</string>
+    <string name="multiview_hide_chat">إخفاء الدردشة</string>
+    <string name="multiview_empty_slot">أضف بثًا ثانيًا للمقارنة.</string>
+    <string name="multiview_close">تم</string>
+    <string name="multiview_remove_stream">إزالة البث</string>
+    <string name="multiview_audio_active">الصوت نشط لـ %s</string>
+    <string name="multiview_audio_muted">الصوت مكتوم لـ %s</string>
+</resources>

--- a/app/src/main/res/values-de/multiview_strings.xml
+++ b/app/src/main/res/values-de/multiview_strings.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="watch_in_multiview">In Multiview ansehen</string>
+    <string name="multiview">Multiview</string>
+    <string name="multiview_add_stream">Stream hinzufügen</string>
+    <string name="multiview_add_stream_title">Zweiten Stream hinzufügen</string>
+    <string name="multiview_channel_hint">Kanalname</string>
+    <string name="multiview_add_stream_description">Gib den Namen eines Live-Kanals ein, um ihn neben dem aktuellen Stream hinzuzufügen.</string>
+    <string name="multiview_add_stream_empty">Gib einen Kanalnamen ein.</string>
+    <string name="multiview_stream_not_found">Dieser Kanal ist offline oder wurde nicht gefunden.</string>
+    <string name="multiview_loading">Stream wird geladen…</string>
+    <string name="multiview_playback_error">Wiedergabe fehlgeschlagen. Zum erneuten Versuch tippen.</string>
+    <string name="multiview_audio">Audio: %s</string>
+    <string name="multiview_chat">Chat</string>
+    <string name="multiview_hide_chat">Chat ausblenden</string>
+    <string name="multiview_empty_slot">Füge einen zweiten Stream zum Vergleichen hinzu.</string>
+    <string name="multiview_close">Fertig</string>
+    <string name="multiview_remove_stream">Stream entfernen</string>
+    <string name="multiview_audio_active">Audio aktiv für %s</string>
+    <string name="multiview_audio_muted">Audio stummgeschaltet für %s</string>
+</resources>

--- a/app/src/main/res/values-es/multiview_strings.xml
+++ b/app/src/main/res/values-es/multiview_strings.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="watch_in_multiview">Ver en multivista</string>
+    <string name="multiview">Multivista</string>
+    <string name="multiview_add_stream">Añadir stream</string>
+    <string name="multiview_add_stream_title">Añadir un segundo stream</string>
+    <string name="multiview_channel_hint">Nombre del canal</string>
+    <string name="multiview_add_stream_description">Introduce el nombre de un canal en directo para añadirlo junto al stream actual.</string>
+    <string name="multiview_add_stream_empty">Introduce un nombre de canal.</string>
+    <string name="multiview_stream_not_found">Ese canal está desconectado o no se ha encontrado.</string>
+    <string name="multiview_loading">Cargando stream…</string>
+    <string name="multiview_playback_error">Error de reproducción. Toca para reintentar.</string>
+    <string name="multiview_audio">Audio: %s</string>
+    <string name="multiview_chat">Chat</string>
+    <string name="multiview_hide_chat">Ocultar chat</string>
+    <string name="multiview_empty_slot">Añade un segundo stream para compararlos.</string>
+    <string name="multiview_close">Listo</string>
+    <string name="multiview_remove_stream">Quitar stream</string>
+    <string name="multiview_audio_active">Audio activo para %s</string>
+    <string name="multiview_audio_muted">Audio silenciado para %s</string>
+</resources>

--- a/app/src/main/res/values-fr/multiview_strings.xml
+++ b/app/src/main/res/values-fr/multiview_strings.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="watch_in_multiview">Regarder en multivue</string>
+    <string name="multiview">Multivue</string>
+    <string name="multiview_add_stream">Ajouter un stream</string>
+    <string name="multiview_add_stream_title">Ajouter un deuxième stream</string>
+    <string name="multiview_channel_hint">Nom de la chaîne</string>
+    <string name="multiview_add_stream_description">Saisissez le nom d’une chaîne en direct pour l’ajouter à côté du stream actuel.</string>
+    <string name="multiview_add_stream_empty">Saisissez un nom de chaîne.</string>
+    <string name="multiview_stream_not_found">Cette chaîne est hors ligne ou introuvable.</string>
+    <string name="multiview_loading">Chargement du stream…</string>
+    <string name="multiview_playback_error">Échec de la lecture. Appuyez pour réessayer.</string>
+    <string name="multiview_audio">Audio : %s</string>
+    <string name="multiview_chat">Chat</string>
+    <string name="multiview_hide_chat">Masquer le chat</string>
+    <string name="multiview_empty_slot">Ajoutez un deuxième stream pour les comparer.</string>
+    <string name="multiview_close">Terminé</string>
+    <string name="multiview_remove_stream">Supprimer le stream</string>
+    <string name="multiview_audio_active">Audio actif pour %s</string>
+    <string name="multiview_audio_muted">Audio désactivé pour %s</string>
+</resources>

--- a/app/src/main/res/values-gl/multiview_strings.xml
+++ b/app/src/main/res/values-gl/multiview_strings.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="watch_in_multiview">Ver en multivista</string>
+    <string name="multiview">Multivista</string>
+    <string name="multiview_add_stream">Engadir emisión</string>
+    <string name="multiview_add_stream_title">Engadir unha segunda emisión</string>
+    <string name="multiview_channel_hint">Nome da canle</string>
+    <string name="multiview_add_stream_description">Introduce o nome dunha canle en directo para engadila xunto á emisión actual.</string>
+    <string name="multiview_add_stream_empty">Introduce un nome de canle.</string>
+    <string name="multiview_stream_not_found">Esta canle está fóra de liña ou non se atopou.</string>
+    <string name="multiview_loading">Cargando emisión…</string>
+    <string name="multiview_playback_error">Produciuse un erro na reprodución. Toca para volver tentalo.</string>
+    <string name="multiview_audio">Audio: %s</string>
+    <string name="multiview_chat">Chat</string>
+    <string name="multiview_hide_chat">Ocultar chat</string>
+    <string name="multiview_empty_slot">Engade unha segunda emisión para comparalas.</string>
+    <string name="multiview_close">Feito</string>
+    <string name="multiview_remove_stream">Eliminar emisión</string>
+    <string name="multiview_audio_active">Audio activo para %s</string>
+    <string name="multiview_audio_muted">Audio silenciado para %s</string>
+</resources>

--- a/app/src/main/res/values-in/multiview_strings.xml
+++ b/app/src/main/res/values-in/multiview_strings.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="watch_in_multiview">Tonton dalam multiview</string>
+    <string name="multiview">Multiview</string>
+    <string name="multiview_add_stream">Tambah streaming</string>
+    <string name="multiview_add_stream_title">Tambahkan streaming kedua</string>
+    <string name="multiview_channel_hint">Nama kanal</string>
+    <string name="multiview_add_stream_description">Masukkan nama kanal live untuk menambahkannya di samping streaming saat ini.</string>
+    <string name="multiview_add_stream_empty">Masukkan nama kanal.</string>
+    <string name="multiview_stream_not_found">Kanal tersebut offline atau tidak ditemukan.</string>
+    <string name="multiview_loading">Memuat streaming…</string>
+    <string name="multiview_playback_error">Pemutaran gagal. Ketuk untuk mencoba lagi.</string>
+    <string name="multiview_audio">Audio: %s</string>
+    <string name="multiview_chat">Chat</string>
+    <string name="multiview_hide_chat">Sembunyikan chat</string>
+    <string name="multiview_empty_slot">Tambahkan streaming kedua untuk membandingkannya.</string>
+    <string name="multiview_close">Selesai</string>
+    <string name="multiview_remove_stream">Hapus streaming</string>
+    <string name="multiview_audio_active">Audio aktif untuk %s</string>
+    <string name="multiview_audio_muted">Audio dibisukan untuk %s</string>
+</resources>

--- a/app/src/main/res/values-it/multiview_strings.xml
+++ b/app/src/main/res/values-it/multiview_strings.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="watch_in_multiview">Guarda in multiview</string>
+    <string name="multiview">Multiview</string>
+    <string name="multiview_add_stream">Aggiungi stream</string>
+    <string name="multiview_add_stream_title">Aggiungi un secondo stream</string>
+    <string name="multiview_channel_hint">Nome del canale</string>
+    <string name="multiview_add_stream_description">Inserisci il nome di un canale live per aggiungerlo accanto allo stream corrente.</string>
+    <string name="multiview_add_stream_empty">Inserisci un nome del canale.</string>
+    <string name="multiview_stream_not_found">Il canale è offline o non è stato trovato.</string>
+    <string name="multiview_loading">Caricamento stream…</string>
+    <string name="multiview_playback_error">Riproduzione non riuscita. Tocca per riprovare.</string>
+    <string name="multiview_audio">Audio: %s</string>
+    <string name="multiview_chat">Chat</string>
+    <string name="multiview_hide_chat">Nascondi chat</string>
+    <string name="multiview_empty_slot">Aggiungi un secondo stream per confrontarli.</string>
+    <string name="multiview_close">Fine</string>
+    <string name="multiview_remove_stream">Rimuovi stream</string>
+    <string name="multiview_audio_active">Audio attivo per %s</string>
+    <string name="multiview_audio_muted">Audio disattivato per %s</string>
+</resources>

--- a/app/src/main/res/values-ja/multiview_strings.xml
+++ b/app/src/main/res/values-ja/multiview_strings.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="watch_in_multiview">マルチビューで見る</string>
+    <string name="multiview">マルチビュー</string>
+    <string name="multiview_add_stream">配信を追加</string>
+    <string name="multiview_add_stream_title">2つ目の配信を追加</string>
+    <string name="multiview_channel_hint">チャンネル名</string>
+    <string name="multiview_add_stream_description">現在の配信の横に追加するライブチャンネル名を入力してください。</string>
+    <string name="multiview_add_stream_empty">チャンネル名を入力してください。</string>
+    <string name="multiview_stream_not_found">そのチャンネルはオフラインか、見つかりませんでした。</string>
+    <string name="multiview_loading">配信を読み込み中…</string>
+    <string name="multiview_playback_error">再生に失敗しました。タップして再試行してください。</string>
+    <string name="multiview_audio">音声: %s</string>
+    <string name="multiview_chat">チャット</string>
+    <string name="multiview_hide_chat">チャットを隠す</string>
+    <string name="multiview_empty_slot">比較するために2つ目の配信を追加してください。</string>
+    <string name="multiview_close">完了</string>
+    <string name="multiview_remove_stream">配信を削除</string>
+    <string name="multiview_audio_active">%s の音声を有効化</string>
+    <string name="multiview_audio_muted">%s の音声をミュート</string>
+</resources>

--- a/app/src/main/res/values-pt-rBR/multiview_strings.xml
+++ b/app/src/main/res/values-pt-rBR/multiview_strings.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="watch_in_multiview">Assistir em multiview</string>
+    <string name="multiview">Multiview</string>
+    <string name="multiview_add_stream">Adicionar transmissão</string>
+    <string name="multiview_add_stream_title">Adicionar uma segunda transmissão</string>
+    <string name="multiview_channel_hint">Nome do canal</string>
+    <string name="multiview_add_stream_description">Digite o nome de um canal ao vivo para adicioná-lo ao lado da transmissão atual.</string>
+    <string name="multiview_add_stream_empty">Digite um nome de canal.</string>
+    <string name="multiview_stream_not_found">Esse canal está offline ou não foi encontrado.</string>
+    <string name="multiview_loading">Carregando transmissão…</string>
+    <string name="multiview_playback_error">Falha na reprodução. Toque para tentar novamente.</string>
+    <string name="multiview_audio">Áudio: %s</string>
+    <string name="multiview_chat">Chat</string>
+    <string name="multiview_hide_chat">Ocultar chat</string>
+    <string name="multiview_empty_slot">Adicione uma segunda transmissão para compará-las.</string>
+    <string name="multiview_close">Concluído</string>
+    <string name="multiview_remove_stream">Remover transmissão</string>
+    <string name="multiview_audio_active">Áudio ativo para %s</string>
+    <string name="multiview_audio_muted">Áudio silenciado para %s</string>
+</resources>

--- a/app/src/main/res/values-ru/multiview_strings.xml
+++ b/app/src/main/res/values-ru/multiview_strings.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="watch_in_multiview">Смотреть в режиме мультипросмотра</string>
+    <string name="multiview">Мультипросмотр</string>
+    <string name="multiview_add_stream">Добавить трансляцию</string>
+    <string name="multiview_add_stream_title">Добавить вторую трансляцию</string>
+    <string name="multiview_channel_hint">Название канала</string>
+    <string name="multiview_add_stream_description">Введите название канала в эфире, чтобы добавить его рядом с текущей трансляцией.</string>
+    <string name="multiview_add_stream_empty">Введите название канала.</string>
+    <string name="multiview_stream_not_found">Канал не в эфире или не найден.</string>
+    <string name="multiview_loading">Загрузка трансляции…</string>
+    <string name="multiview_playback_error">Не удалось воспроизвести. Нажмите, чтобы повторить.</string>
+    <string name="multiview_audio">Аудио: %s</string>
+    <string name="multiview_chat">Чат</string>
+    <string name="multiview_hide_chat">Скрыть чат</string>
+    <string name="multiview_empty_slot">Добавьте вторую трансляцию для сравнения.</string>
+    <string name="multiview_close">Готово</string>
+    <string name="multiview_remove_stream">Удалить трансляцию</string>
+    <string name="multiview_audio_active">Аудио включено для %s</string>
+    <string name="multiview_audio_muted">Аудио отключено для %s</string>
+</resources>

--- a/app/src/main/res/values-tr/multiview_strings.xml
+++ b/app/src/main/res/values-tr/multiview_strings.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="watch_in_multiview">Çoklu görünümde izle</string>
+    <string name="multiview">Çoklu görünüm</string>
+    <string name="multiview_add_stream">Yayın ekle</string>
+    <string name="multiview_add_stream_title">İkinci yayın ekle</string>
+    <string name="multiview_channel_hint">Kanal adı</string>
+    <string name="multiview_add_stream_description">Mevcut yayının yanına eklemek için canlı kanal adını girin.</string>
+    <string name="multiview_add_stream_empty">Kanal adı girin.</string>
+    <string name="multiview_stream_not_found">Bu kanal çevrimdışı veya bulunamadı.</string>
+    <string name="multiview_loading">Yayın yükleniyor…</string>
+    <string name="multiview_playback_error">Oynatma başarısız. Yeniden denemek için dokunun.</string>
+    <string name="multiview_audio">Ses: %s</string>
+    <string name="multiview_chat">Sohbet</string>
+    <string name="multiview_hide_chat">Sohbeti gizle</string>
+    <string name="multiview_empty_slot">Karşılaştırmak için ikinci bir yayın ekleyin.</string>
+    <string name="multiview_close">Bitti</string>
+    <string name="multiview_remove_stream">Yayını kaldır</string>
+    <string name="multiview_audio_active">%s için ses etkin</string>
+    <string name="multiview_audio_muted">%s için ses kapalı</string>
+</resources>

--- a/app/src/main/res/values-zh-rCN/multiview_strings.xml
+++ b/app/src/main/res/values-zh-rCN/multiview_strings.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="watch_in_multiview">在多视图中观看</string>
+    <string name="multiview">多视图</string>
+    <string name="multiview_add_stream">添加直播</string>
+    <string name="multiview_add_stream_title">添加第二个直播</string>
+    <string name="multiview_channel_hint">频道名称</string>
+    <string name="multiview_add_stream_description">输入直播频道名称，将其添加到当前直播旁边。</string>
+    <string name="multiview_add_stream_empty">请输入频道名称。</string>
+    <string name="multiview_stream_not_found">该频道已离线或找不到。</string>
+    <string name="multiview_loading">正在加载直播…</string>
+    <string name="multiview_playback_error">播放失败。点击重试。</string>
+    <string name="multiview_audio">音频：%s</string>
+    <string name="multiview_chat">聊天</string>
+    <string name="multiview_hide_chat">隐藏聊天</string>
+    <string name="multiview_empty_slot">添加第二个直播以进行比较。</string>
+    <string name="multiview_close">完成</string>
+    <string name="multiview_remove_stream">移除直播</string>
+    <string name="multiview_audio_active">%s 的音频已开启</string>
+    <string name="multiview_audio_muted">%s 的音频已静音</string>
+</resources>

--- a/app/src/main/res/values-zh-rTW/multiview_strings.xml
+++ b/app/src/main/res/values-zh-rTW/multiview_strings.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="watch_in_multiview">在多視圖中觀看</string>
+    <string name="multiview">多視圖</string>
+    <string name="multiview_add_stream">新增直播</string>
+    <string name="multiview_add_stream_title">新增第二個直播</string>
+    <string name="multiview_channel_hint">頻道名稱</string>
+    <string name="multiview_add_stream_description">輸入直播頻道名稱，將其新增到目前直播旁邊。</string>
+    <string name="multiview_add_stream_empty">請輸入頻道名稱。</string>
+    <string name="multiview_stream_not_found">此頻道已離線或找不到。</string>
+    <string name="multiview_loading">正在載入直播…</string>
+    <string name="multiview_playback_error">播放失敗。點擊重試。</string>
+    <string name="multiview_audio">音訊：%s</string>
+    <string name="multiview_chat">聊天</string>
+    <string name="multiview_hide_chat">隱藏聊天</string>
+    <string name="multiview_empty_slot">新增第二個直播以進行比較。</string>
+    <string name="multiview_close">完成</string>
+    <string name="multiview_remove_stream">移除直播</string>
+    <string name="multiview_audio_active">%s 的音訊已開啟</string>
+    <string name="multiview_audio_muted">%s 的音訊已靜音</string>
+</resources>

--- a/app/src/main/res/values/multiview_strings.xml
+++ b/app/src/main/res/values/multiview_strings.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="watch_in_multiview">Watch in multiview</string>
+    <string name="multiview">Multiview</string>
+    <string name="multiview_add_stream">Add stream</string>
+    <string name="multiview_add_stream_title">Add a second stream</string>
+    <string name="multiview_channel_hint">Channel name</string>
+    <string name="multiview_add_stream_description">Enter a live channel name to add it beside the current stream.</string>
+    <string name="multiview_add_stream_empty">Enter a channel name.</string>
+    <string name="multiview_stream_not_found">That channel is offline or could not be found.</string>
+    <string name="multiview_loading">Loading stream…</string>
+    <string name="multiview_playback_error">Playback failed. Tap to retry.</string>
+    <string name="multiview_audio">Audio: %s</string>
+    <string name="multiview_chat">Chat</string>
+    <string name="multiview_hide_chat">Hide chat</string>
+    <string name="multiview_empty_slot">Add a second stream to compare them.</string>
+    <string name="multiview_close">Done</string>
+    <string name="multiview_remove_stream">Remove stream</string>
+    <string name="multiview_audio_active">Audio active for %s</string>
+    <string name="multiview_audio_muted">Audio muted for %s</string>
+</resources>


### PR DESCRIPTION
## What changed\n- Adds a multiview action to live stream cards.\n- Plays two live HLS streams in independent foreground Media3 players.\n- Tapping a tile selects its audio; the other tile is muted.\n- Adds a second live channel by login, orientation-aware tile layout, retry state, and optional selected-channel chat.\n\n## Scope\nThis is the first usable slice: chat follows the selected tile rather than merging both channels. Background playback, PiP, and a unified cross-channel chat timeline remain follow-up work.\n\n## Verification\n- :app:testDebugUnitTest passed.\n- :app:assembleDebug passed.\n- Installed and smoke-tested on a connected Android phone: multiview navigation, two live tiles, add-stream dialog, audio switching, and chat entry.\n- Full lint is currently blocked by the repository's existing lint debt and locale policy; no multiview Media3 opt-in findings remain.\n