### PR TITLE
Polish multiview rotation and phone layout

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/multiview/MultiviewFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/multiview/MultiviewFragment.kt
@@ -104,6 +104,7 @@ class MultiviewFragment : Fragment(R.layout.fragment_multiview) {
             )
             insets
         }
+        updateOrientationLayout()
 
         binding.addStreamButton.setOnClickListener { showAddStreamPicker() }
         binding.chatButton.setOnClickListener { toggleChat() }
@@ -133,6 +134,17 @@ class MultiviewFragment : Fragment(R.layout.fragment_multiview) {
         slots.forEachIndexed { index, slot ->
             if (wasPlaying.getOrNull(index) == true) {
                 slot.player?.playWhenReady = true
+            }
+        }
+    }
+
+    override fun onConfigurationChanged(newConfig: Configuration) {
+        super.onConfigurationChanged(newConfig)
+        if (_binding != null) {
+            updateOrientationLayout()
+            binding.multiviewRoot.post {
+                rebuildGrid()
+                updateToolbar()
             }
         }
     }
@@ -240,6 +252,18 @@ class MultiviewFragment : Fragment(R.layout.fragment_multiview) {
         slots.forEach { slot ->
             slot.removeButton.isVisible = slots.size > 1
             updateAudioButton(slot)
+        }
+    }
+
+    private fun updateOrientationLayout() {
+        if (_binding == null) return
+        (binding.chatContainer.layoutParams as? LinearLayout.LayoutParams)?.let { params ->
+            params.weight = if (resources.configuration.orientation == Configuration.ORIENTATION_LANDSCAPE) {
+                if (combinedChat) LANDSCAPE_COMBINED_CHAT_WEIGHT else LANDSCAPE_CHAT_WEIGHT
+            } else {
+                PORTRAIT_CHAT_WEIGHT
+            }
+            binding.chatContainer.layoutParams = params
         }
     }
 
@@ -458,6 +482,8 @@ class MultiviewFragment : Fragment(R.layout.fragment_multiview) {
 
     private fun updateToolbar() {
         val active = slots.getOrNull(activeSlotIndex)?.stream
+        val isLandscape = resources.configuration.orientation == Configuration.ORIENTATION_LANDSCAPE
+        binding.activeAudio.isVisible = active != null && isLandscape
         binding.activeAudio.text = active?.let { getString(R.string.multiview_audio, displayName(it)) }
         binding.addStreamButton.isVisible = slots.size < MAX_STREAMS
         binding.addStreamButton.text = getString(R.string.multiview_add_stream_count, slots.size, MAX_STREAMS)
@@ -494,6 +520,7 @@ class MultiviewFragment : Fragment(R.layout.fragment_multiview) {
         if (streams.size < 2) return
         combinedChat = true
         chatSlot = null
+        updateOrientationLayout()
         binding.chatContainer.isVisible = true
         childFragmentManager.beginTransaction()
             .replace(
@@ -511,6 +538,7 @@ class MultiviewFragment : Fragment(R.layout.fragment_multiview) {
         if (stream.channelLogin.isNullOrBlank()) return
         combinedChat = false
         chatSlot = slot
+        updateOrientationLayout()
         binding.chatContainer.isVisible = true
         childFragmentManager.beginTransaction()
             .replace(
@@ -549,7 +577,7 @@ class MultiviewFragment : Fragment(R.layout.fragment_multiview) {
         val content = FrameLayout(requireContext()).apply {
             layoutParams = LinearLayout.LayoutParams(
                 ViewGroup.LayoutParams.MATCH_PARENT,
-                dp(if (resources.configuration.orientation == Configuration.ORIENTATION_LANDSCAPE) 220 else 320),
+                dp(if (resources.configuration.orientation == Configuration.ORIENTATION_LANDSCAPE) 110 else 320),
             )
         }
         val recycler = RecyclerView(requireContext()).apply {
@@ -741,6 +769,9 @@ class MultiviewFragment : Fragment(R.layout.fragment_multiview) {
         private const val KEY_ACTIVE_SLOT = "multiview_active_slot"
         private const val CHAT_TAG = "multiview_chat"
         private const val MAX_STREAMS = 4
+        private const val LANDSCAPE_CHAT_WEIGHT = 0.7f
+        private const val LANDSCAPE_COMBINED_CHAT_WEIGHT = 1f
+        private const val PORTRAIT_CHAT_WEIGHT = 0.42f
 
         fun arguments(stream: Stream): Bundle = Bundle().apply {
             putParcelable(ARG_STREAM, stream)

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/multiview/MultiviewFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/multiview/MultiviewFragment.kt
@@ -143,8 +143,10 @@ class MultiviewFragment : Fragment(R.layout.fragment_multiview) {
         if (_binding != null) {
             updateOrientationLayout()
             binding.multiviewRoot.post {
-                rebuildGrid()
-                updateToolbar()
+                if (_binding != null) {
+                    rebuildGrid()
+                    updateToolbar()
+                }
             }
         }
     }
@@ -770,7 +772,7 @@ class MultiviewFragment : Fragment(R.layout.fragment_multiview) {
         private const val CHAT_TAG = "multiview_chat"
         private const val MAX_STREAMS = 4
         private const val LANDSCAPE_CHAT_WEIGHT = 0.7f
-        private const val LANDSCAPE_COMBINED_CHAT_WEIGHT = 1f
+        private const val LANDSCAPE_COMBINED_CHAT_WEIGHT = 1.2f
         private const val PORTRAIT_CHAT_WEIGHT = 0.42f
 
         fun arguments(stream: Stream): Bundle = Bundle().apply {

--- a/app/src/main/res/layout/fragment_combined_chat.xml
+++ b/app/src/main/res/layout/fragment_combined_chat.xml
@@ -26,9 +26,9 @@
             android:id="@+id/combinedChatRecyclerView"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:clipToPadding="false"
+            android:clipToPadding="true"
             android:paddingStart="8dp"
-            android:paddingTop="4dp"
+            android:paddingTop="8dp"
             android:paddingEnd="8dp"
             android:paddingBottom="8dp" />
 
@@ -41,6 +41,12 @@
             android:text="@string/multiview_combined_chat_empty"
             android:textAppearance="?attr/textAppearanceBodyMedium"
             android:textColor="?android:attr/textColorSecondary" />
+
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="24dp"
+            android:background="?android:colorBackground"
+            android:elevation="1dp" />
     </FrameLayout>
 
     <FrameLayout


### PR DESCRIPTION
## Summary

- Rebuild the multiview grid when the activity handles an orientation change.
- Give landscape chat, especially combined chat, enough space to remain useful.
- Hide the redundant portrait audio label and keep the landscape stream picker controls visible.

## Verification

- Installed and tested the debug APK on a physical CPH2493 Android device.
- Verified two-stream portrait and landscape layouts, combined chat, picker controls, and rotation.
- :app:testDebugUnitTest (6 tests) and :app:assembleDebug passed.
- Final logcat check showed no fatal exception, ANR, or out-of-memory error.