### PR TITLE
Fix playback ads and chat player UX

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/GraphQLRepository.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/GraphQLRepository.kt
@@ -796,7 +796,7 @@ class GraphQLRepository(
         sendQuery(networkLibrary, headers, query)
     }
 
-    fun getPlaybackAccessTokenRequestBody(login: String?, vodId: String?, playerType: String?): String {
+    fun getPlaybackAccessTokenRequestBody(login: String?, vodId: String?, playerType: String?, platform: String = "web"): String {
         return buildJsonObject {
             putJsonObject("extensions") {
                 putJsonObject("persistedQuery") {
@@ -810,14 +810,14 @@ class GraphQLRepository(
                 put("login", login ?: "")
                 put("isVod", !vodId.isNullOrBlank())
                 put("vodID", vodId ?: "")
-                put("platform", "web")
+                put("platform", platform)
                 put("playerType", playerType)
             }
         }.toString()
     }
 
-    suspend fun loadPlaybackAccessToken(networkLibrary: String?, headers: Map<String, String>, login: String? = null, vodId: String? = null, playerType: String?): PlaybackAccessTokenResponse = withContext(Dispatchers.IO) {
-        val body = getPlaybackAccessTokenRequestBody(login, vodId, playerType)
+    suspend fun loadPlaybackAccessToken(networkLibrary: String?, headers: Map<String, String>, login: String? = null, vodId: String? = null, playerType: String?, platform: String = "web"): PlaybackAccessTokenResponse = withContext(Dispatchers.IO) {
+        val body = getPlaybackAccessTokenRequestBody(login, vodId, playerType, platform)
         json.decodeFromString<PlaybackAccessTokenResponse>(sendPersistedQuery(networkLibrary, headers, body))
     }
 

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/PlayerRepository.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/PlayerRepository.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.net.http.HttpEngine
 import android.net.http.ProxyOptions
 import android.util.Base64
+import android.util.Log
 import androidx.core.net.toUri
 import com.apollographql.apollo.api.CustomScalarAdapters
 import com.apollographql.apollo.api.json.buildJsonString
@@ -72,6 +73,8 @@ import kotlin.math.roundToInt
 import kotlin.random.Random
 import kotlin.uuid.Uuid
 
+private const val AD_TAG = "XtraAd"
+
 class PlayerRepository(
     private val httpEngine: Lazy<HttpEngine?>,
     private val cronetEngine: Lazy<CronetEngine?>,
@@ -135,6 +138,10 @@ class PlayerRepository(
         proxyPassword: String?,
         enableIntegrity: Boolean,
     ): StreamPlaylistCandidate? = withContext(Dispatchers.IO) {
+        // VAFT keeps one device ID while it probes alternate player types. Reusing
+        // one valid ID prevents Twitch from treating each probe as a new client.
+        val deviceId = resolvePlaybackDeviceId(gqlHeaders, randomDeviceId, xDeviceId)
+        logAd("clean probe channel=$channelLogin types=${playerTypes.joinToString()} deviceIdLength=${deviceId.length} integrity=$enableIntegrity")
         playerTypes.forEach { playerType ->
             val url = try {
                 loadStreamPlaylistUrl(
@@ -142,8 +149,8 @@ class PlayerRepository(
                     networkLibrary = networkLibrary,
                     gqlHeaders = gqlHeaders,
                     channelLogin = channelLogin,
-                    randomDeviceId = randomDeviceId,
-                    xDeviceId = xDeviceId,
+                    randomDeviceId = false,
+                    xDeviceId = deviceId,
                     playerType = playerType,
                     supportedCodecs = supportedCodecs,
                     proxyPlaybackAccessToken = proxyPlaybackAccessToken,
@@ -155,14 +162,19 @@ class PlayerRepository(
                 )
             } catch (e: CancellationException) {
                 throw e
-            } catch (_: Exception) {
+            } catch (e: Exception) {
+                logAd("token probe failed channel=$channelLogin playerType=$playerType error=${e.javaClass.simpleName}")
                 null
             } ?: return@forEach
 
-            if (containsAdMarkers(url) != true) {
+            val adMarkers = containsAdMarkers(url)
+            logAd("playlist probe channel=$channelLogin playerType=$playerType adMarkers=$adMarkers")
+            if (adMarkers != true) {
+                logAd("clean candidate selected channel=$channelLogin playerType=$playerType verified=${adMarkers == false}")
                 return@withContext StreamPlaylistCandidate(playerType, url)
             }
         }
+        logAd("no clean candidate channel=$channelLogin")
         null
     }
 
@@ -198,17 +210,20 @@ class PlayerRepository(
                 }
         } catch (e: CancellationException) {
             throw e
-        } catch (_: Exception) {
+        } catch (e: Exception) {
+            logAd("playlist inspection failed error=${e.javaClass.simpleName}")
             null
         }
     }
 
     private suspend fun loadStreamPlaybackAccessToken(context: Context, networkLibrary: String?, gqlHeaders: Map<String, String>, channelLogin: String, randomDeviceId: Boolean?, xDeviceId: String?, playerType: String?, proxyPlaybackAccessToken: Boolean, proxyHost: String?, proxyPort: Int?, proxyUser: String?, proxyPassword: String?, enableIntegrity: Boolean): Pair<String?, String?> = withContext(Dispatchers.IO) {
         val accessTokenHeaders = getPlaybackAccessTokenHeaders(gqlHeaders, randomDeviceId, xDeviceId, enableIntegrity)
+        val platform = if (playerType.equals("autoplay", ignoreCase = true)) "android" else "web"
+        logAd("token request channel=$channelLogin playerType=${playerType ?: "null"} platform=$platform integrity=$enableIntegrity deviceIdLength=${accessTokenHeaders["X-Device-Id"]?.length ?: 0} proxy=$proxyPlaybackAccessToken")
         val url = "https://gql.twitch.tv/gql"
         val headers = accessTokenHeaders.filterKeys { it == C.HEADER_CLIENT_ID || it == "X-Device-Id" }
         try {
-            val body = graphQLRepository.getPlaybackAccessTokenRequestBody(channelLogin, "", playerType)
+            val body = graphQLRepository.getPlaybackAccessTokenRequestBody(channelLogin, "", playerType, platform)
             val response = if (proxyPlaybackAccessToken && !proxyHost.isNullOrBlank() && proxyPort != null) {
                 when {
                     networkLibrary == C.HTTP_ENGINE && httpEngine.value != null -> @SuppressLint("NewApi") {
@@ -387,7 +402,8 @@ class PlayerRepository(
                     networkLibrary = networkLibrary,
                     headers = accessTokenHeaders,
                     login = channelLogin,
-                    playerType = playerType
+                    playerType = playerType,
+                    platform = platform,
                 )
             }
             if (enableIntegrity) {
@@ -399,7 +415,7 @@ class PlayerRepository(
         } catch (e: Exception) {
             if (e.message == C.FAILED_INTEGRITY_CHECK) throw e
             val response = if (proxyPlaybackAccessToken && !proxyHost.isNullOrBlank() && proxyPort != null) {
-                val query = StreamPlaybackAccessTokenQuery(channelLogin, "web", playerType ?: "")
+                val query = StreamPlaybackAccessTokenQuery(channelLogin, platform, playerType ?: "")
                 val body = buildJsonString {
                     query.apply {
                         writeObject {
@@ -599,7 +615,7 @@ class PlayerRepository(
                     networkLibrary = networkLibrary,
                     headers = accessTokenHeaders,
                     login = channelLogin,
-                    platform = "web",
+                    platform = platform,
                     playerType = playerType ?: ""
                 )
             }
@@ -678,17 +694,40 @@ class PlayerRepository(
     }
 
     private fun getPlaybackAccessTokenHeaders(gqlHeaders: Map<String, String>, randomDeviceId: Boolean?, xDeviceId: String? = null, enableIntegrity: Boolean): Map<String, String> {
-        return if (enableIntegrity) {
-            gqlHeaders
-        } else {
-            gqlHeaders.toMutableMap().apply {
-                // X-Device-Id or Device-ID removes "commercial break in progress" (length 16 or 32)
-                if (randomDeviceId != false) {
-                    put("X-Device-Id", Uuid.random().toHexString())
-                } else {
-                    xDeviceId?.let { put("X-Device-Id", it) }
-                }
-            }
+        val headers = gqlHeaders.toMutableMap()
+        headers.keys
+            .filter { it.equals("X-Device-Id", ignoreCase = true) && it != "X-Device-Id" }
+            .forEach { headers.remove(it) }
+        val deviceId = resolvePlaybackDeviceId(gqlHeaders, randomDeviceId, xDeviceId)
+        // VAFT sends X-Device-Id alongside Client-Integrity. Integrity mode must
+        // not silently disable the ad-avoidance header.
+        headers["X-Device-Id"] = deviceId
+        logAd("headers prepared integrity=$enableIntegrity randomDeviceId=${randomDeviceId != false} deviceIdLength=${deviceId.length}")
+        return headers
+    }
+
+    private fun resolvePlaybackDeviceId(gqlHeaders: Map<String, String>, randomDeviceId: Boolean?, xDeviceId: String?): String {
+        val existingDeviceId = gqlHeaders.entries
+            .firstOrNull { it.key.equals("X-Device-Id", ignoreCase = true) }
+            ?.value
+            ?.trim()
+            ?.takeIf(::isValidPlaybackDeviceId)
+        val configuredDeviceId = xDeviceId?.trim()?.takeIf(::isValidPlaybackDeviceId)
+        return when {
+            randomDeviceId != false -> Uuid.random().toHexString()
+            configuredDeviceId != null -> configuredDeviceId
+            existingDeviceId != null -> existingDeviceId
+            else -> Uuid.random().toHexString()
+        }
+    }
+
+    private fun isValidPlaybackDeviceId(deviceId: String): Boolean {
+        return deviceId.length == 16 || deviceId.length == 32
+    }
+
+    private fun logAd(message: String) {
+        if (BuildConfig.DEBUG) {
+            Log.d(AD_TAG, message)
         }
     }
 

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatFragment.kt
@@ -169,11 +169,10 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
         viewLifecycleOwner.lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.connectionState.collectLatest { state ->
-                    val showConnectionStatus = state == ChatViewModel.ConnectionState.CONNECTING ||
-                            state == ChatViewModel.ConnectionState.RECONNECTING
+                    val showConnectionStatus = state == ChatViewModel.ConnectionState.RECONNECTING
                     binding.connectionStatus.isVisible = showConnectionStatus
                     if (showConnectionStatus) {
-                        binding.connectionStatusText.text = getString(R.string.connection_error)
+                        binding.connectionStatusText.setText(R.string.chat_reconnecting)
                         binding.connectionStatus.contentDescription =
                             "${binding.connectionStatusText.text}. ${getString(R.string.retry)}"
                     }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/ExoPlayerService.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/ExoPlayerService.kt
@@ -27,6 +27,7 @@ import android.os.IBinder
 import android.os.Looper
 import android.os.PowerManager
 import android.util.Base64
+import android.util.Log
 import android.view.KeyEvent
 import android.widget.Toast
 import androidx.annotation.OptIn
@@ -59,6 +60,7 @@ import androidx.media3.exoplayer.hls.playlist.HlsPlaylistParserFactory
 import androidx.media3.exoplayer.source.ProgressiveMediaSource
 import androidx.media3.exoplayer.upstream.DefaultLoadErrorHandlingPolicy
 import androidx.media3.exoplayer.upstream.ParsingLoadable
+import com.github.andreyasadchy.xtra.BuildConfig
 import com.github.andreyasadchy.xtra.R
 import com.github.andreyasadchy.xtra.XtraApp
 import com.github.andreyasadchy.xtra.model.VideoPosition
@@ -251,12 +253,16 @@ class ExoPlayerService : BasePlaybackService() {
                             val ads = playlist?.let { TwitchAdDetector.isAd(it) } == true
                             val oldValue = playingAds
                             playingAds = ads
+                            if (ads != oldValue) {
+                                logAd("state channel=${channelLogin ?: "null"} ads=$ads avoid=$avoidAds proxy=$useProxy hidden=$hidden playerType=${prefs().getString(C.TOKEN_PLAYER_TYPE, "site")}")
+                            }
                             if (ads) {
                                 if (avoidAds) {
                                     if (adAvoidanceJob?.isActive != true) {
                                         val playerTypes = adController.playerTypesForAd(
                                             prefs().getString(C.TOKEN_PLAYER_TYPE, "site")
                                         )
+                                        logAd("ad detected channel=${channelLogin ?: "null"} candidates=${playerTypes.joinToString()} jobActive=${adAvoidanceJob?.isActive == true}")
                                         if (playerTypes.isNotEmpty()) {
                                             suppressAdPlayback()
                                             tryAlternateStream(playerTypes, useProxy)
@@ -727,6 +733,7 @@ class ExoPlayerService : BasePlaybackService() {
     private fun suppressAdPlayback() {
         if (!hidden) {
             hidden = true
+            logAd("suppress playback channel=${channelLogin ?: "null"}")
             player?.let { player ->
                 if (quality?.name != AUDIO_ONLY_QUALITY) {
                     player.trackSelectionParameters = player.trackSelectionParameters.buildUpon().apply {
@@ -742,6 +749,7 @@ class ExoPlayerService : BasePlaybackService() {
     private fun restoreAdPlayback() {
         if (hidden) {
             hidden = false
+            logAd("restore playback channel=${channelLogin ?: "null"}")
             player?.let { player ->
                 if (quality?.name != AUDIO_ONLY_QUALITY) {
                     player.trackSelectionParameters = player.trackSelectionParameters.buildUpon().apply {
@@ -754,6 +762,7 @@ class ExoPlayerService : BasePlaybackService() {
     }
 
     private fun fallbackFromAd(useProxy: Boolean, suppressAds: Boolean) {
+        logAd("fallback channel=${channelLogin ?: "null"} usingProxy=$proxyMediaPlaylist useProxy=$useProxy suppress=$suppressAds")
         if (proxyMediaPlaylist) {
             if (!stopProxy) {
                 proxyMediaPlaylist = false
@@ -783,6 +792,7 @@ class ExoPlayerService : BasePlaybackService() {
             fallbackFromAd(useProxy, suppressAds = true)
             return
         }
+        logAd("alternate probe started channel=$channelLogin candidates=${playerTypes.joinToString()}")
         adAvoidanceJob = lifecycleScope.launch {
             val candidate = try {
                 xtraModule.playerRepository.loadCleanStreamPlaylistUrl(
@@ -803,15 +813,18 @@ class ExoPlayerService : BasePlaybackService() {
                 )
             } catch (e: CancellationException) {
                 throw e
-            } catch (_: Exception) {
+            } catch (e: Exception) {
+                logAd("alternate probe exception channel=$channelLogin error=${e.javaClass.simpleName}")
                 null
             }
+            logAd("alternate probe result channel=$channelLogin candidate=${candidate?.playerType ?: "none"}")
             if (candidate != null && type == STREAM) {
                 try {
                     loadStream(restorePauseState = true, playlistUrlOverride = candidate.url)
                 } catch (e: CancellationException) {
                     throw e
-                } catch (_: Exception) {
+                } catch (e: Exception) {
+                    logAd("alternate stream load failed channel=$channelLogin playerType=${candidate.playerType} error=${e.javaClass.simpleName}")
                     fallbackFromAd(useProxy, suppressAds = true)
                 }
             } else {
@@ -826,6 +839,7 @@ class ExoPlayerService : BasePlaybackService() {
         playlistUrlOverride: String? = null,
     ) {
         channelLogin?.let { channelLogin ->
+            logAd("load stream channel=$channelLogin override=${!playlistUrlOverride.isNullOrBlank()} restart=$restart")
             if (!playlistUrlOverride.isNullOrBlank()) {
                 playlistUrl = playlistUrlOverride
                 qualities = null
@@ -2260,6 +2274,8 @@ class ExoPlayerService : BasePlaybackService() {
     }
 
     companion object {
+        private const val AD_TAG = "XtraAd"
+
         const val MULTIVARIANT_PLAYLIST_REGEX = "^usher\\.ttvnw\\.net$"
         const val MEDIA_PLAYLIST_REGEX = "^(?:[a-z0-9-]+\\.playlist\\.(?:live-video|ttvnw)\\.net|video-weaver\\.[a-z0-9-]+\\.hls\\.ttvnw\\.net)$"
 
@@ -2275,5 +2291,11 @@ class ExoPlayerService : BasePlaybackService() {
         private const val INTENT_PLAY_PAUSE = "com.github.andreyasadchy.xtra.PLAY_PAUSE"
         private const val INTENT_FAST_FORWARD = "com.github.andreyasadchy.xtra.FAST_FORWARD"
         const val INTENT_START = "com.github.andreyasadchy.xtra.START_PLAYBACK_SERVICE"
+    }
+
+    private fun logAd(message: String) {
+        if (BuildConfig.DEBUG) {
+            Log.d(AD_TAG, message)
+        }
     }
 }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/Media3PlayerFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/Media3PlayerFragment.kt
@@ -354,7 +354,7 @@ abstract class Media3PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFr
                                 playerControls.root.dispatchTouchEvent(event)
                             } else {
                                 controllerTapDetector.onTouchEvent(event)
-                                if (isTap) {
+                                if (isTap && (!doubleTap || isPortrait)) {
                                     showController()
                                 }
                             }
@@ -797,7 +797,7 @@ abstract class Media3PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFr
                                     isKeyboardShown = false
                                     chatLayout.clearFocus()
                                     if (!isPortrait) {
-                                        chatLayout.updateLayoutParams { width = chatWidthLandscape }
+                                        chatLayout.updateLayoutParams { width = effectiveLandscapeChatWidth() }
                                         if (isMaximized) {
                                             hideStatusBar()
                                         }
@@ -1236,16 +1236,27 @@ abstract class Media3PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFr
                 }
                 if (isMaximized) {
                     hideStatusBar()
-                    val chatWidth = if (isChatOpen) chatWidthLandscape else 0
+                    val chatWidth = if (isChatOpen) effectiveLandscapeChatWidth() else 0
                     playerLayout.updateLayoutParams<FrameLayout.LayoutParams> {
                         width = ViewGroup.LayoutParams.MATCH_PARENT
                         height = ViewGroup.LayoutParams.MATCH_PARENT
                         marginEnd = chatWidth
                     }
                     chatLayout.updateLayoutParams<FrameLayout.LayoutParams> {
-                        width = chatWidthLandscape
+                        width = chatWidth
                         height = ViewGroup.LayoutParams.MATCH_PARENT
                         gravity = Gravity.END
+                    }
+                    slidingLayout.doOnLayout {
+                        if (!isPortrait && isMaximized && isChatOpen) {
+                            val effectiveChatWidth = effectiveLandscapeChatWidth()
+                            playerLayout.updateLayoutParams<FrameLayout.LayoutParams> {
+                                marginEnd = effectiveChatWidth
+                            }
+                            chatLayout.updateLayoutParams<FrameLayout.LayoutParams> {
+                                width = effectiveChatWidth
+                            }
+                        }
                     }
                     if (isChatOpen) {
                         chatLayout.visibility = View.VISIBLE
@@ -1335,6 +1346,15 @@ abstract class Media3PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFr
     fun setResizeMode() {
         resizeMode = (resizeMode + 1).let { if (it < 5) it else 0 }
         binding.aspectRatioFrameLayout.resizeMode = resizeMode
+        if (!isPortrait && isMaximized && isChatOpen) {
+            val chatWidth = effectiveLandscapeChatWidth()
+            binding.playerLayout.updateLayoutParams<FrameLayout.LayoutParams> {
+                marginEnd = chatWidth
+            }
+            binding.chatLayout.updateLayoutParams<FrameLayout.LayoutParams> {
+                width = chatWidth
+            }
+        }
         requireContext().prefs().edit { putInt(C.ASPECT_RATIO_LANDSCAPE, resizeMode) }
     }
 
@@ -1524,18 +1544,31 @@ abstract class Media3PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFr
 
     private fun showChatLayout() {
         with(binding) {
+            val chatWidth = effectiveLandscapeChatWidth()
             playerLayout.updateLayoutParams<FrameLayout.LayoutParams> {
                 width = ViewGroup.LayoutParams.MATCH_PARENT
                 height = ViewGroup.LayoutParams.MATCH_PARENT
-                marginEnd = chatWidthLandscape
+                marginEnd = chatWidth
             }
             chatLayout.updateLayoutParams<FrameLayout.LayoutParams> {
-                width = chatWidthLandscape
+                width = chatWidth
                 height = ViewGroup.LayoutParams.MATCH_PARENT
                 gravity = Gravity.END
             }
             chatLayout.visibility = View.VISIBLE
         }
+    }
+
+    private fun effectiveLandscapeChatWidth(): Int {
+        if (chatWidthLandscape <= 0) return 0
+        if (!isMaximized || resizeMode != AspectRatioFrameLayout.RESIZE_MODE_FIT) return chatWidthLandscape
+
+        val availableWidth = binding.slidingLayout.width - binding.slidingLayout.paddingLeft - binding.slidingLayout.paddingRight
+        val availableHeight = binding.slidingLayout.height - binding.slidingLayout.paddingTop - binding.slidingLayout.paddingBottom
+        if (availableWidth <= 0 || availableHeight <= 0) return chatWidthLandscape
+
+        val widthNeededForVideo = (availableHeight * (16f / 9f)).toInt()
+        return max(chatWidthLandscape, (availableWidth - widthNeededForVideo).coerceAtLeast(0))
     }
 
     fun setQualityText() {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/PlayerFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/PlayerFragment.kt
@@ -347,7 +347,7 @@ abstract class PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFragment
                                 playerControls.root.dispatchTouchEvent(event)
                             } else {
                                 controllerTapDetector.onTouchEvent(event)
-                                if (isTap) {
+                                if (isTap && (!doubleTap || isPortrait)) {
                                     showController()
                                 }
                             }
@@ -845,7 +845,7 @@ abstract class PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFragment
                                     isKeyboardShown = false
                                     chatLayout.clearFocus()
                                     if (!isPortrait) {
-                                        chatLayout.updateLayoutParams { width = chatWidthLandscape }
+                                        chatLayout.updateLayoutParams { width = effectiveLandscapeChatWidth() }
                                         if (isMaximized) {
                                             hideStatusBar()
                                         }
@@ -1205,16 +1205,27 @@ abstract class PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFragment
                 }
                 if (isMaximized) {
                     hideStatusBar()
-                    val chatWidth = if (isChatOpen) chatWidthLandscape else 0
+                    val chatWidth = if (isChatOpen) effectiveLandscapeChatWidth() else 0
                     playerLayout.updateLayoutParams<FrameLayout.LayoutParams> {
                         width = ViewGroup.LayoutParams.MATCH_PARENT
                         height = ViewGroup.LayoutParams.MATCH_PARENT
                         marginEnd = chatWidth
                     }
                     chatLayout.updateLayoutParams<FrameLayout.LayoutParams> {
-                        width = chatWidthLandscape
+                        width = chatWidth
                         height = ViewGroup.LayoutParams.MATCH_PARENT
                         gravity = Gravity.END
+                    }
+                    slidingLayout.doOnLayout {
+                        if (!isPortrait && isMaximized && isChatOpen) {
+                            val effectiveChatWidth = effectiveLandscapeChatWidth()
+                            playerLayout.updateLayoutParams<FrameLayout.LayoutParams> {
+                                marginEnd = effectiveChatWidth
+                            }
+                            chatLayout.updateLayoutParams<FrameLayout.LayoutParams> {
+                                width = effectiveChatWidth
+                            }
+                        }
                     }
                     if (isChatOpen) {
                         chatLayout.visibility = View.VISIBLE
@@ -1304,6 +1315,15 @@ abstract class PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFragment
     fun setResizeMode() {
         resizeMode = (resizeMode + 1).let { if (it < 5) it else 0 }
         binding.aspectRatioFrameLayout.resizeMode = resizeMode
+        if (!isPortrait && isMaximized && isChatOpen) {
+            val chatWidth = effectiveLandscapeChatWidth()
+            binding.playerLayout.updateLayoutParams<FrameLayout.LayoutParams> {
+                marginEnd = chatWidth
+            }
+            binding.chatLayout.updateLayoutParams<FrameLayout.LayoutParams> {
+                width = chatWidth
+            }
+        }
         requireContext().prefs().edit { putInt(C.ASPECT_RATIO_LANDSCAPE, resizeMode) }
     }
 
@@ -1493,18 +1513,31 @@ abstract class PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFragment
 
     private fun showChatLayout() {
         with(binding) {
+            val chatWidth = effectiveLandscapeChatWidth()
             playerLayout.updateLayoutParams<FrameLayout.LayoutParams> {
                 width = ViewGroup.LayoutParams.MATCH_PARENT
                 height = ViewGroup.LayoutParams.MATCH_PARENT
-                marginEnd = chatWidthLandscape
+                marginEnd = chatWidth
             }
             chatLayout.updateLayoutParams<FrameLayout.LayoutParams> {
-                width = chatWidthLandscape
+                width = chatWidth
                 height = ViewGroup.LayoutParams.MATCH_PARENT
                 gravity = Gravity.END
             }
             chatLayout.visibility = View.VISIBLE
         }
+    }
+
+    private fun effectiveLandscapeChatWidth(): Int {
+        if (chatWidthLandscape <= 0) return 0
+        if (!isMaximized || resizeMode != AspectRatioFrameLayout.RESIZE_MODE_FIT) return chatWidthLandscape
+
+        val availableWidth = binding.slidingLayout.width - binding.slidingLayout.paddingLeft - binding.slidingLayout.paddingRight
+        val availableHeight = binding.slidingLayout.height - binding.slidingLayout.paddingTop - binding.slidingLayout.paddingBottom
+        if (availableWidth <= 0 || availableHeight <= 0) return chatWidthLandscape
+
+        val widthNeededForVideo = (availableHeight * (16f / 9f)).toInt()
+        return max(chatWidthLandscape, (availableWidth - widthNeededForVideo).coerceAtLeast(0))
     }
 
     fun setQualityText() {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/TwitchAdController.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/TwitchAdController.kt
@@ -34,6 +34,8 @@ class TwitchAdController {
     }
 
     companion object {
-        val PLAYER_TYPES = listOf("site", "popout", "embed", "autoplay")
+        // Keep the same backup order used by VAFT. Embed is the most reliable
+        // alternate when the current site player is in a commercial break.
+        val PLAYER_TYPES = listOf("site", "embed", "popout", "autoplay")
     }
 }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/chat/ChatAdapterUtils.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/chat/ChatAdapterUtils.kt
@@ -252,6 +252,7 @@ object ChatAdapterUtils {
                         builderIndex += timestamp.length + 1
                     }
                 }
+                var hasBadge = false
                 chatMessage.badges?.forEach { chatBadge ->
                     val badge = synchronized(channelBadges) {
                         channelBadges.find { it.setId == chatBadge.setId && it.version == chatBadge.version }
@@ -260,6 +261,7 @@ object ChatAdapterUtils {
                         globalBadges.find { it.setId == chatBadge.setId && it.version == chatBadge.version }
                     }
                     if (badge != null) {
+                        hasBadge = true
                         builder.append(". ")
                         builder.setSpan(ForegroundColorSpan(Color.TRANSPARENT), builderIndex, builderIndex + 1, SPAN_EXCLUSIVE_EXCLUSIVE)
                         if (imageClick != null) {
@@ -294,6 +296,7 @@ object ChatAdapterUtils {
                         }
                     }
                     if (badge != null) {
+                        hasBadge = true
                         builder.append(". ")
                         builder.setSpan(ForegroundColorSpan(Color.TRANSPARENT), builderIndex, builderIndex + 1, SPAN_EXCLUSIVE_EXCLUSIVE)
                         if (imageClick != null) {
@@ -317,6 +320,10 @@ object ChatAdapterUtils {
                             end = builderIndex++
                         ))
                     }
+                }
+                if (hasBadge && builder.lastOrNull() == ' ') {
+                    builder.delete(builder.length - 1, builder.length)
+                    builderIndex--
                 }
                 val color = if (chatMessage.color != null) {
                     getSavedColor(chatMessage.color, savedColors, useReadableColors, isLightTheme)

--- a/app/src/main/res/layout/chat_list_item.xml
+++ b/app/src/main/res/layout/chat_list_item.xml
@@ -6,9 +6,6 @@
     android:clickable="true"
     android:focusable="true"
     android:linksClickable="true"
-    android:paddingLeft="5dp"
-    android:paddingTop="1dp"
-    android:paddingRight="5dp"
-    android:paddingBottom="1dp"
+    android:padding="0dp"
     android:textAppearance="?attr/textAppearanceBodyMedium"
     android:textDirection="ltr" />

--- a/app/src/main/res/layout/combined_chat_list_item.xml
+++ b/app/src/main/res/layout/combined_chat_list_item.xml
@@ -2,9 +2,6 @@
 <TextView xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:paddingLeft="5dp"
-    android:paddingTop="1dp"
-    android:paddingRight="5dp"
-    android:paddingBottom="1dp"
+    android:padding="0dp"
     android:textAppearance="?attr/textAppearanceBodyMedium"
     android:textDirection="ltr" />

--- a/app/src/main/res/layout/fragment_chat.xml
+++ b/app/src/main/res/layout/fragment_chat.xml
@@ -21,6 +21,7 @@
                 android:id="@+id/recyclerView"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
+                android:padding="0dp"
                 tools:listitem="@layout/chat_list_item" />
 
             <Button

--- a/app/src/main/res/layout/fragment_combined_chat.xml
+++ b/app/src/main/res/layout/fragment_combined_chat.xml
@@ -25,7 +25,8 @@
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/combinedChatRecyclerView"
             android:layout_width="match_parent"
-            android:layout_height="match_parent" />
+            android:layout_height="match_parent"
+            android:padding="0dp" />
 
         <TextView
             android:id="@+id/combinedChatEmpty"

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -5,6 +5,7 @@
     <string name="following">المُتابَعين</string>
     <string name="downloads">التنزيلات</string>
     <string name="connection_error">خطأ في الاتصال بالخادم. الرجاء إعادة المحاولة</string>
+    <string name="chat_reconnecting">جارٍ إعادة الاتصال بالدردشة…</string>
     <string name="sort">فرز حسب</string>
     <string name="upload_date">تاريخ التحميل</string>
     <string name="today">اليوم</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -5,6 +5,7 @@
     <string name="following">Du folgst</string>
     <string name="downloads">Downloads</string>
     <string name="connection_error">Fehler beim Verbinden mit dem Server. Bitte versuchen Sie es erneut</string>
+    <string name="chat_reconnecting">Chat wird erneut verbunden…</string>
     <string name="sort">Sortieren</string>
     <string name="upload_date">Upload-Datum</string>
     <string name="today">Heute</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -10,6 +10,7 @@
     <string name="following">Siguiendo</string>
     <string name="downloads">Descargas</string>
     <string name="connection_error">Error al conectarse al servidor. Inténtalo de nuevo</string>
+    <string name="chat_reconnecting">Reconectando al chat…</string>
     <string name="sort">Ordenar por</string>
     <string name="upload_date">Fecha de subida</string>
     <string name="today">Hoy</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -5,6 +5,7 @@
     <string name="following">Suivi</string>
     <string name="downloads">Téléchargements</string>
     <string name="connection_error">Erreur de connexion au serveur. Veuillez réessayer.</string>
+    <string name="chat_reconnecting">Reconnexion au chat…</string>
     <string name="sort">Trier</string>
     <string name="upload_date">Date de mise en ligne</string>
     <string name="today">Aujourd\'hui</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -5,6 +5,7 @@
     <string name="following">Seguindo</string>
     <string name="downloads">Descargas</string>
     <string name="connection_error">Erro ao conectar co servidor. Téntao de novo.</string>
+    <string name="chat_reconnecting">Volvendo conectar ao chat…</string>
     <string name="sort">Ordenar</string>
     <string name="upload_date">Data de subida</string>
     <string name="today">Hoxe</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -562,4 +562,4 @@
     <string name="recent_messages_api_url">Recent messages API URL</string>
     <string name="access_local_network_title">Grant local network permission</string>
     <string name="access_local_network_desc">Required for connecting to local proxies</string>
-</resources>	
+</resources>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -5,6 +5,7 @@
     <string name="following">Mengikuti</string>
     <string name="downloads">Unduhan</string>
     <string name="connection_error">Terjadi kesalahan saat menyambung ke server. Mohon coba kembali</string>
+    <string name="chat_reconnecting">Menghubungkan kembali ke chat…</string>
     <string name="sort">Urutkan</string>
     <string name="upload_date">Tanggal upload</string>
     <string name="today">Hari Ini</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -5,6 +5,7 @@
     <string name="following">Seguiti</string>
     <string name="downloads">Download</string>
     <string name="connection_error">Errore di connessione al server. Si prega di riprovare</string>
+    <string name="chat_reconnecting">Riconnessione alla chat…</string>
     <string name="sort">Ordina</string>
     <string name="upload_date">Data di caricamento</string>
     <string name="today">Oggi</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -5,6 +5,7 @@
     <string name="following">フォロー中</string>
     <string name="downloads">ダウンロード</string>
     <string name="connection_error">サーバーに接続できませんでした。もう一度お試しください</string>
+    <string name="chat_reconnecting">チャットに再接続中…</string>
     <string name="sort">並べ替え</string>
     <string name="upload_date">アップロード日</string>
     <string name="today">今日</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -5,6 +5,7 @@
     <string name="following">Seguindo</string>
     <string name="downloads">Baixados</string>
     <string name="connection_error">Erro ao conectar o servidor. Por favor, tente de novo.</string>
+    <string name="chat_reconnecting">Reconectando ao chat…</string>
     <string name="sort">Ordenar</string>
     <string name="upload_date">Data de upload</string>
     <string name="today">Hoje</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -5,6 +5,7 @@
     <string name="following">Отслеживания</string>
     <string name="downloads">Загрузки</string>
     <string name="connection_error">Ошибка подключения. Пожалуйста, попробуйте ещё раз</string>
+    <string name="chat_reconnecting">Повторное подключение к чату…</string>
     <string name="sort">Сортировка</string>
     <string name="upload_date">По дате загрузки</string>
     <string name="today">Сегодня</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -6,6 +6,7 @@
     <string name="following">Takip Edilenler</string>
     <string name="downloads">İndirilenler</string>
     <string name="connection_error">Sunucuya bağlanırken hata oluştu. Lütfen tekrar deneyin</string>
+    <string name="chat_reconnecting">Sohbete yeniden bağlanılıyor…</string>
     <string name="sort">Sırala</string>
     <string name="upload_date">Yüklenme tarihi</string>
     <string name="today">Bugün</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -5,6 +5,7 @@
     <string name="following">关注</string>
     <string name="downloads">下载</string>
     <string name="connection_error">连接服务器时发生错误。请再次尝试</string>
+    <string name="chat_reconnecting">正在重新连接聊天…</string>
     <string name="sort">排序</string>
     <string name="upload_date">上传日期</string>
     <string name="today">今日</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -5,6 +5,7 @@
     <string name="following">追隨中</string>
     <string name="downloads">下載</string>
     <string name="connection_error">連接伺服器時發生錯誤。請再次嘗試</string>
+    <string name="chat_reconnecting">正在重新連線至聊天室…</string>
     <string name="sort">排序</string>
     <string name="upload_date">上傳日期</string>
     <string name="today">今日</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -23,6 +23,7 @@
     <string name="following">Following</string>
     <string name="downloads">Downloads</string>
     <string name="connection_error">Error connecting to the server. Please try again.</string>
+    <string name="chat_reconnecting">Reconnecting to chat…</string>
     <string name="sort">Sort</string>
     <string name="upload_date">Upload date</string>
     <string name="today">Today</string>

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/player/TwitchAdControllerTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/player/TwitchAdControllerTest.kt
@@ -1,0 +1,44 @@
+package com.github.andreyasadchy.xtra.ui.player
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class TwitchAdControllerTest {
+
+    @Test
+    fun adWindowExcludesCurrentPlayerAndConsumesEachAlternateOnce() {
+        val controller = TwitchAdController()
+
+        assertEquals(
+            listOf("embed", "popout", "autoplay"),
+            controller.playerTypesForAd("site"),
+        )
+        assertEquals(emptyList<String>(), controller.playerTypesForAd("site"))
+    }
+
+    @Test
+    fun cleanPlaylistAllowsAlternatesOnTheNextAdWindow() {
+        val controller = TwitchAdController()
+
+        controller.playerTypesForAd("site")
+        controller.onCleanPlaylist()
+
+        assertEquals(
+            listOf("embed", "popout", "autoplay"),
+            controller.playerTypesForAd("site"),
+        )
+    }
+
+    @Test
+    fun resetAllowsAlternatesOnTheNextAdWindow() {
+        val controller = TwitchAdController()
+
+        controller.playerTypesForAd("site")
+        controller.reset()
+
+        assertEquals(
+            listOf("embed", "popout", "autoplay"),
+            controller.playerTypesForAd("site"),
+        )
+    }
+}


### PR DESCRIPTION
Summary:
- Keep alternate playback probes on a stable VAFT device ID and retain ad-detection diagnostics in debug builds.
- Avoid showing a transient chat connection error during initial connection; show a reconnecting state only after a disconnect.
- Remove chat row/padding waste and close the landscape FIT-mode letterbox beside chat.
- Prevent the horizontal single-tap controller from being hidden by the delayed double-tap confirmation.

Verification:
- .\gradlew.bat :app:testDebugUnitTest :app:assembleDebug --console=plain
- Installed and manually verified the debug APK on a physical device in horizontal player mode.

An independent review will be posted here before merge.