### PR TITLE
Make live stream feeds cache-first

### DIFF
--- a/app/src/androidTest/java/com/github/andreyasadchy/xtra/db/AppDatabaseMigrationTest.kt
+++ b/app/src/androidTest/java/com/github/andreyasadchy/xtra/db/AppDatabaseMigrationTest.kt
@@ -23,23 +23,26 @@ class AppDatabaseMigrationTest {
     }
 
     @Test
-    fun migrateCurrentVersion38To40CreatesStatisticsSchema() {
+    fun migrateCurrentVersion38To42CreatesStatisticsAndStreamFeedSchema() {
         val name = "migration-v38.db"
         prepareDatabase(name, version = 38, historicalVersion39 = false)
 
         val database = openMigratedDatabase(name)
-        assertStatisticsSchema(database.openHelper.readableDatabase)
+        val sqlite = database.openHelper.readableDatabase
+        assertStatisticsSchema(sqlite)
+        assertStreamFeedSchema(sqlite)
         database.close()
     }
 
     @Test
-    fun migrateHistoricalVersion39NormalizesAndCreatesStatisticsSchema() {
+    fun migrateHistoricalVersion39NormalizesAndCreatesCurrentSchema() {
         val name = "migration-historical-v39.db"
         prepareDatabase(name, version = 39, historicalVersion39 = true)
 
         val database = openMigratedDatabase(name)
         val sqlite = database.openHelper.readableDatabase
         assertStatisticsSchema(sqlite)
+        assertStreamFeedSchema(sqlite)
         assertTrue(tableExists(sqlite, "notification_events"))
         assertFalse(tableExists(sqlite, "live_notification_logs"))
         database.close()
@@ -50,6 +53,8 @@ class AppDatabaseMigrationTest {
             .addMigrations(
                 ViewingStatsMigrations.FROM_38,
                 ViewingStatsMigrations.FROM_HISTORICAL_39,
+                StreamFeedMigrations.FROM_40,
+                StreamFeedMigrations.FROM_41,
             )
             .build()
             .also { it.openHelper.writableDatabase }
@@ -73,6 +78,10 @@ class AppDatabaseMigrationTest {
         sqlite.execSQL("DROP INDEX IF EXISTS index_viewing_sessions_channel_id_started_at")
         sqlite.execSQL("DROP INDEX IF EXISTS index_viewing_sessions_started_at")
         sqlite.execSQL("DROP TABLE IF EXISTS viewing_sessions")
+        sqlite.execSQL("DROP INDEX IF EXISTS index_stream_feed_items_feedKey_position")
+        sqlite.execSQL("DROP INDEX IF EXISTS index_stream_feed_items_feedKey_channelId")
+        sqlite.execSQL("DROP TABLE IF EXISTS stream_feed_items")
+        sqlite.execSQL("DROP TABLE IF EXISTS stream_feed_states")
         if (historicalVersion39) {
             sqlite.execSQL("DROP TABLE IF EXISTS notification_events")
             sqlite.execSQL("CREATE TABLE live_notification_logs (id INTEGER PRIMARY KEY NOT NULL)")
@@ -82,11 +91,21 @@ class AppDatabaseMigrationTest {
     }
 
     private fun assertStatisticsSchema(database: SupportSQLiteDatabase) {
-        assertEquals(40, scalarInt(database, "PRAGMA user_version"))
+        assertEquals(42, scalarInt(database, "PRAGMA user_version"))
         assertTrue(tableExists(database, "viewing_sessions"))
         assertTrue(tableExists(database, "viewing_intervals"))
         assertTrue(indexExists(database, "index_viewing_sessions_started_at"))
         assertTrue(indexExists(database, "index_viewing_intervals_start_at"))
+    }
+
+    private fun assertStreamFeedSchema(database: SupportSQLiteDatabase) {
+        assertTrue(tableExists(database, "stream_feed_items"))
+        assertTrue(tableExists(database, "stream_feed_states"))
+        assertTrue(indexExists(database, "index_stream_feed_items_feedKey_position"))
+        assertTrue(indexExists(database, "index_stream_feed_items_feedKey_channelId"))
+        assertTrue(columnExists(database, "stream_feed_items", "generation"))
+        assertTrue(columnExists(database, "stream_feed_states", "nextCursorApi"))
+        assertTrue(columnExists(database, "stream_feed_states", "activeGeneration"))
     }
 
     private fun tableExists(database: SupportSQLiteDatabase, tableName: String): Boolean {
@@ -107,6 +126,15 @@ class AppDatabaseMigrationTest {
         return database.query(query).use {
             check(it.moveToFirst())
             it.getInt(0)
+        }
+    }
+
+    private fun columnExists(database: SupportSQLiteDatabase, tableName: String, columnName: String): Boolean {
+        return database.query("PRAGMA table_info($tableName)").use { cursor ->
+            while (cursor.moveToNext()) {
+                if (cursor.getString(cursor.getColumnIndexOrThrow("name")) == columnName) return@use true
+            }
+            false
         }
     }
 }

--- a/app/src/androidTest/java/com/github/andreyasadchy/xtra/repository/streamfeed/StreamFeedCacheTest.kt
+++ b/app/src/androidTest/java/com/github/andreyasadchy/xtra/repository/streamfeed/StreamFeedCacheTest.kt
@@ -1,0 +1,195 @@
+package com.github.andreyasadchy.xtra.repository.streamfeed
+
+import androidx.room.Room
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.github.andreyasadchy.xtra.db.AppDatabase
+import com.github.andreyasadchy.xtra.model.ui.Stream
+import com.github.andreyasadchy.xtra.repository.datasource.StreamFeedCursor
+import com.github.andreyasadchy.xtra.repository.datasource.StreamFeedPage
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class StreamFeedCacheTest {
+
+    private lateinit var database: AppDatabase
+
+    @Before
+    fun createDatabase() {
+        database = Room.inMemoryDatabaseBuilder(
+            InstrumentationRegistry.getInstrumentation().targetContext,
+            AppDatabase::class.java,
+        ).build()
+    }
+
+    @After
+    fun closeDatabase() {
+        database.close()
+    }
+
+    @Test
+    fun refreshAndAppendKeepFreshPrefixAndStaleTailPositionsUnique() = runBlocking {
+        val cache = StreamFeedCache(database)
+        val feedKey = StreamFeedKey("top:cache-layout")
+
+        cache.replaceAfterRefresh(
+            feedKey,
+            StreamFeedPage(
+                streams("a", "b", "c", "d", "e", "f", "g", "h", "i"),
+                StreamFeedCursor("gql", "old-page-2"),
+            ),
+            nowMs = 1L,
+            preserveTail = false,
+            pruneStaleOnEnd = true,
+        )
+        cache.replaceAfterRefresh(
+            feedKey,
+            StreamFeedPage(
+                streams("a", "b", "x"),
+                StreamFeedCursor("helix", "fresh-page-2"),
+            ),
+            nowMs = 2L,
+            preserveTail = true,
+            pruneStaleOnEnd = true,
+        )
+
+        assertLayout(
+            feedKey,
+            expectedKeys = listOf("a", "b", "x", "c", "d", "e", "f", "g", "h", "i"),
+            activeCount = 3,
+        )
+
+        cache.appendPage(
+            feedKey,
+            StreamFeedPage(
+                streams("d", "y", "f"),
+                StreamFeedCursor("helix", "fresh-page-3"),
+            ),
+            nowMs = 3L,
+            pruneStaleOnEnd = true,
+        )
+
+        assertLayout(
+            feedKey,
+            expectedKeys = listOf("a", "b", "x", "d", "y", "f", "c", "e", "g", "h", "i"),
+            activeCount = 6,
+        )
+        assertEquals("helix", database.streamFeedDao().state(feedKey.value)?.nextCursorApi)
+
+        cache.appendPage(
+            feedKey,
+            StreamFeedPage(emptyList(), nextCursor = null),
+            nowMs = 4L,
+            pruneStaleOnEnd = true,
+        )
+
+        assertLayout(
+            feedKey,
+            expectedKeys = listOf("a", "b", "x", "d", "y", "f"),
+            activeCount = 6,
+        )
+    }
+
+    @Test
+    fun automaticRefreshEofDefersStalePruningUntilExplicitFinalization() = runBlocking {
+        val cache = StreamFeedCache(database)
+        val feedKey = StreamFeedKey("top:cache-automatic-eof")
+        seedOldFeed(cache, feedKey)
+
+        cache.replaceAfterRefresh(
+            feedKey,
+            StreamFeedPage(streams("fresh-0", "fresh-1"), nextCursor = null),
+            nowMs = 2L,
+            preserveTail = true,
+            pruneStaleOnEnd = false,
+        )
+
+        assertTrue(database.streamFeedDao().itemsForFeed(feedKey.value).any { it.itemKey == "channel:old-80" })
+        assertContiguousLayout(feedKey, activeCount = 2)
+        assertEquals(null, database.streamFeedDao().state(feedKey.value)?.nextCursor)
+
+        cache.pruneStaleGeneration(feedKey)
+
+        val rows = database.streamFeedDao().itemsForFeed(feedKey.value)
+        assertEquals(listOf("channel:fresh-0", "channel:fresh-1"), rows.map { it.itemKey })
+        assertFalse(rows.any { it.itemKey == "channel:old-80" })
+        assertContiguousLayout(feedKey, activeCount = 2)
+    }
+
+    @Test
+    fun speculativeEofDefersStalePruningUntilRealAppendFinalization() = runBlocking {
+        val cache = StreamFeedCache(database)
+        val feedKey = StreamFeedKey("top:cache-speculative-eof")
+        seedOldFeed(cache, feedKey)
+
+        cache.replaceAfterRefresh(
+            feedKey,
+            StreamFeedPage(
+                streams("fresh-0", "fresh-1", "fresh-2"),
+                StreamFeedCursor("gql", "fresh-page-2"),
+            ),
+            nowMs = 2L,
+            preserveTail = true,
+            pruneStaleOnEnd = false,
+        )
+        cache.appendPage(
+            feedKey,
+            StreamFeedPage(streams("fresh-3", "fresh-4"), nextCursor = null),
+            nowMs = 3L,
+            pruneStaleOnEnd = false,
+        )
+
+        val rowsBeforeFinalization = database.streamFeedDao().itemsForFeed(feedKey.value)
+        assertTrue(rowsBeforeFinalization.any { it.itemKey == "channel:old-80" })
+        assertContiguousLayout(feedKey, activeCount = 5)
+        assertEquals(null, database.streamFeedDao().state(feedKey.value)?.nextCursor)
+
+        cache.pruneStaleGeneration(feedKey)
+
+        val rowsAfterFinalization = database.streamFeedDao().itemsForFeed(feedKey.value)
+        assertEquals(5, rowsAfterFinalization.size)
+        assertFalse(rowsAfterFinalization.any { it.itemKey == "channel:old-80" })
+        assertContiguousLayout(feedKey, activeCount = 5)
+    }
+
+    private suspend fun seedOldFeed(cache: StreamFeedCache, feedKey: StreamFeedKey) {
+        cache.replaceAfterRefresh(
+            feedKey,
+            StreamFeedPage(
+                (0 until 90).map { Stream(channelId = "old-$it") },
+                StreamFeedCursor("gql", "old-page-2"),
+            ),
+            nowMs = 1L,
+            preserveTail = false,
+            pruneStaleOnEnd = true,
+        )
+    }
+
+    private fun assertLayout(feedKey: StreamFeedKey, expectedKeys: List<String>, activeCount: Int) {
+        val rows = database.streamFeedDao().itemsForFeed(feedKey.value)
+        assertEquals(expectedKeys.map { "channel:$it" }, rows.map { it.itemKey })
+        assertEquals(rows.indices.toList(), rows.map { it.position })
+        assertEquals(rows.size, rows.map { it.position }.distinct().size)
+        assertTrue(rows.take(activeCount).all { it.generation == rows.first().generation })
+        assertTrue(rows.drop(activeCount).all { it.generation < rows.first().generation })
+    }
+
+    private fun assertContiguousLayout(feedKey: StreamFeedKey, activeCount: Int) {
+        val rows = database.streamFeedDao().itemsForFeed(feedKey.value)
+        assertEquals(rows.indices.toList(), rows.map { it.position })
+        assertEquals(rows.size, rows.map { it.position }.distinct().size)
+        assertTrue(rows.take(activeCount).all { it.generation == rows.first().generation })
+        assertTrue(rows.drop(activeCount).all { it.generation < rows.first().generation })
+    }
+
+    private fun streams(vararg ids: String): List<Stream> {
+        return ids.map { Stream(channelId = it) }
+    }
+}

--- a/app/src/androidTest/java/com/github/andreyasadchy/xtra/repository/streamfeed/StreamFeedPagingIntegrationTest.kt
+++ b/app/src/androidTest/java/com/github/andreyasadchy/xtra/repository/streamfeed/StreamFeedPagingIntegrationTest.kt
@@ -1,0 +1,142 @@
+package com.github.andreyasadchy.xtra.repository.streamfeed
+
+import androidx.paging.AsyncPagingDataDiffer
+import androidx.paging.PagingConfig
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListUpdateCallback
+import androidx.room.Room
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.github.andreyasadchy.xtra.db.AppDatabase
+import com.github.andreyasadchy.xtra.model.ui.Stream
+import com.github.andreyasadchy.xtra.repository.datasource.StreamFeedCursor
+import com.github.andreyasadchy.xtra.repository.datasource.StreamFeedPage
+import com.github.andreyasadchy.xtra.repository.datasource.StreamFeedPageLoader
+import com.github.andreyasadchy.xtra.util.C
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class StreamFeedPagingIntegrationTest {
+
+    private lateinit var database: AppDatabase
+
+    @Before
+    fun createDatabase() {
+        database = Room.inMemoryDatabaseBuilder(
+            InstrumentationRegistry.getInstrumentation().targetContext,
+            AppDatabase::class.java,
+        ).build()
+    }
+
+    @After
+    fun closeDatabase() {
+        database.close()
+    }
+
+    @Test
+    fun retainedTailGetsOneFreshPageWithoutPagingWalkingTheWholeStaleTail() = runBlocking {
+        val cache = StreamFeedCache(database)
+        val feedKey = StreamFeedKey("top:paging-tail")
+        cache.replaceAfterRefresh(
+            feedKey,
+            StreamFeedPage(
+                (0 until 90).map { Stream(channelId = "old-$it") },
+                StreamFeedCursor(C.GQL, "old-page-4"),
+            ),
+            nowMs = 1L,
+            preserveTail = false,
+            pruneStaleOnEnd = true,
+        )
+
+        val cursors = mutableListOf<StreamFeedCursor?>()
+        val secondPageLoaded = kotlinx.coroutines.CompletableDeferred<Unit>()
+        val loader = object : StreamFeedPageLoader {
+            override suspend fun load(cursor: StreamFeedCursor?): StreamFeedPage {
+                cursors += cursor
+                return if (cursor == null) {
+                    StreamFeedPage(
+                        (0 until 30).map { Stream(channelId = "fresh-$it") },
+                        StreamFeedCursor(C.GQL, "fresh-page-2"),
+                    )
+                } else {
+                    assertEquals(StreamFeedCursor(C.GQL, "fresh-page-2"), cursor)
+                    secondPageLoaded.complete(Unit)
+                    StreamFeedPage(
+                        (30 until 60).map { Stream(channelId = "fresh-$it") },
+                        nextCursor = null,
+                    )
+                }
+            }
+        }
+        val coordinatorScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val coordinator = StreamFeedRefreshCoordinator(
+            cache = cache,
+            scope = coordinatorScope,
+            wallClockMs = { 1_000_000L },
+            elapsedRealtimeMs = { 1_000L },
+            debugLoggingEnabled = false,
+        )
+        val pager = StreamFeedPager(cache, coordinator)
+        val differ = AsyncPagingDataDiffer(
+            diffCallback = object : DiffUtil.ItemCallback<Stream>() {
+                override fun areItemsTheSame(oldItem: Stream, newItem: Stream): Boolean {
+                    return oldItem.channelId == newItem.channelId
+                }
+
+                override fun areContentsTheSame(oldItem: Stream, newItem: Stream): Boolean {
+                    return oldItem == newItem
+                }
+            },
+            updateCallback = NoOpListUpdateCallback,
+            mainDispatcher = Dispatchers.Main,
+            workerDispatcher = Dispatchers.Default,
+        )
+        val collectionScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val collectionJob = collectionScope.launch {
+            pager.flow(
+                spec = StreamFeedSpec(feedKey, loader),
+                config = PagingConfig(pageSize = 30, initialLoadSize = 30, prefetchDistance = 3),
+            ).collectLatest { differ.submitData(it) }
+        }
+
+        withTimeout(5_000L) {
+            while (differ.itemCount == 0) delay(20L)
+            differ.getItem(0)
+            secondPageLoaded.await()
+        }
+        delay(100L)
+
+        assertEquals(
+            listOf(null, StreamFeedCursor(C.GQL, "fresh-page-2")),
+            cursors,
+        )
+        assertTrue(differ.itemCount >= 90)
+        assertTrue(database.streamFeedDao().itemsForFeed(feedKey.value).any { it.itemKey == "channel:old-80" })
+        assertEquals(null, database.streamFeedDao().state(feedKey.value)?.nextCursor)
+
+        collectionJob.cancel()
+        collectionScope.cancel()
+        coordinatorScope.cancel()
+    }
+
+    private object NoOpListUpdateCallback : ListUpdateCallback {
+        override fun onInserted(position: Int, count: Int) = Unit
+        override fun onRemoved(position: Int, count: Int) = Unit
+        override fun onMoved(fromPosition: Int, toPosition: Int) = Unit
+        override fun onChanged(position: Int, count: Int, payload: Any?) = Unit
+    }
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/XtraApp.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/XtraApp.kt
@@ -3,6 +3,7 @@ package com.github.andreyasadchy.xtra
 import android.annotation.SuppressLint
 import android.app.Application
 import android.os.Build
+import android.os.SystemClock
 import coil3.ImageLoader
 import coil3.PlatformContext
 import coil3.SingletonImageLoader
@@ -19,6 +20,7 @@ import com.github.andreyasadchy.xtra.util.C
 import com.github.andreyasadchy.xtra.util.NetworkUtils
 import com.github.andreyasadchy.xtra.util.coil.CacheControlCacheStrategy
 import com.github.andreyasadchy.xtra.util.prefs
+import com.github.andreyasadchy.xtra.repository.streamfeed.StreamFeedPrewarmScheduler
 import kotlinx.coroutines.suspendCancellableCoroutine
 import okio.Buffer
 import okio.buffer
@@ -39,19 +41,35 @@ class XtraApp : Application(), SingletonImageLoader.Factory {
     var isInForeground: Boolean = false
         private set
     private var startedActivityCount = 0
+    private var backgroundStartedElapsedMs: Long? = null
 
     override fun onCreate() {
         super.onCreate()
         INSTANCE = this
+        xtraModule = XtraModule(this)
         registerActivityLifecycleCallbacks(object : ActivityLifecycleCallbacks {
             override fun onActivityStarted(activity: android.app.Activity) {
+                val wasInBackground = startedActivityCount == 0
                 startedActivityCount += 1
                 isInForeground = true
+                if (wasInBackground) {
+                    val awayMs = backgroundStartedElapsedMs?.let { (SystemClock.elapsedRealtime() - it).coerceAtLeast(0L) }
+                    if (awayMs != null) {
+                        StreamFeedPrewarmScheduler.recordBackgroundReturn(this@XtraApp, awayMs)
+                        xtraModule.streamFeedRefreshCoordinator.onAppForeground(awayMs)
+                    }
+                    backgroundStartedElapsedMs = null
+                    StreamFeedPrewarmScheduler.cancel(this@XtraApp)
+                }
             }
 
             override fun onActivityStopped(activity: android.app.Activity) {
                 startedActivityCount = (startedActivityCount - 1).coerceAtLeast(0)
                 isInForeground = startedActivityCount > 0
+                if (!isInForeground) {
+                    backgroundStartedElapsedMs = SystemClock.elapsedRealtime()
+                    StreamFeedPrewarmScheduler.schedule(this@XtraApp)
+                }
             }
 
             override fun onActivityCreated(activity: android.app.Activity, savedInstanceState: android.os.Bundle?) = Unit
@@ -60,7 +78,6 @@ class XtraApp : Application(), SingletonImageLoader.Factory {
             override fun onActivitySaveInstanceState(activity: android.app.Activity, outState: android.os.Bundle) = Unit
             override fun onActivityDestroyed(activity: android.app.Activity) = Unit
         })
-        xtraModule = XtraModule(this)
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
             val conscrypt = Conscrypt.newProvider()
             Security.insertProviderAt(conscrypt, 1)

--- a/app/src/main/java/com/github/andreyasadchy/xtra/XtraModule.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/XtraModule.kt
@@ -8,6 +8,7 @@ import android.util.Log
 import androidx.room.Room
 import androidx.room.migration.Migration
 import com.github.andreyasadchy.xtra.db.AppDatabase
+import com.github.andreyasadchy.xtra.db.StreamFeedMigrations
 import com.github.andreyasadchy.xtra.db.ViewingStatsMigrations
 import com.github.andreyasadchy.xtra.repository.AuthRepository
 import com.github.andreyasadchy.xtra.repository.BookmarksRepository
@@ -23,6 +24,9 @@ import com.github.andreyasadchy.xtra.repository.PlayerRepository
 import com.github.andreyasadchy.xtra.repository.RecentSearchesRepository
 import com.github.andreyasadchy.xtra.repository.SavedFiltersRepository
 import com.github.andreyasadchy.xtra.repository.ViewingStatsRepository
+import com.github.andreyasadchy.xtra.repository.streamfeed.StreamFeedCache
+import com.github.andreyasadchy.xtra.repository.streamfeed.StreamFeedPager
+import com.github.andreyasadchy.xtra.repository.streamfeed.StreamFeedRefreshCoordinator
 import com.github.andreyasadchy.xtra.util.viewingstats.ViewingStatsRecorder
 import com.github.andreyasadchy.xtra.util.updater.ReleaseClient
 import com.github.andreyasadchy.xtra.util.updater.UpdateRepository
@@ -41,6 +45,18 @@ import javax.net.ssl.TrustManagerFactory
 import javax.net.ssl.X509TrustManager
 
 class XtraModule(application: Application) {
+
+    val streamFeedCache by lazy {
+        StreamFeedCache(database)
+    }
+
+    val streamFeedRefreshCoordinator by lazy {
+        StreamFeedRefreshCoordinator(streamFeedCache)
+    }
+
+    val streamFeedPager by lazy {
+        StreamFeedPager(streamFeedCache, streamFeedRefreshCoordinator)
+    }
 
     val httpEngine = lazy {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R && SdkExtensions.getExtensionVersion(Build.VERSION_CODES.S) >= 7) {
@@ -321,6 +337,8 @@ class XtraModule(application: Application) {
                     db.execSQL("DROP TABLE IF EXISTS live_notification_logs")
                     db.execSQL("CREATE TABLE IF NOT EXISTS notification_events (eventId TEXT NOT NULL, channelId TEXT NOT NULL, streamId TEXT, channelLogin TEXT, channelName TEXT, channelImageURL TEXT, gameName TEXT, title TEXT, thumbnailURL TEXT, createdAt TEXT, viewerCount INTEGER, startedAt INTEGER NOT NULL, queuedAt INTEGER NOT NULL, PRIMARY KEY (eventId))")
                 },
+                StreamFeedMigrations.FROM_40,
+                StreamFeedMigrations.FROM_41,
             )
         }.build()
     }
@@ -350,7 +368,12 @@ class XtraModule(application: Application) {
     }
 
     val localChannelFollowsRepository by lazy {
-        LocalChannelFollowsRepository(database.localChannelFollows(), database.offlineVideos(), database.bookmarks())
+        LocalChannelFollowsRepository(
+            localChannelFollowsDao = database.localChannelFollows(),
+            offlineVideosDao = database.offlineVideos(),
+            bookmarksDao = database.bookmarks(),
+            onChanged = { streamFeedRefreshCoordinator.invalidateFollowedFeeds() },
+        )
     }
 
     val localGameFollowsRepository by lazy {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/db/AppDatabase.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/db/AppDatabase.kt
@@ -41,8 +41,10 @@ import com.github.andreyasadchy.xtra.model.ui.TranslatedChannel
         PlaybackState::class,
         ViewingSession::class,
         ViewingInterval::class,
+        CachedStreamFeedItem::class,
+        StreamFeedState::class,
     ],
-    version = 40,
+    version = 42,
     exportSchema = false
 )
 abstract class AppDatabase : RoomDatabase() {
@@ -64,4 +66,5 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun recentSearches(): RecentSearchesDao
     abstract fun playbackStates(): PlaybackStatesDao
     abstract fun viewingStats(): ViewingStatsDao
+    abstract fun streamFeedDao(): StreamFeedDao
 }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/db/CachedStreamFeedItem.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/db/CachedStreamFeedItem.kt
@@ -1,0 +1,40 @@
+package com.github.andreyasadchy.xtra.db
+
+import androidx.room.Entity
+import androidx.room.Index
+
+/**
+ * The durable representation of one live stream card in one feed variant.
+ *
+ * The feed key is deliberately part of the identity: the same channel can be
+ * present in Top, Followed, and multiple game/filter feeds without the feeds
+ * overwriting each other.
+ */
+@Entity(
+    tableName = "stream_feed_items",
+    primaryKeys = ["feedKey", "itemKey"],
+    indices = [
+        Index(value = ["feedKey", "position"]),
+        Index(value = ["feedKey", "channelId"]),
+    ],
+)
+data class CachedStreamFeedItem(
+    val feedKey: String,
+    val itemKey: String,
+    val position: Int,
+    val streamId: String? = null,
+    val channelId: String? = null,
+    val channelLogin: String? = null,
+    val channelName: String? = null,
+    val channelImageURL: String? = null,
+    val gameId: String? = null,
+    val gameSlug: String? = null,
+    val gameName: String? = null,
+    val title: String? = null,
+    val thumbnailURL: String? = null,
+    val createdAt: String? = null,
+    val viewerCount: Int? = null,
+    val tags: String? = null,
+    /** Refresh generation used to retain stale deep-page rows during SWR. */
+    val generation: Long = 0L,
+)

--- a/app/src/main/java/com/github/andreyasadchy/xtra/db/StreamFeedDao.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/db/StreamFeedDao.kt
@@ -1,0 +1,38 @@
+package com.github.andreyasadchy.xtra.db
+
+import androidx.paging.PagingSource
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+
+@Dao
+interface StreamFeedDao {
+
+    @Query("SELECT * FROM stream_feed_items WHERE feedKey = :feedKey ORDER BY position ASC, itemKey ASC")
+    fun pagingSource(feedKey: String): PagingSource<Int, CachedStreamFeedItem>
+
+    @Query("SELECT * FROM stream_feed_items WHERE feedKey = :feedKey ORDER BY position ASC, itemKey ASC")
+    fun itemsForFeed(feedKey: String): List<CachedStreamFeedItem>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    fun insertItems(items: List<CachedStreamFeedItem>)
+
+    @Query("DELETE FROM stream_feed_items WHERE feedKey = :feedKey")
+    fun deleteItems(feedKey: String)
+
+    @Query("DELETE FROM stream_feed_items WHERE feedKey = :feedKey AND generation != :generation")
+    fun deleteItemsExceptGeneration(feedKey: String, generation: Long)
+
+    @Query("SELECT * FROM stream_feed_states WHERE feedKey = :feedKey")
+    fun state(feedKey: String): StreamFeedState?
+
+    @Query("SELECT * FROM stream_feed_states ORDER BY lastAccessAt DESC")
+    fun allStates(): List<StreamFeedState>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    fun insertState(state: StreamFeedState)
+
+    @Query("DELETE FROM stream_feed_states WHERE feedKey = :feedKey")
+    fun deleteState(feedKey: String)
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/db/StreamFeedMigrations.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/db/StreamFeedMigrations.kt
@@ -1,0 +1,31 @@
+package com.github.andreyasadchy.xtra.db
+
+import androidx.room.migration.Migration
+
+/** Schema migrations for the cache-first live stream feed tables. */
+object StreamFeedMigrations {
+    val FROM_40 = Migration(40, 41) { db ->
+        db.execSQL(
+            "CREATE TABLE IF NOT EXISTS stream_feed_items (" +
+                    "feedKey TEXT NOT NULL, itemKey TEXT NOT NULL, position INTEGER NOT NULL, " +
+                    "streamId TEXT, channelId TEXT, channelLogin TEXT, channelName TEXT, " +
+                    "channelImageURL TEXT, gameId TEXT, gameSlug TEXT, gameName TEXT, title TEXT, " +
+                    "thumbnailURL TEXT, createdAt TEXT, viewerCount INTEGER, tags TEXT, " +
+                    "PRIMARY KEY(feedKey, itemKey))"
+        )
+        db.execSQL("CREATE INDEX IF NOT EXISTS index_stream_feed_items_feedKey_position ON stream_feed_items(feedKey, position)")
+        db.execSQL("CREATE INDEX IF NOT EXISTS index_stream_feed_items_feedKey_channelId ON stream_feed_items(feedKey, channelId)")
+        db.execSQL(
+            "CREATE TABLE IF NOT EXISTS stream_feed_states (" +
+                    "feedKey TEXT NOT NULL PRIMARY KEY, nextCursor TEXT, lastSuccessAt INTEGER, " +
+                    "lastAttemptAt INTEGER, lastAccessAt INTEGER NOT NULL, " +
+                    "failureBackoffUntil INTEGER, rateLimitUntil INTEGER)"
+        )
+    }
+
+    val FROM_41 = Migration(41, 42) { db ->
+        db.execSQL("ALTER TABLE stream_feed_items ADD COLUMN generation INTEGER NOT NULL DEFAULT 0")
+        db.execSQL("ALTER TABLE stream_feed_states ADD COLUMN nextCursorApi TEXT")
+        db.execSQL("ALTER TABLE stream_feed_states ADD COLUMN activeGeneration INTEGER NOT NULL DEFAULT 0")
+    }
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/db/StreamFeedState.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/db/StreamFeedState.kt
@@ -1,0 +1,20 @@
+package com.github.andreyasadchy.xtra.db
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+/** Refresh and pagination metadata for a cached stream feed. */
+@Entity(tableName = "stream_feed_states")
+data class StreamFeedState(
+    @PrimaryKey val feedKey: String,
+    val nextCursor: String? = null,
+    val lastSuccessAt: Long? = null,
+    val lastAttemptAt: Long? = null,
+    val lastAccessAt: Long = 0L,
+    val failureBackoffUntil: Long? = null,
+    val rateLimitUntil: Long? = null,
+    /** API identity for the persisted cursor; cursors are API-specific. */
+    val nextCursorApi: String? = null,
+    /** Generation currently being refreshed/appended for this feed. */
+    val activeGeneration: Long = 0L,
+)

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/LocalChannelFollowsRepository.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/LocalChannelFollowsRepository.kt
@@ -12,6 +12,7 @@ class LocalChannelFollowsRepository(
     private val localChannelFollowsDao: LocalChannelFollowsDao,
     private val offlineVideosDao: OfflineVideosDao,
     private val bookmarksDao: BookmarksDao,
+    private val onChanged: () -> Unit = {},
 ) {
 
     suspend fun getAll() = withContext(Dispatchers.IO) {
@@ -24,14 +25,17 @@ class LocalChannelFollowsRepository(
 
     suspend fun save(item: LocalChannelFollow) = withContext(Dispatchers.IO) {
         localChannelFollowsDao.insert(item)
+        onChanged()
     }
 
     suspend fun delete(item: LocalChannelFollow) = withContext(Dispatchers.IO) {
         localChannelFollowsDao.delete(item)
+        onChanged()
     }
 
     suspend fun update(item: LocalChannelFollow) = withContext(Dispatchers.IO) {
         localChannelFollowsDao.update(item)
+        onChanged()
     }
 
     suspend fun deleteOldImages() = withContext(Dispatchers.IO) {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/datasource/FollowedStreamsDataSource.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/datasource/FollowedStreamsDataSource.kt
@@ -6,286 +6,41 @@ import com.github.andreyasadchy.xtra.model.ui.Stream
 import com.github.andreyasadchy.xtra.repository.GraphQLRepository
 import com.github.andreyasadchy.xtra.repository.HelixRepository
 import com.github.andreyasadchy.xtra.repository.LocalChannelFollowsRepository
-import com.github.andreyasadchy.xtra.util.C
 
+/** Compatibility PagingSource for callers outside the Room-backed feed path. */
 class FollowedStreamsDataSource(
-    private val userId: String?,
-    private val localChannelFollowsRepository: LocalChannelFollowsRepository,
-    private val gqlHeaders: Map<String, String>,
-    private val graphQLRepository: GraphQLRepository,
-    private val helixHeaders: Map<String, String>,
-    private val helixRepository: HelixRepository,
-    private val enableIntegrity: Boolean,
-    private val networkLibrary: String?,
+    userId: String?,
+    localChannelFollowsRepository: LocalChannelFollowsRepository,
+    gqlHeaders: Map<String, String>,
+    graphQLRepository: GraphQLRepository,
+    helixHeaders: Map<String, String>,
+    helixRepository: HelixRepository,
+    enableIntegrity: Boolean,
+    networkLibrary: String?,
 ) : PagingSource<Int, Stream>() {
-    private var api: String? = null
-    private var offset: String? = null
+    private val loader = FollowedStreamsPageLoader(
+        userId = userId,
+        localChannelFollowsRepository = localChannelFollowsRepository,
+        gqlHeaders = { gqlHeaders },
+        graphQLRepository = graphQLRepository,
+        helixHeaders = { helixHeaders },
+        helixRepository = helixRepository,
+        enableIntegrity = enableIntegrity,
+        networkLibrary = networkLibrary,
+    )
+    private var cursor: StreamFeedCursor? = null
 
     override suspend fun load(params: LoadParams<Int>): LoadResult<Int, Stream> {
-        return if (!offset.isNullOrBlank()) {
-            try {
-                loadFromApi(params)
-            } catch (e: Exception) {
-                LoadResult.Error(e)
-            }
-        } else {
-            val list = mutableListOf<Stream>()
-            localChannelFollowsRepository.getAll().mapNotNull { it.userId }.takeIf { it.isNotEmpty() }?.let {
-                try {
-                    gqlQueryLocal(it)
-                } catch (e: Exception) {
-                    try {
-                        if (!helixHeaders[C.HEADER_TOKEN].isNullOrBlank()) helixLocal(it) else throw Exception()
-                    } catch (e: Exception) {
-                        null
-                    }
-                }
-            }?.let {
-                if (it is LoadResult.Error && it.throwable.message == C.FAILED_INTEGRITY_CHECK) {
-                    return it
-                }
-                (it as? LoadResult.Page)?.data?.let { list.addAll(it) }
-            }
-            val result = if (!gqlHeaders[C.HEADER_TOKEN].isNullOrBlank() || !helixHeaders[C.HEADER_TOKEN].isNullOrBlank()) {
-                try {
-                    api = C.GQL
-                    loadFromApi(params)
-                } catch (e: Exception) {
-                    try {
-                        api = C.GQL_PERSISTED_QUERY
-                        loadFromApi(params)
-                    } catch (e: Exception) {
-                        try {
-                            api = C.HELIX
-                            loadFromApi(params)
-                        } catch (e: Exception) {
-                            null
-                        }
-                    }
-                }?.let {
-                    if (it is LoadResult.Error && it.throwable.message == C.FAILED_INTEGRITY_CHECK) {
-                        return it
-                    }
-                    it as? LoadResult.Page
-                }
-            } else null
-            result?.data?.forEach { stream ->
-                val item = list.find { it.channelId == stream.channelId }
-                if (item == null) {
-                    list.add(stream)
-                }
-            }
-            list.sortByDescending { it.viewerCount }
+        return try {
+            val page = loader.load(cursor).also { cursor = it.nextCursor }
             LoadResult.Page(
-                data = list,
+                data = page.items,
                 prevKey = null,
-                nextKey = result?.nextKey
+                nextKey = page.nextCursor?.let { (params.key ?: 1) + 1 },
             )
+        } catch (error: Exception) {
+            LoadResult.Error(error)
         }
-    }
-
-    private suspend fun loadFromApi(params: LoadParams<Int>): LoadResult<Int, Stream> {
-        return when (api) {
-            C.GQL -> if (!gqlHeaders[C.HEADER_TOKEN].isNullOrBlank()) gqlQueryLoad(params) else throw Exception()
-            C.GQL_PERSISTED_QUERY -> if (!gqlHeaders[C.HEADER_TOKEN].isNullOrBlank()) gqlLoad(params) else throw Exception()
-            C.HELIX -> if (!helixHeaders[C.HEADER_TOKEN].isNullOrBlank()) helixLoad(params) else throw Exception()
-            else -> throw Exception()
-        }
-    }
-
-    private suspend fun gqlQueryLoad(params: LoadParams<Int>): LoadResult<Int, Stream> {
-        val response = graphQLRepository.loadQueryUserFollowedStreams(networkLibrary, gqlHeaders, 100, offset)
-        if (enableIntegrity) {
-            response.errors?.find { it.message == C.FAILED_INTEGRITY_CHECK }?.let { return LoadResult.Error(Exception(it.message)) }
-        }
-        val data = response.data!!.user!!.followedLiveUsers!!
-        val items = data.edges!!
-        val list = items.mapNotNull { item ->
-            item?.node?.let {
-                Stream(
-                    id = it.stream?.id,
-                    channelId = it.id,
-                    channelLogin = it.login,
-                    channelName = it.displayName,
-                    channelImageURL = it.profileImageURL,
-                    gameId = it.stream?.game?.id,
-                    gameSlug = it.stream?.game?.slug,
-                    gameName = it.stream?.game?.displayName,
-                    title = it.stream?.broadcaster?.broadcastSettings?.title,
-                    thumbnailURL = it.stream?.previewImageURL,
-                    createdAt = it.stream?.createdAt?.toString(),
-                    viewerCount = it.stream?.viewersCount,
-                    tags = it.stream?.freeformTags?.mapNotNull { tag -> tag.name },
-                )
-            }
-        }
-        offset = items.lastOrNull()?.cursor?.toString()
-        val nextPage = data.pageInfo?.hasNextPage != false
-        return LoadResult.Page(
-            data = list,
-            prevKey = null,
-            nextKey = if (!offset.isNullOrBlank() && nextPage) {
-                (params.key ?: 1) + 1
-            } else null
-        )
-    }
-
-    private suspend fun gqlLoad(params: LoadParams<Int>): LoadResult<Int, Stream> {
-        val response = graphQLRepository.loadFollowedStreams(networkLibrary, gqlHeaders, 100, offset)
-        if (enableIntegrity) {
-            response.errors?.find { it.message == C.FAILED_INTEGRITY_CHECK }?.let { return LoadResult.Error(Exception(it.message)) }
-        }
-        val data = response.data!!.currentUser.followedLiveUsers
-        val items = data.edges
-        val list = items.map { item ->
-            item.node.let {
-                Stream(
-                    id = it.stream?.id,
-                    channelId = it.id,
-                    channelLogin = it.login,
-                    channelName = it.displayName,
-                    channelImageURL = it.profileImageURL,
-                    gameId = it.stream?.game?.id,
-                    gameSlug = it.stream?.game?.slug,
-                    gameName = it.stream?.game?.displayName,
-                    title = it.stream?.title,
-                    thumbnailURL = it.stream?.previewImageURL,
-                    createdAt = it.stream?.createdAt,
-                    viewerCount = it.stream?.viewersCount,
-                    tags = it.stream?.freeformTags?.mapNotNull { tag -> tag.name },
-                )
-            }
-        }
-        offset = items.lastOrNull()?.cursor
-        val nextPage = data.pageInfo?.hasNextPage != false
-        return LoadResult.Page(
-            data = list,
-            prevKey = null,
-            nextKey = if (!offset.isNullOrBlank() && nextPage) {
-                (params.key ?: 1) + 1
-            } else null
-        )
-    }
-
-    private suspend fun helixLoad(params: LoadParams<Int>): LoadResult<Int, Stream> {
-        val response = helixRepository.getFollowedStreams(
-            networkLibrary = networkLibrary,
-            headers = helixHeaders,
-            userId = userId,
-            limit = 100,
-            offset = offset,
-        )
-        val users = response.data.mapNotNull { it.channelId }.let {
-            helixRepository.getUsers(
-                networkLibrary = networkLibrary,
-                headers = helixHeaders,
-                ids = it,
-            ).data
-        }
-        val list = response.data.map {
-            Stream(
-                id = it.id,
-                channelId = it.channelId,
-                channelLogin = it.channelLogin,
-                channelName = it.channelName,
-                channelImageURL = it.channelId?.let { id ->
-                    users.find { user -> user.id == id }?.profileImageURL
-                },
-                gameId = it.gameId,
-                gameName = it.gameName,
-                title = it.title,
-                thumbnailURL = it.thumbnailURL,
-                createdAt = it.startedAt,
-                viewerCount = it.viewerCount,
-                tags = it.tags,
-            )
-        }
-        offset = response.pagination?.cursor
-        return LoadResult.Page(
-            data = list,
-            prevKey = null,
-            nextKey = if (!offset.isNullOrBlank()) {
-                (params.key ?: 1) + 1
-            } else null
-        )
-    }
-
-    private suspend fun gqlQueryLocal(ids: List<String>): LoadResult<Int, Stream> {
-        val items = ids.chunked(100).map { list ->
-            graphQLRepository.loadQueryUsersStream(networkLibrary, gqlHeaders, list).also { response ->
-                if (enableIntegrity) {
-                    response.errors?.find { it.message == C.FAILED_INTEGRITY_CHECK }?.let { return LoadResult.Error(Exception(it.message)) }
-                }
-            }
-        }.flatMap { it.data!!.users!! }
-        val list = items.mapNotNull { item ->
-            item?.let {
-                if (it.stream?.viewersCount != null) {
-                    Stream(
-                        id = it.stream.id,
-                        channelId = it.id,
-                        channelLogin = it.login,
-                        channelName = it.displayName,
-                        channelImageURL = it.profileImageURL,
-                        gameId = it.stream.game?.id,
-                        gameSlug = it.stream.game?.slug,
-                        gameName = it.stream.game?.displayName,
-                        title = it.stream.broadcaster?.broadcastSettings?.title,
-                        thumbnailURL = it.stream.previewImageURL,
-                        createdAt = it.stream.createdAt?.toString(),
-                        viewerCount = it.stream.viewersCount,
-                        tags = it.stream.freeformTags?.mapNotNull { tag -> tag.name },
-                    )
-                } else null
-            }
-        }
-        return LoadResult.Page(
-            data = list,
-            prevKey = null,
-            nextKey = null
-        )
-    }
-
-    private suspend fun helixLocal(ids: List<String>): LoadResult<Int, Stream> {
-        val items = ids.chunked(100).map {
-            helixRepository.getStreams(
-                networkLibrary = networkLibrary,
-                headers = helixHeaders,
-                ids = it,
-            )
-        }.flatMap { it.data }
-        val users = items.mapNotNull { it.channelId }.chunked(100).map {
-            helixRepository.getUsers(
-                networkLibrary = networkLibrary,
-                headers = helixHeaders,
-                ids = it,
-            )
-        }.flatMap { it.data }
-        val list = items.mapNotNull {
-            if (it.viewerCount != null) {
-                Stream(
-                    id = it.id,
-                    channelId = it.channelId,
-                    channelLogin = it.channelLogin,
-                    channelName = it.channelName,
-                    channelImageURL = it.channelId?.let { id ->
-                        users.find { user -> user.id == id }?.profileImageURL
-                    },
-                    gameId = it.gameId,
-                    gameName = it.gameName,
-                    title = it.title,
-                    thumbnailURL = it.thumbnailURL,
-                    createdAt = it.startedAt,
-                    viewerCount = it.viewerCount,
-                    tags = it.tags,
-                )
-            } else null
-        }
-        return LoadResult.Page(
-            data = list,
-            prevKey = null,
-            nextKey = null
-        )
     }
 
     override fun getRefreshKey(state: PagingState<Int, Stream>): Int? {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/datasource/GameStreamsDataSource.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/datasource/GameStreamsDataSource.kt
@@ -7,195 +7,53 @@ import com.github.andreyasadchy.xtra.graphql.type.StreamSort
 import com.github.andreyasadchy.xtra.model.ui.Stream
 import com.github.andreyasadchy.xtra.repository.GraphQLRepository
 import com.github.andreyasadchy.xtra.repository.HelixRepository
-import com.github.andreyasadchy.xtra.util.C
 
+/** Compatibility PagingSource for callers outside the Room-backed feed path. */
 class GameStreamsDataSource(
-    private val gameId: String?,
-    private val gameSlug: String?,
-    private val gameName: String?,
-    private val gqlQueryLanguages: List<Language>?,
-    private val gqlQuerySort: StreamSort?,
-    private val gqlLanguages: List<String>?,
-    private val gqlSort: String?,
-    private val tags: List<String>?,
-    private val gqlHeaders: Map<String, String>,
-    private val graphQLRepository: GraphQLRepository,
-    private val helixHeaders: Map<String, String>,
-    private val helixRepository: HelixRepository,
-    private val enableIntegrity: Boolean,
-    private val networkLibrary: String?,
+    gameId: String?,
+    gameSlug: String?,
+    gameName: String?,
+    gqlQueryLanguages: List<Language>?,
+    gqlQuerySort: StreamSort?,
+    gqlLanguages: List<String>?,
+    gqlSort: String?,
+    tags: List<String>?,
+    gqlHeaders: Map<String, String>,
+    graphQLRepository: GraphQLRepository,
+    helixHeaders: Map<String, String>,
+    helixRepository: HelixRepository,
+    enableIntegrity: Boolean,
+    networkLibrary: String?,
 ) : PagingSource<Int, Stream>() {
-    private var api: String? = null
-    private var offset: String? = null
+    private val loader = GameStreamsPageLoader(
+        gameId = gameId,
+        gameSlug = gameSlug,
+        gameName = gameName,
+        gqlQueryLanguages = gqlQueryLanguages,
+        gqlQuerySort = gqlQuerySort,
+        gqlLanguages = gqlLanguages,
+        gqlSort = gqlSort,
+        tags = tags,
+        gqlHeaders = { gqlHeaders },
+        graphQLRepository = graphQLRepository,
+        helixHeaders = { helixHeaders },
+        helixRepository = helixRepository,
+        enableIntegrity = enableIntegrity,
+        networkLibrary = networkLibrary,
+    )
+    private var cursor: StreamFeedCursor? = null
 
     override suspend fun load(params: LoadParams<Int>): LoadResult<Int, Stream> {
-        return if (!offset.isNullOrBlank()) {
-            try {
-                loadFromApi(params)
-            } catch (e: Exception) {
-                LoadResult.Error(e)
-            }
-        } else {
-            try {
-                api = C.GQL
-                loadFromApi(params)
-            } catch (e: Exception) {
-                try {
-                    api = C.GQL_PERSISTED_QUERY
-                    loadFromApi(params)
-                } catch (e: Exception) {
-                    try {
-                        api = C.HELIX
-                        loadFromApi(params)
-                    } catch (e: Exception) {
-                        LoadResult.Error(e)
-                    }
-                }
-            }
+        return try {
+            val page = loader.load(cursor).also { cursor = it.nextCursor }
+            LoadResult.Page(
+                data = page.items,
+                prevKey = null,
+                nextKey = page.nextCursor?.let { (params.key ?: 1) + 1 },
+            )
+        } catch (error: Exception) {
+            LoadResult.Error(error)
         }
-    }
-
-    private suspend fun loadFromApi(params: LoadParams<Int>): LoadResult<Int, Stream> {
-        return when (api) {
-            C.GQL -> gqlQueryLoad(params)
-            C.GQL_PERSISTED_QUERY -> gqlLoad(params)
-            C.HELIX -> if (!helixHeaders[C.HEADER_TOKEN].isNullOrBlank() && (gqlSort == "VIEWER_COUNT" || gqlSort == null) && tags.isNullOrEmpty() && gqlQueryLanguages.isNullOrEmpty() && gqlLanguages.isNullOrEmpty()) helixLoad(params) else throw Exception()
-            else -> throw Exception()
-        }
-    }
-
-    private suspend fun gqlQueryLoad(params: LoadParams<Int>): LoadResult<Int, Stream> {
-        val response = graphQLRepository.loadQueryGameStreams(
-            networkLibrary = networkLibrary,
-            headers = gqlHeaders,
-            id = gameId,
-            slug = gameSlug.takeIf { gameId.isNullOrBlank() },
-            name = gameName.takeIf { gameId.isNullOrBlank() && gameSlug.isNullOrBlank() },
-            sort = gqlQuerySort,
-            tags = tags,
-            languages = gqlQueryLanguages,
-            first = params.loadSize,
-            after = offset
-        )
-        if (enableIntegrity) {
-            response.errors?.find { it.message == C.FAILED_INTEGRITY_CHECK }?.let { return LoadResult.Error(Exception(it.message)) }
-        }
-        val data = response.data!!.game!!.streams!!
-        val items = data.edges!!
-        val list = items.mapNotNull { item ->
-            item?.node?.let {
-                Stream(
-                    id = it.id,
-                    channelId = it.broadcaster?.id,
-                    channelLogin = it.broadcaster?.login,
-                    channelName = it.broadcaster?.displayName,
-                    channelImageURL = it.broadcaster?.profileImageURL,
-                    gameId = gameId,
-                    gameSlug = gameSlug,
-                    gameName = gameName,
-                    title = it.broadcaster?.broadcastSettings?.title,
-                    thumbnailURL = it.previewImageURL,
-                    createdAt = it.createdAt?.toString(),
-                    viewerCount = it.viewersCount,
-                    tags = it.freeformTags?.mapNotNull { tag -> tag.name },
-                ).takeIf { stream ->
-                    stream.channelId != null || stream.channelLogin != null
-                }
-            }
-        }
-        offset = items.lastOrNull()?.cursor?.toString()
-        val nextPage = data.pageInfo?.hasNextPage != false
-        return LoadResult.Page(
-            data = list,
-            prevKey = null,
-            nextKey = if (!offset.isNullOrBlank() && nextPage) {
-                (params.key ?: 1) + 1
-            } else null
-        )
-    }
-
-    private suspend fun gqlLoad(params: LoadParams<Int>): LoadResult<Int, Stream> {
-        val response = graphQLRepository.loadGameStreams(networkLibrary, gqlHeaders, gameSlug, gqlSort, tags, gqlLanguages, params.loadSize, offset)
-        if (enableIntegrity) {
-            response.errors?.find { it.message == C.FAILED_INTEGRITY_CHECK }?.let { return LoadResult.Error(Exception(it.message)) }
-        }
-        val data = response.data!!.game.streams
-        val items = data.edges
-        val list = items.mapNotNull { item ->
-            item.node.let {
-                Stream(
-                    id = it.id,
-                    channelId = it.broadcaster?.id,
-                    channelLogin = it.broadcaster?.login,
-                    channelName = it.broadcaster?.displayName,
-                    channelImageURL = it.broadcaster?.profileImageURL,
-                    gameId = gameId,
-                    gameSlug = gameSlug,
-                    gameName = gameName,
-                    title = it.title,
-                    thumbnailURL = it.previewImageURL,
-                    createdAt = it.createdAt,
-                    viewerCount = it.viewersCount,
-                    tags = it.freeformTags?.mapNotNull { tag -> tag.name },
-                ).takeIf { stream ->
-                    stream.channelId != null || stream.channelLogin != null
-                }
-            }
-        }
-        offset = items.lastOrNull()?.cursor
-        val nextPage = data.pageInfo?.hasNextPage != false
-        return LoadResult.Page(
-            data = list,
-            prevKey = null,
-            nextKey = if (!offset.isNullOrBlank() && nextPage) {
-                (params.key ?: 1) + 1
-            } else null
-        )
-    }
-
-    private suspend fun helixLoad(params: LoadParams<Int>): LoadResult<Int, Stream> {
-        val response = helixRepository.getStreams(
-            networkLibrary = networkLibrary,
-            headers = helixHeaders,
-            gameId = gameId,
-            limit = params.loadSize,
-            offset = offset,
-        )
-        val users = response.data.mapNotNull { it.channelId }.let {
-            helixRepository.getUsers(
-                networkLibrary = networkLibrary,
-                headers = helixHeaders,
-                ids = it,
-            ).data
-        }
-        val list = response.data.mapNotNull {
-            Stream(
-                id = it.id,
-                channelId = it.channelId,
-                channelLogin = it.channelLogin,
-                channelName = it.channelName,
-                channelImageURL = it.channelId?.let { id ->
-                    users.find { user -> user.id == id }?.profileImageURL
-                },
-                gameId = gameId,
-                gameName = gameName,
-                title = it.title,
-                thumbnailURL = it.thumbnailURL,
-                createdAt = it.startedAt,
-                viewerCount = it.viewerCount,
-                tags = it.tags,
-            ).takeIf { stream ->
-                stream.channelId != null || stream.channelLogin != null
-            }
-        }
-        offset = response.pagination?.cursor
-        return LoadResult.Page(
-            data = list,
-            prevKey = null,
-            nextKey = if (!offset.isNullOrBlank()) {
-                (params.key ?: 1) + 1
-            } else null
-        )
     }
 
     override fun getRefreshKey(state: PagingState<Int, Stream>): Int? {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/datasource/StreamFeedPageLoader.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/datasource/StreamFeedPageLoader.kt
@@ -1,0 +1,638 @@
+package com.github.andreyasadchy.xtra.repository.datasource
+
+import com.github.andreyasadchy.xtra.graphql.type.Language
+import com.github.andreyasadchy.xtra.graphql.type.StreamSort
+import com.github.andreyasadchy.xtra.model.ui.Stream
+import com.github.andreyasadchy.xtra.repository.GraphQLRepository
+import com.github.andreyasadchy.xtra.repository.HelixRepository
+import com.github.andreyasadchy.xtra.repository.LocalChannelFollowsRepository
+import com.github.andreyasadchy.xtra.util.C
+import java.io.IOException
+import kotlinx.coroutines.CancellationException
+
+/**
+ * A page cursor carries the API that created it. Twitch cursors are not
+ * interchangeable between GraphQL, persisted GraphQL, and Helix, so this
+ * identity must survive the loader instance and process that created it.
+ */
+data class StreamFeedCursor(
+    val api: String,
+    val value: String,
+)
+
+data class StreamFeedPage(
+    val items: List<Stream>,
+    val nextCursor: StreamFeedCursor?,
+)
+
+interface StreamFeedPageLoader {
+    suspend fun load(cursor: StreamFeedCursor?): StreamFeedPage
+}
+
+internal fun String?.toStreamFeedCursor(api: String): StreamFeedCursor? {
+    return this?.takeIf { it.isNotBlank() }?.let { StreamFeedCursor(api, it) }
+}
+
+class StreamFeedIntegrityException : IOException(C.FAILED_INTEGRITY_CHECK)
+
+private fun checkIntegrity(enabled: Boolean, errors: Iterable<Any?>?) {
+    if (enabled && errors?.any { it.toString().contains(C.FAILED_INTEGRITY_CHECK) } == true) {
+        throw StreamFeedIntegrityException()
+    }
+}
+
+/** Select an API only for the first page; subsequent cursors stay on it. */
+internal suspend fun <T> loadFollowedFirstPageWithFallback(
+    onApiSelected: (String) -> Unit,
+    gql: suspend () -> T,
+    persistedGql: suspend () -> T,
+    helix: suspend () -> T,
+): T {
+    return try {
+        onApiSelected(C.GQL)
+        gql()
+    } catch (error: Exception) {
+        if (error is CancellationException) throw error
+        if (error is StreamFeedIntegrityException) throw error
+        try {
+            onApiSelected(C.GQL_PERSISTED_QUERY)
+            persistedGql()
+        } catch (error2: Exception) {
+            if (error2 is CancellationException) throw error2
+            if (error2 is StreamFeedIntegrityException) throw error2
+            onApiSelected(C.HELIX)
+            helix()
+        }
+    }
+}
+
+internal suspend fun <T> loadFollowedPageForCursor(
+    cursor: StreamFeedCursor,
+    gql: suspend (String) -> T,
+    persistedGql: suspend (String) -> T,
+    helix: suspend (String) -> T,
+): T = when (cursor.api) {
+    C.GQL -> gql(cursor.value)
+    C.GQL_PERSISTED_QUERY -> persistedGql(cursor.value)
+    C.HELIX -> helix(cursor.value)
+    else -> throw IOException("Unknown followed-stream cursor API: ${cursor.api}")
+}
+
+class TopStreamsPageLoader(
+    private val gqlQueryLanguages: List<Language>?,
+    private val gqlQuerySort: StreamSort?,
+    private val gqlLanguages: List<String>?,
+    private val gqlSort: String?,
+    private val tags: List<String>?,
+    private val gqlHeaders: () -> Map<String, String>,
+    private val graphQLRepository: GraphQLRepository,
+    private val helixHeaders: () -> Map<String, String>,
+    private val helixRepository: HelixRepository,
+    private val enableIntegrity: Boolean,
+    private val networkLibrary: String?,
+    private val pageSize: Int = 30,
+) : StreamFeedPageLoader {
+    private var api: String? = null
+
+    override suspend fun load(cursor: StreamFeedCursor?): StreamFeedPage {
+        if (cursor == null) api = null
+        if (cursor != null) return loadFromApi(cursor)
+        return if (api == null) {
+            try {
+                api = C.GQL
+                loadFromApi(cursor)
+            } catch (error: Exception) {
+                if (error is CancellationException) throw error
+                if (error is StreamFeedIntegrityException) throw error
+                try {
+                    api = C.GQL_PERSISTED_QUERY
+                    loadFromApi(cursor)
+                } catch (error2: Exception) {
+                    if (error2 is CancellationException) throw error2
+                    if (error2 is StreamFeedIntegrityException) throw error2
+                    api = C.HELIX
+                    loadFromApi(cursor)
+                }
+            }
+        } else {
+            loadFromApi(cursor)
+        }
+    }
+
+    private suspend fun loadFromApi(cursor: StreamFeedCursor?): StreamFeedPage = when (cursor?.api ?: api) {
+        C.GQL -> gqlQueryLoad(cursor?.value)
+        C.GQL_PERSISTED_QUERY -> gqlLoad(cursor?.value)
+        C.HELIX -> if (!helixHeaders()[C.HEADER_TOKEN].isNullOrBlank() && tags.isNullOrEmpty() && gqlQueryLanguages.isNullOrEmpty() && gqlLanguages.isNullOrEmpty()) {
+            helixLoad(cursor?.value)
+        } else {
+            throw IOException("Helix cannot represent this stream filter")
+        }
+        else -> error("No stream API selected")
+    }
+
+    private suspend fun gqlQueryLoad(cursor: String?): StreamFeedPage {
+        val response = graphQLRepository.loadQueryTopStreams(
+            networkLibrary,
+            gqlHeaders(),
+            gqlQuerySort,
+            tags,
+            gqlQueryLanguages,
+            pageSize,
+            cursor,
+        )
+        checkIntegrity(enableIntegrity, response.errors)
+        val data = response.data!!.streams!!
+        val edges = data.edges!!
+        val items = edges.mapNotNull { edge ->
+            edge?.node?.let { node ->
+                Stream(
+                    id = node.id,
+                    channelId = node.broadcaster?.id,
+                    channelLogin = node.broadcaster?.login,
+                    channelName = node.broadcaster?.displayName,
+                    channelImageURL = node.broadcaster?.profileImageURL,
+                    gameId = node.game?.id,
+                    gameSlug = node.game?.slug,
+                    gameName = node.game?.displayName,
+                    title = node.broadcaster?.broadcastSettings?.title,
+                    thumbnailURL = node.previewImageURL,
+                    createdAt = node.createdAt?.toString(),
+                    viewerCount = node.viewersCount,
+                    tags = node.freeformTags?.mapNotNull { tag -> tag.name },
+                ).takeIf { it.channelId != null || it.channelLogin != null }
+            }
+        }
+        return StreamFeedPage(
+            items = items,
+            nextCursor = edges.lastOrNull()?.cursor?.toString()
+                ?.takeIf { !it.isNullOrBlank() && data.pageInfo?.hasNextPage != false }
+                .toStreamFeedCursor(C.GQL),
+        )
+    }
+
+    private suspend fun gqlLoad(cursor: String?): StreamFeedPage {
+        val response = graphQLRepository.loadTopStreams(
+            networkLibrary,
+            gqlHeaders(),
+            gqlSort,
+            tags,
+            gqlLanguages,
+            pageSize,
+            cursor,
+        )
+        checkIntegrity(enableIntegrity, response.errors)
+        val data = response.data!!.streams
+        val edges = data.edges
+        return StreamFeedPage(
+            items = edges.mapNotNull { edge ->
+                edge.node.let { node ->
+                    Stream(
+                        id = node.id,
+                        channelId = node.broadcaster?.id,
+                        channelLogin = node.broadcaster?.login,
+                        channelName = node.broadcaster?.displayName,
+                        channelImageURL = node.broadcaster?.profileImageURL,
+                        gameId = node.game?.id,
+                        gameSlug = node.game?.slug,
+                        gameName = node.game?.displayName,
+                        title = node.title,
+                        thumbnailURL = node.previewImageURL,
+                        createdAt = node.createdAt,
+                        viewerCount = node.viewersCount,
+                        tags = node.freeformTags?.mapNotNull { tag -> tag.name },
+                    ).takeIf { it.channelId != null || it.channelLogin != null }
+                }
+            },
+            nextCursor = edges.lastOrNull()?.cursor
+                ?.takeIf { !it.isNullOrBlank() && data.pageInfo?.hasNextPage != false }
+                .toStreamFeedCursor(C.GQL_PERSISTED_QUERY),
+        )
+    }
+
+    private suspend fun helixLoad(cursor: String?): StreamFeedPage {
+        val response = helixRepository.getStreams(
+            networkLibrary = networkLibrary,
+            headers = helixHeaders(),
+            limit = pageSize,
+            offset = cursor,
+        )
+        val users = response.data.mapNotNull { it.channelId }.let {
+            helixRepository.getUsers(networkLibrary, helixHeaders(), ids = it).data
+        }
+        return StreamFeedPage(
+            items = response.data.mapNotNull { item ->
+                Stream(
+                    id = item.id,
+                    channelId = item.channelId,
+                    channelLogin = item.channelLogin,
+                    channelName = item.channelName,
+                    channelImageURL = item.channelId?.let { id -> users.find { user -> user.id == id }?.profileImageURL },
+                    gameId = item.gameId,
+                    gameName = item.gameName,
+                    title = item.title,
+                    thumbnailURL = item.thumbnailURL,
+                    createdAt = item.startedAt,
+                    viewerCount = item.viewerCount,
+                    tags = item.tags,
+                ).takeIf { it.channelId != null || it.channelLogin != null }
+            },
+            nextCursor = response.pagination?.cursor.toStreamFeedCursor(C.HELIX),
+        )
+    }
+}
+
+class FollowedStreamsPageLoader(
+    private val userId: String?,
+    private val localChannelFollowsRepository: LocalChannelFollowsRepository,
+    private val gqlHeaders: () -> Map<String, String>,
+    private val graphQLRepository: GraphQLRepository,
+    private val helixHeaders: () -> Map<String, String>,
+    private val helixRepository: HelixRepository,
+    private val enableIntegrity: Boolean,
+    private val networkLibrary: String?,
+) : StreamFeedPageLoader {
+    private var api: String? = null
+
+    override suspend fun load(cursor: StreamFeedCursor?): StreamFeedPage {
+        if (cursor != null) {
+            // The persisted cursor is authoritative. This also works after a
+            // process restart or when another loader refreshed the feed.
+            return loadFromCursor(cursor)
+        }
+        api = null
+
+        val hasRemoteCredentials = !gqlHeaders()[C.HEADER_TOKEN].isNullOrBlank() ||
+                !helixHeaders()[C.HEADER_TOKEN].isNullOrBlank()
+        val localIds = localChannelFollowsRepository.getAll().mapNotNull { it.userId }.distinct()
+        val localItems = if (localIds.isEmpty()) {
+            emptyList()
+        } else {
+            try {
+                loadLocalWithFallback(localIds)
+            } catch (error: Exception) {
+                if (error is CancellationException) throw error
+                if (error is StreamFeedIntegrityException || !hasRemoteCredentials) throw error
+                emptyList()
+            }
+        }
+        val remotePage = if (hasRemoteCredentials) {
+            // A followed-account request is required to be successful before
+            // it can replace a prior cache. Local follows are an additive
+            // fallback, not permission to destructively publish a partial feed.
+            loadFirstPageWithFallback()
+        } else {
+            null
+        }
+        val merged = merge(localItems, remotePage?.items.orEmpty())
+        return StreamFeedPage(merged, remotePage?.nextCursor)
+    }
+
+    private suspend fun loadFirstPageWithFallback(): StreamFeedPage {
+        return loadFollowedFirstPageWithFallback(
+            onApiSelected = { api = it },
+            gql = { gqlQueryLoad(null) },
+            persistedGql = { gqlLoad(null) },
+            helix = { helixLoad(null) },
+        )
+    }
+
+    private suspend fun loadFromCursor(cursor: StreamFeedCursor): StreamFeedPage = loadFollowedPageForCursor(
+        cursor = cursor,
+        gql = { gqlQueryLoad(it) },
+        persistedGql = { gqlLoad(it) },
+        helix = { helixLoad(it) },
+    )
+
+    private suspend fun loadLocalWithFallback(ids: List<String>): List<Stream> {
+        if (ids.isEmpty()) return emptyList()
+        return try {
+            gqlQueryLocal(ids)
+        } catch (error: Exception) {
+            if (error is CancellationException) throw error
+            if (error is StreamFeedIntegrityException) throw error
+            if (helixHeaders()[C.HEADER_TOKEN].isNullOrBlank()) throw error
+            helixLocal(ids)
+        }
+    }
+
+    private suspend fun gqlQueryLoad(cursor: String?): StreamFeedPage {
+        val response = graphQLRepository.loadQueryUserFollowedStreams(networkLibrary, gqlHeaders(), 100, cursor)
+        checkIntegrity(enableIntegrity, response.errors)
+        val data = response.data!!.user!!.followedLiveUsers!!
+        val edges = data.edges!!
+        return StreamFeedPage(
+            items = edges.mapNotNull { edge ->
+                edge?.node?.let { node ->
+                    Stream(
+                        id = node.stream?.id,
+                        channelId = node.id,
+                        channelLogin = node.login,
+                        channelName = node.displayName,
+                        channelImageURL = node.profileImageURL,
+                        gameId = node.stream?.game?.id,
+                        gameSlug = node.stream?.game?.slug,
+                        gameName = node.stream?.game?.displayName,
+                        title = node.stream?.broadcaster?.broadcastSettings?.title,
+                        thumbnailURL = node.stream?.previewImageURL,
+                        createdAt = node.stream?.createdAt?.toString(),
+                        viewerCount = node.stream?.viewersCount,
+                        tags = node.stream?.freeformTags?.mapNotNull { tag -> tag.name },
+                    )
+                }
+            },
+            nextCursor = edges.lastOrNull()?.cursor?.toString()
+                ?.takeIf { !it.isNullOrBlank() && data.pageInfo?.hasNextPage != false }
+                .toStreamFeedCursor(C.GQL),
+        )
+    }
+
+    private suspend fun gqlLoad(cursor: String?): StreamFeedPage {
+        val response = graphQLRepository.loadFollowedStreams(networkLibrary, gqlHeaders(), 100, cursor)
+        checkIntegrity(enableIntegrity, response.errors)
+        val data = response.data!!.currentUser.followedLiveUsers
+        val edges = data.edges
+        return StreamFeedPage(
+            items = edges.map { edge ->
+                edge.node.let { node ->
+                    Stream(
+                        id = node.stream?.id,
+                        channelId = node.id,
+                        channelLogin = node.login,
+                        channelName = node.displayName,
+                        channelImageURL = node.profileImageURL,
+                        gameId = node.stream?.game?.id,
+                        gameSlug = node.stream?.game?.slug,
+                        gameName = node.stream?.game?.displayName,
+                        title = node.stream?.title,
+                        thumbnailURL = node.stream?.previewImageURL,
+                        createdAt = node.stream?.createdAt,
+                        viewerCount = node.stream?.viewersCount,
+                        tags = node.stream?.freeformTags?.mapNotNull { tag -> tag.name },
+                    )
+                }
+            },
+            nextCursor = edges.lastOrNull()?.cursor
+                ?.takeIf { !it.isNullOrBlank() && data.pageInfo?.hasNextPage != false }
+                .toStreamFeedCursor(C.GQL_PERSISTED_QUERY),
+        )
+    }
+
+    private suspend fun helixLoad(cursor: String?): StreamFeedPage {
+        val response = helixRepository.getFollowedStreams(networkLibrary, helixHeaders(), userId, 100, cursor)
+        val users = response.data.mapNotNull { it.channelId }.let {
+            helixRepository.getUsers(networkLibrary, helixHeaders(), ids = it).data
+        }
+        return StreamFeedPage(
+            items = response.data.map { item ->
+                Stream(
+                    id = item.id,
+                    channelId = item.channelId,
+                    channelLogin = item.channelLogin,
+                    channelName = item.channelName,
+                    channelImageURL = item.channelId?.let { id -> users.find { user -> user.id == id }?.profileImageURL },
+                    gameId = item.gameId,
+                    gameName = item.gameName,
+                    title = item.title,
+                    thumbnailURL = item.thumbnailURL,
+                    createdAt = item.startedAt,
+                    viewerCount = item.viewerCount,
+                    tags = item.tags,
+                )
+            },
+            nextCursor = response.pagination?.cursor.toStreamFeedCursor(C.HELIX),
+        )
+    }
+
+    private suspend fun gqlQueryLocal(ids: List<String>): List<Stream> {
+        val items = ids.chunked(100).map { chunk ->
+            val response = graphQLRepository.loadQueryUsersStream(networkLibrary, gqlHeaders(), chunk)
+            checkIntegrity(enableIntegrity, response.errors)
+            response.data!!.users!!
+        }.flatMap { it }
+        return items.mapNotNull { item ->
+            item?.takeIf { it.stream?.viewersCount != null }?.let {
+                Stream(
+                    id = it.stream?.id,
+                    channelId = it.id,
+                    channelLogin = it.login,
+                    channelName = it.displayName,
+                    channelImageURL = it.profileImageURL,
+                    gameId = it.stream?.game?.id,
+                    gameSlug = it.stream?.game?.slug,
+                    gameName = it.stream?.game?.displayName,
+                    title = it.stream?.broadcaster?.broadcastSettings?.title,
+                    thumbnailURL = it.stream?.previewImageURL,
+                    createdAt = it.stream?.createdAt?.toString(),
+                    viewerCount = it.stream?.viewersCount,
+                    tags = it.stream?.freeformTags?.mapNotNull { tag -> tag.name },
+                )
+            }
+        }
+    }
+
+    private suspend fun helixLocal(ids: List<String>): List<Stream> {
+        val items = ids.chunked(100).map {
+            helixRepository.getStreams(networkLibrary, helixHeaders(), ids = it).data
+        }.flatMap { it }
+        val users = items.mapNotNull { it.channelId }.chunked(100).map {
+            helixRepository.getUsers(networkLibrary, helixHeaders(), ids = it).data
+        }.flatMap { it }
+        return items.mapNotNull { item ->
+            item.takeIf { it.viewerCount != null }?.let {
+                Stream(
+                    id = it.id,
+                    channelId = it.channelId,
+                    channelLogin = it.channelLogin,
+                    channelName = it.channelName,
+                    channelImageURL = it.channelId?.let { id -> users.find { user -> user.id == id }?.profileImageURL },
+                    gameId = it.gameId,
+                    gameName = it.gameName,
+                    title = it.title,
+                    thumbnailURL = it.thumbnailURL,
+                    createdAt = it.startedAt,
+                    viewerCount = it.viewerCount,
+                    tags = it.tags,
+                )
+            }
+        }
+    }
+
+    private fun merge(local: List<Stream>, remote: List<Stream>): List<Stream> {
+        val result = local.toMutableList()
+        remote.forEach { stream ->
+            val existing = result.indexOfFirst { sameChannel(it, stream) }
+            if (existing < 0) result += stream
+        }
+        return result.sortedByDescending { it.viewerCount ?: -1 }
+    }
+
+    private fun sameChannel(first: Stream, second: Stream): Boolean {
+        return when {
+            !first.channelId.isNullOrBlank() && !second.channelId.isNullOrBlank() -> first.channelId == second.channelId
+            !first.channelLogin.isNullOrBlank() && !second.channelLogin.isNullOrBlank() -> first.channelLogin.equals(second.channelLogin, true)
+            else -> first.id != null && first.id == second.id
+        }
+    }
+}
+
+class GameStreamsPageLoader(
+    private val gameId: String?,
+    private val gameSlug: String?,
+    private val gameName: String?,
+    private val gqlQueryLanguages: List<Language>?,
+    private val gqlQuerySort: StreamSort?,
+    private val gqlLanguages: List<String>?,
+    private val gqlSort: String?,
+    private val tags: List<String>?,
+    private val gqlHeaders: () -> Map<String, String>,
+    private val graphQLRepository: GraphQLRepository,
+    private val helixHeaders: () -> Map<String, String>,
+    private val helixRepository: HelixRepository,
+    private val enableIntegrity: Boolean,
+    private val networkLibrary: String?,
+    private val pageSize: Int = 30,
+) : StreamFeedPageLoader {
+    private var api: String? = null
+
+    override suspend fun load(cursor: StreamFeedCursor?): StreamFeedPage {
+        if (cursor == null) api = null
+        if (cursor != null) return loadFromApi(cursor)
+        return if (api == null) {
+            try {
+                api = C.GQL
+                loadFromApi(cursor)
+            } catch (error: Exception) {
+                if (error is CancellationException) throw error
+                if (error is StreamFeedIntegrityException) throw error
+                try {
+                    api = C.GQL_PERSISTED_QUERY
+                    loadFromApi(cursor)
+                } catch (error2: Exception) {
+                    if (error2 is CancellationException) throw error2
+                    if (error2 is StreamFeedIntegrityException) throw error2
+                    api = C.HELIX
+                    loadFromApi(cursor)
+                }
+            }
+        } else {
+            loadFromApi(cursor)
+        }
+    }
+
+    private suspend fun loadFromApi(cursor: StreamFeedCursor?): StreamFeedPage = when (cursor?.api ?: api) {
+        C.GQL -> if (gameId != null || gameSlug != null || gameName != null) gqlQueryLoad(cursor?.value) else throw IOException("Missing game identity")
+        C.GQL_PERSISTED_QUERY -> gqlLoad(cursor?.value)
+        C.HELIX -> if (!helixHeaders()[C.HEADER_TOKEN].isNullOrBlank() && (gqlSort == "VIEWER_COUNT" || gqlSort == null) && tags.isNullOrEmpty() && gqlQueryLanguages.isNullOrEmpty() && gqlLanguages.isNullOrEmpty()) {
+            helixLoad(cursor?.value)
+        } else {
+            throw IOException("Helix cannot represent this game stream filter")
+        }
+        else -> error("No stream API selected")
+    }
+
+    private suspend fun gqlQueryLoad(cursor: String?): StreamFeedPage {
+        val response = graphQLRepository.loadQueryGameStreams(
+            networkLibrary = networkLibrary,
+            headers = gqlHeaders(),
+            id = gameId,
+            slug = gameSlug.takeIf { gameId.isNullOrBlank() },
+            name = gameName.takeIf { gameId.isNullOrBlank() && gameSlug.isNullOrBlank() },
+            sort = gqlQuerySort,
+            tags = tags,
+            languages = gqlQueryLanguages,
+            first = pageSize,
+            after = cursor,
+        )
+        checkIntegrity(enableIntegrity, response.errors)
+        val data = response.data!!.game!!.streams!!
+        val edges = data.edges!!
+        return StreamFeedPage(
+            items = edges.mapNotNull { edge ->
+                edge?.node?.let { node ->
+                    Stream(
+                        id = node.id,
+                        channelId = node.broadcaster?.id,
+                        channelLogin = node.broadcaster?.login,
+                        channelName = node.broadcaster?.displayName,
+                        channelImageURL = node.broadcaster?.profileImageURL,
+                        gameId = gameId,
+                        gameSlug = gameSlug,
+                        gameName = gameName,
+                        title = node.broadcaster?.broadcastSettings?.title,
+                        thumbnailURL = node.previewImageURL,
+                        createdAt = node.createdAt?.toString(),
+                        viewerCount = node.viewersCount,
+                        tags = node.freeformTags?.mapNotNull { tag -> tag.name },
+                    ).takeIf { it.channelId != null || it.channelLogin != null }
+                }
+            },
+            nextCursor = edges.lastOrNull()?.cursor?.toString()
+                ?.takeIf { !it.isNullOrBlank() && data.pageInfo?.hasNextPage != false }
+                .toStreamFeedCursor(C.GQL),
+        )
+    }
+
+    private suspend fun gqlLoad(cursor: String?): StreamFeedPage {
+        val response = graphQLRepository.loadGameStreams(networkLibrary, gqlHeaders(), gameSlug, gqlSort, tags, gqlLanguages, pageSize, cursor)
+        checkIntegrity(enableIntegrity, response.errors)
+        val data = response.data!!.game.streams
+        val edges = data.edges
+        return StreamFeedPage(
+            items = edges.mapNotNull { edge ->
+                edge.node.let { node ->
+                    Stream(
+                        id = node.id,
+                        channelId = node.broadcaster?.id,
+                        channelLogin = node.broadcaster?.login,
+                        channelName = node.broadcaster?.displayName,
+                        channelImageURL = node.broadcaster?.profileImageURL,
+                        gameId = gameId,
+                        gameSlug = gameSlug,
+                        gameName = gameName,
+                        title = node.title,
+                        thumbnailURL = node.previewImageURL,
+                        createdAt = node.createdAt,
+                        viewerCount = node.viewersCount,
+                        tags = node.freeformTags?.mapNotNull { tag -> tag.name },
+                    ).takeIf { it.channelId != null || it.channelLogin != null }
+                }
+            },
+            nextCursor = edges.lastOrNull()?.cursor
+                ?.takeIf { !it.isNullOrBlank() && data.pageInfo?.hasNextPage != false }
+                .toStreamFeedCursor(C.GQL_PERSISTED_QUERY),
+        )
+    }
+
+    private suspend fun helixLoad(cursor: String?): StreamFeedPage {
+        val response = helixRepository.getStreams(
+            networkLibrary,
+            helixHeaders(),
+            gameId = gameId,
+            limit = pageSize,
+            offset = cursor,
+        )
+        val users = response.data.mapNotNull { it.channelId }.let {
+            helixRepository.getUsers(networkLibrary, helixHeaders(), ids = it).data
+        }
+        return StreamFeedPage(
+            items = response.data.mapNotNull { item ->
+                Stream(
+                    id = item.id,
+                    channelId = item.channelId,
+                    channelLogin = item.channelLogin,
+                    channelName = item.channelName,
+                    channelImageURL = item.channelId?.let { id -> users.find { user -> user.id == id }?.profileImageURL },
+                    gameId = gameId,
+                    gameSlug = gameSlug,
+                    gameName = gameName,
+                    title = item.title,
+                    thumbnailURL = item.thumbnailURL,
+                    createdAt = item.startedAt,
+                    viewerCount = item.viewerCount,
+                    tags = item.tags,
+                ).takeIf { it.channelId != null || it.channelLogin != null }
+            },
+            nextCursor = response.pagination?.cursor.toStreamFeedCursor(C.HELIX),
+        )
+    }
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/datasource/StreamsDataSource.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/datasource/StreamsDataSource.kt
@@ -7,180 +7,47 @@ import com.github.andreyasadchy.xtra.graphql.type.StreamSort
 import com.github.andreyasadchy.xtra.model.ui.Stream
 import com.github.andreyasadchy.xtra.repository.GraphQLRepository
 import com.github.andreyasadchy.xtra.repository.HelixRepository
-import com.github.andreyasadchy.xtra.util.C
 
+/** Compatibility PagingSource for callers outside the Room-backed feed path. */
 class StreamsDataSource(
-    private val gqlQueryLanguages: List<Language>?,
-    private val gqlQuerySort: StreamSort?,
-    private val gqlLanguages: List<String>?,
-    private val gqlSort: String?,
-    private val tags: List<String>?,
-    private val gqlHeaders: Map<String, String>,
-    private val graphQLRepository: GraphQLRepository,
-    private val helixHeaders: Map<String, String>,
-    private val helixRepository: HelixRepository,
-    private val enableIntegrity: Boolean,
-    private val networkLibrary: String?,
+    gqlQueryLanguages: List<Language>?,
+    gqlQuerySort: StreamSort?,
+    gqlLanguages: List<String>?,
+    gqlSort: String?,
+    tags: List<String>?,
+    gqlHeaders: Map<String, String>,
+    graphQLRepository: GraphQLRepository,
+    helixHeaders: Map<String, String>,
+    helixRepository: HelixRepository,
+    enableIntegrity: Boolean,
+    networkLibrary: String?,
 ) : PagingSource<Int, Stream>() {
-    private var api: String? = null
-    private var offset: String? = null
+    private val loader = TopStreamsPageLoader(
+        gqlQueryLanguages = gqlQueryLanguages,
+        gqlQuerySort = gqlQuerySort,
+        gqlLanguages = gqlLanguages,
+        gqlSort = gqlSort,
+        tags = tags,
+        gqlHeaders = { gqlHeaders },
+        graphQLRepository = graphQLRepository,
+        helixHeaders = { helixHeaders },
+        helixRepository = helixRepository,
+        enableIntegrity = enableIntegrity,
+        networkLibrary = networkLibrary,
+    )
+    private var cursor: StreamFeedCursor? = null
 
     override suspend fun load(params: LoadParams<Int>): LoadResult<Int, Stream> {
-        return if (!offset.isNullOrBlank()) {
-            try {
-                loadFromApi(params)
-            } catch (e: Exception) {
-                LoadResult.Error(e)
-            }
-        } else {
-            try {
-                api = C.GQL
-                loadFromApi(params)
-            } catch (e: Exception) {
-                try {
-                    api = C.GQL_PERSISTED_QUERY
-                    loadFromApi(params)
-                } catch (e: Exception) {
-                    try {
-                        api = C.HELIX
-                        loadFromApi(params)
-                    } catch (e: Exception) {
-                        LoadResult.Error(e)
-                    }
-                }
-            }
+        return try {
+            val page = loader.load(cursor).also { cursor = it.nextCursor }
+            LoadResult.Page(
+                data = page.items,
+                prevKey = null,
+                nextKey = page.nextCursor?.let { (params.key ?: 1) + 1 },
+            )
+        } catch (error: Exception) {
+            LoadResult.Error(error)
         }
-    }
-
-    private suspend fun loadFromApi(params: LoadParams<Int>): LoadResult<Int, Stream> {
-        return when (api) {
-            C.GQL -> gqlQueryLoad(params)
-            C.GQL_PERSISTED_QUERY -> gqlLoad(params)
-            C.HELIX -> if (!helixHeaders[C.HEADER_TOKEN].isNullOrBlank() && tags.isNullOrEmpty() && gqlQueryLanguages.isNullOrEmpty() && gqlLanguages.isNullOrEmpty()) helixLoad(params) else throw Exception()
-            else -> throw Exception()
-        }
-    }
-
-    private suspend fun gqlQueryLoad(params: LoadParams<Int>): LoadResult<Int, Stream> {
-        val response = graphQLRepository.loadQueryTopStreams(networkLibrary, gqlHeaders, gqlQuerySort, tags, gqlQueryLanguages, params.loadSize, offset)
-        if (enableIntegrity) {
-            response.errors?.find { it.message == C.FAILED_INTEGRITY_CHECK }?.let { return LoadResult.Error(Exception(it.message)) }
-        }
-        val data = response.data!!.streams!!
-        val items = data.edges!!
-        val list = items.mapNotNull { item ->
-            item?.node?.let {
-                Stream(
-                    id = it.id,
-                    channelId = it.broadcaster?.id,
-                    channelLogin = it.broadcaster?.login,
-                    channelName = it.broadcaster?.displayName,
-                    channelImageURL = it.broadcaster?.profileImageURL,
-                    gameId = it.game?.id,
-                    gameSlug = it.game?.slug,
-                    gameName = it.game?.displayName,
-                    title = it.broadcaster?.broadcastSettings?.title,
-                    thumbnailURL = it.previewImageURL,
-                    createdAt = it.createdAt?.toString(),
-                    viewerCount = it.viewersCount,
-                    tags = it.freeformTags?.mapNotNull { tag -> tag.name },
-                ).takeIf { stream ->
-                    stream.channelId != null || stream.channelLogin != null
-                }
-            }
-        }
-        offset = items.lastOrNull()?.cursor?.toString()
-        val nextPage = data.pageInfo?.hasNextPage != false
-        return LoadResult.Page(
-            data = list,
-            prevKey = null,
-            nextKey = if (!offset.isNullOrBlank() && nextPage) {
-                (params.key ?: 1) + 1
-            } else null
-        )
-    }
-
-    private suspend fun gqlLoad(params: LoadParams<Int>): LoadResult<Int, Stream> {
-        val response = graphQLRepository.loadTopStreams(networkLibrary, gqlHeaders, gqlSort, tags, gqlLanguages, params.loadSize, offset)
-        if (enableIntegrity) {
-            response.errors?.find { it.message == C.FAILED_INTEGRITY_CHECK }?.let { return LoadResult.Error(Exception(it.message)) }
-        }
-        val data = response.data!!.streams
-        val items = data.edges
-        val list = items.mapNotNull { item ->
-            item.node.let {
-                Stream(
-                    id = it.id,
-                    channelId = it.broadcaster?.id,
-                    channelLogin = it.broadcaster?.login,
-                    channelName = it.broadcaster?.displayName,
-                    channelImageURL = it.broadcaster?.profileImageURL,
-                    gameId = it.game?.id,
-                    gameSlug = it.game?.slug,
-                    gameName = it.game?.displayName,
-                    title = it.title,
-                    thumbnailURL = it.previewImageURL,
-                    createdAt = it.createdAt,
-                    viewerCount = it.viewersCount,
-                    tags = it.freeformTags?.mapNotNull { tag -> tag.name },
-                ).takeIf { stream ->
-                    stream.channelId != null || stream.channelLogin != null
-                }
-            }
-        }
-        offset = items.lastOrNull()?.cursor
-        val nextPage = data.pageInfo?.hasNextPage != false
-        return LoadResult.Page(
-            data = list,
-            prevKey = null,
-            nextKey = if (!offset.isNullOrBlank() && nextPage) {
-                (params.key ?: 1) + 1
-            } else null
-        )
-    }
-
-    private suspend fun helixLoad(params: LoadParams<Int>): LoadResult<Int, Stream> {
-        val response = helixRepository.getStreams(
-            networkLibrary = networkLibrary,
-            headers = helixHeaders,
-            limit = params.loadSize,
-            offset = offset
-        )
-        val users = response.data.mapNotNull { it.channelId }.let {
-            helixRepository.getUsers(
-                networkLibrary = networkLibrary,
-                headers = helixHeaders,
-                ids = it
-            ).data
-        }
-        val list = response.data.mapNotNull {
-            Stream(
-                id = it.id,
-                channelId = it.channelId,
-                channelLogin = it.channelLogin,
-                channelName = it.channelName,
-                channelImageURL = it.channelId?.let { id ->
-                    users.find { user -> user.id == id }?.profileImageURL
-                },
-                gameId = it.gameId,
-                gameName = it.gameName,
-                title = it.title,
-                thumbnailURL = it.thumbnailURL,
-                createdAt = it.startedAt,
-                viewerCount = it.viewerCount,
-                tags = it.tags,
-            ).takeIf { stream ->
-                stream.channelId != null || stream.channelLogin != null
-            }
-        }
-        offset = response.pagination?.cursor
-        return LoadResult.Page(
-            data = list,
-            prevKey = null,
-            nextKey = if (!offset.isNullOrBlank()) {
-                (params.key ?: 1) + 1
-            } else null
-        )
     }
 
     override fun getRefreshKey(state: PagingState<Int, Stream>): Int? {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/streamfeed/StreamFeedCache.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/streamfeed/StreamFeedCache.kt
@@ -1,0 +1,362 @@
+package com.github.andreyasadchy.xtra.repository.streamfeed
+
+import com.github.andreyasadchy.xtra.db.AppDatabase
+import com.github.andreyasadchy.xtra.db.CachedStreamFeedItem
+import com.github.andreyasadchy.xtra.db.StreamFeedDao
+import com.github.andreyasadchy.xtra.db.StreamFeedState
+import com.github.andreyasadchy.xtra.model.ui.Stream
+import com.github.andreyasadchy.xtra.repository.datasource.StreamFeedPage
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.json.JSONArray
+
+private const val FEED_RETENTION_MS = 7 * 24 * 60 * 60 * 1_000L
+private const val MAX_FEED_VARIANTS = 80
+
+interface StreamFeedCacheStore {
+    fun pagingSource(feedKey: StreamFeedKey): androidx.paging.PagingSource<Int, CachedStreamFeedItem>
+    suspend fun state(feedKey: StreamFeedKey): StreamFeedState?
+    suspend fun itemCount(feedKey: StreamFeedKey): Int
+    suspend fun touchAccess(feedKey: StreamFeedKey, nowMs: Long)
+    suspend fun markAttempt(feedKey: StreamFeedKey, nowMs: Long)
+    suspend fun replaceAfterRefresh(
+        feedKey: StreamFeedKey,
+        page: StreamFeedPage,
+        nowMs: Long,
+        preserveTail: Boolean,
+        pruneStaleOnEnd: Boolean,
+    )
+    suspend fun appendPage(
+        feedKey: StreamFeedKey,
+        page: StreamFeedPage,
+        nowMs: Long,
+        pruneStaleOnEnd: Boolean,
+    )
+    suspend fun pruneStaleGeneration(feedKey: StreamFeedKey)
+    suspend fun recordFailure(feedKey: StreamFeedKey, nowMs: Long, failureBackoffUntil: Long?, rateLimitUntil: Long?)
+    suspend fun invalidatePrefix(prefix: String, nowMs: Long)
+    suspend fun cleanup(nowMs: Long)
+}
+
+internal fun Stream.cacheItemKey(): String? {
+    return channelId?.trim()?.takeIf { it.isNotEmpty() }?.let { "channel:$it" }
+        ?: id?.trim()?.takeIf { it.isNotEmpty() }?.let { "stream:$it" }
+        ?: channelLogin?.trim()?.takeIf { it.isNotEmpty() }?.let { "login:${it.lowercase()}" }
+}
+
+internal fun Stream.toCachedStreamFeedItem(
+    feedKey: String,
+    position: Int,
+    generation: Long = 0L,
+): CachedStreamFeedItem? {
+    return cacheItemKey()?.let { itemKey ->
+        CachedStreamFeedItem(
+            feedKey = feedKey,
+            itemKey = itemKey,
+            position = position,
+            streamId = id,
+            channelId = channelId,
+            channelLogin = channelLogin,
+            channelName = channelName,
+            channelImageURL = channelImageURL,
+            gameId = gameId,
+            gameSlug = gameSlug,
+            gameName = gameName,
+            title = title,
+            thumbnailURL = thumbnailURL,
+            createdAt = createdAt,
+            viewerCount = viewerCount,
+            tags = tags?.let(::encodeTags),
+            generation = generation,
+        )
+    }
+}
+
+internal fun CachedStreamFeedItem.toStream(): Stream {
+    return Stream(
+        id = streamId,
+        channelId = channelId,
+        channelLogin = channelLogin,
+        channelName = channelName,
+        channelImageURL = channelImageURL,
+        gameId = gameId,
+        gameSlug = gameSlug,
+        gameName = gameName,
+        title = title,
+        thumbnailURL = thumbnailURL,
+        createdAt = createdAt,
+        viewerCount = viewerCount,
+        tags = tags?.let(::decodeTags),
+    )
+}
+
+private fun encodeTags(tags: List<String>): String {
+    return JSONArray().apply { tags.forEach(::put) }.toString()
+}
+
+private fun decodeTags(value: String): List<String>? {
+    return runCatching {
+        JSONArray(value).let { array ->
+            List(array.length()) { index -> array.getString(index) }
+        }
+    }.getOrNull()
+}
+
+internal fun refreshCachedItems(
+    feedKey: String,
+    streams: List<Stream>,
+    generation: Long = 0L,
+): List<CachedStreamFeedItem> {
+    return streams.distinctBy { it.cacheItemKey() }
+        .mapIndexedNotNull { index, stream ->
+            stream.toCachedStreamFeedItem(feedKey, index, generation)
+        }
+}
+
+/**
+ * Apply a fresh first page without dropping the rows loaded by an older
+ * generation. The returned layout is already normalized so Room can upsert
+ * it in one transaction without duplicate positions.
+ */
+internal fun refreshCachedItemsPreservingTail(
+    feedKey: String,
+    existing: List<CachedStreamFeedItem>,
+    streams: List<Stream>,
+    generation: Long,
+): List<CachedStreamFeedItem> {
+    val refreshed = refreshCachedItems(feedKey, streams, generation)
+    val refreshedKeys = refreshed.map { it.itemKey }.toSet()
+    val staleTail = existing
+        .filterNot { it.itemKey in refreshedKeys }
+        .sortedBy { it.position }
+        .mapIndexed { index, item ->
+            item.copy(position = refreshed.size + index)
+        }
+    return refreshed + staleTail
+}
+
+/**
+ * Apply one newly downloaded page while retaining an older generation as a
+ * stale tail. Active rows form a contiguous prefix; every remaining stale
+ * row is reindexed after it. This makes position ordering deterministic even
+ * when the remote page adds, removes, or overlaps different channels.
+ */
+internal fun appendCachedPage(
+    feedKey: String,
+    existing: List<CachedStreamFeedItem>,
+    streams: List<Stream>,
+    generation: Long = 0L,
+): List<CachedStreamFeedItem> {
+    val activeRows = existing
+        .filter { it.generation == generation }
+        .sortedBy { it.position }
+    val staleRows = existing
+        .filter { it.generation != generation }
+        .sortedBy { it.position }
+    val pageStreams = streams
+        .mapNotNull { stream -> stream.cacheItemKey()?.let { it to stream } }
+        .distinctBy { it.first }
+    val pageByKey = pageStreams.toMap()
+    val activeKeys = activeRows.map { it.itemKey }.toSet()
+
+    val updatedActive = activeRows.map { existingItem ->
+        pageByKey[existingItem.itemKey]?.toCachedStreamFeedItem(
+            feedKey = feedKey,
+            position = existingItem.position,
+            generation = generation,
+        ) ?: existingItem
+    }
+    val newActive = pageStreams
+        .filterNot { (itemKey, _) -> itemKey in activeKeys }
+        .mapNotNull { (_, stream) -> stream.toCachedStreamFeedItem(feedKey, 0, generation) }
+    val activePrefix = (updatedActive + newActive).mapIndexed { index, item ->
+        item.copy(position = index, generation = generation)
+    }
+    val pageKeys = pageStreams.map { it.first }.toSet()
+    val staleTail = staleRows
+        .filterNot { it.itemKey in pageKeys }
+        .mapIndexed { index, item ->
+            item.copy(position = activePrefix.size + index)
+        }
+    return activePrefix + staleTail
+}
+
+/**
+ * Room is the source of truth for stream-feed data. All replacement and page
+ * application methods below run their writes in one SQLite transaction.
+ */
+class StreamFeedCache(
+    private val database: AppDatabase,
+    private val dao: StreamFeedDao = database.streamFeedDao(),
+) : StreamFeedCacheStore {
+
+    override fun pagingSource(feedKey: StreamFeedKey) = dao.pagingSource(feedKey.value)
+
+    override suspend fun state(feedKey: StreamFeedKey): StreamFeedState? = withContext(Dispatchers.IO) {
+        dao.state(feedKey.value)
+    }
+
+    override suspend fun itemCount(feedKey: StreamFeedKey): Int = withContext(Dispatchers.IO) {
+        dao.itemsForFeed(feedKey.value).size
+    }
+
+    override suspend fun touchAccess(feedKey: StreamFeedKey, nowMs: Long) = withContext(Dispatchers.IO) {
+        database.runInTransaction {
+            val current = dao.state(feedKey.value)
+            dao.insertState(
+                (current ?: StreamFeedState(feedKey.value)).copy(lastAccessAt = nowMs)
+            )
+        }
+    }
+
+    override suspend fun markAttempt(feedKey: StreamFeedKey, nowMs: Long) = withContext(Dispatchers.IO) {
+        database.runInTransaction {
+            val current = dao.state(feedKey.value)
+            dao.insertState(
+                (current ?: StreamFeedState(feedKey.value)).copy(
+                    lastAttemptAt = nowMs,
+                    lastAccessAt = nowMs,
+                )
+            )
+        }
+    }
+
+    /** Replace the cached refresh page only after its network request succeeded. */
+    override suspend fun replaceAfterRefresh(
+        feedKey: StreamFeedKey,
+        page: StreamFeedPage,
+        nowMs: Long,
+        preserveTail: Boolean,
+        pruneStaleOnEnd: Boolean,
+    ) = withContext(Dispatchers.IO) {
+        database.runInTransaction {
+            val current = dao.state(feedKey.value)
+            val generation = (current?.activeGeneration ?: 0L) + 1L
+            val items = if (preserveTail) {
+                refreshCachedItemsPreservingTail(
+                    feedKey = feedKey.value,
+                    existing = dao.itemsForFeed(feedKey.value),
+                    streams = page.items,
+                    generation = generation,
+                )
+            } else {
+                refreshCachedItems(feedKey.value, page.items, generation)
+            }
+            if (!preserveTail) {
+                dao.deleteItems(feedKey.value)
+            }
+            if (items.isNotEmpty()) {
+                dao.insertItems(items)
+            }
+            if (page.nextCursor == null && pruneStaleOnEnd) {
+                dao.deleteItemsExceptGeneration(feedKey.value, generation)
+            }
+            dao.insertState(
+                StreamFeedState(
+                    feedKey = feedKey.value,
+                    nextCursor = page.nextCursor?.value,
+                    lastSuccessAt = nowMs,
+                    lastAttemptAt = nowMs,
+                    lastAccessAt = nowMs,
+                    failureBackoffUntil = null,
+                    rateLimitUntil = null,
+                    nextCursorApi = page.nextCursor?.api,
+                    activeGeneration = generation,
+                )
+            )
+        }
+    }
+
+    /** Append a downloaded page while keeping an existing channel's position stable. */
+    override suspend fun appendPage(
+        feedKey: StreamFeedKey,
+        page: StreamFeedPage,
+        nowMs: Long,
+        pruneStaleOnEnd: Boolean,
+    ) = withContext(Dispatchers.IO) {
+        database.runInTransaction {
+            val current = dao.state(feedKey.value) ?: StreamFeedState(feedKey.value)
+            val existing = dao.itemsForFeed(feedKey.value)
+            val items = appendCachedPage(feedKey.value, existing, page.items, current.activeGeneration)
+            if (items.isNotEmpty()) {
+                dao.insertItems(items)
+            }
+            if (page.nextCursor == null && pruneStaleOnEnd) {
+                dao.deleteItemsExceptGeneration(feedKey.value, current.activeGeneration)
+            }
+            dao.insertState(
+                current.copy(
+                    nextCursor = page.nextCursor?.value,
+                    lastSuccessAt = current.lastSuccessAt ?: nowMs,
+                    lastAttemptAt = nowMs,
+                    lastAccessAt = nowMs,
+                    failureBackoffUntil = null,
+                    rateLimitUntil = null,
+                    nextCursorApi = page.nextCursor?.api,
+                )
+            )
+        }
+    }
+
+    override suspend fun pruneStaleGeneration(feedKey: StreamFeedKey) = withContext(Dispatchers.IO) {
+        database.runInTransaction {
+            dao.state(feedKey.value)?.let { state ->
+                dao.deleteItemsExceptGeneration(feedKey.value, state.activeGeneration)
+            }
+        }
+    }
+
+    /** Keep old rows and lastSuccessAt intact when an automatic request fails. */
+    override suspend fun recordFailure(
+        feedKey: StreamFeedKey,
+        nowMs: Long,
+        failureBackoffUntil: Long?,
+        rateLimitUntil: Long?,
+    ) = withContext(Dispatchers.IO) {
+        database.runInTransaction {
+            val current = dao.state(feedKey.value) ?: StreamFeedState(feedKey.value)
+            dao.insertState(
+                current.copy(
+                    lastAttemptAt = nowMs,
+                    lastAccessAt = nowMs,
+                    failureBackoffUntil = failureBackoffUntil,
+                    rateLimitUntil = rateLimitUntil,
+                )
+            )
+        }
+    }
+
+    override suspend fun invalidatePrefix(prefix: String, nowMs: Long) = withContext(Dispatchers.IO) {
+        database.runInTransaction {
+            dao.allStates()
+                .filter { it.feedKey.startsWith(prefix) }
+                .forEach { state ->
+                    dao.insertState(
+                        state.copy(
+                            lastSuccessAt = null,
+                            lastAccessAt = nowMs,
+                        )
+                    )
+                }
+        }
+    }
+
+    override suspend fun cleanup(nowMs: Long) = withContext(Dispatchers.IO) {
+        database.runInTransaction {
+            val cutoff = nowMs - FEED_RETENTION_MS
+            val states = dao.allStates()
+            states.filter { it.lastAccessAt <= cutoff }
+                .forEach { state ->
+                    dao.deleteItems(state.feedKey)
+                    dao.deleteState(state.feedKey)
+                }
+            states.asSequence()
+                .filter { it.lastAccessAt >= cutoff }
+                .drop(MAX_FEED_VARIANTS)
+                .forEach { state ->
+                    dao.deleteItems(state.feedKey)
+                    dao.deleteState(state.feedKey)
+                }
+        }
+    }
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/streamfeed/StreamFeedPager.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/streamfeed/StreamFeedPager.kt
@@ -1,0 +1,26 @@
+package com.github.andreyasadchy.xtra.repository.streamfeed
+
+import androidx.paging.Pager
+import androidx.paging.PagingConfig
+import androidx.paging.PagingData
+import androidx.paging.map
+import com.github.andreyasadchy.xtra.model.ui.Stream
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+@OptIn(androidx.paging.ExperimentalPagingApi::class)
+class StreamFeedPager(
+    private val cache: StreamFeedCache,
+    private val coordinator: StreamFeedRefreshCoordinator,
+) {
+    fun flow(spec: StreamFeedSpec, config: PagingConfig): Flow<PagingData<Stream>> {
+        return Pager(
+            config = config,
+            remoteMediator = StreamFeedRemoteMediator(spec, cache, coordinator),
+        ) {
+            cache.pagingSource(spec.key)
+        }.flow.map { pagingData ->
+            pagingData.map { it.toStream() }
+        }
+    }
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/streamfeed/StreamFeedPolicy.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/streamfeed/StreamFeedPolicy.kt
@@ -1,0 +1,198 @@
+package com.github.andreyasadchy.xtra.repository.streamfeed
+
+import com.github.andreyasadchy.xtra.db.StreamFeedState
+import com.github.andreyasadchy.xtra.repository.datasource.StreamFeedPageLoader
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.async
+import java.util.Locale
+import java.util.concurrent.ConcurrentHashMap
+
+/** A stable, credential-free identity for one stream feed variant. */
+data class StreamFeedKey(val value: String) {
+    override fun toString(): String = value
+
+    companion object {
+        fun top(sort: String, tags: Iterable<String>?, languages: Iterable<String>?): StreamFeedKey {
+            return StreamFeedKey("top:${component(sort)}:tags=${list(tags)}:languages=${list(languages)}")
+        }
+
+        fun followed(accountId: String?): StreamFeedKey {
+            val normalized = accountId?.trim()?.takeIf { it.isNotEmpty() }
+            return if (normalized == null) {
+                StreamFeedKey("followed:local")
+            } else {
+                StreamFeedKey("followed:account:${component(normalized)}")
+            }
+        }
+
+        fun game(
+            gameId: String?,
+            gameSlug: String?,
+            gameName: String?,
+            sort: String,
+            tags: Iterable<String>?,
+            languages: Iterable<String>?,
+        ): StreamFeedKey {
+            val identity = gameId?.trim()?.takeIf { it.isNotEmpty() }?.let { "id:${component(it)}" }
+                ?: gameSlug?.trim()?.takeIf { it.isNotEmpty() }?.let { "slug:${component(it)}" }
+                ?: "name:${component(gameName.orEmpty())}"
+            return StreamFeedKey(
+                "game:$identity:${component(sort)}:tags=${list(tags)}:languages=${list(languages)}"
+            )
+        }
+
+        internal fun canonicalValues(values: Iterable<String>?): List<String> {
+            return values?.toList().orEmpty()
+                .map { it.trim().lowercase(Locale.ROOT) }
+                .filter { it.isNotEmpty() }
+                .distinct()
+                .sorted()
+        }
+
+        private fun list(values: Iterable<String>?): String {
+            return canonicalValues(values).joinToString(",", transform = ::component)
+        }
+
+        /** Keep keys readable while preventing delimiters from becoming ambiguous. */
+        private fun component(value: String): String {
+            return buildString {
+                value.trim().lowercase(Locale.ROOT).forEach { character ->
+                    if (character.isLetterOrDigit() || character == '-' || character == '_' || character == '.') {
+                        append(character)
+                    } else {
+                        append('%')
+                        append(character.code.toString(16).padStart(2, '0'))
+                    }
+                }
+            }
+        }
+    }
+}
+
+enum class RefreshReason {
+    INITIAL,
+    APP_FOREGROUND,
+    SCREEN_VISIBLE,
+    PLAYBACK_RETURN,
+    NETWORK_RESTORED,
+    USER_PULL,
+    FOLLOW_STATE_CHANGED,
+    FILTER_CHANGED,
+    BACKGROUND_PREWARM,
+}
+
+enum class RefreshDecision {
+    REFRESH,
+    SKIP_FRESH,
+    SKIP_DEBOUNCED,
+    SKIP_BACKOFF,
+    JOIN,
+}
+
+internal fun refreshDecision(
+    nowMs: Long,
+    lastSuccessAt: Long?,
+    lastAttemptAt: Long?,
+    failureBackoffUntil: Long?,
+    rateLimitUntil: Long?,
+    force: Boolean,
+    ignoreFreshness: Boolean = false,
+): RefreshDecision {
+    if ((rateLimitUntil ?: 0L) > nowMs) return RefreshDecision.SKIP_BACKOFF
+    if (!force && (failureBackoffUntil ?: 0L) > nowMs) return RefreshDecision.SKIP_BACKOFF
+    if (!force && !ignoreFreshness && StreamFeedFreshnessPolicy.isFresh(nowMs, lastSuccessAt)) return RefreshDecision.SKIP_FRESH
+    if (!force && lastAttemptAt?.let { (nowMs - it).coerceAtLeast(0L) < StreamFeedFreshnessPolicy.AUTO_REFRESH_DEBOUNCE_MS } == true) {
+        return RefreshDecision.SKIP_DEBOUNCED
+    }
+    return RefreshDecision.REFRESH
+}
+
+internal fun shouldLaunchInitialRefresh(nowMs: Long, state: StreamFeedState?): Boolean {
+    if (state == null) return true
+    if ((state.rateLimitUntil ?: 0L) > nowMs || (state.failureBackoffUntil ?: 0L) > nowMs) return false
+    if (state.nextCursor?.isNotBlank() == true && state.nextCursorApi.isNullOrBlank()) return true
+    if (state.lastAttemptAt?.let { (nowMs - it).coerceAtLeast(0L) < StreamFeedFreshnessPolicy.AUTO_REFRESH_DEBOUNCE_MS } == true) {
+        return false
+    }
+    return !StreamFeedFreshnessPolicy.isFresh(nowMs, state.lastSuccessAt)
+}
+
+internal data class SingleFlightResult<T>(val value: T, val joined: Boolean)
+
+/** Small keyed single-flight primitive shared by all refresh triggers. */
+internal class StreamFeedSingleFlight<T>(private val scope: CoroutineScope) {
+    private val flights = ConcurrentHashMap<String, Deferred<T>>()
+
+    suspend fun run(key: String, block: suspend () -> T): SingleFlightResult<T> {
+        val existing = flights[key]
+        if (existing != null) {
+            return SingleFlightResult(existing.await(), joined = true)
+        }
+        var joined = false
+        val deferred = synchronized(flights) {
+            flights[key]?.also {
+                joined = true
+            } ?: scope.async(start = CoroutineStart.LAZY) { block() }.also { created ->
+                flights[key] = created
+                created.invokeOnCompletion { flights.remove(key, created) }
+            }
+        }
+        deferred.start()
+        return SingleFlightResult(deferred.await(), joined)
+    }
+
+    suspend fun awaitIfRunning(key: String) {
+        flights[key]?.await()
+    }
+}
+
+/** Central policy for volatile live-stream metadata. */
+object StreamFeedFreshnessPolicy {
+    const val LIVE_STREAM_SOFT_TTL_MS = 90_000L
+    const val VISIBLE_REVALIDATION_INTERVAL_MS = 2 * 60_000L
+    const val APP_BACKGROUND_THRESHOLD_MS = 30_000L
+    const val PLAYBACK_RETURN_THRESHOLD_MS = 45_000L
+    const val AUTO_REFRESH_DEBOUNCE_MS = 20_000L
+    const val AUTOMATIC_FAILURE_BACKOFF_MS = 60_000L
+    const val RATE_LIMIT_SAFETY_MARGIN_MS = 5_000L
+    const val PREWARM_DEFAULT_DELAY_MS = 15 * 60_000L
+    const val PREWARM_LEAD_TIME_MS = 2 * 60_000L
+    const val PREWARM_MIN_DELAY_MS = 10 * 60_000L
+    const val PREWARM_MAX_DELAY_MS = 6 * 60 * 60_000L
+    /** Keep the retained tail useful without eagerly refetching a deep feed. */
+    const val MAX_AUTOMATIC_TAIL_PREFETCH_PAGES = 1
+
+    fun cacheAge(nowMs: Long, lastSuccessAt: Long?): Long? {
+        return lastSuccessAt?.let { maxOf(0L, nowMs - it) }
+    }
+
+    fun isFresh(nowMs: Long, lastSuccessAt: Long?): Boolean {
+        return cacheAge(nowMs, lastSuccessAt)?.let { it < LIVE_STREAM_SOFT_TTL_MS } == true
+    }
+
+    fun backgroundWasMeaningful(awayMs: Long): Boolean = awayMs >= APP_BACKGROUND_THRESHOLD_MS
+
+    fun playbackWasMeaningful(viewedMs: Long): Boolean = viewedMs >= PLAYBACK_RETURN_THRESHOLD_MS
+
+    fun prewarmDelayMs(predictedReturnMs: Long?): Long {
+        if (predictedReturnMs == null) return PREWARM_DEFAULT_DELAY_MS
+        val predicted = predictedReturnMs
+        return (predicted - PREWARM_LEAD_TIME_MS).coerceIn(PREWARM_MIN_DELAY_MS, PREWARM_MAX_DELAY_MS)
+    }
+
+    fun updateReturnIntervalEwma(previousMs: Long?, sampleMs: Long): Long {
+        val sample = sampleMs.coerceAtLeast(0L)
+        return if (previousMs == null) {
+            sample
+        } else {
+            (previousMs * 0.5 + sample * 0.5).toLong()
+        }
+    }
+}
+
+data class StreamFeedSpec(
+    val key: StreamFeedKey,
+    val loader: StreamFeedPageLoader,
+)

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/streamfeed/StreamFeedPrewarmScheduler.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/streamfeed/StreamFeedPrewarmScheduler.kt
@@ -1,0 +1,55 @@
+package com.github.andreyasadchy.xtra.repository.streamfeed
+
+import android.content.Context
+import androidx.core.content.edit
+import androidx.work.Constraints
+import androidx.work.ExistingWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
+import com.github.andreyasadchy.xtra.util.C
+import com.github.andreyasadchy.xtra.util.prefs
+import java.util.concurrent.TimeUnit
+
+object StreamFeedPrewarmScheduler {
+    private const val WORK_NAME = "stream-feed-prewarm"
+
+    fun schedule(context: Context) {
+        val appContext = context.applicationContext
+        val predictedReturn = appContext.prefs().getLong(C.STREAM_FEED_RETURN_INTERVAL_MS, 0L)
+            .takeIf { it > 0L }
+        val delay = StreamFeedFreshnessPolicy.prewarmDelayMs(predictedReturn)
+        val request = OneTimeWorkRequestBuilder<StreamFeedPrewarmWorker>()
+            .setConstraints(
+                Constraints.Builder()
+                    .setRequiredNetworkType(NetworkType.CONNECTED)
+                    .setRequiresBatteryNotLow(true)
+                    .build()
+            )
+            .setInitialDelay(delay, TimeUnit.MILLISECONDS)
+            .build()
+        WorkManager.getInstance(appContext).enqueueUniqueWork(
+            WORK_NAME,
+            ExistingWorkPolicy.REPLACE,
+            request,
+        )
+    }
+
+    fun cancel(context: Context) {
+        WorkManager.getInstance(context.applicationContext).cancelUniqueWork(WORK_NAME)
+    }
+
+    fun recordBackgroundReturn(context: Context, awayMs: Long) {
+        if (awayMs <= 0L) return
+        val prefs = context.applicationContext.prefs()
+        val previous = prefs.getLong(C.STREAM_FEED_RETURN_INTERVAL_MS, 0L).takeIf { it > 0L }
+        val samples = prefs.getInt(C.STREAM_FEED_RETURN_SAMPLE_COUNT, 0)
+        prefs.edit {
+            putLong(
+                C.STREAM_FEED_RETURN_INTERVAL_MS,
+                StreamFeedFreshnessPolicy.updateReturnIntervalEwma(previous, awayMs),
+            )
+            putInt(C.STREAM_FEED_RETURN_SAMPLE_COUNT, (samples + 1).coerceAtMost(Int.MAX_VALUE))
+        }
+    }
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/streamfeed/StreamFeedPrewarmWorker.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/streamfeed/StreamFeedPrewarmWorker.kt
@@ -1,0 +1,77 @@
+package com.github.andreyasadchy.xtra.repository.streamfeed
+
+import android.content.Context
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import com.github.andreyasadchy.xtra.XtraApp
+import com.github.andreyasadchy.xtra.ui.common.StreamsSortDialog
+import com.github.andreyasadchy.xtra.util.C
+import com.github.andreyasadchy.xtra.util.tokenPrefs
+import kotlinx.coroutines.CancellationException
+
+internal fun shouldPrewarm(isForeground: Boolean, cacheFresh: Boolean): Boolean {
+    return !isForeground && !cacheFresh
+}
+
+/** One best-effort refresh of only the feeds useful on the next launch. */
+class StreamFeedPrewarmWorker(
+    appContext: Context,
+    params: WorkerParameters,
+) : CoroutineWorker(appContext, params) {
+
+    override suspend fun doWork(): Result {
+        val application = applicationContext.applicationContext as? XtraApp
+            ?: return Result.success()
+        if (application.isInForeground) return Result.success()
+
+        val module = application.xtraModule
+        val savedTop = module.gameSortRepository.getById("top_streams")
+        val top = StreamFeedSpecs.top(
+            context = application,
+            graphQLRepository = module.graphQLRepository,
+            helixRepository = module.helixRepository,
+            sort = savedTop?.streamSort ?: StreamsSortDialog.SORT_VIEWERS,
+            tags = savedTop?.streamTags?.split(',')?.takeIf { it.isNotEmpty() },
+            languages = savedTop?.streamLanguages?.split(',')?.takeIf { it.isNotEmpty() },
+        )
+        val followed = StreamFeedSpecs.followed(
+            context = application,
+            userId = application.tokenPrefs().getString(C.USER_ID, null),
+            localChannelFollowsRepository = module.localChannelFollowsRepository,
+            graphQLRepository = module.graphQLRepository,
+            helixRepository = module.helixRepository,
+        )
+
+        prewarmIfStale(application, top)
+        if (!application.isInForeground) {
+            prewarmIfStale(application, followed)
+        }
+        return Result.success()
+    }
+
+    private suspend fun prewarmIfStale(application: XtraApp, spec: StreamFeedSpec) {
+        bestEffort {
+            val state = application.xtraModule.streamFeedCache.state(spec.key)
+            val fresh = StreamFeedFreshnessPolicy.isFresh(
+                System.currentTimeMillis(),
+                state?.lastSuccessAt,
+            )
+            if (shouldPrewarm(application.isInForeground, fresh)) {
+                application.xtraModule.streamFeedRefreshCoordinator.maybeRefresh(
+                    spec,
+                    RefreshReason.BACKGROUND_PREWARM,
+                )
+            }
+        }
+    }
+
+    private suspend fun bestEffort(block: suspend () -> Unit) {
+        try {
+            block()
+        } catch (error: CancellationException) {
+            throw error
+        } catch (_: Exception) {
+            // Prewarm is opportunistic; foreground SWR remains authoritative.
+        }
+    }
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/streamfeed/StreamFeedRefreshCoordinator.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/streamfeed/StreamFeedRefreshCoordinator.kt
@@ -1,0 +1,381 @@
+package com.github.andreyasadchy.xtra.repository.streamfeed
+
+import android.os.SystemClock
+import android.util.Log
+import com.github.andreyasadchy.xtra.BuildConfig
+import com.github.andreyasadchy.xtra.repository.TwitchApiException
+import com.github.andreyasadchy.xtra.repository.datasource.StreamFeedPage
+import com.github.andreyasadchy.xtra.repository.datasource.StreamFeedCursor
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import java.util.concurrent.ConcurrentHashMap
+
+data class StreamRefreshResult(
+    val feedKey: StreamFeedKey,
+    val reason: RefreshReason,
+    val decision: RefreshDecision,
+    val cacheAgeMs: Long?,
+    val itemCount: Int = 0,
+    val durationMs: Long = 0L,
+    val joined: Boolean = false,
+)
+
+data class StreamAppendResult(
+    val page: StreamFeedPage?,
+    val endOfPaginationReached: Boolean,
+)
+
+/**
+ * App-scoped single-flight and freshness gate for all stream-feed triggers.
+ * The network operation is deliberately outside the UI/Paging layer; every
+ * successful result is committed through [StreamFeedCache].
+ */
+class StreamFeedRefreshCoordinator(
+    private val cache: StreamFeedCacheStore,
+    private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO),
+    private val wallClockMs: () -> Long = { System.currentTimeMillis() },
+    private val elapsedRealtimeMs: () -> Long = { SystemClock.elapsedRealtime() },
+    private val debugLoggingEnabled: Boolean = BuildConfig.DEBUG,
+) {
+    private val refreshFlights = StreamFeedSingleFlight<StreamRefreshResult>(scope)
+    private val appendFlights = StreamFeedSingleFlight<StreamAppendResult>(scope)
+    private val feedLocks = ConcurrentHashMap<String, Mutex>()
+
+    @Volatile
+    private var visibleFeed: StreamFeedSpec? = null
+
+    @Volatile
+    private var livePlaybackStartedElapsedMs: Long? = null
+
+    @Volatile
+    private var playerFullscreen = false
+
+    fun setVisibleFeed(spec: StreamFeedSpec) {
+        visibleFeed = spec
+    }
+
+    fun clearVisibleFeed(feedKey: StreamFeedKey) {
+        if (visibleFeed?.key == feedKey) {
+            visibleFeed = null
+        }
+    }
+
+    fun currentVisibleFeed(): StreamFeedSpec? = visibleFeed
+
+    suspend fun maybeRefresh(spec: StreamFeedSpec, reason: RefreshReason): StreamRefreshResult {
+        return requestRefresh(spec, reason, force = false)
+    }
+
+    suspend fun forceRefresh(spec: StreamFeedSpec, reason: RefreshReason): StreamRefreshResult {
+        return requestRefresh(spec, reason, force = true)
+    }
+
+    private suspend fun requestRefresh(
+        spec: StreamFeedSpec,
+        reason: RefreshReason,
+        force: Boolean,
+    ): StreamRefreshResult {
+        val result = refreshFlights.run(spec.key.value) {
+            executeRefresh(spec, reason, force)
+        }
+        if (result.joined) {
+            debug(spec, reason, RefreshDecision.JOIN, null, "in-flight")
+            return result.value.copy(joined = true)
+        }
+        return result.value
+    }
+
+    private suspend fun executeRefresh(
+        spec: StreamFeedSpec,
+        reason: RefreshReason,
+        force: Boolean,
+    ): StreamRefreshResult {
+        val lock = feedLocks.getOrPut(spec.key.value) { Mutex() }
+        return lock.withLock {
+            val now = wallClockMs()
+            val state = cache.state(spec.key)
+            val age = StreamFeedFreshnessPolicy.cacheAge(now, state?.lastSuccessAt)
+            val rateLimitUntil = state?.rateLimitUntil ?: 0L
+            val failureBackoffUntil = state?.failureBackoffUntil ?: 0L
+            val lastAttemptAge = state?.lastAttemptAt?.let { maxOf(0L, now - it) }
+            val hasLegacyCursorWithoutApi = state?.nextCursor?.isNotBlank() == true && state.nextCursorApi.isNullOrBlank()
+
+            when (refreshDecision(
+                now,
+                state?.lastSuccessAt,
+                state?.lastAttemptAt,
+                failureBackoffUntil,
+                rateLimitUntil,
+                force,
+                ignoreFreshness = hasLegacyCursorWithoutApi,
+            )) {
+                RefreshDecision.SKIP_BACKOFF -> {
+                    debug(spec, reason, RefreshDecision.SKIP_BACKOFF, age, "backoff")
+                    return@withLock StreamRefreshResult(spec.key, reason, RefreshDecision.SKIP_BACKOFF, age)
+                }
+                RefreshDecision.SKIP_FRESH -> {
+                    debug(spec, reason, RefreshDecision.SKIP_FRESH, age, "ttl")
+                    return@withLock StreamRefreshResult(spec.key, reason, RefreshDecision.SKIP_FRESH, age)
+                }
+                RefreshDecision.SKIP_DEBOUNCED -> {
+                    debug(spec, reason, RefreshDecision.SKIP_DEBOUNCED, age, "attempt-age=$lastAttemptAge")
+                    return@withLock StreamRefreshResult(spec.key, reason, RefreshDecision.SKIP_DEBOUNCED, age)
+                }
+                RefreshDecision.REFRESH -> Unit
+                RefreshDecision.JOIN -> error("JOIN is handled before the feed lock")
+            }
+
+            val preserveTail = reason != RefreshReason.USER_PULL &&
+                    reason != RefreshReason.FILTER_CHANGED &&
+                    reason != RefreshReason.FOLLOW_STATE_CHANGED
+            val cachedItemCount = if (preserveTail) cache.itemCount(spec.key) else 0
+            val started = elapsedRealtimeMs()
+            cache.markAttempt(spec.key, now)
+            try {
+                val page = spec.loader.load(cursor = null)
+                val completedAt = wallClockMs()
+                cache.replaceAfterRefresh(
+                    spec.key,
+                    page,
+                    completedAt,
+                    preserveTail = preserveTail,
+                    pruneStaleOnEnd = !preserveTail,
+                )
+                if (shouldPrefetchTail(
+                        reason = reason,
+                        preserveTail = preserveTail,
+                        cachedItemCount = cachedItemCount,
+                        firstPageItemCount = page.items.size,
+                        nextCursorPresent = page.nextCursor != null,
+                    )
+                ) {
+                    scope.launch {
+                        try {
+                            var prefetchedPages = 0
+                            while (prefetchedPages < StreamFeedFreshnessPolicy.MAX_AUTOMATIC_TAIL_PREFETCH_PAGES) {
+                                prefetchedPages++
+                                if (append(spec, speculative = true).endOfPaginationReached) break
+                            }
+                        } catch (error: CancellationException) {
+                            throw error
+                        } catch (error: Exception) {
+                            debug(
+                                spec,
+                                reason,
+                                RefreshDecision.REFRESH,
+                                age,
+                                "tail-prefetch-failure=${error::class.simpleName}:${error.message}",
+                            )
+                        }
+                    }
+                }
+                cache.cleanup(completedAt)
+                val duration = elapsedRealtimeMs() - started
+                debug(spec, reason, RefreshDecision.REFRESH, age, "success items=${page.items.size} duration=$duration")
+                StreamRefreshResult(spec.key, reason, RefreshDecision.REFRESH, age, page.items.size, duration)
+            } catch (error: CancellationException) {
+                throw error
+            } catch (error: Exception) {
+                val failedAt = wallClockMs()
+                val limitedUntil = rateLimitUntil(error, failedAt)
+                val failureUntil = if (limitedUntil == null) {
+                    failedAt + StreamFeedFreshnessPolicy.AUTOMATIC_FAILURE_BACKOFF_MS
+                } else {
+                    null
+                }
+                cache.recordFailure(spec.key, failedAt, failureUntil, limitedUntil)
+                debug(spec, reason, RefreshDecision.REFRESH, age, "failure=${error::class.simpleName}:${error.message}")
+                throw error
+            }
+        }
+    }
+
+    suspend fun append(spec: StreamFeedSpec): StreamAppendResult {
+        return append(spec, speculative = false)
+    }
+
+    private suspend fun append(spec: StreamFeedSpec, speculative: Boolean): StreamAppendResult {
+        // A user-driven append must not join an optional prefetch that is
+        // about to fail. Both paths still serialize through feedLocks, so
+        // there is never more than one append request on the wire.
+        val flightKey = if (speculative) {
+            "speculative:${spec.key.value}"
+        } else {
+            spec.key.value
+        }
+        return appendFlights.run(flightKey) {
+            executeAppend(spec, speculative)
+        }.value
+    }
+
+    private suspend fun executeAppend(spec: StreamFeedSpec, speculative: Boolean): StreamAppendResult {
+        refreshFlights.awaitIfRunning(spec.key.value)
+        val lock = feedLocks.getOrPut(spec.key.value) { Mutex() }
+        return lock.withLock {
+            val now = wallClockMs()
+            val state = cache.state(spec.key)
+            val cursor = state?.nextCursor
+                ?.takeIf { it.isNotBlank() }
+                ?.let { value -> state.nextCursorApi?.let { api -> StreamFeedCursor(api, value) } }
+            if (cursor == null) {
+                if (!speculative) {
+                    cache.pruneStaleGeneration(spec.key)
+                }
+                return@withLock StreamAppendResult(null, endOfPaginationReached = true)
+            }
+            val blockedUntil = maxOf(state.rateLimitUntil ?: 0L, state.failureBackoffUntil ?: 0L)
+            if (blockedUntil > now) {
+                throw IllegalStateException("Stream feed refresh is backed off")
+            }
+            val started = elapsedRealtimeMs()
+            cache.markAttempt(spec.key, now)
+            try {
+                val page = spec.loader.load(cursor)
+                val completedAt = wallClockMs()
+                cache.appendPage(
+                    spec.key,
+                    page,
+                    completedAt,
+                    pruneStaleOnEnd = !speculative,
+                )
+                cache.cleanup(completedAt)
+                debug(spec, RefreshReason.SCREEN_VISIBLE, RefreshDecision.REFRESH, null, "append items=${page.items.size} duration=${elapsedRealtimeMs() - started}")
+                StreamAppendResult(page, page.nextCursor == null)
+            } catch (error: CancellationException) {
+                throw error
+            } catch (error: Exception) {
+                val failedAt = wallClockMs()
+                val limitedUntil = rateLimitUntil(error, failedAt)
+                cache.recordFailure(
+                    spec.key,
+                    failedAt,
+                    if (limitedUntil == null && !speculative) {
+                        failedAt + StreamFeedFreshnessPolicy.AUTOMATIC_FAILURE_BACKOFF_MS
+                    } else {
+                        null
+                    },
+                    limitedUntil,
+                )
+                throw error
+            }
+        }
+    }
+
+    private fun shouldPrefetchTail(
+        reason: RefreshReason,
+        preserveTail: Boolean,
+        cachedItemCount: Int,
+        firstPageItemCount: Int,
+        nextCursorPresent: Boolean,
+    ): Boolean {
+        return StreamFeedFreshnessPolicy.MAX_AUTOMATIC_TAIL_PREFETCH_PAGES > 0 &&
+                reason != RefreshReason.BACKGROUND_PREWARM &&
+                preserveTail &&
+                cachedItemCount > firstPageItemCount &&
+                nextCursorPresent
+    }
+
+    fun onAppForeground(awayMs: Long) {
+        if (!StreamFeedFreshnessPolicy.backgroundWasMeaningful(awayMs)) return
+        val spec = visibleFeed ?: return
+        scope.launch {
+            runCatching { maybeRefresh(spec, RefreshReason.APP_FOREGROUND) }
+        }
+    }
+
+    fun onNetworkRestored() {
+        val spec = visibleFeed ?: return
+        scope.launch {
+            runCatching { forceRefresh(spec, RefreshReason.NETWORK_RESTORED) }
+        }
+    }
+
+    val isPlayerFullscreen: Boolean
+        get() = playerFullscreen
+
+    /** Mark any fullscreen player active; only a live stream starts the freshness timer. */
+    fun playbackEntered(isLive: Boolean = true) {
+        playerFullscreen = true
+        if (isLive && livePlaybackStartedElapsedMs == null) {
+            livePlaybackStartedElapsedMs = elapsedRealtimeMs()
+        } else if (!isLive) {
+            livePlaybackStartedElapsedMs = null
+        }
+    }
+
+    /** Switch content while keeping the player fullscreen. */
+    fun playbackChanged(isLive: Boolean) {
+        playerFullscreen = true
+        if (isLive) {
+            if (livePlaybackStartedElapsedMs == null) {
+                livePlaybackStartedElapsedMs = elapsedRealtimeMs()
+            }
+        } else {
+            // Do not count VOD/clip/offline viewing as live-stream viewing and
+            // do not pretend the user returned to the browsing screen.
+            livePlaybackStartedElapsedMs = null
+        }
+    }
+
+    fun playbackReturned() {
+        playerFullscreen = false
+        val started = livePlaybackStartedElapsedMs ?: return
+        livePlaybackStartedElapsedMs = null
+        val viewedMs = (elapsedRealtimeMs() - started).coerceAtLeast(0L)
+        if (!StreamFeedFreshnessPolicy.playbackWasMeaningful(viewedMs)) return
+        val spec = visibleFeed ?: return
+        scope.launch {
+            runCatching { maybeRefresh(spec, RefreshReason.PLAYBACK_RETURN) }
+        }
+    }
+
+    /** Mark followed data stale without deleting it, then refresh only the visible variant. */
+    fun invalidateFollowedFeeds() {
+        scope.launch {
+            val now = wallClockMs()
+            cache.invalidatePrefix("followed:", now)
+            visibleFeed?.takeIf { it.key.value.startsWith("followed:") }?.let {
+                runCatching { forceRefresh(it, RefreshReason.FOLLOW_STATE_CHANGED) }
+            }
+        }
+    }
+
+    private fun rateLimitUntil(error: Exception, nowMs: Long): Long? {
+        val twitchError = error as? TwitchApiException
+        if (twitchError == null ||
+            (twitchError.statusCode != 429 && twitchError.rateLimitRemaining != 0L)
+        ) {
+            return null
+        }
+        val reset = twitchError.rateLimitResetEpochSeconds
+        if (reset != null) {
+            return maxOf(
+                nowMs + StreamFeedFreshnessPolicy.RATE_LIMIT_SAFETY_MARGIN_MS,
+                reset * 1_000L + StreamFeedFreshnessPolicy.RATE_LIMIT_SAFETY_MARGIN_MS,
+            )
+        }
+        return if (twitchError.statusCode == 429) {
+            nowMs + 60_000L + StreamFeedFreshnessPolicy.RATE_LIMIT_SAFETY_MARGIN_MS
+        } else null
+    }
+
+    private fun debug(
+        spec: StreamFeedSpec,
+        reason: RefreshReason,
+        decision: RefreshDecision,
+        cacheAgeMs: Long?,
+        details: String,
+    ) {
+        if (debugLoggingEnabled) {
+            Log.d(
+                "StreamFeedRefresh",
+                "feed=${spec.key.value} reason=$reason age=${cacheAgeMs ?: "missing"} decision=$decision $details",
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/streamfeed/StreamFeedRemoteMediator.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/streamfeed/StreamFeedRemoteMediator.kt
@@ -1,0 +1,71 @@
+package com.github.andreyasadchy.xtra.repository.streamfeed
+
+import androidx.paging.LoadType
+import androidx.paging.PagingState
+import androidx.paging.RemoteMediator
+import com.github.andreyasadchy.xtra.db.CachedStreamFeedItem
+
+@OptIn(androidx.paging.ExperimentalPagingApi::class)
+class StreamFeedRemoteMediator(
+    private val spec: StreamFeedSpec,
+    private val cache: StreamFeedCacheStore,
+    private val coordinator: StreamFeedRefreshCoordinator,
+    private val wallClockMs: () -> Long = { System.currentTimeMillis() },
+) : RemoteMediator<Int, CachedStreamFeedItem>() {
+
+    private var initialRefreshRequested = false
+
+    override suspend fun initialize(): InitializeAction {
+        val now = wallClockMs()
+        cache.touchAccess(spec.key, now)
+        val state = cache.state(spec.key)
+        initialRefreshRequested = shouldLaunchInitialRefresh(now, state)
+        return if (initialRefreshRequested) {
+            InitializeAction.LAUNCH_INITIAL_REFRESH
+        } else {
+            InitializeAction.SKIP_INITIAL_REFRESH
+        }
+    }
+
+    override suspend fun load(
+        loadType: LoadType,
+        state: PagingState<Int, CachedStreamFeedItem>,
+    ): MediatorResult {
+        return try {
+            when (loadType) {
+                LoadType.PREPEND -> MediatorResult.Success(endOfPaginationReached = true)
+                LoadType.REFRESH -> {
+                    // The initial stale/missing refresh is still automatic and
+                    // must respect failure backoff. Only an explicit adapter
+                    // refresh bypasses the freshness gate.
+                    val isInitialRefresh = initialRefreshRequested
+                    // A failed initial load must not leave the next retry
+                    // pretending to be the same Paging generation forever.
+                    // An explicit retry becomes a force refresh, while the
+                    // coordinator still honors Twitch's rate-limit deadline.
+                    initialRefreshRequested = false
+                    val result = if (isInitialRefresh) {
+                        coordinator.maybeRefresh(spec, RefreshReason.INITIAL)
+                    } else {
+                        coordinator.forceRefresh(spec, RefreshReason.USER_PULL)
+                    }
+                    when (result.decision) {
+                        RefreshDecision.SKIP_BACKOFF,
+                        RefreshDecision.SKIP_DEBOUNCED,
+                        RefreshDecision.SKIP_FRESH,
+                        -> MediatorResult.Success(endOfPaginationReached = true)
+                        RefreshDecision.REFRESH,
+                        RefreshDecision.JOIN,
+                        -> MediatorResult.Success(endOfPaginationReached = false)
+                    }
+                }
+                LoadType.APPEND -> {
+                    val result = coordinator.append(spec)
+                    MediatorResult.Success(result.endOfPaginationReached)
+                }
+            }
+        } catch (error: Exception) {
+            MediatorResult.Error(error)
+        }
+    }
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/streamfeed/StreamFeedSpecs.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/streamfeed/StreamFeedSpecs.kt
@@ -1,0 +1,123 @@
+package com.github.andreyasadchy.xtra.repository.streamfeed
+
+import android.content.Context
+import com.github.andreyasadchy.xtra.graphql.type.Language
+import com.github.andreyasadchy.xtra.graphql.type.StreamSort
+import com.github.andreyasadchy.xtra.repository.GraphQLRepository
+import com.github.andreyasadchy.xtra.repository.HelixRepository
+import com.github.andreyasadchy.xtra.repository.LocalChannelFollowsRepository
+import com.github.andreyasadchy.xtra.repository.datasource.FollowedStreamsPageLoader
+import com.github.andreyasadchy.xtra.repository.datasource.GameStreamsPageLoader
+import com.github.andreyasadchy.xtra.repository.datasource.TopStreamsPageLoader
+import com.github.andreyasadchy.xtra.ui.common.StreamsSortDialog
+import com.github.andreyasadchy.xtra.util.C
+import com.github.andreyasadchy.xtra.util.TwitchApiHelper
+import com.github.andreyasadchy.xtra.util.prefs
+import java.util.Locale
+
+object StreamFeedSpecs {
+
+    fun top(
+        context: Context,
+        graphQLRepository: GraphQLRepository,
+        helixRepository: HelixRepository,
+        sort: String,
+        tags: Iterable<String>?,
+        languages: Iterable<String>?,
+    ): StreamFeedSpec {
+        val apiTags = apiValues(tags)
+        val apiLanguages = apiValues(languages)
+        return StreamFeedSpec(
+            key = StreamFeedKey.top(sort, apiTags, apiLanguages),
+            loader = TopStreamsPageLoader(
+                gqlQueryLanguages = apiLanguages.takeIf { it.isNotEmpty() }?.mapNotNull { value -> Language.entries.find { it.rawValue == value } },
+                gqlQuerySort = querySort(sort),
+                gqlLanguages = apiLanguages.takeIf { it.isNotEmpty() },
+                gqlSort = querySortName(sort),
+                tags = apiTags.takeIf { it.isNotEmpty() },
+                gqlHeaders = { TwitchApiHelper.getGQLHeaders(context) },
+                graphQLRepository = graphQLRepository,
+                helixHeaders = { TwitchApiHelper.getHelixHeaders(context) },
+                helixRepository = helixRepository,
+                enableIntegrity = context.prefs().getBoolean(C.ENABLE_INTEGRITY, false),
+                networkLibrary = context.prefs().getString(C.NETWORK_LIBRARY, C.OKHTTP),
+            ),
+        )
+    }
+
+    fun followed(
+        context: Context,
+        userId: String?,
+        localChannelFollowsRepository: LocalChannelFollowsRepository,
+        graphQLRepository: GraphQLRepository,
+        helixRepository: HelixRepository,
+    ): StreamFeedSpec {
+        return StreamFeedSpec(
+            key = StreamFeedKey.followed(userId),
+            loader = FollowedStreamsPageLoader(
+                userId = userId,
+                localChannelFollowsRepository = localChannelFollowsRepository,
+                gqlHeaders = { TwitchApiHelper.getGQLHeaders(context, true) },
+                graphQLRepository = graphQLRepository,
+                helixHeaders = { TwitchApiHelper.getHelixHeaders(context) },
+                helixRepository = helixRepository,
+                enableIntegrity = context.prefs().getBoolean(C.ENABLE_INTEGRITY, false),
+                networkLibrary = context.prefs().getString(C.NETWORK_LIBRARY, C.OKHTTP),
+            ),
+        )
+    }
+
+    fun game(
+        context: Context,
+        graphQLRepository: GraphQLRepository,
+        helixRepository: HelixRepository,
+        gameId: String?,
+        gameSlug: String?,
+        gameName: String?,
+        sort: String,
+        tags: Iterable<String>?,
+        languages: Iterable<String>?,
+    ): StreamFeedSpec {
+        val apiTags = apiValues(tags)
+        val apiLanguages = apiValues(languages)
+        return StreamFeedSpec(
+            key = StreamFeedKey.game(gameId, gameSlug, gameName, sort, apiTags, apiLanguages),
+            loader = GameStreamsPageLoader(
+                gameId = gameId,
+                gameSlug = gameSlug,
+                gameName = gameName,
+                gqlQueryLanguages = apiLanguages.takeIf { it.isNotEmpty() }?.mapNotNull { value -> Language.entries.find { it.rawValue == value } },
+                gqlQuerySort = querySort(sort),
+                gqlLanguages = apiLanguages.takeIf { it.isNotEmpty() },
+                gqlSort = querySortName(sort),
+                tags = apiTags.takeIf { it.isNotEmpty() },
+                gqlHeaders = { TwitchApiHelper.getGQLHeaders(context) },
+                graphQLRepository = graphQLRepository,
+                helixHeaders = { TwitchApiHelper.getHelixHeaders(context) },
+                helixRepository = helixRepository,
+                enableIntegrity = context.prefs().getBoolean(C.ENABLE_INTEGRITY, false),
+                networkLibrary = context.prefs().getString(C.NETWORK_LIBRARY, C.OKHTTP),
+            ),
+        )
+    }
+
+    private fun apiValues(values: Iterable<String>?): List<String> {
+        return values?.toList().orEmpty()
+            .map { it.trim() }
+            .filter { it.isNotEmpty() }
+            .distinctBy { it.lowercase(Locale.ROOT) }
+            .sortedBy { it.lowercase(Locale.ROOT) }
+    }
+
+    private fun querySort(sort: String): StreamSort = when (sort) {
+        StreamsSortDialog.SORT_VIEWERS_ASC -> StreamSort.VIEWER_COUNT_ASC
+        StreamsSortDialog.RECENT -> StreamSort.RECENT
+        else -> StreamSort.VIEWER_COUNT
+    }
+
+    private fun querySortName(sort: String): String = when (sort) {
+        StreamsSortDialog.SORT_VIEWERS_ASC -> "VIEWER_COUNT_ASC"
+        StreamsSortDialog.RECENT -> "RECENT"
+        else -> "VIEWER_COUNT"
+    }
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/channel/ChannelPagerViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/channel/ChannelPagerViewModel.kt
@@ -21,6 +21,7 @@ import com.github.andreyasadchy.xtra.repository.HelixRepository
 import com.github.andreyasadchy.xtra.repository.LocalChannelFollowsRepository
 import com.github.andreyasadchy.xtra.repository.NotificationsRepository
 import com.github.andreyasadchy.xtra.repository.OfflineVideosRepository
+import com.github.andreyasadchy.xtra.repository.streamfeed.StreamFeedRefreshCoordinator
 import com.github.andreyasadchy.xtra.util.C
 import com.github.andreyasadchy.xtra.util.NetworkUtils
 import com.github.andreyasadchy.xtra.util.NetworkUtils.executeAsync
@@ -49,6 +50,7 @@ class ChannelPagerViewModel(
     private val cronetEngine: Lazy<CronetEngine?>,
     private val cronetExecutor: Lazy<ExecutorService>,
     private val okHttpClient: Lazy<OkHttpClient>,
+    private val streamFeedRefreshCoordinator: StreamFeedRefreshCoordinator,
     savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
 
@@ -308,6 +310,7 @@ class ChannelPagerViewModel(
                                     notificationsRepository.saveList(listOf(ShownNotification(channelId, it)))
                                 }
                             }
+                            streamFeedRefreshCoordinator.invalidateFollowedFeeds()
                         }
                     } else {
                         localChannelFollowsRepository.save(LocalChannelFollow(channelId, channelLogin, channelName))
@@ -352,6 +355,7 @@ class ChannelPagerViewModel(
                             follow.value = Pair(false, null)
                             _notificationsEnabled.value = false
                             notificationsRepository.deleteUser(NotificationUser(channelId))
+                            streamFeedRefreshCoordinator.invalidateFollowedFeeds()
                         }
                     } else {
                         localChannelFollowsRepository.getById(channelId)?.let { localChannelFollowsRepository.delete(it) }
@@ -469,7 +473,7 @@ class ChannelPagerViewModel(
                 val savedStateHandle = createSavedStateHandle()
                 val application = (this[APPLICATION_KEY] as XtraApp)
                 val xtraModule = application.xtraModule
-                ChannelPagerViewModel(xtraModule.localChannelFollowsRepository, xtraModule.offlineVideosRepository, xtraModule.bookmarksRepository, xtraModule.notificationsRepository, xtraModule.graphQLRepository, xtraModule.helixRepository, xtraModule.httpEngine, xtraModule.cronetEngine, xtraModule.cronetExecutor, xtraModule.okHttpClient, savedStateHandle)
+                ChannelPagerViewModel(xtraModule.localChannelFollowsRepository, xtraModule.offlineVideosRepository, xtraModule.bookmarksRepository, xtraModule.notificationsRepository, xtraModule.graphQLRepository, xtraModule.helixRepository, xtraModule.httpEngine, xtraModule.cronetEngine, xtraModule.cronetExecutor, xtraModule.okHttpClient, xtraModule.streamFeedRefreshCoordinator, savedStateHandle)
             }
         }
     }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/BaseNetworkFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/BaseNetworkFragment.kt
@@ -26,6 +26,8 @@ abstract class BaseNetworkFragment : Fragment() {
     private val mainViewModel: MainViewModel by activityViewModels { MainViewModelFactory }
 
     protected open var enableNetworkCheck = true
+    /** Cache-backed screens can render Room data before a network is validated. */
+    protected open val initializeWithoutNetwork = false
     private var lastIsOnlineState = false
     private var shouldRestore = false
     protected var isInitialized = false
@@ -91,7 +93,7 @@ abstract class BaseNetworkFragment : Fragment() {
         super.onResume()
         if (enableNetworkCheck) {
             if (!isInitialized) {
-                if (created || lastIsOnlineState) {
+                if (created || lastIsOnlineState || initializeWithoutNetwork) {
                     init()
                 }
             } else if (shouldRestore && lastIsOnlineState) {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/PagedListFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/PagedListFragment.kt
@@ -27,25 +27,9 @@ abstract class PagedListFragment : BaseNetworkFragment(), IntegrityDialog.Listen
     private var pageErrorSnackbar: Snackbar? = null
     private var pageError: LoadState.Error? = null
     private var pageErrorState: PagedListErrorState? = null
+    private var manualRefreshRequested = false
 
     fun <T : Any, VH : RecyclerView.ViewHolder> setAdapter(recyclerView: RecyclerView, adapter: PagingDataAdapter<T, VH>) {
-        adapter.registerAdapterDataObserver(object : RecyclerView.AdapterDataObserver() {
-
-            override fun onItemRangeInserted(positionStart: Int, itemCount: Int) {
-                adapter.unregisterAdapterDataObserver(this)
-                adapter.registerAdapterDataObserver(object : RecyclerView.AdapterDataObserver() {
-                    override fun onItemRangeInserted(positionStart: Int, itemCount: Int) {
-                        try {
-                            if (positionStart == 0) {
-                                recyclerView.scrollToPosition(0)
-                            }
-                        } catch (e: Exception) {
-
-                        }
-                    }
-                })
-            }
-        })
         recyclerView.adapter = adapter
     }
 
@@ -123,7 +107,10 @@ abstract class PagedListFragment : BaseNetworkFragment(), IntegrityDialog.Listen
         binding.retryButton.setOnClickListener { pagingAdapter.retry() }
         binding.swipeRefresh.isEnabled = enableSwipeRefresh
         if (enableSwipeRefresh) {
-            binding.swipeRefresh.setOnRefreshListener { pagingAdapter.refresh() }
+            binding.swipeRefresh.setOnRefreshListener {
+                manualRefreshRequested = true
+                pagingAdapter.refresh()
+            }
         }
     }
 
@@ -134,11 +121,29 @@ abstract class PagedListFragment : BaseNetworkFragment(), IntegrityDialog.Listen
         showEmpty: Boolean = true,
         enableSwipeRefresh: Boolean = true,
     ) {
-        val contentState = pagedListContentState(loadState.refresh, pagingAdapter.itemCount)
-        val refreshError = loadState.refresh as? LoadState.Error
-        val appendError = loadState.append as? LoadState.Error
-        val prependError = loadState.prepend as? LoadState.Error
-        val errorState = pagedListErrorState(loadState.refresh, loadState.append, loadState.prepend)
+        val sourceRefresh = loadState.source.refresh
+        val mediatorRefresh = loadState.mediator?.refresh
+        val sourceAppend = loadState.source.append
+        val sourcePrepend = loadState.source.prepend
+        val mediatorAppend = loadState.mediator?.append
+        val mediatorPrepend = loadState.mediator?.prepend
+        val contentState = cacheAwarePagedListContentState(sourceRefresh, mediatorRefresh, pagingAdapter.itemCount)
+        val sourceRefreshError = sourceRefresh as? LoadState.Error
+        val mediatorRefreshError = mediatorRefresh as? LoadState.Error
+        val refreshError = sourceRefreshError ?: mediatorRefreshError
+        val appendError = (sourceAppend as? LoadState.Error) ?: (mediatorAppend as? LoadState.Error)
+        val prependError = (sourcePrepend as? LoadState.Error) ?: (mediatorPrepend as? LoadState.Error)
+        val manualRefreshWasRequested = manualRefreshRequested
+        val showRefreshError = shouldShowPagedListRefreshError(
+            sourceRefreshError = sourceRefreshError != null,
+            mediatorRefreshError = mediatorRefreshError != null,
+            manualRefreshRequested = manualRefreshWasRequested,
+        )
+        val errorState = when {
+            refreshError != null && showRefreshError -> PagedListErrorState.Refresh
+            appendError != null || prependError != null -> PagedListErrorState.Page
+            else -> null
+        }
         val pageError = when (errorState) {
             PagedListErrorState.Refresh -> refreshError
             PagedListErrorState.Page -> appendError ?: prependError
@@ -148,13 +153,22 @@ abstract class PagedListFragment : BaseNetworkFragment(), IntegrityDialog.Listen
         binding.progressBar.isVisible = contentState == PagedListContentState.Loading
         binding.nothingHere.isVisible = showEmpty && contentState == PagedListContentState.Empty
         binding.errorContainer.isVisible = showEmpty && contentState == PagedListContentState.Error
-        binding.retryButton.isVisible = refreshError != null
-        if (showEmpty && refreshError != null) {
+        binding.retryButton.isVisible = pagingAdapter.itemCount == 0 && refreshError != null
+        if (showEmpty && pagingAdapter.itemCount == 0 && refreshError != null) {
             binding.errorMessage.setText(R.string.list_load_error)
         }
 
         if (enableSwipeRefresh) {
-            binding.swipeRefresh.isRefreshing = contentState == PagedListContentState.Content && loadState.refresh is LoadState.Loading
+            // Keep automatic mediator revalidation silent while cached rows are visible.
+            val refreshLoading = sourceRefresh is LoadState.Loading || mediatorRefresh is LoadState.Loading
+            binding.swipeRefresh.isRefreshing = shouldShowPagedListSwipeRefresh(
+                refreshLoading = refreshLoading,
+                itemCount = pagingAdapter.itemCount,
+                manualRefreshRequested = manualRefreshRequested,
+            )
+            if (!refreshLoading) {
+                manualRefreshRequested = false
+            }
         }
 
         if (pageError != null && pagingAdapter.itemCount > 0) {
@@ -169,7 +183,7 @@ abstract class PagedListFragment : BaseNetworkFragment(), IntegrityDialog.Listen
                     } else {
                         R.string.list_load_more_error
                     },
-                    Snackbar.LENGTH_INDEFINITE,
+                    Snackbar.LENGTH_LONG,
                 ).setAction(R.string.retry) { pagingAdapter.retry() }
                 pageErrorSnackbar?.show()
             }
@@ -190,6 +204,7 @@ abstract class PagedListFragment : BaseNetworkFragment(), IntegrityDialog.Listen
         pageErrorSnackbar = null
         pageError = null
         pageErrorState = null
+        manualRefreshRequested = false
         super.onDestroyView()
     }
 }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/PagedListState.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/PagedListState.kt
@@ -23,6 +23,39 @@ internal fun pagedListContentState(refresh: LoadState, itemCount: Int): PagedLis
     }
 }
 
+/**
+ * RemoteMediator refreshes synchronize the cache; they must not hide rows
+ * already supplied by the Room PagingSource.
+ */
+internal fun cacheAwarePagedListContentState(
+    sourceRefresh: LoadState,
+    mediatorRefresh: LoadState?,
+    itemCount: Int,
+): PagedListContentState {
+    return when {
+        itemCount > 0 -> PagedListContentState.Content
+        sourceRefresh is LoadState.Loading || mediatorRefresh is LoadState.Loading -> PagedListContentState.Loading
+        sourceRefresh is LoadState.Error || mediatorRefresh is LoadState.Error -> PagedListContentState.Error
+        else -> PagedListContentState.Empty
+    }
+}
+
+internal fun shouldShowPagedListSwipeRefresh(
+    refreshLoading: Boolean,
+    itemCount: Int,
+    manualRefreshRequested: Boolean,
+): Boolean {
+    return refreshLoading && (itemCount == 0 || manualRefreshRequested)
+}
+
+internal fun shouldShowPagedListRefreshError(
+    sourceRefreshError: Boolean,
+    mediatorRefreshError: Boolean,
+    manualRefreshRequested: Boolean,
+): Boolean {
+    return sourceRefreshError || (mediatorRefreshError && manualRefreshRequested)
+}
+
 internal fun pagedListErrorState(
     refresh: LoadState,
     append: LoadState,

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/StreamFeedScreenController.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/StreamFeedScreenController.kt
@@ -1,0 +1,76 @@
+package com.github.andreyasadchy.xtra.ui.common
+
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import com.github.andreyasadchy.xtra.repository.streamfeed.RefreshReason
+import com.github.andreyasadchy.xtra.repository.streamfeed.StreamFeedFreshnessPolicy
+import com.github.andreyasadchy.xtra.repository.streamfeed.StreamFeedRefreshCoordinator
+import com.github.andreyasadchy.xtra.repository.streamfeed.StreamFeedSpec
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+
+/**
+ * Connects a visible stream screen to the app-scoped freshness coordinator.
+ * The view remains owned by Room/Paging; this class only supplies user-visible
+ * revalidation signals while the fragment is actually resumed.
+ */
+class StreamFeedScreenController(
+    private val fragment: Fragment,
+    private val coordinator: StreamFeedRefreshCoordinator,
+    private val specProvider: () -> StreamFeedSpec?,
+) {
+    private var tickerJob: Job? = null
+
+    fun start() {
+        tickerJob?.cancel()
+        tickerJob = fragment.viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                while (isActive) {
+                    delay(StreamFeedFreshnessPolicy.VISIBLE_REVALIDATION_INTERVAL_MS)
+                    if (fragment.lifecycle.currentState.isAtLeast(Lifecycle.State.RESUMED) && !coordinator.isPlayerFullscreen) {
+                        revalidate(RefreshReason.SCREEN_VISIBLE)
+                    }
+                }
+            }
+        }
+    }
+
+    fun onResume() {
+        if (!coordinator.isPlayerFullscreen) {
+            revalidate(RefreshReason.SCREEN_VISIBLE)
+        }
+    }
+
+    fun onPause() {
+        // Keep the last browsing feed available for an activity-foreground or
+        // player-return signal. A newly resumed screen replaces it.
+    }
+
+    fun onSpecChanged(force: Boolean, reason: RefreshReason = RefreshReason.FILTER_CHANGED) {
+        val spec = specProvider() ?: return
+        coordinator.setVisibleFeed(spec)
+        if (coordinator.isPlayerFullscreen) return
+        fragment.viewLifecycleOwner.lifecycleScope.launch {
+            runCatching {
+                if (force) coordinator.forceRefresh(spec, reason)
+                else coordinator.maybeRefresh(spec, reason)
+            }
+        }
+    }
+
+    private fun revalidate(reason: RefreshReason) {
+        val spec = specProvider() ?: return
+        coordinator.setVisibleFeed(spec)
+        if (coordinator.isPlayerFullscreen) return
+        fragment.viewLifecycleOwner.lifecycleScope.launch {
+            runCatching { coordinator.maybeRefresh(spec, reason) }
+        }
+    }
+
+    private val viewLifecycleOwner
+        get() = fragment.viewLifecycleOwner
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/StreamsAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/StreamsAdapter.kt
@@ -12,13 +12,6 @@ import androidx.navigation.fragment.findNavController
 import androidx.paging.PagingDataAdapter
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
-import coil3.imageLoader
-import coil3.request.CachePolicy
-import coil3.request.ImageRequest
-import coil3.request.crossfade
-import coil3.request.target
-import coil3.request.transformations
-import coil3.transform.CircleCropTransformation
 import com.github.andreyasadchy.xtra.R
 import com.github.andreyasadchy.xtra.databinding.FragmentStreamsListItemBinding
 import com.github.andreyasadchy.xtra.model.ui.Stream
@@ -41,12 +34,10 @@ class StreamsAdapter(
 ) : PagingDataAdapter<Stream, StreamsAdapter.PagingViewHolder>(
     object : DiffUtil.ItemCallback<Stream>() {
         override fun areItemsTheSame(oldItem: Stream, newItem: Stream): Boolean =
-            oldItem.id == newItem.id
+            oldItem.streamIdentity() == newItem.streamIdentity()
 
         override fun areContentsTheSame(oldItem: Stream, newItem: Stream): Boolean =
-            oldItem.viewerCount == newItem.viewerCount &&
-                    oldItem.gameName == newItem.gameName &&
-                    oldItem.title == newItem.title
+            streamContentsSame(oldItem, newItem)
     }) {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): PagingViewHolder {
@@ -102,20 +93,13 @@ class StreamsAdapter(
                         userImage.contentDescription = item.channelName?.let {
                             context.getString(R.string.player_open_channel, it)
                         }
-                        fragment.requireContext().imageLoader.enqueue(
-                            ImageRequest.Builder(fragment.requireContext()).apply {
-                                data(item.channelImage)
-                                if (context.prefs().getBoolean(C.UI_ROUND_USER_IMAGE, true)) {
-                                    transformations(CircleCropTransformation())
-                                }
-                                crossfade(true)
-                                target(userImage)
-                            }.build()
-                        )
+                        loadStreamProfileImage(context, userImage, item)
                         userImage.setOnClickListener(channelListener)
                     } else {
                         userImage.visibility = View.GONE
                         userImage.contentDescription = null
+                        userImage.setImageDrawable(null)
+                        userImage.tag = null
                     }
                     if (item.channelName != null) {
                         username.visibility = View.VISIBLE
@@ -160,23 +144,12 @@ class StreamsAdapter(
                     if (item.thumbnailURL != null) {
                         thumbnail.visibility = View.VISIBLE
                         liveBadge.visibility = View.VISIBLE
-                        //update every 5 minutes
-                        val minutes = System.currentTimeMillis() / 60000L
-                        val lastMinute = minutes % 10
-                        val key = if (lastMinute < 5) minutes - lastMinute else minutes - (lastMinute - 5)
-                        fragment.requireContext().imageLoader.enqueue(
-                            ImageRequest.Builder(fragment.requireContext()).apply {
-                                data(item.thumbnail)
-                                memoryCacheKeyExtra("minutes", key.toString())
-                                diskCachePolicy(CachePolicy.DISABLED)
-                                crossfade(true)
-                                target(thumbnail)
-                                thumbnailState()
-                            }.build()
-                        )
+                        loadStreamThumbnail(context, thumbnail, item)
                     } else {
                         thumbnail.visibility = View.GONE
                         liveBadge.visibility = View.GONE
+                        thumbnail.setImageDrawable(null)
+                        thumbnail.tag = null
                     }
                     if (item.viewerCount != null) {
                         viewers.visibility = View.VISIBLE
@@ -257,6 +230,22 @@ class StreamsAdapter(
                     } else {
                         tagsLayout.visibility = View.GONE
                     }
+                } else {
+                    root.setOnClickListener(null)
+                    multiview.setOnClickListener(null)
+                    userImage.setOnClickListener(null)
+                    userImage.setImageDrawable(null)
+                    userImage.tag = null
+                    thumbnail.setImageDrawable(null)
+                    thumbnail.tag = null
+                    username.visibility = View.GONE
+                    title.visibility = View.GONE
+                    gameName.visibility = View.GONE
+                    viewers.visibility = View.GONE
+                    uptime.visibility = View.GONE
+                    tagsLayout.removeAllViews()
+                    tagsLayout.visibility = View.GONE
+                    liveBadge.visibility = View.GONE
                 }
             }
         }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/StreamsCompactAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/StreamsCompactAdapter.kt
@@ -12,13 +12,6 @@ import androidx.navigation.fragment.findNavController
 import androidx.paging.PagingDataAdapter
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
-import coil3.imageLoader
-import coil3.request.CachePolicy
-import coil3.request.ImageRequest
-import coil3.request.crossfade
-import coil3.request.target
-import coil3.request.transformations
-import coil3.transform.CircleCropTransformation
 import com.github.andreyasadchy.xtra.R
 import com.github.andreyasadchy.xtra.databinding.FragmentStreamsListItemCompactBinding
 import com.github.andreyasadchy.xtra.model.ui.Stream
@@ -41,12 +34,10 @@ class StreamsCompactAdapter(
 ) : PagingDataAdapter<Stream, StreamsCompactAdapter.PagingViewHolder>(
     object : DiffUtil.ItemCallback<Stream>() {
         override fun areItemsTheSame(oldItem: Stream, newItem: Stream): Boolean =
-            oldItem.id == newItem.id
+            oldItem.streamIdentity() == newItem.streamIdentity()
 
         override fun areContentsTheSame(oldItem: Stream, newItem: Stream): Boolean =
-            oldItem.viewerCount == newItem.viewerCount &&
-                    oldItem.gameName == newItem.gameName &&
-                    oldItem.title == newItem.title
+            streamContentsSame(oldItem, newItem)
     }) {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): PagingViewHolder {
@@ -102,20 +93,13 @@ class StreamsCompactAdapter(
                         userImage.contentDescription = item.channelName?.let {
                             context.getString(R.string.player_open_channel, it)
                         }
-                        fragment.requireContext().imageLoader.enqueue(
-                            ImageRequest.Builder(fragment.requireContext()).apply {
-                                data(item.channelImage)
-                                if (context.prefs().getBoolean(C.UI_ROUND_USER_IMAGE, true)) {
-                                    transformations(CircleCropTransformation())
-                                }
-                                crossfade(true)
-                                target(userImage)
-                            }.build()
-                        )
+                        loadStreamProfileImage(context, userImage, item)
                         userImage.setOnClickListener(channelListener)
                     } else {
                         userImage.visibility = View.GONE
                         userImage.contentDescription = null
+                        userImage.setImageDrawable(null)
+                        userImage.tag = null
                     }
                     if (item.channelName != null) {
                         username.visibility = View.VISIBLE
@@ -160,24 +144,12 @@ class StreamsCompactAdapter(
                     if (item.thumbnailURL != null) {
                         thumbnail.visibility = View.VISIBLE
                         liveBadge.visibility = View.VISIBLE
-                        // Refresh thumbnails in the same five-minute buckets
-                        // as the normal live-card surface.
-                        val minutes = System.currentTimeMillis() / 60000L
-                        val lastMinute = minutes % 10
-                        val key = if (lastMinute < 5) minutes - lastMinute else minutes - (lastMinute - 5)
-                        fragment.requireContext().imageLoader.enqueue(
-                            ImageRequest.Builder(fragment.requireContext()).apply {
-                                data(item.thumbnail)
-                                memoryCacheKeyExtra("minutes", key.toString())
-                                diskCachePolicy(CachePolicy.DISABLED)
-                                crossfade(true)
-                                target(thumbnail)
-                                thumbnailState()
-                            }.build()
-                        )
+                        loadStreamThumbnail(context, thumbnail, item)
                     } else {
                         thumbnail.visibility = View.GONE
                         liveBadge.visibility = View.GONE
+                        thumbnail.setImageDrawable(null)
+                        thumbnail.tag = null
                     }
                     if (item.viewerCount != null) {
                         viewers.visibility = View.VISIBLE
@@ -258,6 +230,22 @@ class StreamsCompactAdapter(
                     } else {
                         tagsLayout.visibility = View.GONE
                     }
+                } else {
+                    root.setOnClickListener(null)
+                    multiview.setOnClickListener(null)
+                    userImage.setOnClickListener(null)
+                    userImage.setImageDrawable(null)
+                    userImage.tag = null
+                    thumbnail.setImageDrawable(null)
+                    thumbnail.tag = null
+                    username.visibility = View.GONE
+                    title.visibility = View.GONE
+                    gameName.visibility = View.GONE
+                    viewers.visibility = View.GONE
+                    uptime.visibility = View.GONE
+                    tagsLayout.removeAllViews()
+                    tagsLayout.visibility = View.GONE
+                    liveBadge.visibility = View.GONE
                 }
             }
         }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/ThumbnailImageRequest.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/ThumbnailImageRequest.kt
@@ -1,13 +1,196 @@
 package com.github.andreyasadchy.xtra.ui.common
 
+import android.content.Context
+import android.widget.ImageView
+import coil3.Image
+import coil3.imageLoader
 import coil3.request.ImageRequest
+import coil3.request.CachePolicy
+import coil3.request.crossfade
 import coil3.request.error
 import coil3.request.fallback
 import coil3.request.placeholder
+import coil3.request.target
+import coil3.request.transformations
+import coil3.target.ImageViewTarget
+import coil3.transform.CircleCropTransformation
+import com.github.andreyasadchy.xtra.model.ui.Stream
 import com.github.andreyasadchy.xtra.R
+import com.github.andreyasadchy.xtra.util.C
+import com.github.andreyasadchy.xtra.util.prefs
 
 internal fun ImageRequest.Builder.thumbnailState(): ImageRequest.Builder = apply {
     placeholder(R.drawable.bg_thumbnail_placeholder)
     error(R.drawable.ic_thumbnail_error)
     fallback(R.drawable.ic_thumbnail_error)
+}
+
+internal fun Stream.streamIdentity(): String {
+    return channelId?.takeIf { it.isNotBlank() }?.let { "channel:$it" }
+        ?: id?.takeIf { it.isNotBlank() }?.let { "stream:$it" }
+        ?: channelLogin?.takeIf { it.isNotBlank() }?.let { "login:${it.lowercase()}" }
+        ?: "unknown:${channelName.orEmpty()}"
+}
+
+internal fun streamContentsSame(oldItem: Stream, newItem: Stream): Boolean {
+    return oldItem.id == newItem.id &&
+            oldItem.channelId == newItem.channelId &&
+            oldItem.channelLogin == newItem.channelLogin &&
+            oldItem.channelName == newItem.channelName &&
+            oldItem.channelImageURL == newItem.channelImageURL &&
+            oldItem.gameId == newItem.gameId &&
+            oldItem.gameSlug == newItem.gameSlug &&
+            oldItem.gameName == newItem.gameName &&
+            oldItem.title == newItem.title &&
+            oldItem.thumbnailURL == newItem.thumbnailURL &&
+            oldItem.createdAt == newItem.createdAt &&
+            oldItem.viewerCount == newItem.viewerCount &&
+            oldItem.tags == newItem.tags
+}
+
+/**
+ * Coil normally sends a null onStart value to an ImageViewTarget when a new
+ * request has no placeholder. Keep the existing successful image in that
+ * case, and guard every callback against a recycled ViewHolder identity.
+ */
+private class StreamImageTarget(
+    imageView: ImageView,
+    private val identity: String,
+    private val preserveCurrentImage: Boolean,
+) : ImageViewTarget(imageView) {
+
+    override fun onStart(placeholder: Image?) {
+        if (preserveCurrentImage && view.tag == identity && view.drawable != null) return
+        super.onStart(placeholder)
+    }
+
+    override fun onSuccess(result: Image) {
+        if (view.tag == identity) {
+            super.onSuccess(result)
+        }
+    }
+
+    override fun onError(error: Image?) {
+        if (view.tag != identity) return
+        if (preserveCurrentImage && view.drawable != null) return
+        super.onError(error)
+    }
+}
+
+private class StreamThumbnailCacheTarget(
+    imageView: ImageView,
+    private val identity: String,
+    private val onCacheSettled: () -> Unit,
+) : ImageViewTarget(imageView) {
+
+    private var settled = false
+
+    override fun onStart(placeholder: Image?) {
+        // The cache-only stage is intentionally silent. It must never replace
+        // a valid image with a template while it looks for the stale disk row.
+    }
+
+    override fun onSuccess(result: Image) {
+        if (view.tag == identity) {
+            super.onSuccess(result)
+            settle()
+        }
+    }
+
+    override fun onError(error: Image?) {
+        if (view.tag == identity) {
+            // Preserve whatever was already displayed, including a previous
+            // cached image, and continue to the network stage.
+            settle()
+        }
+    }
+
+    private fun settle() {
+        if (!settled) {
+            settled = true
+            onCacheSettled()
+        }
+    }
+}
+
+internal data class StreamThumbnailRequestPlan(
+    val diskCacheKey: String,
+    val networkUrl: String,
+)
+
+internal fun streamThumbnailRequestPlan(stream: Stream, bucket: Long): StreamThumbnailRequestPlan? {
+    if (stream.thumbnailURL.isNullOrBlank()) return null
+    val thumbnail = stream.thumbnail ?: return null
+    val identity = stream.streamIdentity()
+    val separator = if ('?' in thumbnail) '&' else '?'
+    return StreamThumbnailRequestPlan(
+        diskCacheKey = "xtra:stream-thumbnail:$identity",
+        networkUrl = "$thumbnail${separator}xtra_preview_bucket=$bucket",
+    )
+}
+
+internal fun loadStreamProfileImage(context: Context, imageView: ImageView, stream: Stream) {
+    val identity = stream.streamIdentity()
+    val sameIdentity = imageView.tag == identity
+    if (!sameIdentity) {
+        imageView.setImageDrawable(null)
+    }
+    imageView.tag = identity
+    val url = stream.channelImage
+    if (url.isNullOrBlank()) {
+        imageView.setImageDrawable(null)
+        return
+    }
+    ImageRequest.Builder(context).apply {
+        data(url)
+        diskCachePolicy(CachePolicy.ENABLED)
+        if (context.prefs().getBoolean(C.UI_ROUND_USER_IMAGE, true)) {
+            transformations(CircleCropTransformation())
+        }
+        // Keep an already displayed image in place while a changed profile URL loads.
+        crossfade(false)
+        target(StreamImageTarget(imageView, identity, preserveCurrentImage = sameIdentity))
+    }.build().let(context.imageLoader::enqueue)
+}
+
+internal fun loadStreamThumbnail(context: Context, imageView: ImageView, stream: Stream) {
+    val identity = stream.streamIdentity()
+    if (imageView.tag != identity) {
+        imageView.setImageDrawable(null)
+    }
+    imageView.tag = identity
+    val bucket = System.currentTimeMillis() / (5 * 60_000L)
+    val plan = streamThumbnailRequestPlan(stream, bucket)
+    if (plan == null) {
+        imageView.setImageDrawable(null)
+        return
+    }
+
+    fun enqueueFreshRequest() {
+        val preserveCurrentImage = imageView.tag == identity && imageView.drawable != null
+        ImageRequest.Builder(context).apply {
+            data(plan.networkUrl)
+            // WRITE_ONLY deliberately bypasses the stable stale image while
+            // retaining the new response under that same stable disk key.
+            diskCachePolicy(CachePolicy.WRITE_ONLY)
+            diskCacheKey(plan.diskCacheKey)
+            networkCachePolicy(CachePolicy.ENABLED)
+            crossfade(false)
+            if (!preserveCurrentImage) {
+                thumbnailState()
+            }
+            target(StreamImageTarget(imageView, identity, preserveCurrentImage))
+        }.build().let(context.imageLoader::enqueue)
+    }
+
+    // Stage one renders the stable last-known image without touching the
+    // network. Stage two then revalidates the preview and atomically replaces
+    // the displayed image and the same stable disk entry if successful.
+    ImageRequest.Builder(context).apply {
+        data(plan.networkUrl)
+        diskCachePolicy(CachePolicy.READ_ONLY)
+        diskCacheKey(plan.diskCacheKey)
+        networkCachePolicy(CachePolicy.DISABLED)
+        target(StreamThumbnailCacheTarget(imageView, identity, ::enqueueFreshRequest))
+    }.build().let(context.imageLoader::enqueue)
 }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/streams/FollowedAccountPagerGeneration.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/streams/FollowedAccountPagerGeneration.kt
@@ -1,0 +1,14 @@
+package com.github.andreyasadchy.xtra.ui.following.streams
+
+/** Tracks whether a followed-stream Paging generation belongs to a new account. */
+internal class FollowedAccountPagerGeneration {
+    private var hasGeneration = false
+    private var accountId: String? = null
+
+    fun switchTo(newAccountId: String?): Boolean {
+        val changed = hasGeneration && accountId != newAccountId
+        hasGeneration = true
+        accountId = newAccountId
+        return changed
+    }
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/streams/FollowedStreamsFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/streams/FollowedStreamsFragment.kt
@@ -23,8 +23,10 @@ import com.github.andreyasadchy.xtra.ui.common.PagedListFragment
 import com.github.andreyasadchy.xtra.ui.common.Scrollable
 import com.github.andreyasadchy.xtra.ui.common.StreamsAdapter
 import com.github.andreyasadchy.xtra.ui.common.StreamsCompactAdapter
+import com.github.andreyasadchy.xtra.ui.common.StreamFeedScreenController
 import com.github.andreyasadchy.xtra.ui.following.streams.FollowedStreamsViewModel.Companion.FollowedStreamsViewModelFactory
 import com.github.andreyasadchy.xtra.ui.top.TopStreamsFragmentDirections
+import com.github.andreyasadchy.xtra.repository.streamfeed.RefreshReason
 import com.github.andreyasadchy.xtra.util.C
 import com.github.andreyasadchy.xtra.util.prefs
 import kotlinx.coroutines.flow.collectLatest
@@ -32,10 +34,13 @@ import kotlinx.coroutines.launch
 
 class FollowedStreamsFragment : PagedListFragment(), Scrollable {
 
+    override val initializeWithoutNetwork = true
+
     private var _binding: CommonRecyclerViewLayoutBinding? = null
     private val binding get() = _binding!!
     private val viewModel: FollowedStreamsViewModel by viewModels { FollowedStreamsViewModelFactory }
     private lateinit var pagingAdapter: PagingDataAdapter<Stream, out RecyclerView.ViewHolder>
+    private lateinit var streamFeedScreenController: StreamFeedScreenController
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         _binding = CommonRecyclerViewLayoutBinding.inflate(inflater, container, false)
@@ -62,6 +67,11 @@ class FollowedStreamsFragment : PagedListFragment(), Scrollable {
             })
         }
         setAdapter(binding.recyclerView, pagingAdapter)
+        streamFeedScreenController = StreamFeedScreenController(
+            fragment = this,
+            coordinator = viewModel.refreshCoordinator,
+            specProvider = viewModel::currentFeedSpec,
+        ).also { it.start() }
         ViewCompat.setOnApplyWindowInsetsListener(view) { _, windowInsets ->
             if (activity?.findViewById<LinearLayout>(R.id.navBarContainer)?.isVisible == false) {
                 val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars())
@@ -72,6 +82,8 @@ class FollowedStreamsFragment : PagedListFragment(), Scrollable {
     }
 
     override fun initialize() {
+        viewModel.syncCurrentAccount()
+        streamFeedScreenController.onSpecChanged(force = false, reason = RefreshReason.SCREEN_VISIBLE)
         viewLifecycleOwner.lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.flow.collectLatest { pagingData ->
@@ -87,7 +99,23 @@ class FollowedStreamsFragment : PagedListFragment(), Scrollable {
     }
 
     override fun onNetworkRestored() {
-        pagingAdapter.retry()
+        viewModel.syncCurrentAccount()
+        viewModel.refreshCurrent(RefreshReason.NETWORK_RESTORED, force = true)
+    }
+
+    override fun onResume() {
+        super.onResume()
+        viewModel.syncCurrentAccount()
+        if (::streamFeedScreenController.isInitialized) {
+            streamFeedScreenController.onResume()
+        }
+    }
+
+    override fun onPause() {
+        if (::streamFeedScreenController.isInitialized) {
+            streamFeedScreenController.onPause()
+        }
+        super.onPause()
     }
 
     override fun onIntegrityTokenLoaded(callback: String?) {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/streams/FollowedStreamsViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/streams/FollowedStreamsViewModel.kt
@@ -6,51 +6,113 @@ import androidx.lifecycle.ViewModelProvider.AndroidViewModelFactory.Companion.AP
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
-import androidx.paging.Pager
 import androidx.paging.PagingConfig
+import androidx.paging.PagingData
 import androidx.paging.cachedIn
 import com.github.andreyasadchy.xtra.XtraApp
+import com.github.andreyasadchy.xtra.model.ui.Stream
 import com.github.andreyasadchy.xtra.repository.GraphQLRepository
 import com.github.andreyasadchy.xtra.repository.HelixRepository
 import com.github.andreyasadchy.xtra.repository.LocalChannelFollowsRepository
-import com.github.andreyasadchy.xtra.repository.datasource.FollowedStreamsDataSource
+import com.github.andreyasadchy.xtra.repository.streamfeed.RefreshReason
+import com.github.andreyasadchy.xtra.repository.streamfeed.StreamFeedPager
+import com.github.andreyasadchy.xtra.repository.streamfeed.StreamFeedRefreshCoordinator
+import com.github.andreyasadchy.xtra.repository.streamfeed.StreamFeedSpec
+import com.github.andreyasadchy.xtra.repository.streamfeed.StreamFeedSpecs
 import com.github.andreyasadchy.xtra.util.C
-import com.github.andreyasadchy.xtra.util.TwitchApiHelper
 import com.github.andreyasadchy.xtra.util.prefs
 import com.github.andreyasadchy.xtra.util.tokenPrefs
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.launch
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class FollowedStreamsViewModel(
     applicationContext: Context,
     private val localChannelFollowsRepository: LocalChannelFollowsRepository,
     private val graphQLRepository: GraphQLRepository,
     private val helixRepository: HelixRepository,
+    private val streamFeedPager: StreamFeedPager,
+    val refreshCoordinator: StreamFeedRefreshCoordinator,
 ) : ViewModel() {
 
-    val flow = Pager(
-        if (applicationContext.prefs().getString(C.COMPACT_STREAMS, "disabled") != "disabled") {
-            PagingConfig(pageSize = 30, prefetchDistance = 10, initialLoadSize = 30)
-        } else {
-            PagingConfig(pageSize = 30, prefetchDistance = 3, initialLoadSize = 30)
+    private val applicationContext = applicationContext
+    private val accountId = MutableStateFlow(readCurrentUserId())
+    private val pagingConfig = if (applicationContext.prefs().getString(C.COMPACT_STREAMS, "disabled") != "disabled") {
+        PagingConfig(pageSize = 30, prefetchDistance = 10, initialLoadSize = 30)
+    } else {
+        PagingConfig(pageSize = 30, prefetchDistance = 3, initialLoadSize = 30)
+    }
+    private val accountPagerGeneration = FollowedAccountPagerGeneration()
+
+    val flow = accountId
+        .flatMapLatest { userId ->
+            flow {
+                // An account partition change is the one legitimate case
+                // where the old rows must be removed before the new cache
+                // generation is submitted. The initial generation remains
+                // cache-first and does not emit this empty PagingData.
+                if (accountPagerGeneration.switchTo(userId)) {
+                    emit(PagingData.empty<Stream>())
+                }
+                emitAll(
+                    streamFeedPager.flow(
+                        spec = createSpec(userId),
+                        config = pagingConfig,
+                    )
+                )
+            }
         }
-    ) {
-        FollowedStreamsDataSource(
-            userId = applicationContext.tokenPrefs().getString(C.USER_ID, null),
+        .cachedIn(viewModelScope)
+
+    fun syncCurrentAccount() {
+        accountId.value = readCurrentUserId()
+    }
+
+    fun currentFeedSpec(): StreamFeedSpec {
+        syncCurrentAccount()
+        return createSpec(accountId.value)
+    }
+
+    fun refreshCurrent(reason: RefreshReason, force: Boolean = false) {
+        syncCurrentAccount()
+        val spec = createSpec(accountId.value)
+        viewModelScope.launch {
+            runCatching {
+                if (force) refreshCoordinator.forceRefresh(spec, reason)
+                else refreshCoordinator.maybeRefresh(spec, reason)
+            }
+        }
+    }
+
+    private fun readCurrentUserId(): String? = applicationContext.tokenPrefs().getString(C.USER_ID, null)
+
+    private fun createSpec(userId: String?): StreamFeedSpec {
+        return StreamFeedSpecs.followed(
+            context = applicationContext,
+            userId = userId,
             localChannelFollowsRepository = localChannelFollowsRepository,
-            gqlHeaders = TwitchApiHelper.getGQLHeaders(applicationContext, true),
             graphQLRepository = graphQLRepository,
-            helixHeaders = TwitchApiHelper.getHelixHeaders(applicationContext),
             helixRepository = helixRepository,
-            enableIntegrity = applicationContext.prefs().getBoolean(C.ENABLE_INTEGRITY, false),
-            networkLibrary = applicationContext.prefs().getString(C.NETWORK_LIBRARY, C.OKHTTP),
         )
-    }.flow.cachedIn(viewModelScope)
+    }
 
     companion object {
         val FollowedStreamsViewModelFactory = viewModelFactory {
             initializer {
                 val application = (this[APPLICATION_KEY] as XtraApp)
                 val xtraModule = application.xtraModule
-                FollowedStreamsViewModel(application.applicationContext, xtraModule.localChannelFollowsRepository, xtraModule.graphQLRepository, xtraModule.helixRepository)
+                FollowedStreamsViewModel(
+                    application.applicationContext,
+                    xtraModule.localChannelFollowsRepository,
+                    xtraModule.graphQLRepository,
+                    xtraModule.helixRepository,
+                    xtraModule.streamFeedPager,
+                    xtraModule.streamFeedRefreshCoordinator,
+                )
             }
         }
     }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/game/streams/GameStreamsFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/game/streams/GameStreamsFragment.kt
@@ -14,7 +14,6 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.fragment.navArgs
-import androidx.paging.PagingData
 import androidx.paging.PagingDataAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.github.andreyasadchy.xtra.R
@@ -30,6 +29,7 @@ import com.github.andreyasadchy.xtra.ui.common.Scrollable
 import com.github.andreyasadchy.xtra.ui.common.Sortable
 import com.github.andreyasadchy.xtra.ui.common.StreamsAdapter
 import com.github.andreyasadchy.xtra.ui.common.StreamsCompactAdapter
+import com.github.andreyasadchy.xtra.ui.common.StreamFeedScreenController
 import com.github.andreyasadchy.xtra.ui.common.StreamsSortDialog
 import com.github.andreyasadchy.xtra.ui.common.StreamsSortDialog.Companion.RECENT
 import com.github.andreyasadchy.xtra.ui.common.StreamsSortDialog.Companion.SORT_VIEWERS
@@ -38,16 +38,20 @@ import com.github.andreyasadchy.xtra.ui.game.GamePagerFragmentArgs
 import com.github.andreyasadchy.xtra.ui.game.streams.GameStreamsViewModel.Companion.GameStreamsViewModelFactory
 import com.github.andreyasadchy.xtra.util.C
 import com.github.andreyasadchy.xtra.util.prefs
+import com.github.andreyasadchy.xtra.repository.streamfeed.RefreshReason
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 
 class GameStreamsFragment : PagedListFragment(), Scrollable, Sortable, StreamsSortDialog.OnFilter {
+
+    override val initializeWithoutNetwork = true
 
     private var _binding: CommonRecyclerViewLayoutBinding? = null
     private val binding get() = _binding!!
     private val args: GamePagerFragmentArgs by navArgs()
     private val viewModel: GameStreamsViewModel by viewModels { GameStreamsViewModelFactory }
     private lateinit var pagingAdapter: PagingDataAdapter<Stream, out RecyclerView.ViewHolder>
+    private lateinit var streamFeedScreenController: StreamFeedScreenController
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         _binding = CommonRecyclerViewLayoutBinding.inflate(inflater, container, false)
@@ -62,6 +66,11 @@ class GameStreamsFragment : PagedListFragment(), Scrollable, Sortable, StreamsSo
             StreamsAdapter(this, { addTag(it) }, showGame = false)
         }
         setAdapter(binding.recyclerView, pagingAdapter)
+        streamFeedScreenController = StreamFeedScreenController(
+            fragment = this,
+            coordinator = viewModel.refreshCoordinator,
+            specProvider = viewModel::currentFeedSpec,
+        ).also { it.start() }
         ViewCompat.setOnApplyWindowInsetsListener(view) { _, windowInsets ->
             if (activity?.findViewById<LinearLayout>(R.id.navBarContainer)?.isVisible == false) {
                 val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars())
@@ -117,6 +126,7 @@ class GameStreamsFragment : PagedListFragment(), Scrollable, Sortable, StreamsSo
                     }
                 } else null
             }
+            streamFeedScreenController.onSpecChanged(force = false, reason = RefreshReason.SCREEN_VISIBLE)
             repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.flow.collectLatest { pagingData ->
                     pagingAdapter.submitData(pagingData)
@@ -161,9 +171,9 @@ class GameStreamsFragment : PagedListFragment(), Scrollable, Sortable, StreamsSo
 
     private fun addTag(tag: String) {
         viewLifecycleOwner.lifecycleScope.launch {
-            pagingAdapter.submitData(PagingData.empty())
             val tags = viewModel.tags.plus(tag).sortedArray()
             viewModel.setFilter(viewModel.sort, tags, viewModel.languages)
+            streamFeedScreenController.onSpecChanged(force = true)
             viewModel.filtersText.value = buildString {
                 if (viewModel.tags.isNotEmpty()) {
                     append(
@@ -194,8 +204,8 @@ class GameStreamsFragment : PagedListFragment(), Scrollable, Sortable, StreamsSo
         if ((parentFragment as? FragmentHost)?.currentFragment == this) {
             viewLifecycleOwner.lifecycleScope.launch {
                 if (changed) {
-                    pagingAdapter.submitData(PagingData.empty())
                     viewModel.setFilter(sort, tags, languages)
+                    streamFeedScreenController.onSpecChanged(force = true)
                     viewModel.sortText.value = getString(R.string.sort_by, sortText)
                     viewModel.filtersText.value = if (viewModel.tags.isNotEmpty() || viewModel.languages.isNotEmpty()) {
                         buildString {
@@ -279,7 +289,21 @@ class GameStreamsFragment : PagedListFragment(), Scrollable, Sortable, StreamsSo
     }
 
     override fun onNetworkRestored() {
-        pagingAdapter.retry()
+        viewModel.refreshCurrent(RefreshReason.NETWORK_RESTORED, force = true)
+    }
+
+    override fun onResume() {
+        super.onResume()
+        if (::streamFeedScreenController.isInitialized) {
+            streamFeedScreenController.onResume()
+        }
+    }
+
+    override fun onPause() {
+        if (::streamFeedScreenController.isInitialized) {
+            streamFeedScreenController.onPause()
+        }
+        super.onPause()
     }
 
     override fun onIntegrityTokenLoaded(callback: String?) {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/game/streams/GameStreamsViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/game/streams/GameStreamsViewModel.kt
@@ -8,35 +8,38 @@ import androidx.lifecycle.createSavedStateHandle
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
-import androidx.paging.Pager
 import androidx.paging.PagingConfig
 import androidx.paging.cachedIn
 import com.github.andreyasadchy.xtra.XtraApp
-import com.github.andreyasadchy.xtra.graphql.type.Language
-import com.github.andreyasadchy.xtra.graphql.type.StreamSort
 import com.github.andreyasadchy.xtra.model.ui.GameSort
 import com.github.andreyasadchy.xtra.model.ui.SavedFilter
 import com.github.andreyasadchy.xtra.repository.GameSortRepository
 import com.github.andreyasadchy.xtra.repository.GraphQLRepository
 import com.github.andreyasadchy.xtra.repository.HelixRepository
 import com.github.andreyasadchy.xtra.repository.SavedFiltersRepository
-import com.github.andreyasadchy.xtra.repository.datasource.GameStreamsDataSource
+import com.github.andreyasadchy.xtra.repository.streamfeed.RefreshReason
+import com.github.andreyasadchy.xtra.repository.streamfeed.StreamFeedPager
+import com.github.andreyasadchy.xtra.repository.streamfeed.StreamFeedRefreshCoordinator
+import com.github.andreyasadchy.xtra.repository.streamfeed.StreamFeedSpec
+import com.github.andreyasadchy.xtra.repository.streamfeed.StreamFeedSpecs
 import com.github.andreyasadchy.xtra.ui.common.StreamsSortDialog
 import com.github.andreyasadchy.xtra.ui.game.GamePagerFragmentArgs
 import com.github.andreyasadchy.xtra.util.C
-import com.github.andreyasadchy.xtra.util.TwitchApiHelper
 import com.github.andreyasadchy.xtra.util.prefs
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flatMapLatest
 
 class GameStreamsViewModel(
-    applicationContext: Context,
+    private val applicationContext: Context,
     private val gameSortRepository: GameSortRepository,
     private val savedFiltersRepository: SavedFiltersRepository,
     private val graphQLRepository: GraphQLRepository,
     private val helixRepository: HelixRepository,
     savedStateHandle: SavedStateHandle,
+    private val streamFeedPager: StreamFeedPager,
+    val refreshCoordinator: StreamFeedRefreshCoordinator,
 ) : ViewModel() {
 
     private val args = GamePagerFragmentArgs.fromSavedStateHandle(savedStateHandle)
@@ -53,43 +56,28 @@ class GameStreamsViewModel(
 
     @OptIn(ExperimentalCoroutinesApi::class)
     val flow = filter.flatMapLatest {
-        Pager(
-            if (applicationContext.prefs().getString(C.COMPACT_STREAMS, "disabled") == "all") {
+        streamFeedPager.flow(
+            spec = createSpec(it ?: Filter(null, null, null)),
+            config = if (applicationContext.prefs().getString(C.COMPACT_STREAMS, "disabled") == "all") {
                 PagingConfig(pageSize = 30, prefetchDistance = 10, initialLoadSize = 30)
             } else {
                 PagingConfig(pageSize = 30, prefetchDistance = 3, initialLoadSize = 30)
-            }
-        ) {
-            GameStreamsDataSource(
-                gameId = args.gameId,
-                gameSlug = args.gameSlug,
-                gameName = args.gameName,
-                gqlQueryLanguages = languages.ifEmpty { null }?.mapNotNull { language ->
-                    Language.entries.find { it.rawValue == language }
-                },
-                gqlQuerySort = when (sort) {
-                    StreamsSortDialog.SORT_VIEWERS -> StreamSort.VIEWER_COUNT
-                    StreamsSortDialog.SORT_VIEWERS_ASC -> StreamSort.VIEWER_COUNT_ASC
-                    StreamsSortDialog.RECENT -> StreamSort.RECENT
-                    else -> StreamSort.VIEWER_COUNT
-                },
-                gqlLanguages = languages.ifEmpty { null }?.toList(),
-                gqlSort = when (sort) {
-                    StreamsSortDialog.SORT_VIEWERS -> "VIEWER_COUNT"
-                    StreamsSortDialog.SORT_VIEWERS_ASC -> "VIEWER_COUNT_ASC"
-                    StreamsSortDialog.RECENT -> "RECENT"
-                    else -> "VIEWER_COUNT"
-                },
-                tags = tags.ifEmpty { null }?.toList(),
-                gqlHeaders = TwitchApiHelper.getGQLHeaders(applicationContext),
-                graphQLRepository = graphQLRepository,
-                helixHeaders = TwitchApiHelper.getHelixHeaders(applicationContext),
-                helixRepository = helixRepository,
-                enableIntegrity = applicationContext.prefs().getBoolean(C.ENABLE_INTEGRITY, false),
-                networkLibrary = applicationContext.prefs().getString(C.NETWORK_LIBRARY, C.OKHTTP),
-            )
-        }.flow
+            },
+        )
     }.cachedIn(viewModelScope)
+
+    fun currentFeedSpec(): StreamFeedSpec? = filter.value?.let(::createSpec)
+
+    fun refreshCurrent(reason: RefreshReason, force: Boolean = false) {
+        currentFeedSpec()?.let { spec ->
+            viewModelScope.launch {
+                runCatching {
+                    if (force) refreshCoordinator.forceRefresh(spec, reason)
+                    else refreshCoordinator.maybeRefresh(spec, reason)
+                }
+            }
+        }
+    }
 
     suspend fun getGameSort(id: String): GameSort? {
         return gameSortRepository.getById(id)
@@ -111,6 +99,20 @@ class GameStreamsViewModel(
         filter.value = Filter(sort, tags, languages)
     }
 
+    private fun createSpec(filter: Filter): StreamFeedSpec {
+        return StreamFeedSpecs.game(
+            context = applicationContext,
+            graphQLRepository = graphQLRepository,
+            helixRepository = helixRepository,
+            gameId = args.gameId,
+            gameSlug = args.gameSlug,
+            gameName = args.gameName,
+            sort = filter.sort ?: StreamsSortDialog.SORT_VIEWERS,
+            tags = filter.tags?.asIterable(),
+            languages = filter.languages?.asIterable(),
+        )
+    }
+
     class Filter(
         val sort: String?,
         val tags: Array<String>?,
@@ -123,7 +125,16 @@ class GameStreamsViewModel(
                 val savedStateHandle = createSavedStateHandle()
                 val application = (this[APPLICATION_KEY] as XtraApp)
                 val xtraModule = application.xtraModule
-                GameStreamsViewModel(application.applicationContext, xtraModule.gameSortRepository, xtraModule.savedFiltersRepository, xtraModule.graphQLRepository, xtraModule.helixRepository, savedStateHandle)
+                GameStreamsViewModel(
+                    application.applicationContext,
+                    xtraModule.gameSortRepository,
+                    xtraModule.savedFiltersRepository,
+                    xtraModule.graphQLRepository,
+                    xtraModule.helixRepository,
+                    savedStateHandle,
+                    xtraModule.streamFeedPager,
+                    xtraModule.streamFeedRefreshCoordinator,
+                )
             }
         }
     }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/main/MainActivity.kt
@@ -230,6 +230,7 @@ class MainActivity : AppCompatActivity() {
                                 }
                             }
                             if (isNetworkAvailable) {
+                                (application as XtraApp).xtraModule.streamFeedRefreshCoordinator.onNetworkRestored()
                                 if (!TwitchApiHelper.checkedValidation) {
                                     viewModel.validate(
                                         prefs.getString(C.NETWORK_LIBRARY, C.OKHTTP),
@@ -411,6 +412,9 @@ class MainActivity : AppCompatActivity() {
                                     }
                                 }
                             }
+                            (application as XtraApp).xtraModule.streamFeedRefreshCoordinator.playbackEntered(
+                                isLive = savedState.type == BasePlaybackService.STREAM,
+                            )
                             startPlayer(fragment)
                         }
                     }
@@ -956,6 +960,7 @@ class MainActivity : AppCompatActivity() {
 //Navigation listeners
 
     fun startStream(stream: Stream) {
+        onPlayerEnteredPlayback(isLive = true)
         if (prefs.getString(C.PLAYER, C.EXOPLAYER) != C.MEDIA_PLAYER && !prefs.getBoolean(C.DEBUG_USE_CUSTOM_PLAYBACK_SERVICE, true)) {
             (playerFragment as? Media3PlayerFragment)?.close() ?: (playerFragment as? ExoPlayerFragment)?.close()
             val fragment = Media3Fragment.newInstance(stream)
@@ -986,6 +991,7 @@ class MainActivity : AppCompatActivity() {
     }
 
     fun startVideo(video: Video, offset: Long?, ignoreSavedPosition: Boolean = false, videoUrl: String? = null) {
+        onPlayerChangedPlayback(isLive = false)
         if (prefs.getString(C.PLAYER, C.EXOPLAYER) != C.MEDIA_PLAYER && !prefs.getBoolean(C.DEBUG_USE_CUSTOM_PLAYBACK_SERVICE, true)) {
             (playerFragment as? Media3PlayerFragment)?.close() ?: (playerFragment as? ExoPlayerFragment)?.close()
             val fragment = Media3Fragment.newInstance(video, offset, ignoreSavedPosition)
@@ -1025,6 +1031,7 @@ class MainActivity : AppCompatActivity() {
     }
 
     fun startClip(clip: Clip) {
+        onPlayerChangedPlayback(isLive = false)
         if (prefs.getString(C.PLAYER, C.EXOPLAYER) != C.MEDIA_PLAYER && !prefs.getBoolean(C.DEBUG_USE_CUSTOM_PLAYBACK_SERVICE, true)) {
             (playerFragment as? Media3PlayerFragment)?.close() ?: (playerFragment as? ExoPlayerFragment)?.close()
             val fragment = Media3Fragment.newInstance(clip)
@@ -1059,6 +1066,7 @@ class MainActivity : AppCompatActivity() {
     }
 
     fun startOfflineVideo(video: OfflineVideo, offset: Long? = null) {
+        onPlayerChangedPlayback(isLive = false)
         if (prefs.getString(C.PLAYER, C.EXOPLAYER) != C.MEDIA_PLAYER && !prefs.getBoolean(C.DEBUG_USE_CUSTOM_PLAYBACK_SERVICE, true)) {
             (playerFragment as? Media3PlayerFragment)?.close() ?: (playerFragment as? ExoPlayerFragment)?.close()
             val fragment = Media3Fragment.newInstance(video)
@@ -1110,6 +1118,7 @@ class MainActivity : AppCompatActivity() {
     }
 
     fun closePlayer() {
+        onPlayerReturnedToBrowsing()
         supportFragmentManager.beginTransaction()
             .setTransition(FragmentTransaction.TRANSIT_FRAGMENT_FADE)
             .remove(supportFragmentManager.findFragmentById(R.id.playerContainer)!!)
@@ -1122,6 +1131,18 @@ class MainActivity : AppCompatActivity() {
         viewModel.sleepTimer?.cancel()
         viewModel.sleepTimerEndTime = 0L
         currentMultiviewFragment()?.resumeAfterExternalPlayer()
+    }
+
+    fun onPlayerReturnedToBrowsing() {
+        (application as XtraApp).xtraModule.streamFeedRefreshCoordinator.playbackReturned()
+    }
+
+    fun onPlayerEnteredPlayback(isLive: Boolean = true) {
+        (application as XtraApp).xtraModule.streamFeedRefreshCoordinator.playbackEntered(isLive)
+    }
+
+    fun onPlayerChangedPlayback(isLive: Boolean) {
+        (application as XtraApp).xtraModule.streamFeedRefreshCoordinator.playbackChanged(isLive)
     }
 
     private fun currentMultiviewFragment(): MultiviewFragment? {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/Media3PlayerFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/Media3PlayerFragment.kt
@@ -174,6 +174,7 @@ abstract class Media3PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFr
             enableNetworkCheck = false
         }
         super.onCreate(savedInstanceState)
+        (activity as? MainActivity)?.onPlayerEnteredPlayback(isLive = videoType == STREAM)
         isPortrait = resources.configuration.orientation == Configuration.ORIENTATION_PORTRAIT
         requireActivity().onBackPressedDispatcher.addCallback(this, backPressedCallback)
         WindowCompat.getInsetsController(
@@ -2092,6 +2093,9 @@ abstract class Media3PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFr
     }
 
     override fun initialize() {
+        if (isMaximized) {
+            (activity as? MainActivity)?.onPlayerEnteredPlayback(isLive = videoType == STREAM)
+        }
         if (requireArguments().getString(KEY_TYPE) != OFFLINE_VIDEO) {
             viewModel.isFollowingChannel(
                 requireContext().tokenPrefs().getString(C.USER_ID, null),
@@ -2295,7 +2299,9 @@ abstract class Media3PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFr
                 (chatFragment?.childFragmentManager?.findFragmentByTag("messageDialog") as? BottomSheetDialogFragment)?.dismiss()
                 (chatFragment?.childFragmentManager?.findFragmentByTag("replyDialog") as? BottomSheetDialogFragment)?.dismiss()
                 (chatFragment?.childFragmentManager?.findFragmentByTag("imageDialog") as? BottomSheetDialogFragment)?.dismiss()
+                (activity as? MainActivity)?.onPlayerEnteredPlayback(isLive = videoType == STREAM)
             } else {
+                (activity as? MainActivity)?.onPlayerEnteredPlayback(isLive = videoType == STREAM)
                 useController = true
             }
         }
@@ -2329,7 +2335,11 @@ abstract class Media3PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFr
 
     fun minimize() {
         with(binding) {
+            val wasMaximized = isMaximized
             isMaximized = false
+            if (wasMaximized) {
+                (activity as? com.github.andreyasadchy.xtra.ui.main.MainActivity)?.onPlayerReturnedToBrowsing()
+            }
             if (videoType == STREAM && chatFragment?.emoteMenuIsVisible() == true) {
                 chatFragment?.toggleBackPressedCallback(false)
             }
@@ -2399,6 +2409,7 @@ abstract class Media3PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFr
     fun maximize() {
         with(binding) {
             isMaximized = true
+            (activity as? MainActivity)?.onPlayerEnteredPlayback(isLive = videoType == STREAM)
             requireActivity().onBackPressedDispatcher.addCallback(this@Media3PlayerFragment, backPressedCallback)
             if (videoType == STREAM && chatFragment?.emoteMenuIsVisible() == true) {
                 chatFragment?.toggleBackPressedCallback(true)

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/Media3PlayerViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/Media3PlayerViewModel.kt
@@ -26,6 +26,7 @@ import com.github.andreyasadchy.xtra.repository.LocalChannelFollowsRepository
 import com.github.andreyasadchy.xtra.repository.NotificationsRepository
 import com.github.andreyasadchy.xtra.repository.OfflineVideosRepository
 import com.github.andreyasadchy.xtra.repository.PlayerRepository
+import com.github.andreyasadchy.xtra.repository.streamfeed.StreamFeedRefreshCoordinator
 import com.github.andreyasadchy.xtra.util.C
 import com.github.andreyasadchy.xtra.util.NetworkUtils
 import com.github.andreyasadchy.xtra.util.NetworkUtils.executeAsync
@@ -67,6 +68,7 @@ class Media3PlayerViewModel(
     private val offlineVideosRepository: OfflineVideosRepository,
     private val localChannelFollowsRepository: LocalChannelFollowsRepository,
     private val notificationsRepository: NotificationsRepository,
+    private val streamFeedRefreshCoordinator: StreamFeedRefreshCoordinator,
 ) : ViewModel() {
 
     val integrity = MutableSharedFlow<String?>()
@@ -695,6 +697,7 @@ class Media3PlayerViewModel(
                                     notificationsRepository.saveList(listOf(ShownNotification(channelId, it)))
                                 }
                             }
+                            streamFeedRefreshCoordinator.invalidateFollowedFeeds()
                         }
                     } else {
                         localChannelFollowsRepository.save(LocalChannelFollow(channelId, channelLogin, channelName))
@@ -737,6 +740,7 @@ class Media3PlayerViewModel(
                             _isFollowing.value = false
                             follow.value = Pair(false, null)
                             notificationsRepository.deleteUser(NotificationUser(channelId))
+                            streamFeedRefreshCoordinator.invalidateFollowedFeeds()
                         }
                     } else {
                         localChannelFollowsRepository.getById(channelId)?.let { localChannelFollowsRepository.delete(it) }
@@ -756,7 +760,7 @@ class Media3PlayerViewModel(
             initializer {
                 val application = (this[APPLICATION_KEY] as XtraApp)
                 val xtraModule = application.xtraModule
-                Media3PlayerViewModel(application.applicationContext, xtraModule.httpEngine, xtraModule.cronetEngine, xtraModule.cronetExecutor, xtraModule.okHttpClient, xtraModule.graphQLRepository, xtraModule.helixRepository, xtraModule.playerRepository, xtraModule.bookmarksRepository, xtraModule.offlineVideosRepository, xtraModule.localChannelFollowsRepository, xtraModule.notificationsRepository)
+                Media3PlayerViewModel(application.applicationContext, xtraModule.httpEngine, xtraModule.cronetEngine, xtraModule.cronetExecutor, xtraModule.okHttpClient, xtraModule.graphQLRepository, xtraModule.helixRepository, xtraModule.playerRepository, xtraModule.bookmarksRepository, xtraModule.offlineVideosRepository, xtraModule.localChannelFollowsRepository, xtraModule.notificationsRepository, xtraModule.streamFeedRefreshCoordinator)
             }
         }
     }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/PlayerFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/PlayerFragment.kt
@@ -2014,6 +2014,11 @@ abstract class PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFragment
     }
 
     override fun initialize() {
+        if (isMaximized) {
+            (activity as? com.github.andreyasadchy.xtra.ui.main.MainActivity)?.onPlayerEnteredPlayback(
+                isLive = playbackService?.type == BasePlaybackService.STREAM,
+            )
+        }
         if (!started && playbackService?.started == true) {
             started = true
             start()
@@ -2072,7 +2077,13 @@ abstract class PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFragment
                 (chatFragment?.childFragmentManager?.findFragmentByTag("messageDialog") as? BottomSheetDialogFragment)?.dismiss()
                 (chatFragment?.childFragmentManager?.findFragmentByTag("replyDialog") as? BottomSheetDialogFragment)?.dismiss()
                 (chatFragment?.childFragmentManager?.findFragmentByTag("imageDialog") as? BottomSheetDialogFragment)?.dismiss()
+                (activity as? com.github.andreyasadchy.xtra.ui.main.MainActivity)?.onPlayerEnteredPlayback(
+                    isLive = playbackService?.type == BasePlaybackService.STREAM,
+                )
             } else {
+                (activity as? com.github.andreyasadchy.xtra.ui.main.MainActivity)?.onPlayerEnteredPlayback(
+                    isLive = playbackService?.type == BasePlaybackService.STREAM,
+                )
                 useController = true
             }
         }
@@ -2085,7 +2096,11 @@ abstract class PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFragment
 
     fun minimize() {
         with(binding) {
+            val wasMaximized = isMaximized
             isMaximized = false
+            if (wasMaximized) {
+                (activity as? com.github.andreyasadchy.xtra.ui.main.MainActivity)?.onPlayerReturnedToBrowsing()
+            }
             if (playbackService?.type == BasePlaybackService.STREAM && chatFragment?.emoteMenuIsVisible() == true) {
                 chatFragment?.toggleBackPressedCallback(false)
             }
@@ -2155,6 +2170,9 @@ abstract class PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFragment
     fun maximize() {
         with(binding) {
             isMaximized = true
+            (activity as? com.github.andreyasadchy.xtra.ui.main.MainActivity)?.onPlayerEnteredPlayback(
+                isLive = playbackService?.type == BasePlaybackService.STREAM,
+            )
             requireActivity().onBackPressedDispatcher.addCallback(this@PlayerFragment, backPressedCallback)
             if (playbackService?.type == BasePlaybackService.STREAM && chatFragment?.emoteMenuIsVisible() == true) {
                 chatFragment?.toggleBackPressedCallback(true)

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/PlayerViewModel.kt
@@ -21,6 +21,7 @@ import com.github.andreyasadchy.xtra.repository.HelixRepository
 import com.github.andreyasadchy.xtra.repository.LocalChannelFollowsRepository
 import com.github.andreyasadchy.xtra.repository.NotificationsRepository
 import com.github.andreyasadchy.xtra.repository.PlayerRepository
+import com.github.andreyasadchy.xtra.repository.streamfeed.StreamFeedRefreshCoordinator
 import com.github.andreyasadchy.xtra.util.C
 import com.github.andreyasadchy.xtra.util.NetworkUtils
 import com.github.andreyasadchy.xtra.util.NetworkUtils.executeAsync
@@ -53,6 +54,7 @@ class PlayerViewModel(
     private val bookmarksRepository: BookmarksRepository,
     private val localChannelFollowsRepository: LocalChannelFollowsRepository,
     private val notificationsRepository: NotificationsRepository,
+    private val streamFeedRefreshCoordinator: StreamFeedRefreshCoordinator,
 ) : ViewModel() {
 
     val integrity = MutableSharedFlow<String?>()
@@ -487,6 +489,7 @@ class PlayerViewModel(
                                     notificationsRepository.saveList(listOf(ShownNotification(channelId, it)))
                                 }
                             }
+                            streamFeedRefreshCoordinator.invalidateFollowedFeeds()
                         }
                     } else {
                         localChannelFollowsRepository.save(LocalChannelFollow(channelId, channelLogin, channelName))
@@ -529,6 +532,7 @@ class PlayerViewModel(
                             _isFollowing.value = false
                             follow.value = Pair(false, null)
                             notificationsRepository.deleteUser(NotificationUser(channelId))
+                            streamFeedRefreshCoordinator.invalidateFollowedFeeds()
                         }
                     } else {
                         localChannelFollowsRepository.getById(channelId)?.let { localChannelFollowsRepository.delete(it) }
@@ -548,7 +552,7 @@ class PlayerViewModel(
             initializer {
                 val application = (this[APPLICATION_KEY] as XtraApp)
                 val xtraModule = application.xtraModule
-                PlayerViewModel(xtraModule.httpEngine, xtraModule.cronetEngine, xtraModule.cronetExecutor, xtraModule.okHttpClient, xtraModule.graphQLRepository, xtraModule.helixRepository, xtraModule.playerRepository, xtraModule.bookmarksRepository, xtraModule.localChannelFollowsRepository, xtraModule.notificationsRepository)
+                PlayerViewModel(xtraModule.httpEngine, xtraModule.cronetEngine, xtraModule.cronetExecutor, xtraModule.okHttpClient, xtraModule.graphQLRepository, xtraModule.helixRepository, xtraModule.playerRepository, xtraModule.bookmarksRepository, xtraModule.localChannelFollowsRepository, xtraModule.notificationsRepository, xtraModule.streamFeedRefreshCoordinator)
             }
         }
     }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/top/TopStreamsFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/top/TopStreamsFragment.kt
@@ -19,7 +19,6 @@ import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import androidx.navigation.ui.AppBarConfiguration
 import androidx.navigation.ui.setupWithNavController
-import androidx.paging.PagingData
 import androidx.paging.PagingDataAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.github.andreyasadchy.xtra.R
@@ -35,6 +34,7 @@ import com.github.andreyasadchy.xtra.ui.common.StreamsSortDialog
 import com.github.andreyasadchy.xtra.ui.common.StreamsSortDialog.Companion.RECENT
 import com.github.andreyasadchy.xtra.ui.common.StreamsSortDialog.Companion.SORT_VIEWERS
 import com.github.andreyasadchy.xtra.ui.common.StreamsSortDialog.Companion.SORT_VIEWERS_ASC
+import com.github.andreyasadchy.xtra.ui.common.StreamFeedScreenController
 import com.github.andreyasadchy.xtra.ui.game.GamePagerFragmentArgs
 import com.github.andreyasadchy.xtra.ui.login.LoginActivity
 import com.github.andreyasadchy.xtra.ui.main.MainActivity
@@ -46,16 +46,20 @@ import com.github.andreyasadchy.xtra.util.TwitchApiHelper
 import com.github.andreyasadchy.xtra.util.getAlertDialogBuilder
 import com.github.andreyasadchy.xtra.util.prefs
 import com.github.andreyasadchy.xtra.util.tokenPrefs
+import com.github.andreyasadchy.xtra.repository.streamfeed.RefreshReason
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 
 class TopStreamsFragment : PagedListFragment(), Scrollable, StreamsSortDialog.OnFilter {
+
+    override val initializeWithoutNetwork = true
 
     private var _binding: FragmentGamesBinding? = null
     private val binding get() = _binding!!
     private val args: GamePagerFragmentArgs by navArgs()
     private val viewModel: TopStreamsViewModel by viewModels { TopStreamsViewModelFactory }
     private lateinit var pagingAdapter: PagingDataAdapter<Stream, out RecyclerView.ViewHolder>
+    private lateinit var streamFeedScreenController: StreamFeedScreenController
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         _binding = FragmentGamesBinding.inflate(inflater, container, false)
@@ -132,6 +136,11 @@ class TopStreamsFragment : PagedListFragment(), Scrollable, StreamsSortDialog.On
             StreamsAdapter(this, { addTag(it) })
         }
         setAdapter(binding.recyclerViewLayout.recyclerView, pagingAdapter)
+        streamFeedScreenController = StreamFeedScreenController(
+            fragment = this,
+            coordinator = viewModel.refreshCoordinator,
+            specProvider = viewModel::currentFeedSpec,
+        ).also { it.start() }
     }
 
     override fun initialize() {
@@ -180,6 +189,7 @@ class TopStreamsFragment : PagedListFragment(), Scrollable, StreamsSortDialog.On
                     }
                 } else null
             }
+            streamFeedScreenController.onSpecChanged(force = false, reason = RefreshReason.SCREEN_VISIBLE)
             repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.flow.collectLatest { pagingData ->
                     pagingAdapter.submitData(pagingData)
@@ -227,9 +237,9 @@ class TopStreamsFragment : PagedListFragment(), Scrollable, StreamsSortDialog.On
 
     private fun addTag(tag: String) {
         viewLifecycleOwner.lifecycleScope.launch {
-            pagingAdapter.submitData(PagingData.empty())
             val tags = viewModel.tags.plus(tag).sortedArray()
             viewModel.setFilter(viewModel.sort, tags, viewModel.languages)
+            streamFeedScreenController.onSpecChanged(force = true)
             viewModel.filtersText.value = buildString {
                 if (viewModel.tags.isNotEmpty()) {
                     append(
@@ -259,8 +269,8 @@ class TopStreamsFragment : PagedListFragment(), Scrollable, StreamsSortDialog.On
     override fun onChange(sort: String, sortText: CharSequence, tags: Array<String>, languages: Array<String>, changed: Boolean, saveFilters: Boolean, saveSort: Boolean, saveDefault: Boolean) {
         viewLifecycleOwner.lifecycleScope.launch {
             if (changed) {
-                pagingAdapter.submitData(PagingData.empty())
                 viewModel.setFilter(sort, tags, languages)
+                streamFeedScreenController.onSpecChanged(force = true)
                 viewModel.sortText.value = getString(R.string.sort_by, sortText)
                 viewModel.filtersText.value = if (viewModel.tags.isNotEmpty() || viewModel.languages.isNotEmpty()) {
                     buildString {
@@ -322,7 +332,21 @@ class TopStreamsFragment : PagedListFragment(), Scrollable, StreamsSortDialog.On
     }
 
     override fun onNetworkRestored() {
-        pagingAdapter.retry()
+        viewModel.refreshCurrent(RefreshReason.NETWORK_RESTORED, force = true)
+    }
+
+    override fun onResume() {
+        super.onResume()
+        if (::streamFeedScreenController.isInitialized) {
+            streamFeedScreenController.onResume()
+        }
+    }
+
+    override fun onPause() {
+        if (::streamFeedScreenController.isInitialized) {
+            streamFeedScreenController.onPause()
+        }
+        super.onPause()
     }
 
     override fun onIntegrityTokenLoaded(callback: String?) {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/top/TopStreamsViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/top/TopStreamsViewModel.kt
@@ -6,33 +6,36 @@ import androidx.lifecycle.ViewModelProvider.AndroidViewModelFactory.Companion.AP
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
-import androidx.paging.Pager
 import androidx.paging.PagingConfig
 import androidx.paging.cachedIn
 import com.github.andreyasadchy.xtra.XtraApp
-import com.github.andreyasadchy.xtra.graphql.type.Language
-import com.github.andreyasadchy.xtra.graphql.type.StreamSort
 import com.github.andreyasadchy.xtra.model.ui.GameSort
 import com.github.andreyasadchy.xtra.model.ui.SavedFilter
 import com.github.andreyasadchy.xtra.repository.GameSortRepository
 import com.github.andreyasadchy.xtra.repository.GraphQLRepository
 import com.github.andreyasadchy.xtra.repository.HelixRepository
 import com.github.andreyasadchy.xtra.repository.SavedFiltersRepository
-import com.github.andreyasadchy.xtra.repository.datasource.StreamsDataSource
+import com.github.andreyasadchy.xtra.repository.streamfeed.RefreshReason
+import com.github.andreyasadchy.xtra.repository.streamfeed.StreamFeedPager
+import com.github.andreyasadchy.xtra.repository.streamfeed.StreamFeedRefreshCoordinator
+import com.github.andreyasadchy.xtra.repository.streamfeed.StreamFeedSpec
+import com.github.andreyasadchy.xtra.repository.streamfeed.StreamFeedSpecs
 import com.github.andreyasadchy.xtra.ui.common.StreamsSortDialog
 import com.github.andreyasadchy.xtra.util.C
-import com.github.andreyasadchy.xtra.util.TwitchApiHelper
 import com.github.andreyasadchy.xtra.util.prefs
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flatMapLatest
 
 class TopStreamsViewModel(
-    applicationContext: Context,
+    private val applicationContext: Context,
     private val gameSortRepository: GameSortRepository,
     private val savedFiltersRepository: SavedFiltersRepository,
     private val graphQLRepository: GraphQLRepository,
     private val helixRepository: HelixRepository,
+    private val streamFeedPager: StreamFeedPager,
+    val refreshCoordinator: StreamFeedRefreshCoordinator,
 ) : ViewModel() {
 
     val filter = MutableStateFlow<Filter?>(null)
@@ -48,40 +51,28 @@ class TopStreamsViewModel(
 
     @OptIn(ExperimentalCoroutinesApi::class)
     val flow = filter.flatMapLatest {
-        Pager(
-            if (applicationContext.prefs().getString(C.COMPACT_STREAMS, "disabled") == "all") {
+        streamFeedPager.flow(
+            spec = createSpec(it ?: Filter(null, null, null)),
+            config = if (applicationContext.prefs().getString(C.COMPACT_STREAMS, "disabled") == "all") {
                 PagingConfig(pageSize = 30, prefetchDistance = 10, initialLoadSize = 30)
             } else {
                 PagingConfig(pageSize = 30, prefetchDistance = 3, initialLoadSize = 30)
-            }
-        ) {
-            StreamsDataSource(
-                gqlQueryLanguages = languages.ifEmpty { null }?.mapNotNull { language ->
-                    Language.entries.find { it.rawValue == language }
-                },
-                gqlQuerySort = when (sort) {
-                    StreamsSortDialog.SORT_VIEWERS -> StreamSort.VIEWER_COUNT
-                    StreamsSortDialog.SORT_VIEWERS_ASC -> StreamSort.VIEWER_COUNT_ASC
-                    StreamsSortDialog.RECENT -> StreamSort.RECENT
-                    else -> StreamSort.VIEWER_COUNT
-                },
-                gqlLanguages = languages.ifEmpty { null }?.toList(),
-                gqlSort = when (sort) {
-                    StreamsSortDialog.SORT_VIEWERS -> "VIEWER_COUNT"
-                    StreamsSortDialog.SORT_VIEWERS_ASC -> "VIEWER_COUNT_ASC"
-                    StreamsSortDialog.RECENT -> "RECENT"
-                    else -> "VIEWER_COUNT"
-                },
-                tags = tags.ifEmpty { null }?.toList(),
-                gqlHeaders = TwitchApiHelper.getGQLHeaders(applicationContext),
-                graphQLRepository = graphQLRepository,
-                helixHeaders = TwitchApiHelper.getHelixHeaders(applicationContext),
-                helixRepository = helixRepository,
-                enableIntegrity = applicationContext.prefs().getBoolean(C.ENABLE_INTEGRITY, false),
-                networkLibrary = applicationContext.prefs().getString(C.NETWORK_LIBRARY, C.OKHTTP),
-            )
-        }.flow
+            },
+        )
     }.cachedIn(viewModelScope)
+
+    fun currentFeedSpec(): StreamFeedSpec? = filter.value?.let(::createSpec)
+
+    fun refreshCurrent(reason: RefreshReason, force: Boolean = false) {
+        currentFeedSpec()?.let { spec ->
+            viewModelScope.launch {
+                runCatching {
+                    if (force) refreshCoordinator.forceRefresh(spec, reason)
+                    else refreshCoordinator.maybeRefresh(spec, reason)
+                }
+            }
+        }
+    }
 
     suspend fun getGameSort(id: String): GameSort? {
         return gameSortRepository.getById(id)
@@ -99,6 +90,17 @@ class TopStreamsViewModel(
         filter.value = Filter(sort, tags, languages)
     }
 
+    private fun createSpec(filter: Filter): StreamFeedSpec {
+        return StreamFeedSpecs.top(
+            context = applicationContext,
+            graphQLRepository = graphQLRepository,
+            helixRepository = helixRepository,
+            sort = filter.sort ?: StreamsSortDialog.SORT_VIEWERS,
+            tags = filter.tags?.asIterable(),
+            languages = filter.languages?.asIterable(),
+        )
+    }
+
     class Filter(
         val sort: String?,
         val tags: Array<String>?,
@@ -110,7 +112,15 @@ class TopStreamsViewModel(
             initializer {
                 val application = (this[APPLICATION_KEY] as XtraApp)
                 val xtraModule = application.xtraModule
-                TopStreamsViewModel(application.applicationContext, xtraModule.gameSortRepository, xtraModule.savedFiltersRepository, xtraModule.graphQLRepository, xtraModule.helixRepository)
+                TopStreamsViewModel(
+                    application.applicationContext,
+                    xtraModule.gameSortRepository,
+                    xtraModule.savedFiltersRepository,
+                    xtraModule.graphQLRepository,
+                    xtraModule.helixRepository,
+                    xtraModule.streamFeedPager,
+                    xtraModule.streamFeedRefreshCoordinator,
+                )
             }
         }
     }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/C.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/C.kt
@@ -209,6 +209,8 @@ object C {
     const val PROXY_PORT = "proxy_port"
     const val PROXY_USER = "proxy_user"
     const val PROXY_PASSWORD = "proxy_password"
+    const val STREAM_FEED_RETURN_INTERVAL_MS = "stream_feed_return_interval_ms"
+    const val STREAM_FEED_RETURN_SAMPLE_COUNT = "stream_feed_return_sample_count"
     const val ANIMATED_EMOTES = "animatedGifEmotes"
     const val CHAT_SIZE_MODIFIER = "chat_size_modifier"
     const val CHAT_TEXT_SIZE = "chat_text_size"

--- a/app/src/test/java/com/github/andreyasadchy/xtra/repository/datasource/FollowedStreamsPageLoaderTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/repository/datasource/FollowedStreamsPageLoaderTest.kt
@@ -1,0 +1,68 @@
+package com.github.andreyasadchy.xtra.repository.datasource
+
+import com.github.andreyasadchy.xtra.util.C
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class FollowedStreamsPageLoaderTest {
+
+    @Test
+    fun persistedGraphQlFallbackKeepsItsCursorAffinity() = runBlocking {
+        var selectedApi: String? = null
+        val calls = mutableListOf<String>()
+
+        val firstPage = loadFollowedFirstPageWithFallback(
+            onApiSelected = { selectedApi = it; calls += it },
+            gql = { calls += "gql-first"; error("gql unavailable") },
+            persistedGql = { calls += "persisted-first"; "first" },
+            helix = { calls += "helix-first"; "helix" },
+        )
+        val nextPage = loadFollowedPageForCursor(
+            cursor = StreamFeedCursor(selectedApi!!, "persisted-cursor"),
+            gql = { calls += "gql:$it"; "wrong" },
+            persistedGql = { calls += "persisted:$it"; "second" },
+            helix = { calls += "helix:$it"; "wrong" },
+        )
+
+        assertEquals("first", firstPage)
+        assertEquals("second", nextPage)
+        assertEquals(
+            listOf(C.GQL, "gql-first", C.GQL_PERSISTED_QUERY, "persisted-first", "persisted:persisted-cursor"),
+            calls,
+        )
+    }
+
+    @Test
+    fun helixFallbackKeepsItsCursorAffinity() = runBlocking {
+        var selectedApi: String? = null
+        val calls = mutableListOf<String>()
+
+        loadFollowedFirstPageWithFallback(
+            onApiSelected = { selectedApi = it; calls += it },
+            gql = { calls += "gql-first"; error("gql unavailable") },
+            persistedGql = { calls += "persisted-first"; error("persisted unavailable") },
+            helix = { calls += "helix-first"; "first" },
+        )
+        val nextPage = loadFollowedPageForCursor(
+            cursor = StreamFeedCursor(selectedApi!!, "helix-cursor"),
+            gql = { calls += "gql:$it"; "wrong" },
+            persistedGql = { calls += "persisted:$it"; "wrong" },
+            helix = { calls += "helix:$it"; "second" },
+        )
+
+        assertEquals("second", nextPage)
+        assertEquals(
+            listOf(
+                C.GQL,
+                "gql-first",
+                C.GQL_PERSISTED_QUERY,
+                "persisted-first",
+                C.HELIX,
+                "helix-first",
+                "helix:helix-cursor",
+            ),
+            calls,
+        )
+    }
+}

--- a/app/src/test/java/com/github/andreyasadchy/xtra/repository/streamfeed/StreamFeedKeyTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/repository/streamfeed/StreamFeedKeyTest.kt
@@ -1,0 +1,28 @@
+package com.github.andreyasadchy.xtra.repository.streamfeed
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+
+class StreamFeedKeyTest {
+
+    @Test
+    fun equivalentFilterOrderingProducesOneKey() {
+        assertEquals(
+            StreamFeedKey.top("VIEWER_COUNT", listOf("FPS", "ENGLISH", "fps"), listOf("SK", "EN")),
+            StreamFeedKey.top("viewer_count", listOf("english", "fps"), listOf("en", "sk")),
+        )
+    }
+
+    @Test
+    fun accountScopesNeverShareFollowedKey() {
+        assertNotEquals(StreamFeedKey.followed("100"), StreamFeedKey.followed("200"))
+        assertNotEquals(StreamFeedKey.followed("100"), StreamFeedKey.followed(null))
+    }
+
+    @Test
+    fun credentialsAreNotPartOfKey() {
+        assertEquals(StreamFeedKey.followed("100"), StreamFeedKey.followed(" 100 "))
+        assertEquals("followed:account:100", StreamFeedKey.followed("100").value)
+    }
+}

--- a/app/src/test/java/com/github/andreyasadchy/xtra/repository/streamfeed/StreamFeedPolicyTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/repository/streamfeed/StreamFeedPolicyTest.kt
@@ -1,0 +1,93 @@
+package com.github.andreyasadchy.xtra.repository.streamfeed
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import java.util.concurrent.atomic.AtomicInteger
+
+class StreamFeedPolicyTest {
+
+    @Test
+    fun cacheIsFreshBelowTtlAndStaleAtTtl() {
+        val now = 1_000_000L
+        assertTrue(StreamFeedFreshnessPolicy.isFresh(now, now - StreamFeedFreshnessPolicy.LIVE_STREAM_SOFT_TTL_MS + 1))
+        assertFalse(StreamFeedFreshnessPolicy.isFresh(now, now - StreamFeedFreshnessPolicy.LIVE_STREAM_SOFT_TTL_MS))
+    }
+
+    @Test
+    fun futureClockDoesNotProduceNegativeAge() {
+        assertTrue(StreamFeedFreshnessPolicy.isFresh(1_000L, 2_000L))
+        assertEquals(0L, StreamFeedFreshnessPolicy.cacheAge(1_000L, 2_000L))
+    }
+
+    @Test
+    fun playbackThresholdRequiresMeaningfulViewing() {
+        assertFalse(StreamFeedFreshnessPolicy.playbackWasMeaningful(StreamFeedFreshnessPolicy.PLAYBACK_RETURN_THRESHOLD_MS - 1))
+        assertTrue(StreamFeedFreshnessPolicy.playbackWasMeaningful(StreamFeedFreshnessPolicy.PLAYBACK_RETURN_THRESHOLD_MS))
+    }
+
+    @Test
+    fun prewarmDelayUsesDefaultAndClamps() {
+        assertEquals(
+            StreamFeedFreshnessPolicy.PREWARM_MIN_DELAY_MS,
+            StreamFeedFreshnessPolicy.prewarmDelayMs(1L),
+        )
+        assertEquals(
+            StreamFeedFreshnessPolicy.PREWARM_MAX_DELAY_MS,
+            StreamFeedFreshnessPolicy.prewarmDelayMs(Long.MAX_VALUE),
+        )
+    }
+
+    @Test
+    fun manualRefreshBypassesTtlButBackoffStillWins() {
+        val now = 1_000_000L
+        assertEquals(
+            RefreshDecision.REFRESH,
+            refreshDecision(now, now, now, null, null, force = true),
+        )
+        assertEquals(
+            RefreshDecision.SKIP_BACKOFF,
+            refreshDecision(now, now - 1_000_000L, now - 1_000_000L, null, now + 1, force = true),
+        )
+    }
+
+    @Test
+    fun prewarmOnlyRunsForStaleBackgroundCache() {
+        assertFalse(shouldPrewarm(isForeground = true, cacheFresh = false))
+        assertFalse(shouldPrewarm(isForeground = false, cacheFresh = true))
+        assertTrue(shouldPrewarm(isForeground = false, cacheFresh = false))
+    }
+
+    @Test
+    fun concurrentTriggersUseOneSingleFlight() = runBlocking {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val singleFlight = StreamFeedSingleFlight<Int>(scope)
+        val started = CompletableDeferred<Unit>()
+        val executions = AtomicInteger()
+
+        val first = async {
+            singleFlight.run("top:test") {
+                executions.incrementAndGet()
+                started.complete(Unit)
+                delay(100)
+                7
+            }
+        }
+        started.await()
+        val second = async { singleFlight.run("top:test") { error("must join") } }
+
+        assertEquals(false, first.await().joined)
+        assertEquals(true, second.await().joined)
+        assertEquals(1, executions.get())
+        scope.cancel()
+    }
+}

--- a/app/src/test/java/com/github/andreyasadchy/xtra/repository/streamfeed/StreamFeedRefreshCoordinatorTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/repository/streamfeed/StreamFeedRefreshCoordinatorTest.kt
@@ -1,0 +1,720 @@
+package com.github.andreyasadchy.xtra.repository.streamfeed
+
+import androidx.paging.PagingSource
+import com.github.andreyasadchy.xtra.db.CachedStreamFeedItem
+import com.github.andreyasadchy.xtra.db.StreamFeedState
+import com.github.andreyasadchy.xtra.model.ui.Stream
+import com.github.andreyasadchy.xtra.repository.TwitchApiException
+import com.github.andreyasadchy.xtra.repository.datasource.StreamFeedCursor
+import com.github.andreyasadchy.xtra.repository.datasource.StreamFeedPage
+import com.github.andreyasadchy.xtra.repository.datasource.StreamFeedPageLoader
+import com.github.andreyasadchy.xtra.util.C
+import java.io.IOException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.withTimeout
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class StreamFeedRefreshCoordinatorTest {
+
+    @Test
+    fun failedRefreshDoesNotReplaceExistingRows() = runBlocking {
+        val key = StreamFeedKey("top:test")
+        val oldRows = refreshCachedItems(key.value, listOf(Stream(channelId = "old", title = "still visible")))
+        val cache = FakeCache(key, oldRows, StreamFeedState(key.value, lastSuccessAt = 1L))
+        val loader = object : StreamFeedPageLoader {
+            override suspend fun load(cursor: StreamFeedCursor?): StreamFeedPage {
+                error("offline")
+            }
+        }
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val coordinator = StreamFeedRefreshCoordinator(cache, scope, { 1_000_000L }, { 1_000L }, false)
+
+        assertTrue(runCatching { coordinator.maybeRefresh(StreamFeedSpec(key, loader), RefreshReason.APP_FOREGROUND) }.isFailure)
+        assertEquals(oldRows, cache.rows)
+        assertEquals(0, cache.replacementCount)
+        assertEquals(1L, cache.currentState?.lastSuccessAt)
+        scope.cancel()
+    }
+
+    @Test
+    fun successfulRefreshReplacesEndedRowsAddsNewRowsAndCommitsOrder() = runBlocking {
+        val key = StreamFeedKey("top:test")
+        val oldRows = refreshCachedItems(key.value, listOf(Stream(channelId = "old")))
+        val cache = FakeCache(key, oldRows, StreamFeedState(key.value, lastSuccessAt = 1L))
+        val loader = object : StreamFeedPageLoader {
+            override suspend fun load(cursor: StreamFeedCursor?) = StreamFeedPage(
+                listOf(Stream(channelId = "new-a"), Stream(channelId = "new-b")),
+                nextCursor = null,
+            )
+        }
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val result = StreamFeedRefreshCoordinator(cache, scope, { 1_000_000L }, { 1_000L }, false).forceRefresh(
+            StreamFeedSpec(key, loader),
+            RefreshReason.USER_PULL,
+        )
+
+        assertEquals(RefreshDecision.REFRESH, result.decision)
+        assertEquals(listOf("channel:new-a", "channel:new-b"), cache.rows.map { it.itemKey })
+        assertFalse(cache.rows.any { it.itemKey == "channel:old" })
+        assertEquals(listOf(0, 1), cache.rows.map { it.position })
+        assertEquals(1, cache.replacementCount)
+        scope.cancel()
+    }
+
+    @Test
+    fun automaticRefreshHonorsPersistedBackoff() = runBlocking {
+        val key = StreamFeedKey("top:test")
+        val cache = FakeCache(
+            key = key,
+            rows = emptyList(),
+            currentState = StreamFeedState(key.value, failureBackoffUntil = Long.MAX_VALUE),
+        )
+        var loads = 0
+        val loader = object : StreamFeedPageLoader {
+            override suspend fun load(cursor: StreamFeedCursor?): StreamFeedPage {
+                loads++
+                return StreamFeedPage(emptyList(), null)
+            }
+        }
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val result = StreamFeedRefreshCoordinator(cache, scope, { 1_000_000L }, { 1_000L }, false).maybeRefresh(
+            StreamFeedSpec(key, loader),
+            RefreshReason.APP_FOREGROUND,
+        )
+
+        assertEquals(RefreshDecision.SKIP_BACKOFF, result.decision)
+        assertEquals(0, loads)
+        scope.cancel()
+    }
+
+    @Test
+    fun integrityRetryReadsHeadersFromTheCurrentProvider() = runBlocking {
+        val key = StreamFeedKey("top:integrity")
+        val cache = FakeCache(key, emptyList(), StreamFeedState(key.value, lastSuccessAt = 0L))
+        var currentHeaders = mapOf("X-Integrity" to "expired")
+        val observedHeaders = mutableListOf<Map<String, String>>()
+        val headers = { currentHeaders }
+        val loader = object : StreamFeedPageLoader {
+            override suspend fun load(cursor: StreamFeedCursor?): StreamFeedPage {
+                observedHeaders += headers()
+                if (headers()["X-Integrity"] == "expired") {
+                    throw com.github.andreyasadchy.xtra.repository.datasource.StreamFeedIntegrityException()
+                }
+                return StreamFeedPage(emptyList(), null)
+            }
+        }
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val coordinator = StreamFeedRefreshCoordinator(cache, scope, { 1_000_000L }, { 1_000L }, false)
+        val spec = StreamFeedSpec(key, loader)
+
+        assertTrue(runCatching { coordinator.forceRefresh(spec, RefreshReason.INITIAL) }.isFailure)
+        currentHeaders = mapOf("X-Integrity" to "fresh")
+        assertEquals(RefreshDecision.REFRESH, coordinator.forceRefresh(spec, RefreshReason.USER_PULL).decision)
+        assertEquals(listOf("expired", "fresh"), observedHeaders.map { it["X-Integrity"] })
+        scope.cancel()
+    }
+
+    @Test
+    fun networkRestorationBypassesTransportFailureBackoff() = runBlocking {
+        val key = StreamFeedKey("top:network-restored")
+        val cache = FakeCache(
+            key = key,
+            rows = emptyList(),
+            currentState = StreamFeedState(key.value, failureBackoffUntil = Long.MAX_VALUE),
+        )
+        var loads = 0
+        val loader = object : StreamFeedPageLoader {
+            override suspend fun load(cursor: StreamFeedCursor?): StreamFeedPage {
+                loads++
+                return StreamFeedPage(emptyList(), null)
+            }
+        }
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val result = StreamFeedRefreshCoordinator(cache, scope, { 1_000_000L }, { 1_000L }, false).forceRefresh(
+            StreamFeedSpec(key, loader),
+            RefreshReason.NETWORK_RESTORED,
+        )
+
+        assertEquals(RefreshDecision.REFRESH, result.decision)
+        assertEquals(1, loads)
+        scope.cancel()
+    }
+
+    @Test
+    fun rateLimitResponsePersistsARefreshBlock() = runBlocking {
+        val key = StreamFeedKey("top:test")
+        val now = 1_000_000L
+        val cache = FakeCache(
+            key = key,
+            rows = emptyList(),
+            currentState = StreamFeedState(key.value, lastSuccessAt = 0L),
+        )
+        var loads = 0
+        val loader = object : StreamFeedPageLoader {
+            override suspend fun load(cursor: StreamFeedCursor?): StreamFeedPage {
+                loads += 1
+                throw TwitchApiException(429, 0L, message = "rate limited")
+            }
+        }
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val coordinator = StreamFeedRefreshCoordinator(cache, scope, { now }, { 1_000L }, false)
+        val spec = StreamFeedSpec(key, loader)
+
+        assertTrue(runCatching { coordinator.maybeRefresh(spec, RefreshReason.APP_FOREGROUND) }.isFailure)
+        assertTrue((cache.currentState?.rateLimitUntil ?: 0L) > now)
+        assertEquals(RefreshDecision.SKIP_BACKOFF, coordinator.maybeRefresh(spec, RefreshReason.NETWORK_RESTORED).decision)
+        assertEquals(1, loads)
+        scope.cancel()
+    }
+
+    @Test
+    fun shortPlaybackDoesNotRefreshButMeaningfulPlaybackDoes() = runBlocking {
+        val key = StreamFeedKey("top:test")
+        val cache = FakeCache(
+            key = key,
+            rows = emptyList(),
+            currentState = StreamFeedState(key.value, lastSuccessAt = 0L),
+        )
+        val loaderStarted = CompletableDeferred<Unit>()
+        val loader = object : StreamFeedPageLoader {
+            override suspend fun load(cursor: StreamFeedCursor?): StreamFeedPage {
+                loaderStarted.complete(Unit)
+                return StreamFeedPage(emptyList(), null)
+            }
+        }
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        var elapsed = 0L
+        val coordinator = StreamFeedRefreshCoordinator(cache, scope, { 1_000_000L }, { elapsed }, false)
+        val spec = StreamFeedSpec(key, loader)
+        coordinator.setVisibleFeed(spec)
+
+        coordinator.playbackEntered()
+        elapsed = StreamFeedFreshnessPolicy.PLAYBACK_RETURN_THRESHOLD_MS - 1
+        coordinator.playbackReturned()
+        assertFalse(loaderStarted.isCompleted)
+
+        coordinator.playbackEntered()
+        elapsed += StreamFeedFreshnessPolicy.PLAYBACK_RETURN_THRESHOLD_MS
+        coordinator.playbackReturned()
+        withTimeout(1_000L) { loaderStarted.await() }
+        scope.cancel()
+    }
+
+    @Test
+    fun playbackReturnCanBeRearmedAndMaximizeDoesNotResetTheViewingTimer() = runBlocking {
+        val key = StreamFeedKey("top:playback-rearm")
+        val cache = FakeCache(
+            key = key,
+            rows = emptyList(),
+            currentState = StreamFeedState(key.value, lastSuccessAt = 0L),
+        )
+        val firstLoad = CompletableDeferred<Unit>()
+        val secondLoad = CompletableDeferred<Unit>()
+        var loads = 0
+        val loader = object : StreamFeedPageLoader {
+            override suspend fun load(cursor: StreamFeedCursor?): StreamFeedPage {
+                loads++
+                if (loads == 1) firstLoad.complete(Unit) else secondLoad.complete(Unit)
+                return StreamFeedPage(emptyList(), null)
+            }
+        }
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        var now = 1_000_000L
+        var elapsed = 0L
+        val coordinator = StreamFeedRefreshCoordinator(cache, scope, { now }, { elapsed }, false)
+        val spec = StreamFeedSpec(key, loader)
+        coordinator.setVisibleFeed(spec)
+
+        coordinator.playbackEntered()
+        assertTrue(coordinator.isPlayerFullscreen)
+        elapsed = StreamFeedFreshnessPolicy.PLAYBACK_RETURN_THRESHOLD_MS
+        coordinator.playbackReturned()
+        assertFalse(coordinator.isPlayerFullscreen)
+        withTimeout(1_000L) { firstLoad.await() }
+
+        now += StreamFeedFreshnessPolicy.LIVE_STREAM_SOFT_TTL_MS
+        elapsed += 1L
+        coordinator.playbackEntered()
+        elapsed += StreamFeedFreshnessPolicy.PLAYBACK_RETURN_THRESHOLD_MS / 2
+        // Maximizing the minimized player must keep the original session start.
+        coordinator.playbackEntered()
+        elapsed += StreamFeedFreshnessPolicy.PLAYBACK_RETURN_THRESHOLD_MS / 2
+        coordinator.playbackReturned()
+        withTimeout(1_000L) { secondLoad.await() }
+        assertEquals(2, loads)
+        scope.cancel()
+    }
+
+    @Test
+    fun refreshCursorIsUsedByAppendAfterADeepListRefresh() = runBlocking {
+        val key = StreamFeedKey("top:deep-scroll")
+        val cache = FakeCache(
+            key = key,
+            rows = refreshCachedItems(key.value, listOf(Stream(channelId = "old"))),
+            currentState = StreamFeedState(key.value, nextCursor = "old-cursor", lastSuccessAt = 0L),
+        )
+        val cursors = mutableListOf<StreamFeedCursor?>()
+        val loader = object : StreamFeedPageLoader {
+            override suspend fun load(cursor: StreamFeedCursor?): StreamFeedPage {
+                cursors += cursor
+                return if (cursor == null) {
+                    StreamFeedPage(
+                        listOf(Stream(channelId = "fresh")),
+                        nextCursor = StreamFeedCursor(com.github.andreyasadchy.xtra.util.C.GQL, "new-cursor"),
+                    )
+                } else {
+                    assertEquals("new-cursor", cursor.value)
+                    StreamFeedPage(listOf(Stream(channelId = "appended")), nextCursor = null)
+                }
+            }
+        }
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val coordinator = StreamFeedRefreshCoordinator(cache, scope, { 1_000_000L }, { 1_000L }, false)
+        val spec = StreamFeedSpec(key, loader)
+
+        coordinator.forceRefresh(spec, RefreshReason.USER_PULL)
+        val append = coordinator.append(spec)
+
+        assertTrue(append.endOfPaginationReached)
+        assertEquals(listOf(null, StreamFeedCursor(com.github.andreyasadchy.xtra.util.C.GQL, "new-cursor")), cursors)
+        assertEquals(listOf("channel:fresh", "channel:appended"), cache.rows.map { it.itemKey })
+        scope.cancel()
+    }
+
+    @Test
+    fun automaticRefreshKeepsDeepRowsUntilPaginationCompletes() = runBlocking {
+        val key = StreamFeedKey("top:deep-scroll-automatic")
+        val oldRows = refreshCachedItems(
+            key.value,
+            (0 until 90).map { Stream(channelId = "deep-$it") },
+            generation = 1L,
+        )
+        val cache = FakeCache(
+            key = key,
+            rows = oldRows,
+            currentState = StreamFeedState(
+                feedKey = key.value,
+                nextCursor = "old-page-4",
+                nextCursorApi = com.github.andreyasadchy.xtra.util.C.GQL,
+                lastSuccessAt = 0L,
+                activeGeneration = 1L,
+            ),
+        )
+        val appendCommitted = CompletableDeferred<Unit>()
+        cache.appendCommitted = appendCommitted
+        val cursors = mutableListOf<StreamFeedCursor?>()
+        val loader = object : StreamFeedPageLoader {
+            override suspend fun load(cursor: StreamFeedCursor?): StreamFeedPage {
+                cursors += cursor
+                return when (cursor?.value) {
+                    null -> StreamFeedPage(
+                        listOf(Stream(channelId = "fresh-0")),
+                        StreamFeedCursor(com.github.andreyasadchy.xtra.util.C.GQL, "page-2"),
+                    )
+                    "page-2" -> StreamFeedPage(
+                        listOf(Stream(channelId = "fresh-1")),
+                        StreamFeedCursor(com.github.andreyasadchy.xtra.util.C.GQL, "page-3"),
+                    )
+                    else -> StreamFeedPage(listOf(Stream(channelId = "fresh-2")), null)
+                }
+            }
+        }
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val coordinator = StreamFeedRefreshCoordinator(cache, scope, { 1_000_000L }, { 1_000L }, false)
+        val spec = StreamFeedSpec(key, loader)
+
+        coordinator.maybeRefresh(spec, RefreshReason.APP_FOREGROUND)
+        withTimeout(1_000L) { appendCommitted.await() }
+
+        assertTrue(cache.rows.any { it.itemKey == "channel:deep-80" })
+        assertTrue(cache.rows.size > 1)
+        coordinator.append(spec)
+        assertFalse(cache.rows.any { it.itemKey == "channel:deep-80" })
+        assertEquals(
+            listOf(null, StreamFeedCursor(com.github.andreyasadchy.xtra.util.C.GQL, "page-2"), StreamFeedCursor(com.github.andreyasadchy.xtra.util.C.GQL, "page-3")),
+            cursors,
+        )
+        scope.cancel()
+    }
+
+    @Test
+    fun automaticRefreshPrefetchesOneFreshPageWhenRetainingADeepTail() = runBlocking {
+        val key = StreamFeedKey("top:bounded-tail-prefetch")
+        val cache = FakeCache(
+            key = key,
+            rows = refreshCachedItems(
+                key.value,
+                (0 until 90).map { Stream(channelId = "old-$it") },
+                generation = 1L,
+            ),
+            currentState = StreamFeedState(
+                feedKey = key.value,
+                nextCursor = "old-page-4",
+                nextCursorApi = C.GQL,
+                lastSuccessAt = 0L,
+                activeGeneration = 1L,
+            ),
+        )
+        val appendCommitted = CompletableDeferred<Unit>()
+        cache.appendCommitted = appendCommitted
+        var loads = 0
+        val loader = object : StreamFeedPageLoader {
+            override suspend fun load(cursor: StreamFeedCursor?): StreamFeedPage {
+                loads++
+                return if (cursor == null) {
+                    StreamFeedPage(
+                        listOf(Stream(channelId = "fresh-0")),
+                        StreamFeedCursor(C.GQL, "fresh-page-2"),
+                    )
+                } else {
+                    assertEquals(StreamFeedCursor(C.GQL, "fresh-page-2"), cursor)
+                    StreamFeedPage(listOf(Stream(channelId = "fresh-1")), StreamFeedCursor(C.GQL, "fresh-page-3"))
+                }
+            }
+        }
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val coordinator = StreamFeedRefreshCoordinator(cache, scope, { 1_000_000L }, { 1_000L }, false)
+
+        coordinator.maybeRefresh(StreamFeedSpec(key, loader), RefreshReason.APP_FOREGROUND)
+        withTimeout(1_000L) { appendCommitted.await() }
+
+        assertEquals(2, loads)
+        assertTrue(cache.rows.any { it.itemKey == "channel:fresh-1" })
+        assertTrue(cache.rows.any { it.itemKey == "channel:old-80" })
+        scope.cancel()
+    }
+
+    @Test
+    fun speculativeTailPrefetchFailureDoesNotBackoffImmediateAppend() = runBlocking {
+        val key = StreamFeedKey("top:speculative-prefetch-failure")
+        val cache = FakeCache(
+            key = key,
+            rows = refreshCachedItems(
+                key.value,
+                (0 until 90).map { Stream(channelId = "old-$it") },
+                generation = 1L,
+            ),
+            currentState = StreamFeedState(
+                feedKey = key.value,
+                lastSuccessAt = 0L,
+                activeGeneration = 1L,
+            ),
+        )
+        val failureRecorded = CompletableDeferred<Unit>()
+        cache.failureRecorded = failureRecorded
+        var loads = 0
+        val loader = object : StreamFeedPageLoader {
+            override suspend fun load(cursor: StreamFeedCursor?): StreamFeedPage {
+                loads++
+                return when {
+                    cursor == null -> StreamFeedPage(
+                        listOf(Stream(channelId = "fresh-0")),
+                        StreamFeedCursor(C.GQL, "fresh-page-2"),
+                    )
+                    loads == 2 -> throw IOException("temporary append failure")
+                    else -> StreamFeedPage(listOf(Stream(channelId = "fresh-1")), null)
+                }
+            }
+        }
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val coordinator = StreamFeedRefreshCoordinator(cache, scope, { 1_000_000L }, { 1_000L }, false)
+        val spec = StreamFeedSpec(key, loader)
+
+        coordinator.maybeRefresh(spec, RefreshReason.APP_FOREGROUND)
+        withTimeout(1_000L) { failureRecorded.await() }
+
+        val appendResult = withTimeout(1_000L) { coordinator.append(spec) }
+
+        assertTrue(appendResult.endOfPaginationReached)
+        assertEquals(3, loads)
+        assertEquals(null, cache.currentState?.failureBackoffUntil)
+        scope.cancel()
+    }
+
+    @Test
+    fun speculativeTailPrefetchRateLimitStillBlocksImmediateAppend() = runBlocking {
+        val key = StreamFeedKey("top:speculative-prefetch-rate-limit")
+        val cache = FakeCache(
+            key = key,
+            rows = refreshCachedItems(
+                key.value,
+                (0 until 90).map { Stream(channelId = "old-$it") },
+                generation = 1L,
+            ),
+            currentState = StreamFeedState(
+                feedKey = key.value,
+                lastSuccessAt = 0L,
+                activeGeneration = 1L,
+            ),
+        )
+        val failureRecorded = CompletableDeferred<Unit>()
+        cache.failureRecorded = failureRecorded
+        var loads = 0
+        val loader = object : StreamFeedPageLoader {
+            override suspend fun load(cursor: StreamFeedCursor?): StreamFeedPage {
+                loads++
+                return if (cursor == null) {
+                    StreamFeedPage(
+                        listOf(Stream(channelId = "fresh-0")),
+                        StreamFeedCursor(C.GQL, "fresh-page-2"),
+                    )
+                } else {
+                    throw TwitchApiException(429, 0L, message = "rate limited")
+                }
+            }
+        }
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val coordinator = StreamFeedRefreshCoordinator(cache, scope, { 1_000_000L }, { 1_000L }, false)
+        val spec = StreamFeedSpec(key, loader)
+
+        coordinator.maybeRefresh(spec, RefreshReason.APP_FOREGROUND)
+        withTimeout(1_000L) { failureRecorded.await() }
+
+        assertTrue((cache.currentState?.rateLimitUntil ?: 0L) > 1_000_000L)
+        assertEquals(null, cache.currentState?.failureBackoffUntil)
+        assertTrue(runCatching { coordinator.append(spec) }.isFailure)
+        assertEquals(2, loads)
+        scope.cancel()
+    }
+
+    @Test
+    fun automaticRefreshEofRetainsStaleRowsUntilRealAppendFinalizesGeneration() = runBlocking {
+        val key = StreamFeedKey("top:automatic-eof")
+        val cache = FakeCache(
+            key = key,
+            rows = refreshCachedItems(
+                key.value,
+                (0 until 90).map { Stream(channelId = "old-$it") },
+                generation = 1L,
+            ),
+            currentState = StreamFeedState(key.value, lastSuccessAt = 0L, activeGeneration = 1L),
+        )
+        val loader = object : StreamFeedPageLoader {
+            override suspend fun load(cursor: StreamFeedCursor?): StreamFeedPage {
+                assertEquals(null, cursor)
+                return StreamFeedPage(
+                    (0 until 20).map { Stream(channelId = "fresh-$it") },
+                    nextCursor = null,
+                )
+            }
+        }
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val coordinator = StreamFeedRefreshCoordinator(cache, scope, { 1_000_000L }, { 1_000L }, false)
+        val spec = StreamFeedSpec(key, loader)
+
+        coordinator.maybeRefresh(spec, RefreshReason.APP_FOREGROUND)
+
+        assertTrue(cache.rows.any { it.itemKey == "channel:old-80" })
+        assertEquals(null, cache.currentState?.nextCursor)
+        assertTrue(coordinator.append(spec).endOfPaginationReached)
+        assertFalse(cache.rows.any { it.itemKey == "channel:old-80" })
+        assertEquals(20, cache.rows.size)
+        scope.cancel()
+    }
+
+    @Test
+    fun speculativeEofRetainsStaleRowsUntilRealAppendFinalizesGeneration() = runBlocking {
+        val key = StreamFeedKey("top:speculative-eof")
+        val cache = FakeCache(
+            key = key,
+            rows = refreshCachedItems(
+                key.value,
+                (0 until 90).map { Stream(channelId = "old-$it") },
+                generation = 1L,
+            ),
+            currentState = StreamFeedState(key.value, lastSuccessAt = 0L, activeGeneration = 1L),
+        )
+        val appendCommitted = CompletableDeferred<Unit>()
+        cache.appendCommitted = appendCommitted
+        var loads = 0
+        val loader = object : StreamFeedPageLoader {
+            override suspend fun load(cursor: StreamFeedCursor?): StreamFeedPage {
+                loads++
+                return if (cursor == null) {
+                    StreamFeedPage(
+                        (0 until 30).map { Stream(channelId = "fresh-$it") },
+                        StreamFeedCursor(C.GQL, "fresh-page-2"),
+                    )
+                } else {
+                    assertEquals(StreamFeedCursor(C.GQL, "fresh-page-2"), cursor)
+                    StreamFeedPage(
+                        (30 until 50).map { Stream(channelId = "fresh-$it") },
+                        nextCursor = null,
+                    )
+                }
+            }
+        }
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val coordinator = StreamFeedRefreshCoordinator(cache, scope, { 1_000_000L }, { 1_000L }, false)
+        val spec = StreamFeedSpec(key, loader)
+
+        coordinator.maybeRefresh(spec, RefreshReason.APP_FOREGROUND)
+        withTimeout(1_000L) { appendCommitted.await() }
+
+        assertEquals(2, loads)
+        assertTrue(cache.rows.any { it.itemKey == "channel:old-80" })
+        assertEquals(null, cache.currentState?.nextCursor)
+        assertTrue(coordinator.append(spec).endOfPaginationReached)
+        assertFalse(cache.rows.any { it.itemKey == "channel:old-80" })
+        assertEquals(50, cache.rows.size)
+        scope.cancel()
+    }
+
+    @Test
+    fun appendUsesCursorApiPersistedByAnotherLoaderInstance() = runBlocking {
+        val key = StreamFeedKey("top:cursor-affinity")
+        val cache = FakeCache(
+            key = key,
+            rows = emptyList(),
+            currentState = StreamFeedState(key.value, lastSuccessAt = 0L),
+        )
+        var appendCursor: StreamFeedCursor? = null
+        val refreshLoader = object : StreamFeedPageLoader {
+            override suspend fun load(cursor: StreamFeedCursor?): StreamFeedPage {
+                return StreamFeedPage(
+                    listOf(Stream(channelId = "fresh")),
+                    StreamFeedCursor(C.HELIX, "helix-cursor"),
+                )
+            }
+        }
+        val appendLoader = object : StreamFeedPageLoader {
+            override suspend fun load(cursor: StreamFeedCursor?): StreamFeedPage {
+                appendCursor = cursor
+                return StreamFeedPage(emptyList(), null)
+            }
+        }
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val coordinator = StreamFeedRefreshCoordinator(cache, scope, { 1_000_000L }, { 1_000L }, false)
+
+        coordinator.forceRefresh(StreamFeedSpec(key, refreshLoader), RefreshReason.USER_PULL)
+        coordinator.append(StreamFeedSpec(key, appendLoader))
+
+        assertEquals(StreamFeedCursor(C.HELIX, "helix-cursor"), appendCursor)
+        scope.cancel()
+    }
+
+    @Test
+    fun nonLiveFullscreenSuppressesStreamRefreshAndDoesNotCountAsLiveViewing() = runBlocking {
+        val key = StreamFeedKey("top:non-live-player")
+        val cache = FakeCache(key, emptyList(), StreamFeedState(key.value, lastSuccessAt = 0L))
+        var loads = 0
+        val loader = object : StreamFeedPageLoader {
+            override suspend fun load(cursor: StreamFeedCursor?): StreamFeedPage {
+                loads++
+                return StreamFeedPage(emptyList(), null)
+            }
+        }
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        var elapsed = 0L
+        val coordinator = StreamFeedRefreshCoordinator(cache, scope, { 1_000_000L }, { elapsed }, false)
+        coordinator.setVisibleFeed(StreamFeedSpec(key, loader))
+
+        coordinator.playbackEntered(isLive = true)
+        elapsed = StreamFeedFreshnessPolicy.PLAYBACK_RETURN_THRESHOLD_MS
+        coordinator.playbackChanged(isLive = false)
+        assertTrue(coordinator.isPlayerFullscreen)
+        coordinator.playbackReturned()
+
+        assertFalse(coordinator.isPlayerFullscreen)
+        assertEquals(0, loads)
+        scope.cancel()
+    }
+
+    private class FakeCache(
+        private val key: StreamFeedKey,
+        var rows: List<CachedStreamFeedItem>,
+        var currentState: StreamFeedState?,
+    ) : StreamFeedCacheStore {
+        var replacementCount = 0
+        var appendCommitted: CompletableDeferred<Unit>? = null
+        var failureRecorded: CompletableDeferred<Unit>? = null
+
+        override fun pagingSource(feedKey: StreamFeedKey): PagingSource<Int, CachedStreamFeedItem> = error("unused")
+
+        override suspend fun state(feedKey: StreamFeedKey): StreamFeedState? = currentState
+
+        override suspend fun itemCount(feedKey: StreamFeedKey): Int = rows.size
+
+        override suspend fun touchAccess(feedKey: StreamFeedKey, nowMs: Long) {
+            currentState = (currentState ?: StreamFeedState(feedKey.value)).copy(lastAccessAt = nowMs)
+        }
+
+        override suspend fun markAttempt(feedKey: StreamFeedKey, nowMs: Long) {
+            currentState = (currentState ?: StreamFeedState(feedKey.value)).copy(lastAttemptAt = nowMs)
+        }
+
+        override suspend fun replaceAfterRefresh(
+            feedKey: StreamFeedKey,
+            page: StreamFeedPage,
+            nowMs: Long,
+            preserveTail: Boolean,
+            pruneStaleOnEnd: Boolean,
+        ) {
+            val generation = (currentState?.activeGeneration ?: 0L) + 1L
+            rows = if (preserveTail) {
+                refreshCachedItemsPreservingTail(feedKey.value, rows, page.items, generation)
+            } else {
+                refreshCachedItems(feedKey.value, page.items, generation)
+            }
+            if (page.nextCursor == null && pruneStaleOnEnd) {
+                rows = rows.filter { it.generation == generation }
+            }
+            currentState = StreamFeedState(
+                feedKey = feedKey.value,
+                nextCursor = page.nextCursor?.value,
+                lastSuccessAt = nowMs,
+                lastAttemptAt = nowMs,
+                lastAccessAt = nowMs,
+                nextCursorApi = page.nextCursor?.api,
+                activeGeneration = generation,
+            )
+            replacementCount++
+        }
+
+        override suspend fun appendPage(
+            feedKey: StreamFeedKey,
+            page: StreamFeedPage,
+            nowMs: Long,
+            pruneStaleOnEnd: Boolean,
+        ) {
+            val current = currentState ?: StreamFeedState(feedKey.value)
+            rows = appendCachedPage(feedKey.value, rows, page.items, current.activeGeneration)
+            if (page.nextCursor == null && pruneStaleOnEnd) {
+                rows = rows.filter { it.generation == current.activeGeneration }
+            }
+            currentState = current.copy(
+                nextCursor = page.nextCursor?.value,
+                nextCursorApi = page.nextCursor?.api,
+                lastAttemptAt = nowMs,
+                lastAccessAt = nowMs,
+            )
+            appendCommitted?.complete(Unit)
+        }
+
+        override suspend fun pruneStaleGeneration(feedKey: StreamFeedKey) {
+            val generation = currentState?.activeGeneration ?: return
+            rows = rows.filter { it.generation == generation }
+        }
+
+        override suspend fun recordFailure(feedKey: StreamFeedKey, nowMs: Long, failureBackoffUntil: Long?, rateLimitUntil: Long?) {
+            currentState = (currentState ?: StreamFeedState(feedKey.value)).copy(
+                lastAttemptAt = nowMs,
+                failureBackoffUntil = failureBackoffUntil,
+                rateLimitUntil = rateLimitUntil,
+            )
+            failureRecorded?.complete(Unit)
+        }
+
+        override suspend fun invalidatePrefix(prefix: String, nowMs: Long) = Unit
+
+        override suspend fun cleanup(nowMs: Long) = Unit
+    }
+}

--- a/app/src/test/java/com/github/andreyasadchy/xtra/repository/streamfeed/StreamFeedRemoteMediatorTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/repository/streamfeed/StreamFeedRemoteMediatorTest.kt
@@ -1,0 +1,186 @@
+package com.github.andreyasadchy.xtra.repository.streamfeed
+
+import androidx.paging.ExperimentalPagingApi
+import androidx.paging.LoadType
+import androidx.paging.PagingConfig
+import androidx.paging.PagingSource
+import androidx.paging.PagingState
+import androidx.paging.RemoteMediator
+import com.github.andreyasadchy.xtra.db.CachedStreamFeedItem
+import com.github.andreyasadchy.xtra.db.StreamFeedState
+import com.github.andreyasadchy.xtra.model.ui.Stream
+import com.github.andreyasadchy.xtra.repository.datasource.StreamFeedPage
+import com.github.andreyasadchy.xtra.repository.datasource.StreamFeedCursor
+import com.github.andreyasadchy.xtra.repository.datasource.StreamFeedPageLoader
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+@OptIn(ExperimentalPagingApi::class)
+class StreamFeedRemoteMediatorTest {
+
+    @Test
+    fun initialFailureCanBeRetriedWithoutLeavingTheMediatorLoading() = runBlocking {
+        val now = 1_000_000L
+        val key = StreamFeedKey("top:mediator-retry")
+        val cache = FakeCache(key, emptyList(), StreamFeedState(key.value, lastSuccessAt = 0L))
+        var loads = 0
+        val loader = object : StreamFeedPageLoader {
+            override suspend fun load(cursor: StreamFeedCursor?): StreamFeedPage {
+                loads++
+                if (loads == 1) error("offline")
+                return StreamFeedPage(listOf(Stream(channelId = "fresh")), null)
+            }
+        }
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val mediator = StreamFeedRemoteMediator(
+            StreamFeedSpec(key, loader),
+            cache,
+            StreamFeedRefreshCoordinator(cache, scope, { now }, { 1_000L }, false),
+            { now },
+        )
+
+        assertEquals(RemoteMediator.InitializeAction.LAUNCH_INITIAL_REFRESH, mediator.initialize())
+        assertTrue(mediator.load(LoadType.REFRESH, emptyPagingState()) is RemoteMediator.MediatorResult.Error)
+        val retry = mediator.load(LoadType.REFRESH, emptyPagingState())
+
+        assertTrue(retry is RemoteMediator.MediatorResult.Success)
+        assertEquals(2, loads)
+        assertEquals(listOf("channel:fresh"), cache.rows.map { it.itemKey })
+        scope.cancel()
+    }
+
+    @Test
+    fun persistedBackoffSkipsLaunchingInitialRefresh() = runBlocking {
+        val now = 1_000_000L
+        val key = StreamFeedKey("top:mediator-backoff")
+        val cache = FakeCache(
+            key,
+            emptyList(),
+            StreamFeedState(key.value, failureBackoffUntil = now + 60_000L),
+        )
+        var loads = 0
+        val loader = object : StreamFeedPageLoader {
+            override suspend fun load(cursor: StreamFeedCursor?): StreamFeedPage {
+                loads++
+                return StreamFeedPage(emptyList(), null)
+            }
+        }
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val mediator = StreamFeedRemoteMediator(
+            StreamFeedSpec(key, loader),
+            cache,
+            StreamFeedRefreshCoordinator(cache, scope, { now }, { 1_000L }, false),
+            { now },
+        )
+
+        assertEquals(RemoteMediator.InitializeAction.SKIP_INITIAL_REFRESH, mediator.initialize())
+        assertEquals(0, loads)
+        scope.cancel()
+    }
+
+    @Test
+    fun noOpRefreshSettlesAsEndOfPagination() = runBlocking {
+        val now = 1_000_000L
+        val key = StreamFeedKey("top:mediator-noop")
+        val cache = FakeCache(key, emptyList(), StreamFeedState(key.value, lastSuccessAt = 0L))
+        var loads = 0
+        val loader = object : StreamFeedPageLoader {
+            override suspend fun load(cursor: StreamFeedCursor?): StreamFeedPage {
+                loads++
+                return StreamFeedPage(emptyList(), null)
+            }
+        }
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val mediator = StreamFeedRemoteMediator(
+            StreamFeedSpec(key, loader),
+            cache,
+            StreamFeedRefreshCoordinator(cache, scope, { now }, { 1_000L }, false),
+            { now },
+        )
+
+        assertEquals(RemoteMediator.InitializeAction.LAUNCH_INITIAL_REFRESH, mediator.initialize())
+        cache.currentState = cache.currentState!!.copy(failureBackoffUntil = Long.MAX_VALUE)
+        val result = mediator.load(LoadType.REFRESH, emptyPagingState())
+
+        assertTrue(result is RemoteMediator.MediatorResult.Success)
+        assertTrue((result as RemoteMediator.MediatorResult.Success).endOfPaginationReached)
+        assertEquals(0, loads)
+        scope.cancel()
+    }
+
+    private fun emptyPagingState(): PagingState<Int, CachedStreamFeedItem> {
+        return PagingState(
+            pages = emptyList(),
+            anchorPosition = null,
+            config = PagingConfig(pageSize = 30),
+            leadingPlaceholderCount = 0,
+        )
+    }
+
+    private class FakeCache(
+        private val key: StreamFeedKey,
+        var rows: List<CachedStreamFeedItem>,
+        var currentState: StreamFeedState?,
+    ) : StreamFeedCacheStore {
+        override fun pagingSource(feedKey: StreamFeedKey): PagingSource<Int, CachedStreamFeedItem> = error("unused")
+
+        override suspend fun state(feedKey: StreamFeedKey): StreamFeedState? = currentState
+
+        override suspend fun itemCount(feedKey: StreamFeedKey): Int = rows.size
+
+        override suspend fun touchAccess(feedKey: StreamFeedKey, nowMs: Long) {
+            currentState = (currentState ?: StreamFeedState(feedKey.value)).copy(lastAccessAt = nowMs)
+        }
+
+        override suspend fun markAttempt(feedKey: StreamFeedKey, nowMs: Long) {
+            currentState = (currentState ?: StreamFeedState(feedKey.value)).copy(lastAttemptAt = nowMs)
+        }
+
+        override suspend fun replaceAfterRefresh(
+            feedKey: StreamFeedKey,
+            page: StreamFeedPage,
+            nowMs: Long,
+            preserveTail: Boolean,
+            pruneStaleOnEnd: Boolean,
+        ) {
+            rows = refreshCachedItems(feedKey.value, page.items)
+            currentState = StreamFeedState(
+                feedKey.value,
+                page.nextCursor?.value,
+                nowMs,
+                nowMs,
+                nowMs,
+                nextCursorApi = page.nextCursor?.api,
+            )
+        }
+
+        override suspend fun appendPage(
+            feedKey: StreamFeedKey,
+            page: StreamFeedPage,
+            nowMs: Long,
+            pruneStaleOnEnd: Boolean,
+        ) = Unit
+
+        override suspend fun pruneStaleGeneration(feedKey: StreamFeedKey) {
+            rows = rows.filter { it.generation == currentState?.activeGeneration }
+        }
+
+        override suspend fun recordFailure(feedKey: StreamFeedKey, nowMs: Long, failureBackoffUntil: Long?, rateLimitUntil: Long?) {
+            currentState = (currentState ?: StreamFeedState(feedKey.value)).copy(
+                lastAttemptAt = nowMs,
+                failureBackoffUntil = failureBackoffUntil,
+                rateLimitUntil = rateLimitUntil,
+            )
+        }
+
+        override suspend fun invalidatePrefix(prefix: String, nowMs: Long) = Unit
+
+        override suspend fun cleanup(nowMs: Long) = Unit
+    }
+}

--- a/app/src/test/java/com/github/andreyasadchy/xtra/repository/streamfeed/StreamFeedSnapshotTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/repository/streamfeed/StreamFeedSnapshotTest.kt
@@ -1,0 +1,92 @@
+package com.github.andreyasadchy.xtra.repository.streamfeed
+
+import com.github.andreyasadchy.xtra.model.ui.Stream
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class StreamFeedSnapshotTest {
+
+    @Test
+    fun refreshRemovesEndedStreamsAddsNewStreamsAndUpdatesOrder() {
+        val old = listOf(
+            Stream(id = null, channelId = "a", title = "old-a"),
+            Stream(id = null, channelId = "b", title = "old-b"),
+        )
+        val fresh = listOf(
+            Stream(id = null, channelId = "b", title = "new-b"),
+            Stream(id = null, channelId = "c", title = "new-c"),
+        )
+
+        val items = refreshCachedItems("top:test", fresh)
+
+        assertEquals(listOf("channel:b", "channel:c"), items.map { it.itemKey })
+        assertEquals(listOf(0, 1), items.map { it.position })
+        assertEquals("new-b", items.first().title)
+        assertFalse(items.any { it.itemKey == "channel:a" })
+        assertTrue(old.any { it.channelId == "a" }) // the old snapshot is untouched until a successful commit
+    }
+
+    @Test
+    fun appendPreservesExistingChannelPosition() {
+        val existing = refreshCachedItems(
+            "top:test",
+            listOf(Stream(id = null, channelId = "a"), Stream(id = null, channelId = "b")),
+        )
+        val appended = appendCachedPage(
+            "top:test",
+            existing,
+            listOf(Stream(id = null, channelId = "b", viewerCount = 4), Stream(id = null, channelId = "c")),
+        )
+
+        assertEquals(listOf("channel:a", "channel:b", "channel:c"), appended.map { it.itemKey })
+        assertEquals(listOf(0, 1, 2), appended.map { it.position })
+        assertEquals(4, appended[1].viewerCount)
+    }
+
+    @Test
+    fun appendReindexesFreshPrefixAndStaleTailAfterOverlapAndChanges() {
+        val existing = refreshCachedItems(
+            "top:test",
+            listOf(
+                Stream(channelId = "a"),
+                Stream(channelId = "b"),
+                Stream(channelId = "c"),
+                Stream(channelId = "d"),
+                Stream(channelId = "e"),
+                Stream(channelId = "f"),
+                Stream(channelId = "g"),
+                Stream(channelId = "h"),
+                Stream(channelId = "i"),
+            ),
+            generation = 1L,
+        )
+        val afterRefresh = refreshCachedItemsPreservingTail(
+            feedKey = "top:test",
+            existing = existing,
+            streams = listOf(Stream(channelId = "a"), Stream(channelId = "b"), Stream(channelId = "x")),
+            generation = 2L,
+        )
+
+        val afterAppend = appendCachedPage(
+            feedKey = "top:test",
+            existing = afterRefresh,
+            streams = listOf(Stream(channelId = "d"), Stream(channelId = "y"), Stream(channelId = "f")),
+            generation = 2L,
+        )
+
+        assertEquals(
+            listOf(
+                "channel:a", "channel:b", "channel:x",
+                "channel:d", "channel:y", "channel:f",
+                "channel:c", "channel:e", "channel:g", "channel:h", "channel:i",
+            ),
+            afterAppend.map { it.itemKey },
+        )
+        assertEquals(afterAppend.size, afterAppend.map { it.position }.distinct().size)
+        assertEquals(afterAppend.indices.toList(), afterAppend.map { it.position })
+        assertTrue(afterAppend.take(6).all { it.generation == 2L })
+        assertTrue(afterAppend.drop(6).all { it.generation == 1L })
+    }
+}

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/common/PagedListStateTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/common/PagedListStateTest.kt
@@ -2,6 +2,8 @@ package com.github.andreyasadchy.xtra.ui.common
 
 import androidx.paging.LoadState
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class PagedListStateTest {
@@ -70,6 +72,59 @@ class PagedListStateTest {
                 refresh = LoadState.NotLoading(endOfPaginationReached = false),
                 append = LoadState.NotLoading(endOfPaginationReached = false),
                 prepend = LoadState.NotLoading(endOfPaginationReached = false),
+            ),
+        )
+    }
+
+    @Test
+    fun mediatorRefreshKeepsCachedRowsVisible() {
+        assertEquals(
+            PagedListContentState.Content,
+            cacheAwarePagedListContentState(
+                sourceRefresh = LoadState.NotLoading(endOfPaginationReached = false),
+                mediatorRefresh = LoadState.Loading,
+                itemCount = 6,
+            ),
+        )
+        assertEquals(
+            PagedListContentState.Content,
+            cacheAwarePagedListContentState(
+                sourceRefresh = LoadState.NotLoading(endOfPaginationReached = false),
+                mediatorRefresh = LoadState.Error(IllegalStateException("offline")),
+                itemCount = 6,
+            ),
+        )
+    }
+
+    @Test
+    fun automaticRefreshWithRowsIsSilentButManualRefreshShowsSpinner() {
+        assertFalse(shouldShowPagedListSwipeRefresh(true, itemCount = 3, manualRefreshRequested = false))
+        assertTrue(shouldShowPagedListSwipeRefresh(true, itemCount = 3, manualRefreshRequested = true))
+        assertTrue(shouldShowPagedListSwipeRefresh(true, itemCount = 0, manualRefreshRequested = false))
+        assertFalse(shouldShowPagedListSwipeRefresh(false, itemCount = 3, manualRefreshRequested = true))
+    }
+
+    @Test
+    fun automaticMediatorRefreshErrorsStaySilentButManualErrorsAreShown() {
+        assertFalse(
+            shouldShowPagedListRefreshError(
+                sourceRefreshError = false,
+                mediatorRefreshError = true,
+                manualRefreshRequested = false,
+            ),
+        )
+        assertTrue(
+            shouldShowPagedListRefreshError(
+                sourceRefreshError = false,
+                mediatorRefreshError = true,
+                manualRefreshRequested = true,
+            ),
+        )
+        assertTrue(
+            shouldShowPagedListRefreshError(
+                sourceRefreshError = true,
+                mediatorRefreshError = false,
+                manualRefreshRequested = false,
             ),
         )
     }

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/common/ThumbnailImageRequestTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/common/ThumbnailImageRequestTest.kt
@@ -1,0 +1,30 @@
+package com.github.andreyasadchy.xtra.ui.common
+
+import com.github.andreyasadchy.xtra.model.ui.Stream
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ThumbnailImageRequestTest {
+
+    @Test
+    fun previewBucketsUseOneStableDiskEntryButFreshNetworkUrls() {
+        val stream = Stream(
+            channelId = "channel-42",
+            thumbnailURL = "https://static-cdn.jtvnw.net/previews/{width}x{height}.jpg",
+        )
+
+        val first = streamThumbnailRequestPlan(stream, bucket = 10L)
+        val second = streamThumbnailRequestPlan(stream, bucket = 11L)
+
+        assertEquals(first!!.diskCacheKey, second!!.diskCacheKey)
+        assertNotEquals(first.networkUrl, second.networkUrl)
+        assertEquals("xtra:stream-thumbnail:channel:channel-42", first.diskCacheKey)
+    }
+
+    @Test
+    fun missingThumbnailHasNoTwoStageRequest() {
+        assertNull(streamThumbnailRequestPlan(Stream(channelId = "channel-42"), bucket = 10L))
+    }
+}

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/following/streams/FollowedAccountPagerGenerationTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/following/streams/FollowedAccountPagerGenerationTest.kt
@@ -1,0 +1,19 @@
+package com.github.andreyasadchy.xtra.ui.following.streams
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class FollowedAccountPagerGenerationTest {
+
+    @Test
+    fun accountSwitchStartsASeparateGenerationWithoutRepeatingForTheSameAccount() {
+        val generation = FollowedAccountPagerGeneration()
+
+        assertFalse(generation.switchTo("account-a"))
+        assertTrue(generation.switchTo("account-b"))
+        assertFalse(generation.switchTo("account-b"))
+        assertTrue(generation.switchTo(null))
+        assertFalse(generation.switchTo(null))
+    }
+}


### PR DESCRIPTION
## What changed

Top, Followed, and Game Streams now show the last known stream data immediately and refresh it in the background.

## Why

Returning to Xtra no longer requires waiting for a network request before the stream list is usable. Offline and transient failures keep the last successful data visible.

## Included

- Durable Room-backed stream feed cache with safe schema migration.
- Shared refresh timing, lifecycle, player-return, connectivity, and rate-limit handling.
- Persistent live thumbnail caching with stale-first display and fresh replacement.
- Account-safe Followed Streams cache keys.
- Background prewarm for the most useful feeds.
- Dynamic integrity headers so renewed credentials are used on retry.
- RemoteMediator no-op settlement and safe initial-refresh retry behavior.
- Explicit pull-to-refresh indication while automatic revalidation remains silent.
- Focused tests for freshness, coalescing, cache replacement, feed keys, backoff, playback, thumbnails, RemoteMediator, and load-state behavior.

## Validation

- Unit tests passed: 259 tests.
- Debug APK and connected Android tests passed on `xtra-api35`.
- Lint remains blocked by the repository's existing baseline; no new diagnostics were found in the changed stream-feed files.
