### PR TITLE
Fix multiview feed quality controls

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/multiview/MultiviewFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/multiview/MultiviewFragment.kt
@@ -50,8 +50,7 @@ class MultiviewFragment : Fragment(R.layout.fragment_multiview) {
     private val controlsHandler = Handler(Looper.getMainLooper())
     private val hideControls = Runnable {
         if (controlsLockCount > 0) return@Runnable
-        bindingOrNull?.controlsOverlay?.isVisible = false
-        slotViews.values.forEach { it.setControlsVisible(false) }
+        setControlsOverlayVisible(false)
     }
     private var latestState = MultiviewSessionState()
     private var latestPlayback: Map<String, MultiviewPlaybackSnapshot> = emptyMap()
@@ -572,13 +571,14 @@ class MultiviewFragment : Fragment(R.layout.fragment_multiview) {
 
     private fun showSlotQualityMenu(identity: String, slot: MultiviewSlotView) {
         val stream = slot.stream ?: return
-        val qualities = listOf(getString(R.string.multiview_smart)) + latestPlayback[identity]
+        val autoLabel = getString(R.string.multiview_quality_auto)
+        val qualities = listOf(autoLabel) + latestPlayback[identity]
             ?.availableQualities.orEmpty()
         lockControls()
         MaterialAlertDialogBuilder(requireContext())
             .setTitle(getString(R.string.multiview_quality_for, displayName(stream)))
             .setItems(qualities.toTypedArray()) { _, which ->
-                viewModel.setQualityOverride(identity, qualities[which].takeUnless { it == getString(R.string.multiview_smart) })
+                viewModel.setQualityOverride(identity, qualities[which].takeUnless { it == autoLabel })
             }
             .setNegativeButton(android.R.string.cancel, null)
             .setOnDismissListener { unlockControls(slot) }
@@ -597,11 +597,29 @@ class MultiviewFragment : Fragment(R.layout.fragment_multiview) {
 
     private fun revealControls(slot: MultiviewSlotView? = null) {
         val binding = _binding ?: return
-        binding.controlsOverlay.isVisible = true
+        setControlsOverlayVisible(true)
         slotViews.values.forEach { it.setControlsVisible(it === slot) }
         controlsHandler.removeCallbacks(hideControls)
         if (controlsLockCount == 0) {
             controlsHandler.postDelayed(hideControls, CONTROLS_TIMEOUT_MS)
+        }
+    }
+
+    private fun setControlsOverlayVisible(visible: Boolean) {
+        val binding = _binding ?: return
+        binding.controlsOverlay.isVisible = visible
+        if (!visible) {
+            binding.videoGrid.updatePadding(top = 0)
+            return
+        }
+
+        // The toolbar is an overlay, while each tile also owns a top info bar.
+        // Reserve the toolbar's measured height so those two rows cannot cover
+        // each other when controls are revealed.
+        binding.controlsOverlay.doOnLayout { controls ->
+            if (_binding == null || !controls.isVisible) return@doOnLayout
+            binding.videoGrid.updatePadding(top = controls.height + dp(16))
+            binding.multiviewContent.doOnLayout { renderTileBounds() }
         }
     }
 
@@ -681,10 +699,11 @@ private fun MultiviewLayoutMode.labelRes(): Int = when (this) {
 }
 
 private fun MultiviewQualityMode.labelRes(): Int = when (this) {
-    MultiviewQualityMode.SMART -> R.string.multiview_quality_smart
-    MultiviewQualityMode.DATA_SAVER -> R.string.multiview_quality_data_saver
-    MultiviewQualityMode.HIGH_QUALITY -> R.string.multiview_quality_high
-    MultiviewQualityMode.CUSTOM -> R.string.multiview_quality_custom
+    MultiviewQualityMode.AUTO -> R.string.multiview_quality_auto
+    MultiviewQualityMode.QUALITY_360P -> R.string.multiview_quality_360p
+    MultiviewQualityMode.QUALITY_480P -> R.string.multiview_quality_480p
+    MultiviewQualityMode.QUALITY_720P -> R.string.multiview_quality_720p
+    MultiviewQualityMode.QUALITY_1080P -> R.string.multiview_quality_1080p
 }
 
 private inline fun <reified T : Parcelable> Bundle.parcelable(key: String): T? {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/multiview/MultiviewFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/multiview/MultiviewFragment.kt
@@ -51,6 +51,7 @@ class MultiviewFragment : Fragment(R.layout.fragment_multiview) {
     private val hideControls = Runnable {
         if (controlsLockCount > 0) return@Runnable
         setControlsOverlayVisible(false)
+        slotViews.values.forEach { it.setControlsVisible(false) }
     }
     private var latestState = MultiviewSessionState()
     private var latestPlayback: Map<String, MultiviewPlaybackSnapshot> = emptyMap()

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/multiview/MultiviewFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/multiview/MultiviewFragment.kt
@@ -610,6 +610,7 @@ class MultiviewFragment : Fragment(R.layout.fragment_multiview) {
         binding.controlsOverlay.isVisible = visible
         if (!visible) {
             binding.videoGrid.updatePadding(top = 0)
+            binding.multiviewContent.doOnLayout { renderTileBounds() }
             return
         }
 

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/multiview/MultiviewSessionState.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/multiview/MultiviewSessionState.kt
@@ -14,7 +14,7 @@ data class MultiviewSessionState(
     val chatVisible: Boolean = false,
     val combinedChat: Boolean = false,
     val chatIdentity: String? = null,
-    val qualityMode: MultiviewQualityMode = MultiviewQualityMode.SMART,
+    val qualityMode: MultiviewQualityMode = MultiviewQualityMode.AUTO,
     val qualityOverrides: Map<String, String> = emptyMap(),
 ) {
     val identities: List<String>

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/multiview/MultiviewViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/multiview/MultiviewViewModel.kt
@@ -288,10 +288,10 @@ class MultiviewViewModel(
         val streams = savedStateHandle.get<ArrayList<Stream>>(KEY_STREAMS)?.toList().orEmpty()
         val fillVideo = savedStateHandle.get<Boolean>(KEY_FILL) ?: preferences.getBoolean(C.MULTIVIEW_FILL, false)
         val qualityMode = savedStateHandle.get<String>(KEY_QUALITY_MODE)
-            ?.let { runCatching { MultiviewQualityMode.valueOf(it) }.getOrNull() }
-            ?: preferences.getString(C.MULTIVIEW_QUALITY_MODE, MultiviewQualityMode.SMART.name)
-                ?.let { runCatching { MultiviewQualityMode.valueOf(it) }.getOrNull() }
-            ?: MultiviewQualityMode.SMART
+            ?.let(MultiviewQualityMode::fromPersistedName)
+            ?: preferences.getString(C.MULTIVIEW_QUALITY_MODE, MultiviewQualityMode.AUTO.name)
+                ?.let(MultiviewQualityMode::fromPersistedName)
+            ?: MultiviewQualityMode.AUTO
         return MultiviewSessionState(
             streams = streams,
             activeIdentity = savedStateHandle[KEY_ACTIVE] ?: streams.firstOrNull()?.let(MultiviewSessionReducer::stableIdentity),

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/multiview/playback/MultiviewPlaybackCoordinator.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/multiview/playback/MultiviewPlaybackCoordinator.kt
@@ -14,6 +14,7 @@ import androidx.media3.common.MimeTypes
 import androidx.media3.common.PlaybackException
 import androidx.media3.common.Player
 import androidx.media3.common.Timeline
+import androidx.media3.common.TrackSelectionOverride
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.datasource.DataSource
 import androidx.media3.datasource.DefaultDataSource
@@ -68,7 +69,7 @@ class MultiviewPlaybackCoordinator(
     private val tileBounds = mutableMapOf<String, Pair<Int, Int>>()
     private var activeIdentity: String? = null
     private var focusedIdentity: String? = null
-    private var qualityMode = MultiviewQualityMode.SMART
+    private var qualityMode = MultiviewQualityMode.AUTO
     private var qualityOverrides: Map<String, String> = emptyMap()
     private var foreground = true
 
@@ -211,6 +212,18 @@ class MultiviewPlaybackCoordinator(
 
                 override fun onTracksChanged(tracks: androidx.media3.common.Tracks) {
                     updateFormats(slot)
+                    val preferredHeight = slot.target?.preferredHeightPx
+                    val preferredFrameRate = slot.target?.preferredFrameRate
+                    val selectedFormat = player.videoFormat
+                    if (preferredHeight != null && (
+                            selectedFormat == null ||
+                                selectedFormat.height != preferredHeight ||
+                                preferredFrameRate != null && selectedFormat.frameRate > 0f &&
+                                selectedFormat.frameRate.toInt() != preferredFrameRate
+                            )
+                    ) {
+                        applyQuality(slot, force = true)
+                    }
                     logSelectedFormat(slot, player.videoFormat)
                 }
 
@@ -500,7 +513,7 @@ class MultiviewPlaybackCoordinator(
             uri.contains("/api/v2/channel/hls/", ignoreCase = true)
     }
 
-    private fun applyQuality(slot: MultiviewPlayerSlot) {
+    private fun applyQuality(slot: MultiviewPlayerSlot, force: Boolean = false) {
         val bounds = tileBounds[slot.identity]
         val target = MultiviewQualityPolicy.target(
             MultiviewQualityInput(
@@ -515,18 +528,61 @@ class MultiviewPlaybackCoordinator(
                 resourcePressure = slot.resourceFailure,
             )
         )
-        if (slot.target == target) return
+        if (!force && slot.target == target) return
         slot.target = target
         val builder = slot.player.trackSelectionParameters.buildUpon()
             .clearVideoSizeConstraints()
+            .clearOverridesOfType(androidx.media3.common.C.TRACK_TYPE_VIDEO)
             .setMaxVideoFrameRate(target.maxFrameRate)
             .setMaxVideoBitrate(Int.MAX_VALUE)
         if (target.maxWidthPx != null && target.maxHeightPx != null) {
             builder.setMaxVideoSize(target.maxWidthPx, target.maxHeightPx)
         }
+        target.preferredHeightPx?.let { preferredHeight ->
+            findPreferredVideoOverride(
+                slot.player,
+                preferredHeight,
+                target.preferredFrameRate ?: target.maxFrameRate,
+            )?.let(builder::setOverrideForType)
+        }
         slot.player.trackSelectionParameters = builder.build()
         onSnapshot(slot.identity, slot.snapshot(target.label))
         debugLog("channel=${slot.identity} policy mode=$qualityMode streams=${slots.size} active=${slot.identity == activeIdentity} focus=${slot.identity == focusedIdentity} target=${target.label} downgrade=${slot.downgradeLevel}")
+    }
+
+    private fun findPreferredVideoOverride(
+        player: ExoPlayer,
+        preferredHeight: Int,
+        preferredFrameRate: Int,
+    ): TrackSelectionOverride? {
+        val group = player.currentTracks.groups.firstOrNull {
+            it.type == androidx.media3.common.C.TRACK_TYPE_VIDEO && it.isSupported
+        } ?: return null
+        if (group.mediaTrackGroup.length == 0) return null
+
+        val formats = (0 until group.mediaTrackGroup.length).map { index ->
+            index to group.mediaTrackGroup.getFormat(index)
+        }
+        val atOrBelow = formats.filter { (_, format) ->
+            format.height in 1..preferredHeight &&
+                (format.frameRate <= 0f || format.frameRate <= preferredFrameRate)
+        }
+        val selected = atOrBelow.maxWithOrNull(
+            compareBy<Pair<Int, androidx.media3.common.Format>> { it.second.height }
+                .thenBy { it.second.frameRate }
+                .thenBy { it.second.bitrate },
+        ) ?: formats.minWithOrNull(
+            compareBy<Pair<Int, androidx.media3.common.Format>> {
+                kotlin.math.abs(it.second.height - preferredHeight)
+            }.thenBy {
+                kotlin.math.abs(
+                    (it.second.frameRate.takeIf { fps -> fps > 0f } ?: preferredFrameRate.toFloat()) -
+                        preferredFrameRate.toFloat(),
+                )
+            }.thenByDescending { it.second.bitrate },
+        ) ?: return null
+
+        return TrackSelectionOverride(group.mediaTrackGroup, selected.first)
     }
 
     private fun scheduleStableQualityRecovery(slot: MultiviewPlayerSlot) {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/multiview/playback/MultiviewPlaybackCoordinator.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/multiview/playback/MultiviewPlaybackCoordinator.kt
@@ -213,20 +213,15 @@ class MultiviewPlaybackCoordinator(
                 override fun onTracksChanged(tracks: androidx.media3.common.Tracks) {
                     updateFormats(slot)
                     val preferredHeight = slot.target?.preferredHeightPx
-                    val preferredFrameRate = slot.target?.preferredFrameRate
                     val selectedFormat = player.videoFormat
                     preferredHeight?.let { height ->
-                        val preferredOverride = findPreferredVideoOverride(
+                        val preferredSelection = findPreferredVideoSelection(
                             player,
                             height,
-                            preferredFrameRate ?: slot.target?.maxFrameRate ?: 60,
+                            slot.target?.preferredFrameRate ?: slot.target?.maxFrameRate ?: 60,
                         )
-                        if (preferredOverride != null && (
-                                selectedFormat == null ||
-                                    selectedFormat.height != height ||
-                                    preferredFrameRate != null &&
-                                    !frameRateMatches(selectedFormat.frameRate, preferredFrameRate)
-                            )
+                        if (preferredSelection != null &&
+                            !selectedFormatMatches(selectedFormat, preferredSelection.format)
                         ) {
                             applyQuality(slot, force = true)
                         }
@@ -546,22 +541,27 @@ class MultiviewPlaybackCoordinator(
             builder.setMaxVideoSize(target.maxWidthPx, target.maxHeightPx)
         }
         target.preferredHeightPx?.let { preferredHeight ->
-            findPreferredVideoOverride(
+            findPreferredVideoSelection(
                 slot.player,
                 preferredHeight,
                 target.preferredFrameRate ?: target.maxFrameRate,
-            )?.let(builder::setOverrideForType)
+            )?.override?.let(builder::setOverrideForType)
         }
         slot.player.trackSelectionParameters = builder.build()
         onSnapshot(slot.identity, slot.snapshot(target.label))
         debugLog("channel=${slot.identity} policy mode=$qualityMode streams=${slots.size} active=${slot.identity == activeIdentity} focus=${slot.identity == focusedIdentity} target=${target.label} downgrade=${slot.downgradeLevel}")
     }
 
-    private fun findPreferredVideoOverride(
+    private data class PreferredVideoSelection(
+        val override: TrackSelectionOverride,
+        val format: androidx.media3.common.Format,
+    )
+
+    private fun findPreferredVideoSelection(
         player: ExoPlayer,
         preferredHeight: Int,
         preferredFrameRate: Int,
-    ): TrackSelectionOverride? {
+    ): PreferredVideoSelection? {
         data class SupportedFormat(
             val group: androidx.media3.common.Tracks.Group,
             val index: Int,
@@ -599,11 +599,20 @@ class MultiviewPlaybackCoordinator(
             }.thenByDescending { it.format.bitrate },
         ) ?: return null
 
-        return TrackSelectionOverride(selected.group.mediaTrackGroup, selected.index)
+        return PreferredVideoSelection(
+            override = TrackSelectionOverride(selected.group.mediaTrackGroup, selected.index),
+            format = selected.format,
+        )
     }
 
-    private fun frameRateMatches(actual: Float, preferred: Int): Boolean =
-        actual <= 0f || kotlin.math.abs(actual - preferred) <= FRAME_RATE_TOLERANCE
+    private fun selectedFormatMatches(
+        selected: androidx.media3.common.Format?,
+        candidate: androidx.media3.common.Format,
+    ): Boolean {
+        if (selected == null || selected.height != candidate.height) return false
+        return candidate.frameRate <= 0f || selected.frameRate <= 0f ||
+            kotlin.math.abs(selected.frameRate - candidate.frameRate) <= FRAME_RATE_TOLERANCE
+    }
 
     private fun scheduleStableQualityRecovery(slot: MultiviewPlayerSlot) {
         if (slot.downgradeLevel <= 0 && !slot.resourceFailure) return

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/multiview/playback/MultiviewPlaybackCoordinator.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/multiview/playback/MultiviewPlaybackCoordinator.kt
@@ -215,14 +215,21 @@ class MultiviewPlaybackCoordinator(
                     val preferredHeight = slot.target?.preferredHeightPx
                     val preferredFrameRate = slot.target?.preferredFrameRate
                     val selectedFormat = player.videoFormat
-                    if (preferredHeight != null && (
-                            selectedFormat == null ||
-                                selectedFormat.height != preferredHeight ||
-                                preferredFrameRate != null && selectedFormat.frameRate > 0f &&
-                                selectedFormat.frameRate.toInt() != preferredFrameRate
+                    preferredHeight?.let { height ->
+                        val preferredOverride = findPreferredVideoOverride(
+                            player,
+                            height,
+                            preferredFrameRate ?: slot.target?.maxFrameRate ?: 60,
+                        )
+                        if (preferredOverride != null && (
+                                selectedFormat == null ||
+                                    selectedFormat.height != height ||
+                                    preferredFrameRate != null &&
+                                    !frameRateMatches(selectedFormat.frameRate, preferredFrameRate)
                             )
-                    ) {
-                        applyQuality(slot, force = true)
+                        ) {
+                            applyQuality(slot, force = true)
+                        }
                     }
                     logSelectedFormat(slot, player.videoFormat)
                 }
@@ -555,35 +562,48 @@ class MultiviewPlaybackCoordinator(
         preferredHeight: Int,
         preferredFrameRate: Int,
     ): TrackSelectionOverride? {
-        val group = player.currentTracks.groups.firstOrNull {
-            it.type == androidx.media3.common.C.TRACK_TYPE_VIDEO && it.isSupported
-        } ?: return null
-        if (group.mediaTrackGroup.length == 0) return null
+        data class SupportedFormat(
+            val group: androidx.media3.common.Tracks.Group,
+            val index: Int,
+            val format: androidx.media3.common.Format,
+        )
 
-        val formats = (0 until group.mediaTrackGroup.length).map { index ->
-            index to group.mediaTrackGroup.getFormat(index)
-        }
-        val atOrBelow = formats.filter { (_, format) ->
-            format.height in 1..preferredHeight &&
-                (format.frameRate <= 0f || format.frameRate <= preferredFrameRate)
+        val formats = player.currentTracks.groups
+            .filter {
+                it.type == androidx.media3.common.C.TRACK_TYPE_VIDEO && it.isSupported
+            }
+            .flatMap { group ->
+                (0 until group.mediaTrackGroup.length)
+                    .filter { index -> group.isTrackSupported(index) }
+                    .map { index -> SupportedFormat(group, index, group.mediaTrackGroup.getFormat(index)) }
+            }
+        if (formats.isEmpty()) return null
+
+        val atOrBelow = formats.filter { candidate ->
+            candidate.format.height in 1..preferredHeight &&
+                (candidate.format.frameRate <= 0f ||
+                    candidate.format.frameRate <= preferredFrameRate + FRAME_RATE_TOLERANCE)
         }
         val selected = atOrBelow.maxWithOrNull(
-            compareBy<Pair<Int, androidx.media3.common.Format>> { it.second.height }
-                .thenBy { it.second.frameRate }
-                .thenBy { it.second.bitrate },
+            compareBy<SupportedFormat> { it.format.height }
+                .thenBy { it.format.frameRate }
+                .thenBy { it.format.bitrate },
         ) ?: formats.minWithOrNull(
-            compareBy<Pair<Int, androidx.media3.common.Format>> {
-                kotlin.math.abs(it.second.height - preferredHeight)
+            compareBy<SupportedFormat> {
+                kotlin.math.abs(it.format.height - preferredHeight)
             }.thenBy {
                 kotlin.math.abs(
-                    (it.second.frameRate.takeIf { fps -> fps > 0f } ?: preferredFrameRate.toFloat()) -
+                    (it.format.frameRate.takeIf { fps -> fps > 0f } ?: preferredFrameRate.toFloat()) -
                         preferredFrameRate.toFloat(),
                 )
-            }.thenByDescending { it.second.bitrate },
+            }.thenByDescending { it.format.bitrate },
         ) ?: return null
 
-        return TrackSelectionOverride(group.mediaTrackGroup, selected.first)
+        return TrackSelectionOverride(selected.group.mediaTrackGroup, selected.index)
     }
+
+    private fun frameRateMatches(actual: Float, preferred: Int): Boolean =
+        actual <= 0f || kotlin.math.abs(actual - preferred) <= FRAME_RATE_TOLERANCE
 
     private fun scheduleStableQualityRecovery(slot: MultiviewPlayerSlot) {
         if (slot.downgradeLevel <= 0 && !slot.resourceFailure) return
@@ -1011,6 +1031,7 @@ class MultiviewPlaybackCoordinator(
         private const val MAX_RETRIES = 6
         private const val NETWORK_RETRY_DELAY_MS = 15_000L
         private const val PRIMARY_RESTORE_INTERVAL_MS = 10_000L
+        private const val FRAME_RATE_TOLERANCE = 0.5f
         private val RETRY_DELAYS_MS = longArrayOf(1_500L, 3_000L, 6_000L, 12_000L, 20_000L, 30_000L)
         private const val MULTIVARIANT_PLAYLIST_REGEX = "^usher\\.ttvnw\\.net$"
         private const val MEDIA_PLAYLIST_REGEX = "^(?:[a-z0-9-]+\\.playlist\\.(?:live-video|ttvnw)\\.net|video-weaver\\.[a-z0-9-]+\\.hls\\.ttvnw\\.net)$"

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/multiview/playback/MultiviewQualityMode.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/multiview/playback/MultiviewQualityMode.kt
@@ -1,8 +1,19 @@
 package com.github.andreyasadchy.xtra.ui.multiview.playback
 
 enum class MultiviewQualityMode {
-    SMART,
-    DATA_SAVER,
-    HIGH_QUALITY,
-    CUSTOM,
+    AUTO,
+    QUALITY_360P,
+    QUALITY_480P,
+    QUALITY_720P,
+    QUALITY_1080P;
+
+    companion object {
+        fun fromPersistedName(name: String?): MultiviewQualityMode? = when (name) {
+            // Values used by the original multiview quality menu.
+            "SMART", "CUSTOM" -> AUTO
+            "DATA_SAVER" -> QUALITY_480P
+            "HIGH_QUALITY" -> QUALITY_1080P
+            else -> name?.let { runCatching { valueOf(it) }.getOrNull() }
+        }
+    }
 }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/multiview/playback/MultiviewQualityPolicy.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/multiview/playback/MultiviewQualityPolicy.kt
@@ -8,7 +8,7 @@ data class MultiviewQualityInput(
     val isFocused: Boolean,
     val tileWidthPx: Int = 0,
     val tileHeightPx: Int = 0,
-    val mode: MultiviewQualityMode = MultiviewQualityMode.SMART,
+    val mode: MultiviewQualityMode = MultiviewQualityMode.AUTO,
     val manualOverride: String? = null,
     val bufferingDowngradeLevel: Int = 0,
     val resourcePressure: Boolean = false,
@@ -18,6 +18,8 @@ data class MultiviewQualityTarget(
     val maxWidthPx: Int? = null,
     val maxHeightPx: Int? = null,
     val maxFrameRate: Int = 60,
+    val preferredHeightPx: Int? = null,
+    val preferredFrameRate: Int? = null,
     val label: String,
     val isConstrained: Boolean,
 )
@@ -34,7 +36,7 @@ object MultiviewQualityPolicy {
         val override = input.manualOverride?.let(::parseHeight)
         val sourceOverride = input.manualOverride.equals("Source", ignoreCase = true)
         val recoveryRequested = input.resourcePressure ||
-            (input.mode == MultiviewQualityMode.SMART || input.mode == MultiviewQualityMode.CUSTOM) &&
+            input.mode == MultiviewQualityMode.AUTO &&
             input.bufferingDowngradeLevel > 0
 
         // Decoder/resource pressure is deliberately handled before explicit quality
@@ -54,18 +56,23 @@ object MultiviewQualityPolicy {
         }
 
         if (override != null || sourceOverride) {
-            return override?.let { constrainedHeight(it, "${it}p60") }
+            return override?.let {
+                val frameRate = input.manualOverride.let(::parseFrameRate) ?: 60
+                constrainedHeight(
+                    it,
+                    "${it}p$frameRate",
+                    preferredHeight = it,
+                    preferredFrameRate = frameRate,
+                )
+            }
                 ?: unconstrained("Source")
         }
-        if (input.mode == MultiviewQualityMode.HIGH_QUALITY) {
-            return unconstrained("HIGH")
-        }
-
         val normalCap = when (input.mode) {
-            MultiviewQualityMode.DATA_SAVER -> if (input.streamCount <= 1) 720 else 480
-            MultiviewQualityMode.HIGH_QUALITY -> null
-            MultiviewQualityMode.CUSTOM -> null
-            MultiviewQualityMode.SMART -> when {
+            MultiviewQualityMode.QUALITY_360P -> 360
+            MultiviewQualityMode.QUALITY_480P -> 480
+            MultiviewQualityMode.QUALITY_720P -> 720
+            MultiviewQualityMode.QUALITY_1080P -> 1080
+            MultiviewQualityMode.AUTO -> when {
                 input.isFocused && input.streamCount > 1 -> null
                 input.streamCount <= 1 -> null
                 input.isActive -> 720
@@ -79,7 +86,7 @@ object MultiviewQualityPolicy {
             // but a decoder failure or sustained rebuffers must still have a
             // resource-saving fallback. Resolution is reduced before fps.
             if (!recoveryRequested) {
-                return unconstrained(if (input.mode == MultiviewQualityMode.CUSTOM) "CUSTOM · AUTO" else "AUTO")
+                return unconstrained("AUTO")
             }
             val recoveryCap = if (input.streamCount >= 3 && !input.isActive && !input.isFocused) 480 else 720
             val degradedCap = downgrade(recoveryCap, recoveryLevel(input))
@@ -88,14 +95,19 @@ object MultiviewQualityPolicy {
             return constrainedHeight(effectiveHeight, "AUTO · ${effectiveHeight}p60")
         }
 
-        val degradedCap = if (input.mode == MultiviewQualityMode.SMART) {
+        val degradedCap = if (input.mode == MultiviewQualityMode.AUTO) {
             downgrade(normalCap, recoveryLevel(input))
         } else {
             normalCap
         }
         val tileCap = tileCap(input.tileWidthPx, input.tileHeightPx, degradedCap)
         val effectiveHeight = minOf(degradedCap, tileCap)
-        return constrainedHeight(effectiveHeight, "AUTO · ${effectiveHeight}p60")
+        val isExplicit = input.mode != MultiviewQualityMode.AUTO
+        return constrainedHeight(
+            effectiveHeight,
+            if (isExplicit) "${effectiveHeight}p" else "AUTO · ${effectiveHeight}p60",
+            preferredHeight = effectiveHeight.takeIf { isExplicit },
+        )
     }
 
     fun targetForManualOverride(label: String?): MultiviewQualityTarget? {
@@ -105,7 +117,7 @@ object MultiviewQualityPolicy {
                 streamCount = 1,
                 isActive = true,
                 isFocused = false,
-                mode = MultiviewQualityMode.CUSTOM,
+                mode = MultiviewQualityMode.AUTO,
                 manualOverride = label,
             )
         )
@@ -128,12 +140,19 @@ object MultiviewQualityPolicy {
         return "${height}p${fps}"
     }
 
-    private fun constrainedHeight(height: Int, label: String): MultiviewQualityTarget {
+    private fun constrainedHeight(
+        height: Int,
+        label: String,
+        preferredHeight: Int? = null,
+        preferredFrameRate: Int? = null,
+    ): MultiviewQualityTarget {
         val normalizedHeight = height.coerceAtLeast(144)
         return MultiviewQualityTarget(
             maxWidthPx = normalizedHeight * 16 / 9,
             maxHeightPx = normalizedHeight,
             maxFrameRate = 60,
+            preferredHeightPx = preferredHeight,
+            preferredFrameRate = preferredFrameRate,
             label = label,
             isConstrained = true,
         )
@@ -177,6 +196,14 @@ object MultiviewQualityPolicy {
 
     private fun parseHeight(label: String): Int? {
         return Regex("^(\\d{3,4})p(?:\\d+)?$", RegexOption.IGNORE_CASE)
+            .matchEntire(label.trim())
+            ?.groupValues
+            ?.getOrNull(1)
+            ?.toIntOrNull()
+    }
+
+    private fun parseFrameRate(label: String): Int? {
+        return Regex("^\\d{3,4}p(\\d+)$", RegexOption.IGNORE_CASE)
             .matchEntire(label.trim())
             ?.groupValues
             ?.getOrNull(1)

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/multiview/playback/MultiviewQualityPolicy.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/multiview/playback/MultiviewQualityPolicy.kt
@@ -51,7 +51,8 @@ object MultiviewQualityPolicy {
                 recoveryLevel(input),
             )
             val manualCap = override ?: Int.MAX_VALUE
-            val effectiveHeight = minOf(manualCap, degradedCap)
+            val globalCap = explicitQualityHeight(input.mode) ?: Int.MAX_VALUE
+            val effectiveHeight = minOf(manualCap, degradedCap, globalCap)
             return constrainedHeight(effectiveHeight, "RECOVERY · ${effectiveHeight}p60")
         }
 
@@ -188,6 +189,14 @@ object MultiviewQualityPolicy {
             }
         }
         return result
+    }
+
+    private fun explicitQualityHeight(mode: MultiviewQualityMode): Int? = when (mode) {
+        MultiviewQualityMode.AUTO -> null
+        MultiviewQualityMode.QUALITY_360P -> 360
+        MultiviewQualityMode.QUALITY_480P -> 480
+        MultiviewQualityMode.QUALITY_720P -> 720
+        MultiviewQualityMode.QUALITY_1080P -> 1080
     }
 
     private fun recoveryLevel(input: MultiviewQualityInput): Int {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/multiview/playback/MultiviewQualityPolicy.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/multiview/playback/MultiviewQualityPolicy.kt
@@ -1,6 +1,7 @@
 package com.github.andreyasadchy.xtra.ui.multiview.playback
 
 import kotlin.math.ceil
+import kotlin.math.roundToInt
 
 data class MultiviewQualityInput(
     val streamCount: Int,
@@ -50,8 +51,7 @@ object MultiviewQualityPolicy {
                 recoveryLevel(input),
             )
             val manualCap = override ?: Int.MAX_VALUE
-            val tileCap = tileCap(input.tileWidthPx, input.tileHeightPx, degradedCap)
-            val effectiveHeight = minOf(manualCap, degradedCap, tileCap)
+            val effectiveHeight = minOf(manualCap, degradedCap)
             return constrainedHeight(effectiveHeight, "RECOVERY · ${effectiveHeight}p60")
         }
 
@@ -100,9 +100,11 @@ object MultiviewQualityPolicy {
         } else {
             normalCap
         }
-        val tileCap = tileCap(input.tileWidthPx, input.tileHeightPx, degradedCap)
-        val effectiveHeight = minOf(degradedCap, tileCap)
         val isExplicit = input.mode != MultiviewQualityMode.AUTO
+        val effectiveHeight = if (isExplicit) degradedCap else minOf(
+            degradedCap,
+            tileCap(input.tileWidthPx, input.tileHeightPx, degradedCap),
+        )
         return constrainedHeight(
             effectiveHeight,
             if (isExplicit) "${effectiveHeight}p" else "AUTO · ${effectiveHeight}p60",
@@ -127,7 +129,7 @@ object MultiviewQualityPolicy {
         val labels = availableFormats
             .mapNotNull { format -> format.height.takeIf { it > 0 }?.let { height -> height to format.frameRate } }
             .sortedWith(compareByDescending<Pair<Int, Float>> { it.first }.thenByDescending { it.second })
-            .map { (height, frameRate) -> "${height}p${frameRate.toInt().takeIf { it > 0 } ?: 60}" }
+            .map { (height, frameRate) -> "${height}p${frameRate.takeIf { it > 0 }?.roundToInt() ?: 60}" }
             .distinctBy { it.substringBefore('p') }
             .toMutableList()
         if (availableFormats.any { it.isSource }) labels.add(0, "Source")
@@ -136,7 +138,7 @@ object MultiviewQualityPolicy {
 
     fun effectiveFormatLabel(width: Int, height: Int, frameRate: Float): String {
         if (width <= 0 || height <= 0) return "AUTO"
-        val fps = frameRate.takeIf { it > 0 }?.toInt() ?: 60
+        val fps = frameRate.takeIf { it > 0 }?.roundToInt() ?: 60
         return "${height}p${fps}"
     }
 

--- a/app/src/main/res/layout/multiview_slot.xml
+++ b/app/src/main/res/layout/multiview_slot.xml
@@ -37,7 +37,8 @@
         android:minHeight="40dp"
         android:orientation="horizontal"
         android:paddingStart="8dp"
-        android:paddingEnd="2dp">
+        android:paddingEnd="2dp"
+        android:weightSum="1">
 
         <TextView
             android:id="@+id/channelName"
@@ -46,6 +47,7 @@
             android:layout_weight="1"
             android:ellipsize="end"
             android:maxLines="1"
+            android:minWidth="0dp"
             android:textAppearance="?attr/textAppearanceBodySmall"
             android:textColor="@android:color/white" />
 
@@ -54,8 +56,11 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginStart="4dp"
+            android:layout_marginEnd="4dp"
             android:ellipsize="end"
+            android:maxWidth="72dp"
             android:maxLines="1"
+            android:minWidth="0dp"
             android:textAppearance="?attr/textAppearanceLabelSmall"
             android:textColor="@android:color/white" />
 

--- a/app/src/main/res/values/multiview_strings.xml
+++ b/app/src/main/res/values/multiview_strings.xml
@@ -31,7 +31,12 @@
     <string name="multiview_layout_grid">Grid</string>
     <string name="multiview_layout_focus">Focus</string>
     <string name="multiview_more_options">More multiview options</string>
-    <string name="multiview_quality_mode">Quality mode</string>
+    <string name="multiview_quality_mode">Quality</string>
+    <string name="multiview_quality_auto">Auto</string>
+    <string name="multiview_quality_360p">360p</string>
+    <string name="multiview_quality_480p">480p</string>
+    <string name="multiview_quality_720p">720p</string>
+    <string name="multiview_quality_1080p">1080p</string>
     <string name="multiview_quality_smart">Smart</string>
     <string name="multiview_quality_data_saver">Data Saver</string>
     <string name="multiview_quality_high">High Quality</string>

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/multiview/playback/MultiviewQualityPolicyTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/multiview/playback/MultiviewQualityPolicyTest.kt
@@ -105,6 +105,24 @@ class MultiviewQualityPolicyTest {
     }
 
     @Test
+    fun resourcePressureNeverRaises360pSelection() {
+        val target = MultiviewQualityPolicy.target(
+            input(streamCount = 1, active = true, mode = MultiviewQualityMode.QUALITY_360P, resourcePressure = true),
+        )
+
+        assertTrue(target.maxHeightPx!! <= 360)
+    }
+
+    @Test
+    fun resourcePressureNeverRaises480pSelection() {
+        val target = MultiviewQualityPolicy.target(
+            input(streamCount = 1, active = true, mode = MultiviewQualityMode.QUALITY_480P, resourcePressure = true),
+        )
+
+        assertTrue(target.maxHeightPx!! <= 480)
+    }
+
+    @Test
     fun resourcePressureOverridesSourceOverrideTemporarily() {
         val target = MultiviewQualityPolicy.target(
             input(streamCount = 2, active = true, override = "Source", resourcePressure = true),

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/multiview/playback/MultiviewQualityPolicyTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/multiview/playback/MultiviewQualityPolicyTest.kt
@@ -134,9 +134,9 @@ class MultiviewQualityPolicyTest {
     }
 
     @Test
-    fun customModeLeavesUnoverriddenStreamAdaptive() {
+    fun autoModeLeavesFocusedStreamAdaptive() {
         val target = MultiviewQualityPolicy.target(
-            input(streamCount = 4, active = false, mode = MultiviewQualityMode.AUTO),
+            input(streamCount = 4, active = false, focused = true, mode = MultiviewQualityMode.AUTO),
         )
 
         assertNull(target.maxHeightPx)
@@ -150,6 +150,38 @@ class MultiviewQualityPolicyTest {
         )
 
         assertEquals(720, target.maxHeightPx)
+    }
+
+    @Test
+    fun explicit1080pIgnoresSmallTileSize() {
+        val target = MultiviewQualityPolicy.target(
+            input(
+                streamCount = 4,
+                active = false,
+                tileWidth = 960,
+                tileHeight = 540,
+                mode = MultiviewQualityMode.QUALITY_1080P,
+            ),
+        )
+
+        assertEquals(1080, target.maxHeightPx)
+        assertEquals(1080, target.preferredHeightPx)
+    }
+
+    @Test
+    fun explicit720pIgnoresSmallTileSize() {
+        val target = MultiviewQualityPolicy.target(
+            input(
+                streamCount = 4,
+                active = false,
+                tileWidth = 320,
+                tileHeight = 180,
+                mode = MultiviewQualityMode.QUALITY_720P,
+            ),
+        )
+
+        assertEquals(720, target.maxHeightPx)
+        assertEquals(720, target.preferredHeightPx)
     }
 
     @Test
@@ -194,6 +226,16 @@ class MultiviewQualityPolicyTest {
         )
 
         assertEquals(listOf("Source", "1080p60", "720p60", "480p30"), labels)
+    }
+
+    @Test
+    fun fractionalFrameRatesUseNearestWholeFrameRateLabel() {
+        val labels = MultiviewQualityPolicy.availableManualLabels(
+            listOf(MultiviewQualityPolicy.AvailableFormat(720, 59.94f)),
+        )
+
+        assertEquals(listOf("720p60"), labels)
+        assertEquals("720p60", MultiviewQualityPolicy.effectiveFormatLabel(1280, 720, 59.94f))
     }
 
     private fun input(

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/multiview/playback/MultiviewQualityPolicyTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/multiview/playback/MultiviewQualityPolicyTest.kt
@@ -59,7 +59,7 @@ class MultiviewQualityPolicyTest {
     @Test
     fun manualOverrideWinsOverHighQualityMode() {
         val target = MultiviewQualityPolicy.target(
-            input(streamCount = 2, active = false, override = "480p", mode = MultiviewQualityMode.HIGH_QUALITY),
+            input(streamCount = 2, active = false, override = "480p", mode = MultiviewQualityMode.QUALITY_1080P),
         )
 
         assertEquals(480, target.maxHeightPx)
@@ -97,7 +97,7 @@ class MultiviewQualityPolicyTest {
     @Test
     fun resourcePressureOverridesHighQualityTemporarily() {
         val target = MultiviewQualityPolicy.target(
-            input(streamCount = 4, active = true, mode = MultiviewQualityMode.HIGH_QUALITY, resourcePressure = true),
+            input(streamCount = 4, active = true, mode = MultiviewQualityMode.QUALITY_1080P, resourcePressure = true),
         )
 
         assertEquals(480, target.maxHeightPx)
@@ -136,11 +136,11 @@ class MultiviewQualityPolicyTest {
     @Test
     fun customModeLeavesUnoverriddenStreamAdaptive() {
         val target = MultiviewQualityPolicy.target(
-            input(streamCount = 4, active = false, mode = MultiviewQualityMode.CUSTOM),
+            input(streamCount = 4, active = false, mode = MultiviewQualityMode.AUTO),
         )
 
         assertNull(target.maxHeightPx)
-        assertEquals("CUSTOM · AUTO", target.label)
+        assertEquals("AUTO", target.label)
     }
 
     @Test
@@ -204,7 +204,7 @@ class MultiviewQualityPolicyTest {
         tileHeight: Int = 0,
         override: String? = null,
         bufferingLevel: Int = 0,
-        mode: MultiviewQualityMode = MultiviewQualityMode.SMART,
+        mode: MultiviewQualityMode = MultiviewQualityMode.AUTO,
         resourcePressure: Boolean = false,
     ) = MultiviewQualityInput(
         streamCount = streamCount,


### PR DESCRIPTION
## What changed

Multiview now uses precise quality choices (`Auto`, `360p`, `480p`, `720p`, and `1080p`) and applies the selected height to each live-feed player. The quality controls also reserve space above the grid so they do not overlap the tile UI.

## Why

The previous high-level quality labels could leave a feed on a lower-resolution track, and the toolbar could overlap the multiview content.

## Validation

- `:app:assembleDebug`
- Manual smoke test on the shared `xtra-api35` AVD
- Confirmed the toolbar and tile controls have separate bounds with controls visible
