### PR TITLE
Improve recoverable error feedback

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatFragment.kt
@@ -64,6 +64,7 @@ import com.github.andreyasadchy.xtra.util.prefs
 import com.github.andreyasadchy.xtra.util.reduceDragSensitivity
 import com.github.andreyasadchy.xtra.util.tokenPrefs
 import com.google.android.material.color.MaterialColors
+import com.google.android.material.snackbar.Snackbar
 import com.google.android.material.tabs.TabLayoutMediator
 import com.google.mlkit.nl.languageid.LanguageIdentification
 import com.google.mlkit.nl.languageid.LanguageIdentifier
@@ -1171,7 +1172,7 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
         } else {
             getString(R.string.channel_points_reward_failed, result.rewardTitle, result.message.orEmpty())
         }
-        android.widget.Toast.makeText(requireContext(), message, android.widget.Toast.LENGTH_LONG).show()
+        Snackbar.make(binding.root, message, Snackbar.LENGTH_LONG).show()
     }
 
     private fun handleWatchStreakShare(result: WatchStreakShareResult) {
@@ -1188,7 +1189,7 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
         } else {
             getString(R.string.channel_points_streak_share_failed, result.message.orEmpty())
         }
-        android.widget.Toast.makeText(requireContext(), message, android.widget.Toast.LENGTH_LONG).show()
+        Snackbar.make(binding.root, message, Snackbar.LENGTH_LONG).show()
     }
 
     private fun sendMessage(replyId: String? = null): Boolean {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/PagedListFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/PagedListFragment.kt
@@ -22,6 +22,7 @@ abstract class PagedListFragment : BaseNetworkFragment(), IntegrityDialog.Listen
 
     private var pageErrorSnackbar: Snackbar? = null
     private var pageError: LoadState.Error? = null
+    private var pageErrorState: PagedListErrorState? = null
 
     fun <T : Any, VH : RecyclerView.ViewHolder> setAdapter(recyclerView: RecyclerView, adapter: PagingDataAdapter<T, VH>) {
         adapter.registerAdapterDataObserver(object : RecyclerView.AdapterDataObserver() {
@@ -103,7 +104,12 @@ abstract class PagedListFragment : BaseNetworkFragment(), IntegrityDialog.Listen
         val refreshError = loadState.refresh as? LoadState.Error
         val appendError = loadState.append as? LoadState.Error
         val prependError = loadState.prepend as? LoadState.Error
-        val pageError = appendError ?: prependError
+        val errorState = pagedListErrorState(loadState.refresh, loadState.append, loadState.prepend)
+        val pageError = when (errorState) {
+            PagedListErrorState.Refresh -> refreshError
+            PagedListErrorState.Page -> appendError ?: prependError
+            null -> null
+        }
 
         binding.progressBar.isVisible = contentState == PagedListContentState.Loading
         binding.nothingHere.isVisible = showEmpty && contentState == PagedListContentState.Empty
@@ -117,13 +123,18 @@ abstract class PagedListFragment : BaseNetworkFragment(), IntegrityDialog.Listen
             binding.swipeRefresh.isRefreshing = contentState == PagedListContentState.Content && loadState.refresh is LoadState.Loading
         }
 
-        if (pageError != null && pagingAdapter.itemCount > 0 && showEmpty) {
-            if (this.pageError !== pageError) {
+        if (pageError != null && pagingAdapter.itemCount > 0) {
+            if (this.pageError !== pageError || this.pageErrorState != errorState) {
                 pageErrorSnackbar?.dismiss()
                 this.pageError = pageError
+                this.pageErrorState = errorState
                 pageErrorSnackbar = Snackbar.make(
                     binding.recyclerView,
-                    R.string.list_load_more_error,
+                    if (errorState == PagedListErrorState.Refresh) {
+                        R.string.list_refresh_error
+                    } else {
+                        R.string.list_load_more_error
+                    },
                     Snackbar.LENGTH_INDEFINITE,
                 ).setAction(R.string.retry) { pagingAdapter.retry() }
                 pageErrorSnackbar?.show()
@@ -132,6 +143,7 @@ abstract class PagedListFragment : BaseNetworkFragment(), IntegrityDialog.Listen
             pageErrorSnackbar?.dismiss()
             pageErrorSnackbar = null
             this.pageError = null
+            this.pageErrorState = null
         }
 
         if ((refreshError ?: appendError ?: prependError)?.error?.message == C.FAILED_INTEGRITY_CHECK) {
@@ -143,6 +155,7 @@ abstract class PagedListFragment : BaseNetworkFragment(), IntegrityDialog.Listen
         pageErrorSnackbar?.dismiss()
         pageErrorSnackbar = null
         pageError = null
+        pageErrorState = null
         super.onDestroyView()
     }
 }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/PagedListState.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/PagedListState.kt
@@ -9,11 +9,28 @@ internal enum class PagedListContentState {
     Error,
 }
 
+internal enum class PagedListErrorState {
+    Refresh,
+    Page,
+}
+
 internal fun pagedListContentState(refresh: LoadState, itemCount: Int): PagedListContentState {
     return when {
         itemCount > 0 -> PagedListContentState.Content
         refresh is LoadState.Loading -> PagedListContentState.Loading
         refresh is LoadState.Error -> PagedListContentState.Error
         else -> PagedListContentState.Empty
+    }
+}
+
+internal fun pagedListErrorState(
+    refresh: LoadState,
+    append: LoadState,
+    prepend: LoadState,
+): PagedListErrorState? {
+    return when {
+        refresh is LoadState.Error -> PagedListErrorState.Refresh
+        append is LoadState.Error || prepend is LoadState.Error -> PagedListErrorState.Page
+        else -> null
     }
 }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/main/MainActivity.kt
@@ -92,6 +92,7 @@ import com.github.andreyasadchy.xtra.util.getAlertDialogBuilder
 import com.github.andreyasadchy.xtra.util.prefs
 import com.github.andreyasadchy.xtra.util.tokenPrefs
 import com.google.android.material.color.MaterialColors
+import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import org.chromium.net.CronetProvider
@@ -125,6 +126,7 @@ class MainActivity : AppCompatActivity() {
     var logoutResultLauncher: ActivityResultLauncher<Intent>? = null
     private var updateDownloadDialogBinding: DialogUpdateDownloadBinding? = null
     private var updateDownloadDialog: AlertDialog? = null
+    private var networkSnackbar: Snackbar? = null
 
     //Lifecycle methods
 
@@ -191,7 +193,7 @@ class MainActivity : AppCompatActivity() {
                     && networkCapabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
             if (!isNetworkAvailable) {
                 initialized = true
-                Toast.makeText(this, R.string.no_connection, Toast.LENGTH_SHORT).show()
+                showNetworkFeedback(isNetworkAvailable = false)
             }
         }
         lifecycleScope.launch {
@@ -206,9 +208,12 @@ class MainActivity : AppCompatActivity() {
                         if (viewModel.isNetworkAvailable.value != isNetworkAvailable) {
                             viewModel.isNetworkAvailable.value = isNetworkAvailable
                             if (initialized) {
-                                Toast.makeText(this@MainActivity, if (isNetworkAvailable) R.string.connection_restored else R.string.no_connection, Toast.LENGTH_SHORT).show()
+                                showNetworkFeedback(isNetworkAvailable, showRestored = true)
                             } else {
                                 initialized = true
+                                if (!isNetworkAvailable) {
+                                    showNetworkFeedback(isNetworkAvailable = false)
+                                }
                             }
                             if (isNetworkAvailable) {
                                 if (!TwitchApiHelper.checkedValidation && prefs.getBoolean(C.VALIDATE_TOKENS, true)) {
@@ -648,6 +653,8 @@ class MainActivity : AppCompatActivity() {
     }
 
     override fun onDestroy() {
+        networkSnackbar?.dismiss()
+        networkSnackbar = null
         networkCallback?.let {
             val connectivityManager = getSystemService(CONNECTIVITY_SERVICE) as ConnectivityManager
             connectivityManager.unregisterNetworkCallback(it)
@@ -657,6 +664,27 @@ class MainActivity : AppCompatActivity() {
             (playerFragment as? Media3PlayerFragment)?.close() ?: (playerFragment as? PlayerFragment)?.close()
         }
         super.onDestroy()
+    }
+
+    private fun showNetworkFeedback(isNetworkAvailable: Boolean, showRestored: Boolean = false) {
+        if (!isNetworkAvailable) {
+            if (networkSnackbar == null) {
+                networkSnackbar = Snackbar.make(
+                    binding.root,
+                    R.string.no_connection,
+                    Snackbar.LENGTH_INDEFINITE,
+                ).setAction(R.string.retry) {
+                    viewModel.checkNetworkStatus.value = true
+                }
+            }
+            networkSnackbar?.show()
+        } else {
+            networkSnackbar?.dismiss()
+            networkSnackbar = null
+            if (showRestored) {
+                Snackbar.make(binding.root, R.string.connection_restored, Snackbar.LENGTH_SHORT).show()
+            }
+        }
     }
 
     override fun onNewIntent(intent: Intent) {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/multiview/MultiviewFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/multiview/MultiviewFragment.kt
@@ -50,8 +50,10 @@ import com.github.andreyasadchy.xtra.player.lowlatency.CronetDataSource
 import com.github.andreyasadchy.xtra.player.lowlatency.HttpEngineDataSource
 import com.github.andreyasadchy.xtra.player.lowlatency.OkHttpDataSource
 import com.github.andreyasadchy.xtra.ui.chat.ChatFragment
+import com.github.andreyasadchy.xtra.ui.common.PagedListErrorState
 import com.github.andreyasadchy.xtra.ui.common.StreamsAdapter
 import com.github.andreyasadchy.xtra.ui.common.StreamsCompactAdapter
+import com.github.andreyasadchy.xtra.ui.common.pagedListErrorState
 import com.github.andreyasadchy.xtra.ui.following.streams.FollowedStreamsViewModel
 import com.github.andreyasadchy.xtra.ui.main.MainActivity
 import com.github.andreyasadchy.xtra.ui.player.ExoPlayerService
@@ -59,6 +61,7 @@ import com.github.andreyasadchy.xtra.util.C
 import com.github.andreyasadchy.xtra.util.prefs
 import com.google.android.material.button.MaterialButton
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import com.google.android.material.snackbar.Snackbar
 import com.google.android.material.textfield.TextInputEditText
 import com.google.android.material.textfield.TextInputLayout
 import kotlinx.coroutines.Job
@@ -599,9 +602,30 @@ class MultiviewFragment : Fragment(R.layout.fragment_multiview) {
             setPadding(dp(16), dp(16), dp(16), dp(16))
             isVisible = false
         }
+        val pickerError = LinearLayout(requireContext()).apply {
+            orientation = LinearLayout.VERTICAL
+            gravity = Gravity.CENTER
+            setPadding(dp(16), dp(16), dp(16), dp(16))
+            isVisible = false
+        }
+        val pickerErrorMessage = TextView(requireContext()).apply {
+            gravity = Gravity.CENTER
+            text = getString(R.string.list_load_error)
+            setTextAppearance(com.google.android.material.R.style.TextAppearance_Material3_BodyMedium)
+        }
+        val pickerRetry = MaterialButton(requireContext()).apply {
+            text = getString(R.string.retry)
+            minWidth = 0
+            layoutParams = LinearLayout.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT).apply {
+                topMargin = dp(8)
+            }
+        }
+        pickerError.addView(pickerErrorMessage)
+        pickerError.addView(pickerRetry)
         content.addView(recycler, FrameLayout.LayoutParams.MATCH_PARENT, FrameLayout.LayoutParams.MATCH_PARENT)
         content.addView(progress, FrameLayout.LayoutParams(dp(40), dp(40), Gravity.CENTER))
         content.addView(empty, FrameLayout.LayoutParams.MATCH_PARENT, FrameLayout.LayoutParams.MATCH_PARENT)
+        content.addView(pickerError, FrameLayout.LayoutParams.MATCH_PARENT, FrameLayout.LayoutParams.MATCH_PARENT)
 
         val input = TextInputEditText(requireContext()).apply {
             setSingleLine(true)
@@ -648,6 +672,7 @@ class MultiviewFragment : Fragment(R.layout.fragment_multiview) {
                 StreamsAdapter(this, {}, showGame = false, onStreamClick = selectStream)
             }
         recycler.adapter = pagingAdapter
+        pickerRetry.setOnClickListener { pagingAdapter.retry() }
 
         val dialog = MaterialAlertDialogBuilder(requireContext())
             .setTitle(R.string.multiview_picker_title)
@@ -657,9 +682,14 @@ class MultiviewFragment : Fragment(R.layout.fragment_multiview) {
         pickerDialog = dialog
         var pagingJob: Job? = null
         var loadStateJob: Job? = null
+        var pickerErrorSnackbar: Snackbar? = null
+        var pickerErrorState: PagedListErrorState? = null
         dialog.setOnDismissListener {
             pagingJob?.cancel()
             loadStateJob?.cancel()
+            pickerErrorSnackbar?.dismiss()
+            pickerErrorSnackbar = null
+            pickerErrorState = null
         }
         useButton.setOnClickListener {
             val login = input.text?.toString()?.trim()?.removePrefix("@")?.lowercase().orEmpty()
@@ -695,8 +725,32 @@ class MultiviewFragment : Fragment(R.layout.fragment_multiview) {
         }
         loadStateJob = viewLifecycleOwner.lifecycleScope.launch {
             pagingAdapter.loadStateFlow.collectLatest { loadStates ->
+                val refreshError = loadStates.refresh is LoadState.Error
+                val hasItems = pagingAdapter.itemCount > 0
+                val errorState = pagedListErrorState(loadStates.refresh, loadStates.append, loadStates.prepend)
                 progress.isVisible = loadStates.refresh is LoadState.Loading
-                empty.isVisible = loadStates.refresh is LoadState.NotLoading && pagingAdapter.itemCount == 0
+                empty.isVisible = !refreshError && loadStates.refresh is LoadState.NotLoading && !hasItems
+                pickerError.isVisible = errorState == PagedListErrorState.Refresh && !hasItems
+                if (errorState != null && hasItems) {
+                    if (pickerErrorSnackbar == null || pickerErrorState != errorState) {
+                        pickerErrorSnackbar?.dismiss()
+                        pickerErrorState = errorState
+                        pickerErrorSnackbar = Snackbar.make(
+                            recycler,
+                            if (errorState == PagedListErrorState.Refresh) {
+                                R.string.list_refresh_error
+                            } else {
+                                R.string.list_load_more_error
+                            },
+                            Snackbar.LENGTH_INDEFINITE,
+                        ).setAction(R.string.retry) { pagingAdapter.retry() }
+                        pickerErrorSnackbar?.show()
+                    }
+                } else {
+                    pickerErrorSnackbar?.dismiss()
+                    pickerErrorSnackbar = null
+                    pickerErrorState = null
+                }
             }
         }
     }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/ExoPlayerFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/ExoPlayerFragment.kt
@@ -38,6 +38,7 @@ import com.github.andreyasadchy.xtra.ui.main.MainActivity
 import com.github.andreyasadchy.xtra.util.C
 import com.github.andreyasadchy.xtra.util.getAlertDialogBuilder
 import com.github.andreyasadchy.xtra.util.prefs
+import com.google.android.material.snackbar.Snackbar
 
 @OptIn(UnstableApi::class)
 class ExoPlayerFragment : PlayerFragment() {
@@ -210,7 +211,11 @@ class ExoPlayerFragment : PlayerFragment() {
 
             override fun toast(resId: Int, duration: Int) {
                 if (view != null) {
-                    Toast.makeText(requireContext(), resId, duration).show()
+                    Snackbar.make(
+                        binding.playerBackground,
+                        resId,
+                        if (duration == Toast.LENGTH_LONG) Snackbar.LENGTH_LONG else Snackbar.LENGTH_SHORT,
+                    ).show()
                 }
             }
 

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/Media3Fragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/Media3Fragment.kt
@@ -14,7 +14,6 @@ import android.util.Log
 import android.view.View
 import android.widget.HorizontalScrollView
 import android.widget.TextView
-import android.widget.Toast
 import androidx.annotation.OptIn
 import androidx.core.content.ContextCompat
 import androidx.core.content.edit
@@ -48,6 +47,7 @@ import com.github.andreyasadchy.xtra.util.C
 import com.github.andreyasadchy.xtra.util.getAlertDialogBuilder
 import com.github.andreyasadchy.xtra.util.prefs
 import com.github.andreyasadchy.xtra.util.shouldAvoidTwitchAds
+import com.google.android.material.snackbar.Snackbar
 import com.google.common.util.concurrent.ListenableFuture
 import com.google.common.util.concurrent.MoreExecutors
 import kotlinx.coroutines.CancellationException
@@ -340,15 +340,19 @@ class Media3Fragment : Media3PlayerFragment() {
                                         if (isNetworkAvailable) {
                                             when {
                                                 responseCode == 404 -> {
-                                                    Toast.makeText(requireContext(), R.string.stream_ended, Toast.LENGTH_LONG).show()
+                                                    Snackbar.make(binding.playerBackground, R.string.stream_ended, Snackbar.LENGTH_LONG).show()
                                                 }
                                                 viewModel.useCustomProxy && responseCode >= 400 -> {
-                                                    Toast.makeText(requireContext(), R.string.proxy_error, Toast.LENGTH_LONG).show()
+                                                    Snackbar.make(binding.playerBackground, R.string.proxy_error, Snackbar.LENGTH_LONG)
+                                                        .setAction(R.string.retry) { restartPlayer() }
+                                                        .show()
                                                     viewModel.useCustomProxy = false
                                                     scheduleStreamRecovery()
                                                 }
                                                 else -> {
-                                                    Toast.makeText(requireContext(), R.string.player_error, Toast.LENGTH_SHORT).show()
+                                                    Snackbar.make(binding.playerBackground, R.string.player_error, Snackbar.LENGTH_LONG)
+                                                        .setAction(R.string.retry) { restartPlayer() }
+                                                        .show()
                                                     scheduleStreamRecovery()
                                                 }
                                             }
@@ -382,10 +386,12 @@ class Media3Fragment : Media3PlayerFragment() {
                                                     playVideo(true, player?.currentPosition)
                                                 }
                                                 responseCode == 403 -> {
-                                                    Toast.makeText(requireContext(), R.string.video_subscribers_only, Toast.LENGTH_LONG).show()
+                                                    Snackbar.make(binding.playerBackground, R.string.video_subscribers_only, Snackbar.LENGTH_LONG).show()
                                                 }
                                                 else -> {
-                                                    Toast.makeText(requireContext(), R.string.player_error, Toast.LENGTH_SHORT).show()
+                                                    Snackbar.make(binding.playerBackground, R.string.player_error, Snackbar.LENGTH_LONG)
+                                                        .setAction(R.string.retry) { restartPlayer() }
+                                                        .show()
                                                     viewLifecycleOwner.lifecycleScope.launch {
                                                         delay(1500.milliseconds)
                                                         try {
@@ -530,7 +536,7 @@ class Media3Fragment : Media3PlayerFragment() {
                 }
                 player.volume = 0f
             }
-            Toast.makeText(requireContext(), R.string.waiting_ads, Toast.LENGTH_LONG).show()
+            Snackbar.make(binding.playerBackground, R.string.waiting_ads, Snackbar.LENGTH_LONG).show()
         }
     }
 

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/MediaPlayerFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/MediaPlayerFragment.kt
@@ -24,6 +24,7 @@ import com.github.andreyasadchy.xtra.ui.game.GamePagerFragmentDirections
 import com.github.andreyasadchy.xtra.ui.main.MainActivity
 import com.github.andreyasadchy.xtra.util.C
 import com.github.andreyasadchy.xtra.util.prefs
+import com.google.android.material.snackbar.Snackbar
 
 @OptIn(UnstableApi::class)
 class MediaPlayerFragment : PlayerFragment() {
@@ -120,7 +121,11 @@ class MediaPlayerFragment : PlayerFragment() {
 
             override fun toast(resId: Int, duration: Int) {
                 if (view != null) {
-                    Toast.makeText(requireContext(), resId, duration).show()
+                    Snackbar.make(
+                        binding.playerBackground,
+                        resId,
+                        if (duration == Toast.LENGTH_LONG) Snackbar.LENGTH_LONG else Snackbar.LENGTH_SHORT,
+                    ).show()
                 }
             }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -71,6 +71,7 @@
     <string name="permission_denied">Required permissions were denied.</string>
     <string name="nothing_here">Nothing here</string>
     <string name="list_load_error">Couldn’t load this content.</string>
+    <string name="list_refresh_error">Couldn’t refresh this content.</string>
     <string name="list_load_more_error">Couldn’t load more content.</string>
     <string name="retry">Retry</string>
     <string name="watch_live">Watch live</string>

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/common/PagedListStateTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/common/PagedListStateTest.kt
@@ -37,4 +37,40 @@ class PagedListStateTest {
             pagedListContentState(LoadState.Error(IllegalStateException("offline")), itemCount = 4),
         )
     }
+
+    @Test
+    fun refreshErrorTakesPriorityOverPageError() {
+        assertEquals(
+            PagedListErrorState.Refresh,
+            pagedListErrorState(
+                refresh = LoadState.Error(IllegalStateException("refresh")),
+                append = LoadState.Error(IllegalStateException("append")),
+                prepend = LoadState.NotLoading(endOfPaginationReached = false),
+            ),
+        )
+    }
+
+    @Test
+    fun pageErrorsAreReportedWhenRefreshSucceeds() {
+        assertEquals(
+            PagedListErrorState.Page,
+            pagedListErrorState(
+                refresh = LoadState.NotLoading(endOfPaginationReached = false),
+                append = LoadState.Error(IllegalStateException("append")),
+                prepend = LoadState.NotLoading(endOfPaginationReached = false),
+            ),
+        )
+    }
+
+    @Test
+    fun noLoadErrorIsReportedWhenAllPagesAreHealthy() {
+        assertEquals(
+            null,
+            pagedListErrorState(
+                refresh = LoadState.NotLoading(endOfPaginationReached = false),
+                append = LoadState.NotLoading(endOfPaginationReached = false),
+                prepend = LoadState.NotLoading(endOfPaginationReached = false),
+            ),
+        )
+    }
 }


### PR DESCRIPTION
## Summary
- surface refresh failures even when a paged list already has content, with retry actions
- make offline state persistent and actionable, including a retry action and restored feedback
- add inline/snackbar retry feedback to the multiview channel picker
- use contextual Snackbar feedback for playback and chat action failures, with playback retry actions

## Verification
- `:app:testDebugUnitTest`
- `:app:assembleDebug`
- `git diff --check`
- `:app:lintDebug` attempted; the task timed out after 3 minutes without diagnostics in this repository

The debug APK was rebuilt. Phone installation was not performed because no ADB device was available.
