### PR TITLE
Fix landscape multiview chat spacing

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatFragment.kt
@@ -882,7 +882,7 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
                     chatReplayUnavailable.visibility = View.VISIBLE
                 }
             }
-            if ((view.parent?.parent?.parent?.parent as? View)?.id != R.id.slidingLayout) {
+            if (!isInsideInsetAwareContainer(view)) {
                 ViewCompat.setOnApplyWindowInsetsListener(view) { _, windowInsets ->
                     if (activity?.findViewById<LinearLayout>(R.id.navBarContainer)?.isVisible == false) {
                         val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars())
@@ -894,6 +894,17 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
                 }
             }
         }
+    }
+
+    private fun isInsideInsetAwareContainer(view: View): Boolean {
+        var parent = view.parent
+        while (parent != null) {
+            if (parent is View && (parent.id == R.id.slidingLayout || parent.id == R.id.multiviewRoot)) {
+                return true
+            }
+            parent = parent.parent
+        }
+        return false
     }
 
     override fun initialize() {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/multiview/MultiviewFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/multiview/MultiviewFragment.kt
@@ -94,13 +94,18 @@ class MultiviewFragment : Fragment(R.layout.fragment_multiview) {
 
         ViewCompat.setOnApplyWindowInsetsListener(binding.multiviewRoot) { root, insets ->
             val systemBars = insets.getInsets(
-                WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout()
+                WindowInsetsCompat.Type.systemBars() or
+                    WindowInsetsCompat.Type.displayCutout() or
+                    WindowInsetsCompat.Type.ime()
             )
             root.updatePadding(
-                left = systemBars.left,
                 top = systemBars.top,
-                right = systemBars.right,
                 bottom = systemBars.bottom,
+                // MainActivity already applies the horizontal safe-area margins to
+                // navHostFragment. Applying them again here leaves visible gutters
+                // around the landscape grid and chat.
+                left = 0,
+                right = 0,
             )
             insets
         }


### PR DESCRIPTION
## What changed
- remove duplicate horizontal safe-area padding from multiview; `MainActivity` already owns the nav-host horizontal margins
- prevent embedded chat from adding a second bottom inset margin inside player/multiview containers
- include IME in multiview's outer inset handling so the chat composer remains usable with the keyboard open

## Verification
- `:app:testDebugUnitTest`
- `:app:assembleDebug`
- `git diff --check`
- `:app:lintDebug` attempted; timed out after 3 minutes without diagnostics
- phone install/landscape verification pending because the previously paired ADB device disconnected

The app review document and unrelated working-tree changes are intentionally not part of this PR.
