### PR TITLE
Show current Twitch predictions on channel entry

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/GraphQLRepository.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/GraphQLRepository.kt
@@ -1548,6 +1548,32 @@ class GraphQLRepository(
         json.decodeFromString<ChannelPointContextResponse>(sendPersistedQuery(networkLibrary, headers, body))
     }
 
+    /**
+     * Returns Twitch's viewer-facing prediction snapshot. This is intentionally
+     * a raw response because the private web operation has changed its
+     * collection shape over time.
+     */
+    suspend fun loadChannelPointsPredictionContext(
+        networkLibrary: String?,
+        headers: Map<String, String>,
+        channelLogin: String,
+    ): String = withContext(Dispatchers.IO) {
+        val body = buildJsonObject {
+            putJsonObject("extensions") {
+                putJsonObject("persistedQuery") {
+                    put("sha256Hash", TwitchGqlOperations.CHANNEL_POINTS_PREDICTION_CONTEXT_HASH)
+                    put("version", 1)
+                }
+            }
+            put("operationName", TwitchGqlOperations.CHANNEL_POINTS_PREDICTION_CONTEXT_NAME)
+            putJsonObject("variables") {
+                put("count", 1)
+                put("channelLogin", channelLogin)
+            }
+        }.toString()
+        sendPersistedQuery(networkLibrary, headers, body)
+    }
+
     suspend fun loadWatchStreak(networkLibrary: String?, headers: Map<String, String>, channelId: String): WatchStreakResponse = withContext(Dispatchers.IO) {
         val body = buildJsonObject {
             put("operationName", "RewardList")

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/TwitchGqlOperations.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/TwitchGqlOperations.kt
@@ -2,6 +2,11 @@ package com.github.andreyasadchy.xtra.repository
 
 /** Private Twitch web operations used for viewer participation. */
 internal object TwitchGqlOperations {
+    const val CHANNEL_POINTS_PREDICTION_CONTEXT_NAME = "ChannelPointsPredictionContext"
+    // Private Twitch web operation used by the channel page to discover the
+    // current prediction for viewers who are not the broadcaster.
+    const val CHANNEL_POINTS_PREDICTION_CONTEXT_HASH = "beb846598256b75bd7c1fe54a80431335996153e358ca9c7837ce7bb83d7d383"
+
     const val MAKE_PREDICTION_NAME = "MakePrediction"
     // Current Twitch web clients use this persisted MakePrediction document.
     const val MAKE_PREDICTION_HASH = "b44682ecc88358817009f20e69d75081b1e58825bb40aa53d5dbadcc17c881d8"

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatViewModel.kt
@@ -60,6 +60,8 @@ import com.github.andreyasadchy.xtra.util.chat.EventSubChatConnectionState
 import com.github.andreyasadchy.xtra.util.chat.EventSubChatConnectionStatus
 import com.github.andreyasadchy.xtra.util.chat.EventSubUtils
 import com.github.andreyasadchy.xtra.util.chat.EventSubWebSocket
+import com.github.andreyasadchy.xtra.util.chat.GqlPredictionParser
+import com.github.andreyasadchy.xtra.util.chat.GqlPredictionSnapshot
 import com.github.andreyasadchy.xtra.util.chat.HermesWebSocket
 import com.github.andreyasadchy.xtra.util.chat.PollCache
 import com.github.andreyasadchy.xtra.util.chat.PollState
@@ -157,6 +159,9 @@ class ChatViewModel(
     private var pollTimeoutPollId: String? = null
     private var pollVoteJob: Job? = null
     private var predictionBetJob: Job? = null
+    private var predictionSnapshotJob: Job? = null
+    private var predictionSessionToken = 0L
+    private var predictionSubscriptionSessionToken: Long? = null
     private var started = false
     private var activeChannelId: String? = null
     private var activeChannelLogin: String? = null
@@ -1639,6 +1644,7 @@ class ChatViewModel(
 
     fun startLiveChat(channelId: String?, channelLogin: String) {
         stopLiveChat()
+        val sessionToken = predictionSessionToken
         started = true
         _connectionState.value = ConnectionState.CONNECTING
         activeChannelId = channelId
@@ -1676,8 +1682,12 @@ class ChatViewModel(
         }
         if (showPredictions && !channelId.isNullOrBlank()) {
             val cached = PredictionCache.load(applicationContext.prefs(), channelId, broadcastId = streamId)
-            if (cached != null) {
+            if (cached != null &&
+                (!PredictionState.isFinal(cached) || PredictionState.isFreshFinalForDisplay(cached))
+            ) {
                 predictionStateStore.restore(cached, ::publishPrediction)
+            } else if (cached != null) {
+                PredictionCache.clear(applicationContext.prefs(), channelId)
             } else if (!streamId.isNullOrBlank()) {
                 ViewerParticipationCache.loadPredictionBet(
                     preferences = applicationContext.prefs(),
@@ -1686,6 +1696,9 @@ class ChatViewModel(
                     broadcastId = streamId,
                 )
             }
+        }
+        if (showPredictions) {
+            loadCurrentPredictionSnapshot(networkLibrary, channelLogin, channelId, sessionToken)
         }
         if (isLoggedIn) {
             loadChannelPoints(networkLibrary, gqlHeaders, channelLogin, enableIntegrity)
@@ -1737,7 +1750,7 @@ class ChatViewModel(
                 showPolls = showPolls,
                 showPredictions = showPredictions,
                 trustManager = trustManager,
-                listener = PubSubListener(channelLogin, collectPoints, notifyPoints, showRaids, showPolls, showPredictions, networkLibrary, gqlHeaders, isLoggedIn, accountId, channelId, enableIntegrity, showWebSocketDebugInfo)
+                listener = PubSubListener(channelLogin, collectPoints, notifyPoints, showRaids, showPolls, showPredictions, networkLibrary, gqlHeaders, isLoggedIn, accountId, channelId, enableIntegrity, showWebSocketDebugInfo, sessionToken)
             )
             pubSubJob = hermesWebSocket?.connect(viewModelScope)
         }
@@ -1777,6 +1790,9 @@ class ChatViewModel(
     }
 
     fun stopLiveChat() {
+        predictionSessionToken += 1
+        predictionSnapshotJob?.cancel()
+        predictionSnapshotJob = null
         _connectionState.value = ConnectionState.IDLE
         watchStreakSession++
         activeChannelId = null
@@ -2132,9 +2148,17 @@ class ChatViewModel(
         }
     }
 
-    private fun updatePrediction(value: Prediction, sourceChannelId: String? = activeChannelId) {
+    private fun updatePrediction(
+        value: Prediction,
+        sourceChannelId: String? = activeChannelId,
+        sourceChannelLogin: String? = null,
+        sourceSessionToken: Long? = null,
+    ) {
         predictionStateStore.withLock {
-            if (sourceChannelId != null && sourceChannelId != activeChannelId) return@withLock
+            if ((sourceChannelId != null && sourceChannelId != activeChannelId) ||
+                (sourceChannelLogin != null && sourceChannelLogin != activeChannelLogin) ||
+                (sourceSessionToken != null && sourceSessionToken != predictionSessionToken)
+            ) return@withLock
             predictionStateStore.update(
                 incoming = value,
                 normalize = PredictionState::normalizeLive,
@@ -2410,6 +2434,97 @@ class ChatViewModel(
         }
     }
 
+    private fun loadCurrentPredictionSnapshot(
+        networkLibrary: String?,
+        channelLogin: String,
+        channelId: String?,
+        sessionToken: Long,
+    ) {
+        if (sessionToken != predictionSessionToken || activeChannelLogin != channelLogin) return
+        predictionSnapshotJob?.cancel()
+        val authenticatedHeaders = TwitchApiHelper.getWebGQLHeaders(applicationContext, includeToken = true)
+        predictionSnapshotJob = viewModelScope.launch(Dispatchers.IO) {
+            try {
+                val snapshotRequestedAt = System.currentTimeMillis()
+                val authenticatedSnapshot = GqlPredictionParser.parse(
+                    graphQLRepository.loadChannelPointsPredictionContext(
+                        networkLibrary,
+                        authenticatedHeaders,
+                        channelLogin,
+                    ),
+                    snapshotRequestedAt,
+                )
+                var snapshot = authenticatedSnapshot
+                if ((authenticatedSnapshot == null || !authenticatedSnapshot.hasActiveOrLockedPrediction) &&
+                    !authenticatedHeaders[C.HEADER_TOKEN].isNullOrBlank()
+                ) {
+                    val anonymousSnapshot = GqlPredictionParser.parse(
+                        graphQLRepository.loadChannelPointsPredictionContext(
+                            networkLibrary,
+                            TwitchApiHelper.getWebGQLHeaders(applicationContext, includeToken = false),
+                            channelLogin,
+                        ),
+                        snapshotRequestedAt,
+                    )
+                    snapshot = choosePredictionSnapshot(authenticatedSnapshot, anonymousSnapshot)
+                }
+                if (sessionToken != predictionSessionToken || activeChannelLogin != channelLogin || snapshot == null) {
+                    return@launch
+                }
+                val prediction = snapshot.prediction
+                if (prediction != null) {
+                    updatePrediction(
+                        prediction,
+                        sourceChannelId = channelId,
+                        sourceChannelLogin = channelLogin,
+                        sourceSessionToken = sessionToken,
+                    )
+                }
+                if (snapshot.authoritative && !snapshot.hasActiveOrLockedPrediction) {
+                    clearStalePrediction(channelId, channelLogin, sessionToken, snapshotRequestedAt)
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                // Hermes remains the primary live path; a snapshot failure is harmless.
+            }
+        }
+    }
+
+    private fun choosePredictionSnapshot(
+        authenticatedSnapshot: GqlPredictionSnapshot?,
+        anonymousSnapshot: GqlPredictionSnapshot?,
+    ): GqlPredictionSnapshot? = listOfNotNull(authenticatedSnapshot, anonymousSnapshot)
+        .maxByOrNull { snapshot ->
+            when {
+                snapshot.hasActiveOrLockedPrediction -> 3
+                snapshot.authoritative -> 2
+                snapshot.prediction != null -> 1
+                else -> 0
+            }
+        }
+
+    private fun clearStalePrediction(
+        channelId: String?,
+        channelLogin: String,
+        sessionToken: Long,
+        notAfter: Long,
+    ) {
+        val cleared = predictionStateStore.clearIf(
+            {
+                sessionToken == predictionSessionToken &&
+                        channelLogin == activeChannelLogin &&
+                        ((PredictionState.isOngoing(it) &&
+                                (it.observedAt == null || it.observedAt <= notAfter)) ||
+                                PredictionState.isFinal(it) && !PredictionState.isFreshFinalForDisplay(it))
+            },
+            ::clearPredictionState,
+        )
+        if (cleared && !channelId.isNullOrBlank() && activeChannelId == channelId) {
+            PredictionCache.clear(applicationContext.prefs(), channelId)
+        }
+    }
+
     private inner class PubSubListener(
         private val channelLogin: String,
         private val collectPoints: Boolean,
@@ -2424,10 +2539,20 @@ class ChatViewModel(
         private val channelId: String?,
         private val enableIntegrity: Boolean,
         private val showWebSocketDebugInfo: Boolean,
+        private val sessionToken: Long,
     ) : HermesWebSocket.Listener {
         override suspend fun onConnect() {
             if (showWebSocketDebugInfo) {
                 onMessage(ChatMessage(systemMsg = ContextCompat.getString(applicationContext, R.string.websocket_connected).format("PubSub")))
+            }
+        }
+
+        override suspend fun onSubscriptionsSent() {
+            if (!showPredictions || sessionToken != predictionSessionToken || activeChannelLogin != channelLogin) return
+            if (predictionSubscriptionSessionToken == sessionToken) {
+                loadCurrentPredictionSnapshot(networkLibrary, channelLogin, channelId, sessionToken)
+            } else {
+                predictionSubscriptionSessionToken = sessionToken
             }
         }
 
@@ -2560,7 +2685,12 @@ class ChatViewModel(
         override suspend fun onPredictionUpdate(message: JSONObject) {
             if (showPredictions && channelId == activeChannelId) {
                 PubSubUtils.onPredictionUpdate(message)?.let {
-                    updatePrediction(it, sourceChannelId = channelId)
+                    updatePrediction(
+                        it,
+                        sourceChannelId = channelId,
+                        sourceChannelLogin = channelLogin,
+                        sourceSessionToken = sessionToken,
+                    )
                 }
             }
         }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/TwitchApiHelper.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/TwitchApiHelper.kt
@@ -21,6 +21,7 @@ import java.time.temporal.ChronoUnit
 import java.util.Calendar
 import java.util.Date
 import java.util.Locale
+import kotlin.uuid.Uuid
 
 object TwitchApiHelper {
 
@@ -280,6 +281,30 @@ object TwitchApiHelper {
                     }
                     put(C.HEADER_TOKEN, addTokenPrefixGQL(gqlWebToken))
                 }
+            }
+        }
+    }
+
+    /**
+     * Headers for private operations used by the Twitch web channel page.
+     * Keep these separate from the TV/integrity GQL identity: web operations
+     * can reject an otherwise valid client identity, while this prediction
+     * lookup also works without an Authorization header.
+     */
+    fun getWebGQLHeaders(context: Context, includeToken: Boolean = true): Map<String, String> {
+        return mutableMapOf(
+            C.HEADER_CLIENT_ID to (context.prefs().getString(C.GQL_CLIENT_ID_WEB, C.DEFAULT_GQL_CLIENT_ID_WEB)
+                ?: C.DEFAULT_GQL_CLIENT_ID_WEB),
+            "Client-Session-Id" to Uuid.random().toString(),
+            "X-Device-Id" to Uuid.random().toHexString(),
+            "Origin" to "https://www.twitch.tv",
+            "Referer" to "https://www.twitch.tv/",
+            "User-Agent" to "Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Mobile Safari/537.36",
+        ).apply {
+            if (includeToken) {
+                context.tokenPrefs().getString(C.GQL_TOKEN_WEB, null)
+                    ?.takeIf { it.isNotBlank() }
+                    ?.let { put(C.HEADER_TOKEN, addTokenPrefixGQL(it)) }
             }
         }
     }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/chat/GqlPredictionParser.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/chat/GqlPredictionParser.kt
@@ -1,0 +1,176 @@
+package com.github.andreyasadchy.xtra.util.chat
+
+import com.github.andreyasadchy.xtra.model.chat.Prediction
+import org.json.JSONArray
+import org.json.JSONObject
+import kotlin.time.Instant
+
+/** Parsed result of Twitch's viewer-facing current-prediction operation. */
+internal data class GqlPredictionSnapshot(
+    val prediction: Prediction?,
+    /** True only when the response contained both current collections. */
+    val authoritative: Boolean,
+    val hasActiveOrLockedPrediction: Boolean,
+)
+
+/**
+ * Parser for the private ChannelPointsPredictionContext operation.
+ *
+ * Twitch has returned both arrays and connection-shaped collections for this
+ * operation. The parser deliberately accepts both, and keeps its camelCase
+ * handling separate from the snake_case PubSub/Helix parser.
+ */
+internal object GqlPredictionParser {
+    fun parse(body: String, observedAt: Long = System.currentTimeMillis()): GqlPredictionSnapshot? {
+        val root = runCatching { JSONObject(body) }.getOrNull() ?: return null
+        val channel = root.optJSONObject("data")
+            ?.optJSONObject("community")
+            ?.optJSONObject("channel")
+            ?: return null
+
+        val activeEvents = channel.opt("activePredictionEvents")
+            .predictionObjects()
+            .mapNotNull { parsePrediction(it, "ACTIVE", observedAt) }
+            .filter { prediction -> PredictionState.isOngoing(prediction) }
+        val lockedEvents = channel.opt("lockedPredictionEvents")
+            .predictionObjects()
+            .mapNotNull { parsePrediction(it, "LOCKED", observedAt) }
+            .filter { prediction -> PredictionState.isOngoing(prediction) }
+        val resolvedEvents = channel.opt("resolvedPredictionEvents")
+            .predictionObjects()
+            .mapNotNull { parsePrediction(it, "RESOLVED", observedAt) }
+            .filter { prediction ->
+                PredictionState.isFinal(prediction) && isRecentResolved(prediction, observedAt)
+            }
+
+        return GqlPredictionSnapshot(
+            prediction = (activeEvents + lockedEvents + resolvedEvents)
+                .firstOrNull { !it.id.isNullOrBlank() },
+            authoritative = channel.hasNonNullCollection("activePredictionEvents") &&
+                    channel.hasNonNullCollection("lockedPredictionEvents"),
+            hasActiveOrLockedPrediction = activeEvents.isNotEmpty() || lockedEvents.isNotEmpty(),
+        )
+    }
+
+    private fun parsePrediction(
+        json: JSONObject,
+        fallbackStatus: String,
+        observedAt: Long,
+    ): Prediction? {
+        val id = json.optionalString("id") ?: return null
+        val startedAt = json.timestamp("startedAt", "started_at")
+        val createdAt = json.timestamp("createdAt", "created_at") ?: startedAt
+        val locksAt = json.timestamp("locksAt", "locks_at")
+        val lockedAt = json.timestamp("lockedAt", "locked_at")
+        val endedAt = json.timestamp("endedAt", "ended_at")
+        val status = json.optionalString("status")?.uppercase() ?: fallbackStatus
+        val effectiveWindow = json.optionalInt(
+            "predictionWindowSeconds",
+            "prediction_window_seconds",
+            "predictionWindow",
+            "prediction_window",
+        ) ?: if (startedAt != null && locksAt != null) {
+            ((locksAt - startedAt) / 1_000L).toInt().takeIf { it > 0 }
+        } else {
+            null
+        }
+
+        val outcomes = json.optJSONArray("outcomes")?.let { array ->
+            buildList {
+                for (index in 0 until array.length()) {
+                    val outcome = array.optJSONObject(index) ?: continue
+                    add(
+                        Prediction.PredictionOutcome(
+                            id = outcome.optionalString("id"),
+                            title = outcome.optionalString("title"),
+                            totalPoints = outcome.optionalInt("totalPoints", "total_points"),
+                            totalUsers = outcome.optionalInt("totalUsers", "total_users"),
+                            color = outcome.optionalString("color")?.uppercase(),
+                        ),
+                    )
+                }
+            }
+        }.orEmpty()
+
+        val winningOutcomeId = json.optionalString("winning_outcome_id")
+            ?: json.optJSONObject("winningOutcome")?.optionalString("id")
+
+        return Prediction(
+            id = id,
+            createdAt = createdAt,
+            outcomes = outcomes,
+            predictionWindowSeconds = effectiveWindow,
+            status = status,
+            title = json.optionalString("title"),
+            winningOutcomeId = winningOutcomeId,
+            startedAt = startedAt,
+            locksAt = locksAt,
+            lockedAt = lockedAt,
+            endedAt = endedAt,
+            observedAt = observedAt,
+        )
+    }
+
+    private fun isRecentResolved(prediction: Prediction, observedAt: Long): Boolean {
+        val endedAt = prediction.endedAt ?: return false
+        val age = observedAt - endedAt
+        return age in 0L..PredictionState.RESULT_DISPLAY_GRACE_MILLIS
+    }
+
+    private fun Any?.predictionObjects(): List<JSONObject> = when (this) {
+        is JSONArray -> buildList {
+            for (index in 0 until length()) {
+                optJSONObject(index)?.let(::add)
+            }
+        }
+        is JSONObject -> {
+            val entries = optJSONArray("edges") ?: optJSONArray("nodes")
+            if (entries != null) {
+                buildList {
+                    for (index in 0 until entries.length()) {
+                        val entry = entries.optJSONObject(index) ?: continue
+                        (entry.optJSONObject("node") ?: entry).let(::add)
+                    }
+                }
+            } else if (has("id")) {
+                listOf(this)
+            } else {
+                emptyList()
+            }
+        }
+        else -> emptyList()
+    }
+
+    private fun JSONObject.hasNonNullCollection(key: String): Boolean = has(key) && !isNull(key)
+
+    private fun JSONObject.optionalString(vararg keys: String): String? = keys.firstNotNullOfOrNull { key ->
+        if (!has(key) || isNull(key)) null else optString(key).takeIf { it.isNotBlank() }
+    }
+
+    private fun JSONObject.optionalInt(vararg keys: String): Int? = keys.firstNotNullOfOrNull { key ->
+        if (!has(key) || isNull(key)) {
+            null
+        } else {
+            opt(key)?.toString()?.toDoubleOrNull()?.toInt()
+        }
+    }
+
+    private fun JSONObject.timestamp(vararg keys: String): Long? = keys.firstNotNullOfOrNull { key ->
+        if (!has(key) || isNull(key)) {
+            null
+        } else {
+            when (val value = opt(key)) {
+                is Number -> value.toLong().toEpochMillis()
+                null -> null
+                else -> value.toString().toLongOrNull()?.toEpochMillis()
+                    ?: Instant.parseOrNull(value.toString())?.toEpochMilliseconds()
+            }
+        }
+    }
+
+    private fun Long.toEpochMillis(): Long? = when {
+        this <= 0L -> null
+        this < 100_000_000_000L -> this * 1_000L
+        else -> this
+    }
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/chat/HermesWebSocket.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/chat/HermesWebSocket.kt
@@ -96,6 +96,7 @@ class HermesWebSocket(
             }.toString()
             webSocket?.write(subscribe)
         }
+        listener.onSubscriptionsSent()
     }
 
     private suspend fun startPongTimer() = withContext(Dispatchers.IO) {
@@ -120,6 +121,8 @@ class HermesWebSocket(
 
     interface Listener {
         suspend fun onConnect() {}
+        /** Called after every topic (re-)subscription message has been sent. */
+        suspend fun onSubscriptionsSent() {}
         suspend fun onPlaybackMessage(message: JSONObject) {}
         suspend fun onStreamInfo(message: JSONObject) {}
         suspend fun onRewardMessage(message: JSONObject) {}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/chat/PredictionCache.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/chat/PredictionCache.kt
@@ -62,6 +62,14 @@ object PredictionCache {
             .apply()
     }
 
+    fun clear(preferences: SharedPreferences, channelId: String) {
+        val index = readIndex(preferences).toMutableMap().apply { remove(channelId) }
+        preferences.edit()
+            .remove(ENTRY_PREFIX + channelId)
+            .putString(INDEX_KEY, JSONObject(index).toString())
+            .apply()
+    }
+
     /** Kept pure so cache-age and session invalidation rules can be unit tested. */
     internal fun isFresh(
         prediction: Prediction,

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/chat/PredictionState.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/chat/PredictionState.kt
@@ -13,6 +13,9 @@ import com.github.andreyasadchy.xtra.model.chat.Prediction
  * result.
  */
 object PredictionState {
+    /** Final prediction results are visible briefly; cache retention is longer. */
+    const val RESULT_DISPLAY_GRACE_MILLIS = 20_000L
+
     private val finalStatuses = setOf(
         "RESOLVED",
         "COMPLETED",
@@ -42,6 +45,16 @@ object PredictionState {
     }
 
     fun isFinal(prediction: Prediction?): Boolean = isFinalStatus(status(prediction))
+
+    fun isFreshFinalForDisplay(
+        prediction: Prediction?,
+        now: Long = System.currentTimeMillis(),
+    ): Boolean {
+        if (!isFinal(prediction)) return false
+        val endedAt = prediction?.endedAt ?: return false
+        val age = now - endedAt
+        return age in 0L..RESULT_DISPLAY_GRACE_MILLIS
+    }
 
     /** Normalizes an incoming live snapshot without guessing when timing is absent. */
     fun normalizeLive(prediction: Prediction, now: Long = System.currentTimeMillis()): Prediction {
@@ -192,6 +205,14 @@ internal class PredictionStateStore {
     fun reset(apply: () -> Unit) = synchronized(lock) {
         current = null
         apply()
+    }
+
+    fun clearIf(predicate: (Prediction) -> Boolean, apply: () -> Unit): Boolean = synchronized(lock) {
+        val value = current ?: return@synchronized false
+        if (!predicate(value)) return@synchronized false
+        current = null
+        apply()
+        true
     }
 
     fun <T> withLock(block: (Prediction?) -> T): T = synchronized(lock) {


### PR DESCRIPTION
Show the current Twitch prediction when opening a live channel. Twitch does not send the current prediction when Xtra first subscribes to live updates, so an existing ACTIVE or LOCKED prediction could be missing until a later event. This adds a viewer snapshot on entry and after reconnects while keeping Hermes updates and existing betting behavior intact.