### PR TITLE
Fix tiny emotes in picker

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -38,6 +38,7 @@ android {
         applicationId = "com.github.andreyasadchy.xtra"
         minSdk = 23
         targetSdk = 37
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         versionCode = applicationVersionCode
         versionName = applicationVersionName
         buildConfigField("int", "CI_VERSION_CODE_BASE", defaultVersionCode.toString())
@@ -85,6 +86,8 @@ tasks.register("printVersionInfo") {
 dependencies {
     testImplementation("junit:junit:4.13.2")
     testImplementation("org.json:json:20240303")
+    androidTestImplementation("androidx.test.ext:junit:1.2.1")
+    androidTestImplementation("androidx.test:runner:1.6.2")
 
     compileOnly("com.google.j2objc:j2objc-annotations:3.0.0") // OkHttpDataSource SettableFuture
     implementation("com.google.android.gms:play-services-cronet:18.1.0")

--- a/app/src/androidTest/java/com/github/andreyasadchy/xtra/ui/chat/EmotesPickerLayoutTest.kt
+++ b/app/src/androidTest/java/com/github/andreyasadchy/xtra/ui/chat/EmotesPickerLayoutTest.kt
@@ -1,0 +1,46 @@
+package com.github.andreyasadchy.xtra.ui.chat
+
+import android.graphics.Bitmap
+import android.graphics.Matrix
+import android.graphics.drawable.BitmapDrawable
+import android.view.LayoutInflater
+import android.view.View
+import android.widget.ImageButton
+import android.widget.ImageView
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.github.andreyasadchy.xtra.R
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class EmotesPickerLayoutTest {
+
+    @Test
+    fun pickerImageScalesSmallEmotesToTheCell() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val imageButton = LayoutInflater.from(context)
+            .inflate(R.layout.fragment_emotes_list_item, null) as ImageButton
+        val size = (48 * context.resources.displayMetrics.density).toInt()
+        imageButton.setImageDrawable(
+            BitmapDrawable(
+                context.resources,
+                Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888),
+            ),
+        )
+        imageButton.measure(
+            View.MeasureSpec.makeMeasureSpec(size, View.MeasureSpec.EXACTLY),
+            View.MeasureSpec.makeMeasureSpec(size, View.MeasureSpec.EXACTLY),
+        )
+        imageButton.layout(0, 0, size, size)
+
+        val matrixValues = FloatArray(9)
+        imageButton.imageMatrix.getValues(matrixValues)
+
+        assertEquals(ImageView.ScaleType.FIT_CENTER, imageButton.scaleType)
+        assertTrue(matrixValues[Matrix.MSCALE_X] > 1f)
+        assertTrue(matrixValues[Matrix.MSCALE_Y] > 1f)
+    }
+}

--- a/app/src/main/res/layout/fragment_emotes_list_item.xml
+++ b/app/src/main/res/layout/fragment_emotes_list_item.xml
@@ -6,6 +6,7 @@
     android:background="?android:selectableItemBackgroundBorderless"
     android:contentDescription="@string/room_emote"
     android:padding="8dp"
+    android:scaleType="fitCenter"
     android:layout_marginTop="5dp"
     android:layout_marginBottom="5dp"
     android:layout_marginLeft="10dp"


### PR DESCRIPTION
## Summary
Keep emote picker images scaled to the cell after making picker items accessible buttons.

The button style defaults to center, so small emote assets stayed at their native size. The picker now explicitly uses fitCenter while keeping the 48dp touch target.

## Testing
- .\\gradlew.bat :app:testDebugUnitTest :app:assembleDebug
- .\\gradlew.bat :app:connectedDebugAndroidTest on xtra-api35 (API 35)
- Debug APK installed and launched on xtra-api35