### PR TITLE
Fix landscape chat width setting

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/settings/SettingsActivity.kt
@@ -122,8 +122,8 @@ class SettingsActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        SettingsMigration.migrate(this)
-        if (savedInstanceState?.getBoolean(KEY_CHANGED) == true) {
+        val landscapeChatWidthChanged = SettingsMigration.migrate(this)
+        if (landscapeChatWidthChanged || savedInstanceState?.getBoolean(KEY_CHANGED) == true) {
             setResult()
         }
         applyTheme()
@@ -1048,6 +1048,18 @@ class SettingsActivity : AppCompatActivity() {
         private fun configureChatSizePreferences() {
             appendCustomListValue(findPreference(C.CHAT_TEXT_SIZE), "sp")
             appendCustomListValue(findPreference(C.CHAT_EMOTE_SIZE), "dp")
+            findPreference<SeekBarPreference>(C.CHAT_WIDTH_PERCENT)?.apply {
+                if (SettingsMigration.synchronizeLandscapeChatWidth(requireContext(), value)) {
+                    (requireActivity() as? SettingsActivity)?.setResult()
+                }
+                setOnPreferenceChangeListener { _, newValue ->
+                    SettingsMigration.synchronizeLandscapeChatWidth(requireContext(), newValue as Int)
+
+                    (requireActivity() as? SettingsActivity)?.setResult()
+
+                    true
+                }
+            }
         }
 
         private fun configureLiveDownloadPreferences() {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/C.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/C.kt
@@ -77,6 +77,7 @@ object C {
     const val SETTINGS_PLAYER_SPEED_OPTIONS = "player_speed_options"
     const val SETTINGS_DEVELOPER_UNLOCKED = "developer_options_unlocked"
     const val SETTINGS_DEVELOPER_ENABLED = "developer_options_enabled"
+    const val CHAT_WIDTH_PERCENT = "chatWidth"
     const val LANDSCAPE_CHAT_WIDTH = "landscape_chat_width"
     const val KEY_CHAT_OPENED = "key_chat_opened"
     const val KEY_CHAT_BAR_VISIBLE = "key_chat_bar_visible"

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/SettingsMigration.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/SettingsMigration.kt
@@ -13,6 +13,7 @@ import androidx.core.content.edit
 object SettingsMigration {
 
     private const val DEFAULT_SPEEDS = "0.25,0.5,0.75,1.0,1.25,1.5,1.75,2.0,3.0,4.0,8.0"
+    private const val DEFAULT_CHAT_WIDTH_PERCENT = 30
     private const val TIMESTAMP_FORMAT_SCHEMA_VERSION = 1
 
     /** Settings reset deliberately names the keys it owns; authentication and app data are separate. */
@@ -42,6 +43,7 @@ object SettingsMigration {
         C.SETTINGS_PLAYER_SPEED_OPTIONS,
         C.SETTINGS_DEVELOPER_UNLOCKED,
         C.SETTINGS_DEVELOPER_ENABLED,
+        C.CHAT_WIDTH_PERCENT,
         C.LANDSCAPE_CHAT_WIDTH,
         C.KEY_CHAT_OPENED,
         C.KEY_CHAT_BAR_VISIBLE,
@@ -300,8 +302,25 @@ object SettingsMigration {
         migrate(context, freshInstall = true)
     }
 
-    fun migrate(context: Context, freshInstall: Boolean? = null) {
+    fun migrate(context: Context, freshInstall: Boolean? = null): Boolean {
         migratePreferences(context.rawPrefs(), freshInstall)
+        return synchronizeLandscapeChatWidth(context)
+    }
+
+    /** Keeps the player-facing pixel value in sync with the percentage setting. */
+    fun synchronizeLandscapeChatWidth(context: Context, percentage: Int? = null): Boolean {
+        val preferences = context.rawPrefs()
+        val chatWidthPercent = percentage
+            ?: preferences.getInt(C.CHAT_WIDTH_PERCENT, DEFAULT_CHAT_WIDTH_PERCENT)
+        val displayMetrics = context.resources.displayMetrics
+        val landscapePixels =
+            (maxOf(displayMetrics.widthPixels, displayMetrics.heightPixels) * (chatWidthPercent / 100f)).toInt()
+        if (preferences.getInt(C.LANDSCAPE_CHAT_WIDTH, 0) == landscapePixels) return false
+
+        preferences.edit {
+            putInt(C.LANDSCAPE_CHAT_WIDTH, landscapePixels)
+        }
+        return true
     }
 
     internal fun migratePreferences(preferences: SharedPreferences, freshInstall: Boolean? = null) {


### PR DESCRIPTION
Landscape chat width now updates the player correctly and repairs old saved values after the settings redesign. Verified with the debug build and Android emulator at 20%, 70%, restart persistence, stale-value repair, and both player implementations.