### PR TITLE
Improve multiview playback

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -79,6 +79,11 @@
         </service>
 
         <service
+            android:name=".ui.multiview.playback.MultiviewBackgroundPlaybackService"
+            android:foregroundServiceType="mediaPlayback"
+            android:exported="false" />
+
+        <service
             android:name=".ui.download.VideoDownloadService"
             android:foregroundServiceType="specialUse" />
 

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/main/MainActivity.kt
@@ -766,6 +766,10 @@ class MainActivity : AppCompatActivity() {
 
     override fun onUserLeaveHint() {
         super.onUserLeaveHint()
+        // Multiview uses background audio when Home is pressed. Its explicit
+        // toolbar action is the opt-in path into PiP, so Home never leaves a
+        // grid unexpectedly floating over another app.
+        if (playerFragment == null && currentMultiviewFragment() != null) return
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S &&
             Build.VERSION.SDK_INT >= Build.VERSION_CODES.O &&
             packageManager.hasSystemFeature(PackageManager.FEATURE_PICTURE_IN_PICTURE) &&
@@ -778,6 +782,36 @@ class MainActivity : AppCompatActivity() {
                 //device doesn't support PIP
             }
         }
+    }
+
+    fun canMinimizeMultiview(): Boolean {
+        return playerFragment == null &&
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.O &&
+            packageManager.hasSystemFeature(PackageManager.FEATURE_PICTURE_IN_PICTURE) &&
+            prefs.getBoolean(C.PLAYER_PICTURE_IN_PICTURE, true)
+    }
+
+    fun minimizeMultiview() {
+        if (!canMinimizeMultiview()) return
+        runCatching {
+            enterPictureInPictureMode(PictureInPictureParams.Builder().build())
+        }
+    }
+
+    fun prepareMultiviewPictureInPicture() {
+        if (!canMinimizeMultiview() || Build.VERSION.SDK_INT < Build.VERSION_CODES.S) return
+        setPictureInPictureParams(
+            PictureInPictureParams.Builder()
+                // Multiview deliberately keeps background audio on Home. PiP
+                // is available through the explicit minimize control instead.
+                .setAutoEnterEnabled(false)
+                .build(),
+        )
+    }
+
+    fun clearMultiviewPictureInPicture() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S || playerFragment != null) return
+        setPictureInPictureParams(PictureInPictureParams.Builder().setAutoEnterEnabled(false).build())
     }
 
     private fun handleIntent(intent: Intent?) {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/multiview/MultiviewFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/multiview/MultiviewFragment.kt
@@ -27,6 +27,7 @@ import androidx.lifecycle.repeatOnLifecycle
 import androidx.media3.ui.AspectRatioFrameLayout
 import com.github.andreyasadchy.xtra.R
 import com.github.andreyasadchy.xtra.databinding.FragmentMultiviewBinding
+import com.github.andreyasadchy.xtra.databinding.PlayerVolumeBinding
 import com.github.andreyasadchy.xtra.model.ui.Stream
 import com.github.andreyasadchy.xtra.ui.chat.ChatFragment
 import com.github.andreyasadchy.xtra.ui.main.MainActivity
@@ -39,6 +40,7 @@ import com.github.andreyasadchy.xtra.ui.multiview.ui.MultiviewSlotView
 import com.github.andreyasadchy.xtra.util.C
 import com.github.andreyasadchy.xtra.util.prefs
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import com.google.android.material.slider.Slider
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 
@@ -59,6 +61,7 @@ class MultiviewFragment : Fragment(R.layout.fragment_multiview) {
     private var renderedLayoutKey: String? = null
     private var previousNavBarVisibility = View.VISIBLE
     private var controlsLockCount = 0
+    private var suppressBackgroundOnNextStop = false
 
     private val bindingOrNull: FragmentMultiviewBinding?
         get() = _binding
@@ -88,6 +91,7 @@ class MultiviewFragment : Fragment(R.layout.fragment_multiview) {
         binding.combinedChatButton.setOnClickListener { toggleCombinedChat() }
         binding.layoutButton.setOnClickListener { showLayoutMenu() }
         binding.moreButton.setOnClickListener { showMoreMenu(binding.moreButton) }
+        binding.pipButton.setOnClickListener { (activity as? MainActivity)?.minimizeMultiview() }
 
         childFragmentManager.setFragmentResultListener(
             AddMultiviewStreamsSheet.RESULT_KEY,
@@ -141,11 +145,22 @@ class MultiviewFragment : Fragment(R.layout.fragment_multiview) {
 
     override fun onStart() {
         super.onStart()
+        if ((activity as? MainActivity)?.playerFragment != null) return
+        (activity as? MainActivity)?.prepareMultiviewPictureInPicture()
         viewModel.onStart()
     }
 
     override fun onStop() {
-        viewModel.onStop()
+        if ((activity as? MainActivity)?.playerFragment != null) {
+            suppressBackgroundOnNextStop = false
+            super.onStop()
+            return
+        }
+        val inPictureInPicture = Build.VERSION.SDK_INT >= Build.VERSION_CODES.N &&
+            requireActivity().isInPictureInPictureMode
+        val allowBackground = !suppressBackgroundOnNextStop
+        suppressBackgroundOnNextStop = false
+        viewModel.onStop(allowBackground = allowBackground, inPictureInPicture = inPictureInPicture)
         super.onStop()
     }
 
@@ -170,6 +185,7 @@ class MultiviewFragment : Fragment(R.layout.fragment_multiview) {
             .forEach(::releaseChatFragment)
         renderedChatKey = null
         renderedLayoutKey = null
+        (activity as? MainActivity)?.clearMultiviewPictureInPicture()
         requireActivity().findViewById<View>(R.id.navBarContainer)?.visibility = previousNavBarVisibility
         _binding = null
         super.onDestroyView()
@@ -196,7 +212,7 @@ class MultiviewFragment : Fragment(R.layout.fragment_multiview) {
                 identity = identity,
                 stream = stream,
                 snapshot = latestPlayback[identity],
-                audioActive = identity.equals(state.activeIdentity, true),
+                audioVolume = viewModel.audioVolume(identity),
                 focused = identity.equals(state.focusedIdentity, true),
                 fillVideo = state.fillVideo,
             )
@@ -208,6 +224,7 @@ class MultiviewFragment : Fragment(R.layout.fragment_multiview) {
             focusedIdentity = state.focusedIdentity,
             qualityMode = state.qualityMode,
             qualityOverrides = state.qualityOverrides,
+            audioVolumes = state.audioVolumes,
         )
         applyLayout(state)
         updateOrientationLayout()
@@ -236,6 +253,10 @@ class MultiviewFragment : Fragment(R.layout.fragment_multiview) {
             onOverflow = {
                 revealControls(this)
                 showSlotMenu(this)
+            }
+            onAudioClick = {
+                viewModel.toggleAudio(identity)
+                revealControls(this)
             }
             onRetry = { viewModel.playbackCoordinator.retry(identity) }
         }
@@ -272,7 +293,7 @@ class MultiviewFragment : Fragment(R.layout.fragment_multiview) {
             ).apply {
                 width = 0
                 height = 0
-                setMargins(dp(2), dp(2), dp(2), dp(2))
+                setMargins(dp(1), dp(1), dp(1), dp(1))
             }
             binding.videoGrid.addView(slotView, params)
             slotView.doOnLayout {
@@ -294,9 +315,18 @@ class MultiviewFragment : Fragment(R.layout.fragment_multiview) {
         val active = state.streams.firstOrNull { stream ->
             MultiviewSessionReducer.stableIdentity(stream).equals(state.activeIdentity, true)
         }
-        binding.activeAudio.isVisible = active != null
-        binding.activeAudio.text = active?.let { getString(R.string.multiview_audio, displayName(it)) }
+        val audible = state.streams.filter { stream ->
+            MultiviewSessionReducer.stableIdentity(stream)?.let(viewModel::audioVolume)?.let { it > 0f } == true
+        }
+        binding.activeAudio.isVisible = audible.isNotEmpty()
+        binding.activeAudio.text = when {
+            audible.size == 1 -> getString(R.string.multiview_audio, displayName(audible.first()))
+            audible.size > 1 -> getString(R.string.multiview_audio_multiple, audible.size)
+            else -> null
+        }
         binding.addStreamButton.isVisible = state.streams.size < MAX_STREAMS
+        binding.pipButton.isVisible = (activity as? MainActivity)?.canMinimizeMultiview() == true &&
+            !(Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && requireActivity().isInPictureInPictureMode)
         binding.chatButton.isVisible = !requireContext().prefs().getBoolean(C.CHAT_DISABLE, false) && active != null
         binding.chatContainer.isVisible = state.chatVisible
         binding.combinedChatButton.isVisible = state.chatVisible && state.streams.size > 1
@@ -535,6 +565,17 @@ class MultiviewFragment : Fragment(R.layout.fragment_multiview) {
                 showSlotQualityMenu(identity, slot)
                 true
             }
+            menu.add(R.string.multiview_volume).setOnMenuItemClickListener {
+                showVolumeDialog(identity, stream)
+                true
+            }
+            menu.add(
+                if (viewModel.audioVolume(identity) > 0f) R.string.multiview_mute
+                else R.string.multiview_unmute,
+            ).setOnMenuItemClickListener {
+                viewModel.toggleAudio(identity)
+                true
+            }
             menu.add(
                 if (latestState.focusedIdentity.equals(identity, true)) R.string.multiview_unfocus
                 else R.string.multiview_focus,
@@ -584,6 +625,55 @@ class MultiviewFragment : Fragment(R.layout.fragment_multiview) {
             .setNegativeButton(android.R.string.cancel, null)
             .setOnDismissListener { unlockControls(slot) }
             .show()
+    }
+
+    private fun showVolumeDialog(identity: String, stream: Stream) {
+        lockControls()
+        val volumeBinding = PlayerVolumeBinding.inflate(layoutInflater)
+        var currentVolume = viewModel.audioVolume(identity)
+        fun renderVolume(volume: Float) {
+            currentVolume = volume.coerceIn(0f, 1f)
+            val percent = (currentVolume * 100f).toInt()
+            volumeBinding.volumeText.text = percent.toString()
+            volumeBinding.volumeMute.setImageResource(
+                if (currentVolume == 0f) R.drawable.baseline_volume_off_black_24
+                else R.drawable.baseline_volume_up_black_24,
+            )
+        }
+
+        volumeBinding.volumeBar.value = currentVolume * 100f
+        renderVolume(currentVolume)
+        val dialog = MaterialAlertDialogBuilder(requireContext())
+            .setTitle(getString(R.string.multiview_volume_for, displayName(stream)))
+            .setView(volumeBinding.root)
+            .setNegativeButton(R.string.multiview_close, null)
+            .create()
+        volumeBinding.volumeBar.addOnChangeListener { _, value, _ ->
+            renderVolume(value / 100f)
+            viewModel.setAudioVolume(identity, currentVolume, persist = false)
+        }
+        volumeBinding.volumeBar.addOnSliderTouchListener(object : Slider.OnSliderTouchListener {
+            override fun onStartTrackingTouch(slider: Slider) = Unit
+
+            override fun onStopTrackingTouch(slider: Slider) {
+                viewModel.persistSession()
+            }
+        })
+        volumeBinding.volumeMute.setOnClickListener {
+            val next = if (currentVolume > 0f) {
+                0f
+            } else {
+                viewModel.defaultAudioVolume().takeIf { it > 0f } ?: 1f
+            }
+            volumeBinding.volumeBar.value = next * 100f
+            renderVolume(next)
+            viewModel.setAudioVolume(identity, next)
+        }
+        dialog.setOnDismissListener {
+            viewModel.persistSession()
+            unlockControls()
+        }
+        dialog.show()
     }
 
     private fun openNormalPlayer(identity: String) {
@@ -673,11 +763,33 @@ class MultiviewFragment : Fragment(R.layout.fragment_multiview) {
     suspend fun resolveManualStream(login: String): Stream? = viewModel.resolveLiveStream(login)
 
     fun pauseForExternalPlayer() {
-        if (_binding != null) viewModel.onStop()
+        suppressBackgroundOnNextStop = true
+        if (_binding != null) viewModel.onStop(allowBackground = false)
     }
 
     fun resumeAfterExternalPlayer() {
-        if (_binding != null) viewModel.onStart()
+        suppressBackgroundOnNextStop = false
+        if (_binding != null) {
+            (activity as? MainActivity)?.prepareMultiviewPictureInPicture()
+            viewModel.onStart()
+        }
+    }
+
+    override fun onPictureInPictureModeChanged(isInPictureInPictureMode: Boolean) {
+        super.onPictureInPictureModeChanged(isInPictureInPictureMode)
+        if (_binding == null || (activity as? MainActivity)?.playerFragment != null) return
+        controlsHandler.removeCallbacks(hideControls)
+        controlsLockCount = 0
+        if (isInPictureInPictureMode) {
+            viewModel.onStart()
+            setControlsOverlayVisible(false)
+            slotViews.values.forEach { it.setControlsVisible(false) }
+            binding.chatContainer.isVisible = false
+        } else {
+            updateToolbar(latestState)
+            updateChat(latestState)
+            revealControls()
+        }
     }
 
     companion object {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/multiview/MultiviewSessionState.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/multiview/MultiviewSessionState.kt
@@ -16,13 +16,19 @@ data class MultiviewSessionState(
     val chatIdentity: String? = null,
     val qualityMode: MultiviewQualityMode = MultiviewQualityMode.AUTO,
     val qualityOverrides: Map<String, String> = emptyMap(),
+    val audioVolumes: Map<String, Float> = emptyMap(),
 ) {
     val identities: List<String>
         get() = streams.mapNotNull(MultiviewSessionReducer::stableIdentity)
 }
 
 object MultiviewSessionReducer {
-    fun add(state: MultiviewSessionState, stream: Stream, maximum: Int = 4): MultiviewSessionState {
+    fun add(
+        state: MultiviewSessionState,
+        stream: Stream,
+        maximum: Int = 4,
+        initialAudioVolume: Float = 1f,
+    ): MultiviewSessionState {
         val identity = stableIdentity(stream) ?: return state
         if (state.streams.size >= maximum || state.identities.any { it.equals(identity, true) }) return state
         val streams = state.streams + stream
@@ -30,12 +36,57 @@ object MultiviewSessionReducer {
             streams = streams,
             activeIdentity = state.activeIdentity ?: identity,
             chatIdentity = state.chatIdentity ?: identity,
+            audioVolumes = state.audioVolumes + (identity to initialAudioVolume.coerceIn(0f, 1f)),
+        )
+    }
+
+    fun addOrReplaceLast(
+        state: MultiviewSessionState,
+        stream: Stream,
+        maximum: Int = 4,
+        initialAudioVolume: Float = 1f,
+    ): MultiviewSessionState {
+        val identity = stableIdentity(stream) ?: return state
+        if (state.identities.any { it.equals(identity, true) }) {
+            return setActive(state, identity)
+        }
+        if (state.streams.size < maximum) {
+            return setActive(add(state, stream, maximum, initialAudioVolume), identity)
+        }
+        if (state.streams.isEmpty()) return state
+
+        val replacedIdentity = stableIdentity(state.streams.last())
+        val remaining = state.streams.dropLast(1)
+        val wasFocused = replacedIdentity != null && state.focusedIdentity.equals(replacedIdentity, true)
+        val fallbackChatIdentity = remaining.firstOrNull()?.let(::stableIdentity) ?: identity
+        return state.copy(
+            streams = remaining + stream,
+            activeIdentity = identity,
+            focusedIdentity = state.focusedIdentity.takeUnless { it.equals(replacedIdentity, true) },
+            layoutMode = if (wasFocused) state.layoutBeforeFocus ?: state.layoutMode else state.layoutMode,
+            layoutBeforeFocus = if (wasFocused) null else state.layoutBeforeFocus,
+            chatIdentity = state.chatIdentity.takeUnless { it.equals(replacedIdentity, true) }
+                ?: fallbackChatIdentity,
+            qualityOverrides = state.qualityOverrides.filterKeys {
+                !it.equals(replacedIdentity, true)
+            },
+            audioVolumes = state.audioVolumes.filterKeys {
+                !it.equals(replacedIdentity, true)
+            } + (identity to initialAudioVolume.coerceIn(0f, 1f)),
         )
     }
 
     fun remove(state: MultiviewSessionState, identity: String): MultiviewSessionState {
         val remaining = state.streams.filterNot { stableIdentity(it).equals(identity, true) }
-        if (remaining.isEmpty()) return state.copy(streams = emptyList(), activeIdentity = null, focusedIdentity = null, chatIdentity = null)
+        if (remaining.isEmpty()) {
+            return state.copy(
+                streams = emptyList(),
+                activeIdentity = null,
+                focusedIdentity = null,
+                chatIdentity = null,
+                audioVolumes = emptyMap(),
+            )
+        }
         val fallback = remaining.firstOrNull()?.let(::stableIdentity)
         return state.copy(
             streams = remaining,
@@ -43,6 +94,7 @@ object MultiviewSessionReducer {
             focusedIdentity = state.focusedIdentity.takeUnless { it.equals(identity, true) },
             chatIdentity = state.chatIdentity.takeUnless { it.equals(identity, true) } ?: fallback,
             qualityOverrides = state.qualityOverrides.filterKeys { !it.equals(identity, true) },
+            audioVolumes = state.audioVolumes.filterKeys { !it.equals(identity, true) },
         )
     }
 
@@ -57,6 +109,14 @@ object MultiviewSessionReducer {
 
     fun setActive(state: MultiviewSessionState, identity: String): MultiviewSessionState {
         return if (state.identities.any { it.equals(identity, true) }) state.copy(activeIdentity = identity) else state
+    }
+
+    fun setAudioVolume(state: MultiviewSessionState, identity: String, volume: Float): MultiviewSessionState {
+        return if (state.identities.any { it.equals(identity, true) }) {
+            state.copy(audioVolumes = state.audioVolumes + (identity to volume.coerceIn(0f, 1f)))
+        } else {
+            state
+        }
     }
 
     fun setFocus(state: MultiviewSessionState, identity: String?): MultiviewSessionState {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/multiview/MultiviewSessionStore.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/multiview/MultiviewSessionStore.kt
@@ -1,0 +1,130 @@
+package com.github.andreyasadchy.xtra.ui.multiview
+
+import com.github.andreyasadchy.xtra.model.ui.Stream
+import com.github.andreyasadchy.xtra.ui.multiview.playback.MultiviewQualityMode
+import com.github.andreyasadchy.xtra.ui.multiview.ui.MultiviewLayoutMode
+import org.json.JSONArray
+import org.json.JSONObject
+
+/** Small JSON store for restoring a multiview after navigation or process recreation. */
+object MultiviewSessionStore {
+    fun encode(state: MultiviewSessionState): String {
+        return JSONObject().apply {
+            put("streams", JSONArray().apply { state.streams.forEach { put(encodeStream(it)) } })
+            putNullable("activeIdentity", state.activeIdentity)
+            putNullable("focusedIdentity", state.focusedIdentity)
+            put("layoutMode", state.layoutMode.name)
+            putNullable("layoutBeforeFocus", state.layoutBeforeFocus?.name)
+            put("fillVideo", state.fillVideo)
+            put("chatVisible", state.chatVisible)
+            put("combinedChat", state.combinedChat)
+            putNullable("chatIdentity", state.chatIdentity)
+            put("qualityMode", state.qualityMode.name)
+            put("qualityOverrides", JSONObject().apply {
+                state.qualityOverrides.forEach { (identity, quality) -> put(identity, quality) }
+            })
+            put("audioVolumes", JSONObject().apply {
+                state.audioVolumes.forEach { (identity, volume) -> put(identity, volume.toDouble()) }
+            })
+        }.toString()
+    }
+
+    fun decode(raw: String?): MultiviewSessionState? {
+        if (raw.isNullOrBlank()) return null
+        return runCatching {
+            JSONObject(raw).let { json ->
+                val streams = json.optJSONArray("streams")?.let { array ->
+                    (0 until array.length()).mapNotNull { index ->
+                        array.optJSONObject(index)?.let(::decodeStream)
+                    }
+                }.orEmpty()
+                MultiviewSessionState(
+                    streams = streams,
+                    activeIdentity = json.stringOrNull("activeIdentity"),
+                    focusedIdentity = json.stringOrNull("focusedIdentity"),
+                    layoutMode = json.enumOrDefault("layoutMode", MultiviewLayoutMode.AUTO),
+                    layoutBeforeFocus = json.enumOrNull("layoutBeforeFocus"),
+                    fillVideo = json.optBoolean("fillVideo", false),
+                    chatVisible = json.optBoolean("chatVisible", false),
+                    combinedChat = json.optBoolean("combinedChat", false),
+                    chatIdentity = json.stringOrNull("chatIdentity"),
+                    qualityMode = json.enumOrDefault("qualityMode", MultiviewQualityMode.AUTO),
+                    qualityOverrides = json.stringMap("qualityOverrides"),
+                    audioVolumes = json.floatMap("audioVolumes"),
+                )
+            }
+        }.getOrNull()
+    }
+
+    private fun encodeStream(stream: Stream): JSONObject = JSONObject().apply {
+        putNullable("id", stream.id)
+        putNullable("channelId", stream.channelId)
+        putNullable("channelLogin", stream.channelLogin)
+        putNullable("channelName", stream.channelName)
+        putNullable("channelImageURL", stream.channelImageURL)
+        putNullable("gameId", stream.gameId)
+        putNullable("gameSlug", stream.gameSlug)
+        putNullable("gameName", stream.gameName)
+        putNullable("title", stream.title)
+        putNullable("thumbnailURL", stream.thumbnailURL)
+        putNullable("createdAt", stream.createdAt)
+        stream.viewerCount?.let { put("viewerCount", it) }
+        put("tags", JSONArray().apply { stream.tags.orEmpty().forEach(::put) })
+    }
+
+    private fun decodeStream(json: JSONObject): Stream? {
+        val id = json.stringOrNull("id")
+        val channelId = json.stringOrNull("channelId")
+        val channelLogin = json.stringOrNull("channelLogin")
+        if (id == null && channelId == null && channelLogin == null) return null
+        val tags = json.optJSONArray("tags")?.let { array ->
+            (0 until array.length()).mapNotNull { index -> array.optString(index).takeIf(String::isNotBlank) }
+        }
+        return Stream(
+            id = id,
+            channelId = channelId,
+            channelLogin = channelLogin,
+            channelName = json.stringOrNull("channelName"),
+            channelImageURL = json.stringOrNull("channelImageURL"),
+            gameId = json.stringOrNull("gameId"),
+            gameSlug = json.stringOrNull("gameSlug"),
+            gameName = json.stringOrNull("gameName"),
+            title = json.stringOrNull("title"),
+            thumbnailURL = json.stringOrNull("thumbnailURL"),
+            createdAt = json.stringOrNull("createdAt"),
+            viewerCount = json.optInt("viewerCount").takeIf { json.has("viewerCount") },
+            tags = tags,
+        )
+    }
+
+    private fun JSONObject.putNullable(key: String, value: String?) {
+        put(key, value ?: JSONObject.NULL)
+    }
+
+    private fun JSONObject.stringOrNull(key: String): String? {
+        return optString(key).takeUnless { it.isBlank() || it == JSONObject.NULL.toString() }
+    }
+
+    private inline fun <reified T : Enum<T>> JSONObject.enumOrDefault(key: String, default: T): T {
+        return enumOrNull<T>(key) ?: default
+    }
+
+    private inline fun <reified T : Enum<T>> JSONObject.enumOrNull(key: String): T? {
+        return stringOrNull(key)?.let { value -> runCatching { enumValueOf<T>(value) }.getOrNull() }
+    }
+
+    private fun JSONObject.stringMap(key: String): Map<String, String> {
+        val objectValue = optJSONObject(key) ?: return emptyMap()
+        return objectValue.keys().asSequence().mapNotNull { name ->
+            objectValue.optString(name).takeIf(String::isNotBlank)?.let { name to it }
+        }.toMap()
+    }
+
+    private fun JSONObject.floatMap(key: String): Map<String, Float> {
+        val objectValue = optJSONObject(key) ?: return emptyMap()
+        return objectValue.keys().asSequence().mapNotNull { name ->
+            if (!objectValue.has(name)) return@mapNotNull null
+            name to objectValue.optDouble(name, 0.0).toFloat().coerceIn(0f, 1f)
+        }.toMap()
+    }
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/multiview/MultiviewViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/multiview/MultiviewViewModel.kt
@@ -47,14 +47,23 @@ class MultiviewViewModel(
     )
 
     fun initialize(initialStream: Stream?) {
-        if (_state.value.streams.isEmpty() && initialStream != null) {
-            update(MultiviewSessionReducer.add(_state.value, initialStream))
-        }
+        val current = _state.value
+        val next = initializeStateOnce(
+            savedStateHandle = savedStateHandle,
+            state = current,
+            initialStream = initialStream,
+            initialAudioVolume = { if (current.streams.isEmpty()) defaultAudioVolume() else 0f },
+        ) ?: return
+        if (next != current) update(next)
     }
 
     fun addStreams(streams: Collection<Stream>) {
         val next = streams.fold(_state.value) { state, stream ->
-            MultiviewSessionReducer.add(state, stream)
+            MultiviewSessionReducer.add(
+                state = state,
+                stream = stream,
+                initialAudioVolume = if (state.streams.isEmpty()) defaultAudioVolume() else 0f,
+            )
         }
         update(next)
     }
@@ -137,9 +146,34 @@ class MultiviewViewModel(
         update(_state.value.copy(qualityOverrides = overrides))
     }
 
+    fun setAudioVolume(identity: String, volume: Float, persist: Boolean = true) {
+        update(
+            next = MultiviewSessionReducer.setAudioVolume(_state.value, identity, volume),
+            persist = persist,
+        )
+    }
+
+    fun toggleAudio(identity: String) {
+        val current = _state.value.audioVolumes[identity] ?: 0f
+        setAudioVolume(
+            identity,
+            if (current > 0f) 0f else defaultAudioVolume().takeIf { it > 0f } ?: 1f,
+        )
+    }
+
+    fun audioVolume(identity: String): Float {
+        return _state.value.audioVolumes[identity]
+            ?: if (_state.value.activeIdentity.equals(identity, true)) defaultAudioVolume() else 0f
+    }
+
+    fun persistSession() {
+        persistSession(_state.value)
+    }
+
     fun onStart() = playbackCoordinator.onStart()
 
-    fun onStop() = playbackCoordinator.onStop()
+    fun onStop(allowBackground: Boolean = true, inPictureInPicture: Boolean = false) =
+        playbackCoordinator.onStop(allowBackground, inPictureInPicture)
 
     suspend fun resolveLiveStream(channelLogin: String): Stream? {
         val preferences = applicationContext.prefs()
@@ -268,7 +302,7 @@ class MultiviewViewModel(
         _playback.value = _playback.value + (identity to snapshot)
     }
 
-    private fun update(next: MultiviewSessionState) {
+    private fun update(next: MultiviewSessionState, persist: Boolean = true) {
         _state.value = next
         savedStateHandle[KEY_STREAMS] = ArrayList(next.streams)
         savedStateHandle[KEY_ACTIVE] = next.activeIdentity
@@ -281,11 +315,27 @@ class MultiviewViewModel(
         savedStateHandle[KEY_CHAT_IDENTITY] = next.chatIdentity
         savedStateHandle[KEY_QUALITY_MODE] = next.qualityMode.name
         savedStateHandle[KEY_OVERRIDES] = HashMap(next.qualityOverrides)
+        savedStateHandle[KEY_AUDIO_VOLUMES] = HashMap(next.audioVolumes)
+        if (persist) persistSession(next)
+    }
+
+    private fun persistSession(state: MultiviewSessionState) {
+        applicationContext.prefs().edit().apply {
+            if (state.streams.isEmpty()) {
+                remove(C.MULTIVIEW_SESSION)
+            } else {
+                putString(C.MULTIVIEW_SESSION, MultiviewSessionStore.encode(state))
+            }
+        }.apply()
     }
 
     private fun loadState(): MultiviewSessionState {
         val preferences = applicationContext.prefs()
+        val persisted = MultiviewSessionStore.decode(preferences.getString(C.MULTIVIEW_SESSION, null))
         val streams = savedStateHandle.get<ArrayList<Stream>>(KEY_STREAMS)?.toList().orEmpty()
+        if (streams.isEmpty() && persisted != null) {
+            return persisted.withAudioDefaults(preferences)
+        }
         val fillVideo = savedStateHandle.get<Boolean>(KEY_FILL) ?: preferences.getBoolean(C.MULTIVIEW_FILL, false)
         val qualityMode = savedStateHandle.get<String>(KEY_QUALITY_MODE)
             ?.let(MultiviewQualityMode::fromPersistedName)
@@ -307,10 +357,29 @@ class MultiviewViewModel(
             chatIdentity = savedStateHandle[KEY_CHAT_IDENTITY],
             qualityMode = qualityMode,
             qualityOverrides = (savedStateHandle.get<HashMap<String, String>>(KEY_OVERRIDES) ?: hashMapOf()).toMap(),
-        )
+            audioVolumes = (savedStateHandle.get<HashMap<String, Float>>(KEY_AUDIO_VOLUMES) ?: hashMapOf()).toMap(),
+        ).withAudioDefaults(preferences)
+    }
+
+    fun defaultAudioVolume(): Float {
+        return (applicationContext.prefs().getInt(C.PLAYER_VOLUME, 100) / 100f).coerceIn(0f, 1f)
+    }
+
+    private fun MultiviewSessionState.withAudioDefaults(
+        preferences: android.content.SharedPreferences,
+    ): MultiviewSessionState {
+        val fallback = (preferences.getInt(C.PLAYER_VOLUME, 100) / 100f).coerceIn(0f, 1f)
+        val volumes = audioVolumes.toMutableMap()
+        streams.mapNotNull(MultiviewSessionReducer::stableIdentity).forEach { identity ->
+            if (identity !in volumes) {
+                volumes[identity] = if (identity.equals(activeIdentity, true)) fallback else 0f
+            }
+        }
+        return copy(audioVolumes = volumes)
     }
 
     companion object {
+        private const val KEY_INITIAL_STREAM_APPLIED = "multiview_initial_stream_applied"
         private const val KEY_STREAMS = "multiview_state_streams"
         private const val KEY_ACTIVE = "multiview_state_active"
         private const val KEY_FOCUSED = "multiview_state_focused"
@@ -322,6 +391,23 @@ class MultiviewViewModel(
         private const val KEY_CHAT_IDENTITY = "multiview_state_chat_identity"
         private const val KEY_QUALITY_MODE = "multiview_state_quality_mode"
         private const val KEY_OVERRIDES = "multiview_state_quality_overrides"
+        private const val KEY_AUDIO_VOLUMES = "multiview_state_audio_volumes"
+
+        internal fun initializeStateOnce(
+            savedStateHandle: SavedStateHandle,
+            state: MultiviewSessionState,
+            initialStream: Stream?,
+            initialAudioVolume: () -> Float,
+        ): MultiviewSessionState? {
+            if (savedStateHandle.get<Boolean>(KEY_INITIAL_STREAM_APPLIED) == true) return null
+            savedStateHandle[KEY_INITIAL_STREAM_APPLIED] = true
+            if (initialStream == null) return state
+            return MultiviewSessionReducer.addOrReplaceLast(
+                state = state,
+                stream = initialStream,
+                initialAudioVolume = initialAudioVolume(),
+            )
+        }
 
         val MultiviewViewModelFactory = viewModelFactory {
             initializer {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/multiview/playback/MultiviewAudioPolicy.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/multiview/playback/MultiviewAudioPolicy.kt
@@ -7,6 +7,20 @@ package com.github.andreyasadchy.xtra.ui.multiview.playback
 object MultiviewAudioPolicy {
     fun volumeFor(
         identity: String,
+        audioVolumes: Map<String, Float>,
+        hiddenForAd: Boolean,
+        fallbackVolume: Float = 0f,
+    ): Float {
+        return if (hiddenForAd) {
+            0f
+        } else {
+            (audioVolumes[identity] ?: fallbackVolume).coerceIn(0f, 1f)
+        }
+    }
+
+    /** Compatibility overload for the original single-active-stream policy. */
+    fun volumeFor(
+        identity: String,
         activeIdentity: String?,
         hiddenForAd: Boolean,
         activeVolume: Float,

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/multiview/playback/MultiviewBackgroundPlaybackService.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/multiview/playback/MultiviewBackgroundPlaybackService.kt
@@ -1,0 +1,108 @@
+package com.github.andreyasadchy.xtra.ui.multiview.playback
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.content.pm.ServiceInfo
+import android.os.Build
+import android.os.IBinder
+import android.util.Log
+import androidx.core.app.NotificationCompat
+import androidx.core.content.ContextCompat
+import com.github.andreyasadchy.xtra.R
+import com.github.andreyasadchy.xtra.ui.main.MainActivity
+
+/** Keeps the multiview process alive while its video surfaces are detached in the background. */
+class MultiviewBackgroundPlaybackService : Service() {
+    override fun onCreate() {
+        super.onCreate()
+        ensureNotificationChannel(this)
+        val notification = NotificationCompat.Builder(this, CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_multiview)
+            .setContentTitle(getString(R.string.multiview_background_playback))
+            .setContentText(getString(R.string.multiview_background_playback_description))
+            .setCategory(NotificationCompat.CATEGORY_TRANSPORT)
+            .setPriority(NotificationCompat.PRIORITY_LOW)
+            .setOngoing(true)
+            .setSilent(true)
+            .setOnlyAlertOnce(true)
+            .setContentIntent(
+                PendingIntent.getActivity(
+                    this,
+                    NOTIFICATION_REQUEST_CODE,
+                    Intent(this, MainActivity::class.java).apply {
+                        flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP
+                    },
+                    PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+                )
+            )
+            .build()
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            startForeground(
+                NOTIFICATION_ID,
+                notification,
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK,
+            )
+        } else {
+            startForeground(NOTIFICATION_ID, notification)
+        }
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        if (intent?.action == ACTION_STOP) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                stopForeground(STOP_FOREGROUND_REMOVE)
+            } else {
+                @Suppress("DEPRECATION")
+                stopForeground(true)
+            }
+            stopSelf()
+        }
+        return START_NOT_STICKY
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    companion object {
+        private const val CHANNEL_ID = "multiview_background_playback"
+        private const val NOTIFICATION_ID = 1101
+        private const val NOTIFICATION_REQUEST_CODE = 1102
+        private const val ACTION_STOP = "com.github.andreyasadchy.xtra.action.STOP_MULTIVIEW_BACKGROUND"
+        private const val TAG = "MultiviewBackground"
+
+        fun start(context: Context): Boolean {
+            return runCatching {
+                ContextCompat.startForegroundService(
+                    context,
+                    Intent(context, MultiviewBackgroundPlaybackService::class.java),
+                )
+                true
+            }.onFailure { error ->
+                Log.e(TAG, "Unable to start multiview background playback", error)
+            }.getOrDefault(false)
+        }
+
+        fun stop(context: Context) {
+            context.stopService(Intent(context, MultiviewBackgroundPlaybackService::class.java))
+        }
+
+        private fun ensureNotificationChannel(context: Context) {
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+            val manager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            manager.createNotificationChannel(
+                NotificationChannel(
+                    CHANNEL_ID,
+                    context.getString(R.string.multiview_background_playback),
+                    NotificationManager.IMPORTANCE_LOW,
+                ).apply {
+                    description = context.getString(R.string.multiview_background_playback_description)
+                    setSound(null, null)
+                    enableVibration(false)
+                },
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/multiview/playback/MultiviewPlaybackCoordinator.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/multiview/playback/MultiviewPlaybackCoordinator.kt
@@ -75,7 +75,11 @@ class MultiviewPlaybackCoordinator(
     private var focusedIdentity: String? = null
     private var qualityMode = MultiviewQualityMode.AUTO
     private var qualityOverrides: Map<String, String> = emptyMap()
+    private var audioVolumes: Map<String, Float> = emptyMap()
     private var foreground = true
+    private var backgroundPlayback = false
+    private var lifecycleStarted = false
+    private var backgroundServicePrepared = false
 
     fun sync(
         streams: List<Stream>,
@@ -83,11 +87,13 @@ class MultiviewPlaybackCoordinator(
         focusedIdentity: String?,
         qualityMode: MultiviewQualityMode,
         qualityOverrides: Map<String, String>,
+        audioVolumes: Map<String, Float> = emptyMap(),
     ) {
         this.activeIdentity = activeIdentity
         this.focusedIdentity = focusedIdentity
         this.qualityMode = qualityMode
         this.qualityOverrides = qualityOverrides
+        this.audioVolumes = audioVolumes
         val desired = streams.mapNotNull { stream ->
             identityOf(stream)?.let { identity -> identity to stream }
         }.toMap()
@@ -112,6 +118,7 @@ class MultiviewPlaybackCoordinator(
         }
         slots.values.forEach { applyQuality(it) }
         updateAudio()
+        if (lifecycleStarted) maintainBackgroundPlaybackService()
     }
 
     fun attach(identity: String, playerView: PlayerView) {
@@ -148,19 +155,53 @@ class MultiviewPlaybackCoordinator(
         }
     }
 
-    fun onStart() {
-        foreground = true
-        slots.values.forEach { slot ->
-            if (slot.shouldPlay) slot.player.playWhenReady = true
-        }
+    private fun shouldPlayWhenReady(slot: MultiviewPlayerSlot): Boolean {
+        return (slot.shouldPlay && foreground) ||
+            (slot.shouldPlay && backgroundPlayback && configuredVolume(slot) > 0f)
     }
 
-    fun onStop() {
-        foreground = false
+    fun onStart() {
+        lifecycleStarted = true
+        foreground = true
+        backgroundPlayback = false
         slots.values.forEach { slot ->
-            slot.shouldPlay = slot.player.playWhenReady
-            slot.player.playWhenReady = false
-            updateViewingStats(slot, forceNotPlaying = true)
+            restoreBackgroundVideo(slot)
+            slot.attachedView?.player = slot.player
+            slot.player.playWhenReady = shouldPlayWhenReady(slot)
+        }
+        maintainBackgroundPlaybackService()
+    }
+
+    fun onStop(allowBackground: Boolean = true, inPictureInPicture: Boolean = false) {
+        if (inPictureInPicture) {
+            lifecycleStarted = true
+            foreground = true
+            backgroundPlayback = false
+            slots.values.forEach { slot ->
+                slot.player.playWhenReady = shouldPlayWhenReady(slot)
+            }
+            return
+        }
+        lifecycleStarted = false
+        foreground = false
+        val keepAudioInBackground = allowBackground && applicationContext.prefs()
+            .getBoolean(C.SETTINGS_BACKGROUND_PLAYBACK, true)
+        val canPlayInBackground = keepAudioInBackground && backgroundServicePrepared
+        backgroundPlayback = canPlayInBackground
+        slots.values.forEach { slot ->
+            // onStop may be called once by the explicit external-player handoff
+            // and again by Fragment lifecycle dispatch. Preserve the original
+            // intent instead of turning a playing tile into a paused tile on
+            // the second callback.
+            slot.shouldPlay = slot.shouldPlay || slot.player.playWhenReady
+            suppressBackgroundVideo(slot)
+            val shouldPlayInBackground = shouldPlayWhenReady(slot)
+            slot.player.playWhenReady = shouldPlayInBackground
+            updateViewingStats(slot, forceNotPlaying = !shouldPlayInBackground)
+        }
+        if (!canPlayInBackground) {
+            backgroundServicePrepared = false
+            MultiviewBackgroundPlaybackService.stop(applicationContext)
         }
     }
 
@@ -172,6 +213,10 @@ class MultiviewPlaybackCoordinator(
         }
         slots.clear()
         tileBounds.clear()
+        lifecycleStarted = false
+        backgroundPlayback = false
+        backgroundServicePrepared = false
+        MultiviewBackgroundPlaybackService.stop(applicationContext)
     }
 
     fun player(identity: String): ExoPlayer? = slots[identity]?.player
@@ -359,7 +404,7 @@ class MultiviewPlaybackCoordinator(
                 applyQuality(slot)
                 updateAudio()
                 slot.player.prepare()
-                slot.player.playWhenReady = foreground && slot.shouldPlay
+                slot.player.playWhenReady = shouldPlayWhenReady(slot)
                 debugLog("channel=${slot.identity} playlistLoaded quality=${slot.target?.label} urlType=${if (slot.customProxy) "proxy" else "usher"} playerType=${slot.currentPlayerType ?: "custom"} alternate=${slot.usingAlternateStream} httpProxyDisabled=${slot.httpProxyDisabled}")
             } catch (cancelled: CancellationException) {
                 throw cancelled
@@ -504,7 +549,7 @@ class MultiviewPlaybackCoordinator(
             slot.lastResponseCode = null
             slot.lastMasterResponseCode = null
             slot.player.prepare()
-            slot.player.playWhenReady = foreground && slot.shouldPlay
+            slot.player.playWhenReady = shouldPlayWhenReady(slot)
         } else {
             slot.reloadRequired = false
             start(slot)
@@ -795,14 +840,60 @@ class MultiviewPlaybackCoordinator(
     }
 
     private fun updateAudio() {
-        val volume = activeVolume()
+        val fallbackVolume = activeVolume()
         slots.values.forEach { slot ->
             slot.player.volume = MultiviewAudioPolicy.volumeFor(
                 identity = slot.identity,
-                activeIdentity = activeIdentity,
+                audioVolumes = audioVolumes,
                 hiddenForAd = slot.hiddenForAd,
-                activeVolume = volume,
+                fallbackVolume = if (slot.identity == activeIdentity) fallbackVolume else 0f,
             )
+        }
+    }
+
+    private fun maintainBackgroundPlaybackService() {
+        val shouldPrepare = lifecycleStarted &&
+            applicationContext.prefs().getBoolean(C.SETTINGS_BACKGROUND_PLAYBACK, true) &&
+            slots.values.any { it.shouldPlay && configuredVolume(it) > 0f }
+        if (!shouldPrepare) {
+            backgroundServicePrepared = false
+            MultiviewBackgroundPlaybackService.stop(applicationContext)
+            return
+        }
+        if (!backgroundServicePrepared) {
+            backgroundServicePrepared = MultiviewBackgroundPlaybackService.start(applicationContext)
+        }
+    }
+
+    private fun configuredVolume(slot: MultiviewPlayerSlot): Float {
+        return MultiviewAudioPolicy.volumeFor(
+            identity = slot.identity,
+            audioVolumes = audioVolumes,
+            hiddenForAd = false,
+            fallbackVolume = if (slot.identity == activeIdentity) activeVolume() else 0f,
+        )
+    }
+
+    @androidx.media3.common.util.UnstableApi
+    private fun suppressBackgroundVideo(slot: MultiviewPlayerSlot) {
+        if (!slot.videoDisabledForBackground) {
+            slot.videoDisabledForBackground = true
+            slot.player.trackSelectionParameters = slot.player.trackSelectionParameters
+                .buildUpon()
+                .setTrackTypeDisabled(androidx.media3.common.C.TRACK_TYPE_VIDEO, true)
+                .build()
+        }
+        slot.attachedView?.player = null
+    }
+
+    @androidx.media3.common.util.UnstableApi
+    private fun restoreBackgroundVideo(slot: MultiviewPlayerSlot) {
+        if (slot.videoDisabledForBackground) {
+            slot.videoDisabledForBackground = false
+            slot.player.trackSelectionParameters = slot.player.trackSelectionParameters
+                .buildUpon()
+                .setTrackTypeDisabled(androidx.media3.common.C.TRACK_TYPE_VIDEO, false)
+                .build()
         }
     }
 
@@ -1018,6 +1109,7 @@ class MultiviewPlaybackCoordinator(
         var usingAlternateStream: Boolean = false
         var playingAds: Boolean = false
         var hiddenForAd: Boolean = false
+        var videoDisabledForBackground: Boolean = false
         var lastResponseCode: Int? = null
         var lastMasterResponseCode: Int? = null
         var lastResponseWasMaster: Boolean = false

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/multiview/ui/MultiviewSlotView.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/multiview/ui/MultiviewSlotView.kt
@@ -55,6 +55,7 @@ class MultiviewSlotView(context: Context) : FrameLayout(context) {
     var onDoubleTap: (() -> Unit)? = null
     var onLongPress: (() -> Unit)? = null
     var onOverflow: (() -> Unit)? = null
+    var onAudioClick: (() -> Unit)? = null
     var onRetry: (() -> Unit)? = null
 
     init {
@@ -66,6 +67,7 @@ class MultiviewSlotView(context: Context) : FrameLayout(context) {
             true
         }
         binding.overflowButton.setOnClickListener { onOverflow?.invoke() }
+        binding.audioIcon.setOnClickListener { onAudioClick?.invoke() }
         binding.statusMessage.setOnClickListener { onRetry?.invoke() }
         setControlsVisible(false)
     }
@@ -74,13 +76,14 @@ class MultiviewSlotView(context: Context) : FrameLayout(context) {
         identity: String,
         stream: Stream,
         snapshot: MultiviewPlaybackSnapshot?,
-        audioActive: Boolean,
+        audioVolume: Float,
         focused: Boolean,
         fillVideo: Boolean,
     ) {
         this.identity = identity
         this.stream = stream
         val name = displayName(stream)
+        val audioActive = audioVolume > 0f
         binding.channelName.text = name
         binding.qualityBadge.text = snapshot?.qualityLabel.orEmpty()
         binding.qualityBadge.isVisible = !snapshot?.qualityLabel.isNullOrBlank()
@@ -89,7 +92,6 @@ class MultiviewSlotView(context: Context) : FrameLayout(context) {
         } else {
             AspectRatioFrameLayout.RESIZE_MODE_FIT
         }
-        binding.audioIcon.isVisible = audioActive
         binding.audioIcon.setImageResource(
             if (audioActive) R.drawable.baseline_volume_up_black_24 else R.drawable.baseline_volume_off_black_24,
         )
@@ -118,6 +120,8 @@ class MultiviewSlotView(context: Context) : FrameLayout(context) {
     }
 
     fun setControlsVisible(visible: Boolean) {
+        binding.infoBar.isVisible = visible
+        binding.audioIcon.isVisible = visible
         binding.overflowButton.isVisible = visible
     }
 

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/C.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/C.kt
@@ -200,6 +200,7 @@ object C {
     const val PLAYER_STREAM_HEADERS = "player_stream_headers"
     const val MULTIVIEW_FILL = "multiview_fill_video"
     const val MULTIVIEW_QUALITY_MODE = "multiview_quality_mode"
+    const val MULTIVIEW_SESSION = "multiview_session"
     const val PLAYER_SHOW_UPTIME = "player_show_uptime"
     const val PROXY_PLAYBACK_ACCESS_TOKEN = "proxy_playback_access_token"
     const val PROXY_MULTIVARIANT_PLAYLIST = "proxy_multivariant_playlist"

--- a/app/src/main/res/drawable/ic_picture_in_picture.xml
+++ b/app/src/main/res/drawable/ic_picture_in_picture.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M19,7H5c-1.1,0 -2,0.9 -2,2v6c0,1.1 0.9,2 2,2h14c1.1,0 2,-0.9 2,-2V9c0,-1.1 -0.9,-2 -2,-2zM19,15H13v-4h6v4zM7,13h4v2H7z" />
+</vector>

--- a/app/src/main/res/layout/fragment_multiview.xml
+++ b/app/src/main/res/layout/fragment_multiview.xml
@@ -71,6 +71,17 @@
                 tools:text="Audio: channel" />
 
             <ImageButton
+                android:id="@+id/pipButton"
+                android:layout_width="48dp"
+                android:layout_height="48dp"
+                android:background="?attr/selectableItemBackgroundBorderless"
+                android:contentDescription="@string/multiview_minimize"
+                android:padding="12dp"
+                android:src="@drawable/ic_picture_in_picture"
+                android:visibility="gone"
+                app:tint="@android:color/white" />
+
+            <ImageButton
                 android:id="@+id/chatButton"
                 android:layout_width="48dp"
                 android:layout_height="48dp"

--- a/app/src/main/res/layout/multiview_slot.xml
+++ b/app/src/main/res/layout/multiview_slot.xml
@@ -31,7 +31,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_gravity="top"
-        android:layout_margin="6dp"
+        android:layout_margin="2dp"
         android:background="@drawable/bg_stream_overlay"
         android:gravity="center_vertical"
         android:minHeight="40dp"
@@ -64,11 +64,14 @@
             android:textAppearance="?attr/textAppearanceLabelSmall"
             android:textColor="@android:color/white" />
 
-        <ImageView
+        <ImageButton
             android:id="@+id/audioIcon"
-            android:layout_width="32dp"
-            android:layout_height="40dp"
+            android:layout_width="40dp"
+            android:layout_height="48dp"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:clickable="true"
             android:contentDescription="@string/multiview_audio_muted_short"
+            android:focusable="true"
             android:padding="8dp"
             android:src="@drawable/baseline_volume_off_black_24"
             android:visibility="gone"

--- a/app/src/main/res/values/multiview_strings.xml
+++ b/app/src/main/res/values/multiview_strings.xml
@@ -9,6 +9,7 @@
     <string name="multiview_loading">Loading stream…</string>
     <string name="multiview_playback_error">Playback failed. Tap to retry.</string>
     <string name="multiview_audio">Audio: %s</string>
+    <string name="multiview_audio_multiple">Audio: %d streams</string>
     <string name="multiview_chat">Chat</string>
     <string name="multiview_hide_chat">Hide chat</string>
     <string name="multiview_close">Done</string>
@@ -55,6 +56,11 @@
     <string name="multiview_open_player">Open in player</string>
     <string name="multiview_open_active_player">Open active stream in player</string>
     <string name="multiview_stream_actions">Stream actions</string>
+    <string name="multiview_volume">Volume</string>
+    <string name="multiview_volume_for">Volume for %s</string>
+    <string name="multiview_mute">Mute</string>
+    <string name="multiview_unmute">Unmute</string>
+    <string name="multiview_minimize">Minimize multiview</string>
     <string name="multiview_buffering">Buffering…</string>
     <string name="multiview_reconnecting">Reconnecting…</string>
     <string name="multiview_offline">Stream is offline</string>
@@ -80,4 +86,6 @@
     <string name="multiview_viewers">%d viewers</string>
     <string name="multiview_already_added">Already added</string>
     <string name="multiview_combined_message_description">%1$s chat message: %2$s</string>
+    <string name="multiview_background_playback">Multiview playback</string>
+    <string name="multiview_background_playback_description">Audio is playing while video is hidden.</string>
 </resources>

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/multiview/MultiviewSessionReducerTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/multiview/MultiviewSessionReducerTest.kt
@@ -9,6 +9,8 @@ class MultiviewSessionReducerTest {
     private val first = Stream(id = "stream-1", channelId = "100", channelLogin = "Alpha", channelName = "Alpha")
     private val second = Stream(id = "stream-2", channelId = "200", channelLogin = "Beta", channelName = "Beta")
     private val third = Stream(id = "stream-3", channelId = "300", channelLogin = "Gamma", channelName = "Gamma")
+    private val fourth = Stream(id = "stream-4", channelId = "400", channelLogin = "Delta", channelName = "Delta")
+    private val requested = Stream(id = "stream-5", channelId = "500", channelLogin = "Epsilon", channelName = "Epsilon")
 
     @Test
     fun addUsesStableIdentityAndCapsAtFour() {
@@ -63,5 +65,22 @@ class MultiviewSessionReducerTest {
 
         state = MultiviewSessionReducer.setActive(state, "id:100")
         assertEquals("id:100", state.activeIdentity)
+    }
+
+    @Test
+    fun explicitInitialStreamReplacesLastWhenRestoredSessionIsFull() {
+        var state = MultiviewSessionState()
+        listOf(first, second, third, fourth).forEach {
+            state = MultiviewSessionReducer.add(state, it, initialAudioVolume = 0f)
+        }
+
+        state = MultiviewSessionReducer.addOrReplaceLast(
+            state = state,
+            stream = requested,
+            initialAudioVolume = 0f,
+        )
+
+        assertEquals(listOf("id:100", "id:200", "id:300", "id:500"), state.identities)
+        assertEquals("id:500", state.activeIdentity)
     }
 }

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/multiview/MultiviewSessionStoreTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/multiview/MultiviewSessionStoreTest.kt
@@ -1,0 +1,67 @@
+package com.github.andreyasadchy.xtra.ui.multiview
+
+import com.github.andreyasadchy.xtra.model.ui.Stream
+import com.github.andreyasadchy.xtra.ui.multiview.playback.MultiviewQualityMode
+import com.github.andreyasadchy.xtra.ui.multiview.ui.MultiviewLayoutMode
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+
+class MultiviewSessionStoreTest {
+    @Test
+    fun roundTripsSessionConfigurationAndStreamMetadata() {
+        val first = Stream(
+            id = "stream-1",
+            channelId = "100",
+            channelLogin = "Alpha",
+            channelName = "Alpha Channel",
+            gameId = "game-1",
+            gameName = "Game",
+            title = "First stream",
+            createdAt = "2026-08-14T10:00:00Z",
+            viewerCount = 123,
+            tags = listOf("English", "Esports"),
+        )
+        val second = Stream(
+            id = "stream-2",
+            channelId = "200",
+            channelLogin = "Beta",
+            channelName = "Beta Channel",
+        )
+        val state = MultiviewSessionState(
+            streams = listOf(first, second),
+            activeIdentity = "id:200",
+            focusedIdentity = "id:100",
+            layoutMode = MultiviewLayoutMode.FOCUS,
+            layoutBeforeFocus = MultiviewLayoutMode.GRID,
+            fillVideo = true,
+            chatVisible = true,
+            combinedChat = true,
+            chatIdentity = "id:200",
+            qualityMode = MultiviewQualityMode.QUALITY_720P,
+            qualityOverrides = mapOf("id:100" to "720p60"),
+            audioVolumes = mapOf("id:100" to 0.25f, "id:200" to 0.75f),
+        )
+
+        val decoded = MultiviewSessionStore.decode(MultiviewSessionStore.encode(state))
+
+        assertNotNull(decoded)
+        assertEquals(state.activeIdentity, decoded?.activeIdentity)
+        assertEquals(state.focusedIdentity, decoded?.focusedIdentity)
+        assertEquals(state.layoutMode, decoded?.layoutMode)
+        assertEquals(state.layoutBeforeFocus, decoded?.layoutBeforeFocus)
+        assertEquals(state.fillVideo, decoded?.fillVideo)
+        assertEquals(state.chatVisible, decoded?.chatVisible)
+        assertEquals(state.combinedChat, decoded?.combinedChat)
+        assertEquals(state.chatIdentity, decoded?.chatIdentity)
+        assertEquals(state.qualityMode, decoded?.qualityMode)
+        assertEquals(state.qualityOverrides, decoded?.qualityOverrides)
+        assertEquals(state.audioVolumes, decoded?.audioVolumes)
+        assertEquals(2, decoded?.streams?.size)
+        assertEquals(first.id, decoded?.streams?.get(0)?.id)
+        assertEquals(first.channelName, decoded?.streams?.get(0)?.channelName)
+        assertEquals(first.viewerCount, decoded?.streams?.get(0)?.viewerCount)
+        assertEquals(first.tags, decoded?.streams?.get(0)?.tags)
+        assertEquals(second.channelLogin, decoded?.streams?.get(1)?.channelLogin)
+    }
+}

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/multiview/MultiviewViewModelTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/multiview/MultiviewViewModelTest.kt
@@ -1,0 +1,63 @@
+package com.github.andreyasadchy.xtra.ui.multiview
+
+import androidx.lifecycle.SavedStateHandle
+import com.github.andreyasadchy.xtra.model.ui.Stream
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class MultiviewViewModelTest {
+    private val initialStream = Stream(
+        id = "stream-1",
+        channelId = "100",
+        channelLogin = "Alpha",
+        channelName = "Alpha",
+    )
+    private val otherStream = Stream(
+        id = "stream-2",
+        channelId = "200",
+        channelLogin = "Beta",
+        channelName = "Beta",
+    )
+
+    @Test
+    fun restoredActiveStreamIsNotResetBySecondInitialize() {
+        val handle = SavedStateHandle()
+        var state = applyInitialStream(handle, MultiviewSessionState())
+        state = MultiviewSessionReducer.add(state, otherStream, initialAudioVolume = 0f)
+        state = MultiviewSessionReducer.setActive(state, "id:200")
+
+        val restoredState = applyInitialStream(recreateHandle(handle), state)
+
+        assertEquals("id:200", restoredState.activeIdentity)
+        assertEquals(listOf("id:100", "id:200"), restoredState.identities)
+    }
+
+    @Test
+    fun removedInitialStreamIsNotReaddedDuringRecreation() {
+        val handle = SavedStateHandle()
+        var state = applyInitialStream(handle, MultiviewSessionState())
+        state = MultiviewSessionReducer.remove(state, "id:100")
+
+        val restoredState = applyInitialStream(recreateHandle(handle), state)
+
+        assertEquals(emptyList<String>(), restoredState.identities)
+    }
+
+    private fun applyInitialStream(
+        handle: SavedStateHandle,
+        state: MultiviewSessionState,
+    ): MultiviewSessionState {
+        return MultiviewViewModel.initializeStateOnce(
+            savedStateHandle = handle,
+            state = state,
+            initialStream = initialStream,
+            initialAudioVolume = { 0f },
+        ) ?: state
+    }
+
+    private fun recreateHandle(handle: SavedStateHandle): SavedStateHandle {
+        return SavedStateHandle(
+            handle.keys().associateWith { key -> handle.get<Any?>(key) },
+        )
+    }
+}

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/multiview/playback/MultiviewAudioPolicyTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/multiview/playback/MultiviewAudioPolicyTest.kt
@@ -5,6 +5,27 @@ import org.junit.Test
 
 class MultiviewAudioPolicyTest {
     @Test
+    fun configuredVolumesRemainIndependentAcrossSlots() {
+        val volumes = mapOf("a" to 0.25f, "b" to 0.75f)
+
+        assertEquals(
+            0.25f,
+            MultiviewAudioPolicy.volumeFor("a", volumes, hiddenForAd = false),
+            0f,
+        )
+        assertEquals(
+            0.75f,
+            MultiviewAudioPolicy.volumeFor("b", volumes, hiddenForAd = false),
+            0f,
+        )
+        assertEquals(
+            0f,
+            MultiviewAudioPolicy.volumeFor("b", volumes, hiddenForAd = true),
+            0f,
+        )
+    }
+
+    @Test
     fun hiddenAdSlotStaysMutedAcrossActiveStreamChangesAndRenders() {
         fun render(activeIdentity: String): Map<String, Float> {
             return mapOf(


### PR DESCRIPTION
## What changed

Multiview can now play audio from multiple streams with separate volume controls. It keeps audio playing when the app is sent to the background, hides video rendering, and offers an explicit PiP button. Tiles are more compact and their overlays hide automatically.

The current multiview arrangement, quality choices, and volume levels are saved so returning to multiview restores the setup.

## Validation

- `:app:assembleDebug`
- Manual smoke test on `xtra-api35`
