### PR TITLE
Expand cache-first page metadata

### DIFF
--- a/app/src/androidTest/java/com/github/andreyasadchy/xtra/db/AppDatabaseMigrationTest.kt
+++ b/app/src/androidTest/java/com/github/andreyasadchy/xtra/db/AppDatabaseMigrationTest.kt
@@ -55,6 +55,7 @@ class AppDatabaseMigrationTest {
                 ViewingStatsMigrations.FROM_HISTORICAL_39,
                 StreamFeedMigrations.FROM_40,
                 StreamFeedMigrations.FROM_41,
+                MetadataCacheMigrations.FROM_42,
             )
             .build()
             .also { it.openHelper.writableDatabase }
@@ -82,6 +83,8 @@ class AppDatabaseMigrationTest {
         sqlite.execSQL("DROP INDEX IF EXISTS index_stream_feed_items_feedKey_channelId")
         sqlite.execSQL("DROP TABLE IF EXISTS stream_feed_items")
         sqlite.execSQL("DROP TABLE IF EXISTS stream_feed_states")
+        sqlite.execSQL("DROP INDEX IF EXISTS index_metadata_cache_lastAccessAt")
+        sqlite.execSQL("DROP TABLE IF EXISTS metadata_cache")
         if (historicalVersion39) {
             sqlite.execSQL("DROP TABLE IF EXISTS notification_events")
             sqlite.execSQL("CREATE TABLE live_notification_logs (id INTEGER PRIMARY KEY NOT NULL)")
@@ -91,7 +94,7 @@ class AppDatabaseMigrationTest {
     }
 
     private fun assertStatisticsSchema(database: SupportSQLiteDatabase) {
-        assertEquals(42, scalarInt(database, "PRAGMA user_version"))
+        assertEquals(43, scalarInt(database, "PRAGMA user_version"))
         assertTrue(tableExists(database, "viewing_sessions"))
         assertTrue(tableExists(database, "viewing_intervals"))
         assertTrue(indexExists(database, "index_viewing_sessions_started_at"))
@@ -106,6 +109,8 @@ class AppDatabaseMigrationTest {
         assertTrue(columnExists(database, "stream_feed_items", "generation"))
         assertTrue(columnExists(database, "stream_feed_states", "nextCursorApi"))
         assertTrue(columnExists(database, "stream_feed_states", "activeGeneration"))
+        assertTrue(tableExists(database, "metadata_cache"))
+        assertTrue(indexExists(database, "index_metadata_cache_lastAccessAt"))
     }
 
     private fun tableExists(database: SupportSQLiteDatabase, tableName: String): Boolean {

--- a/app/src/androidTest/java/com/github/andreyasadchy/xtra/repository/MetadataCacheTest.kt
+++ b/app/src/androidTest/java/com/github/andreyasadchy/xtra/repository/MetadataCacheTest.kt
@@ -17,6 +17,8 @@ import kotlinx.serialization.json.Json
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -81,5 +83,53 @@ class MetadataCacheTest {
             nowMs = now,
         )
         assertEquals("Tag", cache.readGame(null, null, "game")?.game?.tags?.firstOrNull()?.name)
+    }
+
+    @Test
+    fun failedStreamFallbackKeepsLiveChannelInRoom() = runBlocking {
+        val now = System.currentTimeMillis()
+        val liveSnapshot = ChannelPageCacheSnapshot(
+            user = User(id = "99", login = "channel", name = "Old name"),
+            stream = Stream(id = "stream", channelId = "99", title = "Still live"),
+        )
+        cache.writeChannel("99", "channel", liveSnapshot, now)
+
+        val resolution = resolveChannelFallback(
+            cached = cache.readChannel("99", "channel"),
+            streamResult = Result.failure(IllegalStateException("temporary failure")),
+            userResult = Result.success(User(id = "99", login = "channel", name = "New name")),
+        )
+        assertTrue(resolution.shouldPersist)
+        resolution.snapshot?.let { cache.writeChannel("99", "channel", it, now + 1) }
+
+        val persisted = cache.readChannel("99", "channel")
+        assertEquals("New name", persisted?.user?.name)
+        assertEquals("stream", persisted?.stream?.id)
+        assertEquals("Still live", persisted?.stream?.title)
+    }
+
+    @Test
+    fun stableIdRejectsMismatchedAccountAliasAndSameIdAliasStillWorks() = runBlocking {
+        val oldSnapshot = AccountCacheSnapshot(
+            user = HelixUser(id = "old", login = "old-login", displayName = "Old"),
+            scopes = setOf("old:scope"),
+        )
+        cache.writeAccount("old", "old-login", oldSnapshot)
+
+        assertNull(cache.readAccount("new", "old-login"))
+        assertNull(cache.readAccount(null, "old-login"))
+
+        val currentSnapshot = AccountCacheSnapshot(
+            user = HelixUser(id = "new", login = "new-login", displayName = "New"),
+            scopes = setOf("new:scope"),
+        )
+        cache.writeAccount("new", "new-login", currentSnapshot)
+        assertEquals("New", cache.readAccount("new", "new-login")?.user?.displayName)
+        assertEquals("New", cache.readAccount(null, "new-login")?.user?.displayName)
+
+        cache.writeAccount("new", "renamed-login", currentSnapshot)
+        assertNull(cache.readAccount(null, "new-login"))
+        assertEquals("New", cache.readAccount(null, "renamed-login")?.user?.displayName)
+        assertNull(cache.readAccount(null, "old-login"))
     }
 }

--- a/app/src/androidTest/java/com/github/andreyasadchy/xtra/repository/MetadataCacheTest.kt
+++ b/app/src/androidTest/java/com/github/andreyasadchy/xtra/repository/MetadataCacheTest.kt
@@ -1,0 +1,85 @@
+package com.github.andreyasadchy.xtra.repository
+
+import androidx.room.Room
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.github.andreyasadchy.xtra.db.AppDatabase
+import com.github.andreyasadchy.xtra.model.helix.channel.ChannelInformation
+import com.github.andreyasadchy.xtra.model.helix.chat.ChatSettings
+import com.github.andreyasadchy.xtra.model.helix.user.BlockedUser
+import com.github.andreyasadchy.xtra.model.helix.user.User as HelixUser
+import com.github.andreyasadchy.xtra.model.ui.Game
+import com.github.andreyasadchy.xtra.model.ui.Stream
+import com.github.andreyasadchy.xtra.model.ui.Tag
+import com.github.andreyasadchy.xtra.model.ui.User
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class MetadataCacheTest {
+
+    private val database = Room.inMemoryDatabaseBuilder(
+        InstrumentationRegistry.getInstrumentation().targetContext,
+        AppDatabase::class.java,
+    ).build()
+    private val cache = MetadataCache(database, Json { ignoreUnknownKeys = true })
+
+    @After
+    fun closeDatabase() {
+        database.close()
+    }
+
+    @Test
+    fun accountChannelAndGamePayloadsRoundTripThroughRoom() = runBlocking {
+        val now = System.currentTimeMillis()
+        cache.writeAccount(
+            userId = "42",
+            login = "Streamer",
+            snapshot = AccountCacheSnapshot(
+                user = HelixUser(id = "42", login = "Streamer", displayName = "Streamer", description = "Bio"),
+                scopes = setOf("user:edit", "channel:manage:broadcast"),
+                chatColor = "#123456",
+                channel = ChannelInformation(broadcasterId = "42", title = "Live", tags = listOf("one")),
+                chatSettings = ChatSettings(broadcasterId = "42", followerMode = true, followerModeDuration = 10),
+                blockedUsers = listOf(BlockedUser(id = "9", login = "blocked", displayName = "Blocked")),
+                blockedUsersCursor = "next",
+            ),
+            nowMs = now,
+        )
+
+        val account = cache.readAccount(null, "STREAMER")
+        assertNotNull(account)
+        assertEquals("Bio", account?.user?.description)
+        assertEquals(setOf("user:edit", "channel:manage:broadcast"), account?.scopes)
+        assertEquals("Live", account?.channel?.title)
+        assertEquals(true, account?.chatSettings?.followerMode)
+        assertEquals("next", account?.blockedUsersCursor)
+
+        cache.writeChannel(
+            channelId = "99",
+            login = "Channel",
+            snapshot = ChannelPageCacheSnapshot(
+                user = User(id = "99", login = "Channel", name = "Channel"),
+                stream = Stream(id = "stream", channelId = "99", title = "Title"),
+            ),
+            nowMs = now,
+        )
+        assertEquals("Title", cache.readChannel(null, "channel")?.stream?.title)
+
+        cache.writeGame(
+            gameId = "7",
+            slug = "game-slug",
+            name = "Game",
+            snapshot = GamePageCacheSnapshot(
+                Game(id = "7", slug = "game-slug", name = "Game", tags = listOf(Tag(id = "t", name = "Tag"))),
+            ),
+            nowMs = now,
+        )
+        assertEquals("Tag", cache.readGame(null, null, "game")?.game?.tags?.firstOrNull()?.name)
+    }
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/XtraModule.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/XtraModule.kt
@@ -8,6 +8,7 @@ import android.util.Log
 import androidx.room.Room
 import androidx.room.migration.Migration
 import com.github.andreyasadchy.xtra.db.AppDatabase
+import com.github.andreyasadchy.xtra.db.MetadataCacheMigrations
 import com.github.andreyasadchy.xtra.db.StreamFeedMigrations
 import com.github.andreyasadchy.xtra.db.ViewingStatsMigrations
 import com.github.andreyasadchy.xtra.repository.AuthRepository
@@ -18,6 +19,7 @@ import com.github.andreyasadchy.xtra.repository.GraphQLRepository
 import com.github.andreyasadchy.xtra.repository.HelixRepository
 import com.github.andreyasadchy.xtra.repository.LocalChannelFollowsRepository
 import com.github.andreyasadchy.xtra.repository.LocalGameFollowsRepository
+import com.github.andreyasadchy.xtra.repository.MetadataCache
 import com.github.andreyasadchy.xtra.repository.NotificationsRepository
 import com.github.andreyasadchy.xtra.repository.OfflineVideosRepository
 import com.github.andreyasadchy.xtra.repository.PlayerRepository
@@ -56,6 +58,10 @@ class XtraModule(application: Application) {
 
     val streamFeedPager by lazy {
         StreamFeedPager(streamFeedCache, streamFeedRefreshCoordinator)
+    }
+
+    val metadataCache by lazy {
+        MetadataCache(database, json)
     }
 
     val httpEngine = lazy {
@@ -339,6 +345,7 @@ class XtraModule(application: Application) {
                 },
                 StreamFeedMigrations.FROM_40,
                 StreamFeedMigrations.FROM_41,
+                MetadataCacheMigrations.FROM_42,
             )
         }.build()
     }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/db/AppDatabase.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/db/AppDatabase.kt
@@ -43,8 +43,9 @@ import com.github.andreyasadchy.xtra.model.ui.TranslatedChannel
         ViewingInterval::class,
         CachedStreamFeedItem::class,
         StreamFeedState::class,
+        MetadataCacheEntry::class,
     ],
-    version = 42,
+    version = 43,
     exportSchema = false
 )
 abstract class AppDatabase : RoomDatabase() {
@@ -67,4 +68,5 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun playbackStates(): PlaybackStatesDao
     abstract fun viewingStats(): ViewingStatsDao
     abstract fun streamFeedDao(): StreamFeedDao
+    abstract fun metadataCache(): MetadataCacheDao
 }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/db/MetadataCacheDao.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/db/MetadataCacheDao.kt
@@ -22,4 +22,7 @@ interface MetadataCacheDao {
 
     @Query("SELECT * FROM metadata_cache ORDER BY lastAccessAt DESC")
     fun allEntries(): List<MetadataCacheEntry>
+
+    @Query("SELECT * FROM metadata_cache WHERE kind = :kind")
+    fun entries(kind: String): List<MetadataCacheEntry>
 }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/db/MetadataCacheDao.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/db/MetadataCacheDao.kt
@@ -1,0 +1,25 @@
+package com.github.andreyasadchy.xtra.db
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+
+@Dao
+interface MetadataCacheDao {
+
+    @Query("SELECT * FROM metadata_cache WHERE kind = :kind AND cacheKey = :cacheKey LIMIT 1")
+    fun entry(kind: String, cacheKey: String): MetadataCacheEntry?
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    fun insert(entry: MetadataCacheEntry)
+
+    @Query("UPDATE metadata_cache SET lastAccessAt = :nowMs WHERE kind = :kind AND cacheKey = :cacheKey")
+    fun touch(kind: String, cacheKey: String, nowMs: Long)
+
+    @Query("DELETE FROM metadata_cache WHERE kind = :kind AND cacheKey = :cacheKey")
+    fun delete(kind: String, cacheKey: String)
+
+    @Query("SELECT * FROM metadata_cache ORDER BY lastAccessAt DESC")
+    fun allEntries(): List<MetadataCacheEntry>
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/db/MetadataCacheEntry.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/db/MetadataCacheEntry.kt
@@ -1,0 +1,21 @@
+package com.github.andreyasadchy.xtra.db
+
+import androidx.room.Entity
+import androidx.room.Index
+
+/**
+ * Small durable metadata cache shared by account and public detail pages.
+ * Payloads are typed and versioned by their cache kind in MetadataCache.
+ */
+@Entity(
+    tableName = "metadata_cache",
+    primaryKeys = ["kind", "cacheKey"],
+    indices = [Index(value = ["lastAccessAt"])],
+)
+data class MetadataCacheEntry(
+    val kind: String,
+    val cacheKey: String,
+    val payload: String,
+    val updatedAt: Long,
+    val lastAccessAt: Long,
+)

--- a/app/src/main/java/com/github/andreyasadchy/xtra/db/MetadataCacheMigrations.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/db/MetadataCacheMigrations.kt
@@ -1,0 +1,16 @@
+package com.github.andreyasadchy.xtra.db
+
+import androidx.room.migration.Migration
+
+/** Schema migration for cache-first account and detail pages. */
+object MetadataCacheMigrations {
+    val FROM_42 = Migration(42, 43) { db ->
+        db.execSQL(
+            "CREATE TABLE IF NOT EXISTS metadata_cache (" +
+                    "kind TEXT NOT NULL, cacheKey TEXT NOT NULL, payload TEXT NOT NULL, " +
+                    "updatedAt INTEGER NOT NULL, lastAccessAt INTEGER NOT NULL, " +
+                    "PRIMARY KEY(kind, cacheKey))"
+        )
+        db.execSQL("CREATE INDEX IF NOT EXISTS index_metadata_cache_lastAccessAt ON metadata_cache(lastAccessAt)")
+    }
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/MetadataCache.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/MetadataCache.kt
@@ -1,0 +1,366 @@
+package com.github.andreyasadchy.xtra.repository
+
+import com.github.andreyasadchy.xtra.db.AppDatabase
+import com.github.andreyasadchy.xtra.db.MetadataCacheDao
+import com.github.andreyasadchy.xtra.db.MetadataCacheEntry
+import com.github.andreyasadchy.xtra.model.helix.channel.ChannelInformation
+import com.github.andreyasadchy.xtra.model.helix.chat.ChatSettings
+import com.github.andreyasadchy.xtra.model.helix.user.BlockedUser
+import com.github.andreyasadchy.xtra.model.helix.user.User as HelixUser
+import com.github.andreyasadchy.xtra.model.ui.Game
+import com.github.andreyasadchy.xtra.model.ui.Stream
+import com.github.andreyasadchy.xtra.model.ui.Tag
+import com.github.andreyasadchy.xtra.model.ui.User
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import java.util.Locale
+
+private const val ACCOUNT_KIND = "account"
+private const val CHANNEL_KIND = "channel"
+private const val GAME_KIND = "game"
+private const val CACHE_RETENTION_MS = 30L * 24 * 60 * 60 * 1_000L
+private const val MAX_CACHE_ENTRIES = 240
+
+data class AccountCacheSnapshot(
+    val user: HelixUser? = null,
+    val scopes: Set<String> = emptySet(),
+    val chatColor: String? = null,
+    val channel: ChannelInformation? = null,
+    val chatSettings: ChatSettings? = null,
+    val blockedUsers: List<BlockedUser> = emptyList(),
+    val blockedUsersCursor: String? = null,
+)
+
+data class ChannelPageCacheSnapshot(
+    val user: User,
+    val stream: Stream? = null,
+)
+
+data class GamePageCacheSnapshot(
+    val game: Game,
+)
+
+/**
+ * Durable stale-while-revalidate metadata for screens that are useful before
+ * their network response arrives. Live stream values are still refreshed by
+ * the existing stream-feed coordinator; this cache only supplies fast UI data.
+ */
+class MetadataCache(
+    private val database: AppDatabase,
+    private val json: Json,
+    private val dao: MetadataCacheDao = database.metadataCache(),
+) {
+
+    suspend fun readAccount(userId: String?, login: String?): AccountCacheSnapshot? = withContext(Dispatchers.IO) {
+        val hit = readPayload<AccountCachePayload>(ACCOUNT_KIND, identityKeys("id", "login", userId, login))
+            ?: return@withContext null
+        AccountCacheSnapshot(
+            user = hit.payload.user,
+            scopes = hit.payload.scopes.toSet(),
+            chatColor = hit.payload.chatColor,
+            channel = hit.payload.channel,
+            chatSettings = hit.payload.chatSettings,
+            blockedUsers = hit.payload.blockedUsers,
+            blockedUsersCursor = hit.payload.blockedUsersCursor,
+        )
+    }
+
+    suspend fun writeAccount(
+        userId: String?,
+        login: String?,
+        snapshot: AccountCacheSnapshot,
+        nowMs: Long = System.currentTimeMillis(),
+    ) = withContext(Dispatchers.IO) {
+        writePayload(
+            kind = ACCOUNT_KIND,
+            keys = identityKeys("id", "login", userId ?: snapshot.user?.id, login ?: snapshot.user?.login),
+            payload = AccountCachePayload(
+                user = snapshot.user,
+                scopes = snapshot.scopes.sorted(),
+                chatColor = snapshot.chatColor,
+                channel = snapshot.channel,
+                chatSettings = snapshot.chatSettings,
+                blockedUsers = snapshot.blockedUsers,
+                blockedUsersCursor = snapshot.blockedUsersCursor,
+            ),
+            nowMs = nowMs,
+        )
+    }
+
+    suspend fun clearAccount(userId: String?, login: String?) = withContext(Dispatchers.IO) {
+        database.runInTransaction {
+            identityKeys("id", "login", userId, login).forEach { dao.delete(ACCOUNT_KIND, it) }
+        }
+    }
+
+    suspend fun readChannel(channelId: String?, login: String?): ChannelPageCacheSnapshot? = withContext(Dispatchers.IO) {
+        val hit = readPayload<ChannelPageCachePayload>(CHANNEL_KIND, identityKeys("id", "login", channelId, login))
+            ?: return@withContext null
+        val user = hit.payload.user?.toUiUser() ?: return@withContext null
+        ChannelPageCacheSnapshot(user = user, stream = hit.payload.stream?.toUiStream())
+    }
+
+    suspend fun writeChannel(
+        channelId: String?,
+        login: String?,
+        snapshot: ChannelPageCacheSnapshot,
+        nowMs: Long = System.currentTimeMillis(),
+    ) = withContext(Dispatchers.IO) {
+        writePayload(
+            kind = CHANNEL_KIND,
+            keys = identityKeys("id", "login", channelId ?: snapshot.user.id, login ?: snapshot.user.login),
+            payload = ChannelPageCachePayload(
+                user = snapshot.user.toCacheUser(),
+                stream = snapshot.stream?.toCacheStream(),
+            ),
+            nowMs = nowMs,
+        )
+    }
+
+    suspend fun readGame(gameId: String?, slug: String?, name: String?): GamePageCacheSnapshot? = withContext(Dispatchers.IO) {
+        val hit = readPayload<GamePageCachePayload>(GAME_KIND, gameIdentityKeys(gameId, slug, name))
+            ?: return@withContext null
+        hit.payload.game?.let { GamePageCacheSnapshot(it.toUiGame()) }
+    }
+
+    suspend fun writeGame(
+        gameId: String?,
+        slug: String?,
+        name: String?,
+        snapshot: GamePageCacheSnapshot,
+        nowMs: Long = System.currentTimeMillis(),
+    ) = withContext(Dispatchers.IO) {
+        writePayload(
+            kind = GAME_KIND,
+            keys = gameIdentityKeys(gameId ?: snapshot.game.id, slug ?: snapshot.game.slug, name ?: snapshot.game.name),
+            payload = GamePageCachePayload(snapshot.game.toCacheGame()),
+            nowMs = nowMs,
+        )
+    }
+
+    private inline fun <reified T> readPayload(kind: String, keys: List<String>): CacheHit<T>? {
+        for (key in keys) {
+            val entry = dao.entry(kind, key) ?: continue
+            val nowMs = System.currentTimeMillis()
+            if (entry.updatedAt <= nowMs - CACHE_RETENTION_MS) {
+                dao.delete(kind, key)
+                continue
+            }
+            val payload = runCatching { json.decodeFromString<T>(entry.payload) }.getOrNull()
+            if (payload == null) {
+                dao.delete(kind, key)
+                continue
+            }
+            dao.touch(kind, key, nowMs)
+            return CacheHit(payload)
+        }
+        return null
+    }
+
+    private inline fun <reified T> writePayload(kind: String, keys: List<String>, payload: T, nowMs: Long) {
+        if (keys.isEmpty()) return
+        database.runInTransaction {
+            val payloadJson = json.encodeToString(payload)
+            keys.distinct().forEach { key ->
+                dao.insert(
+                    MetadataCacheEntry(
+                        kind = kind,
+                        cacheKey = key,
+                        payload = payloadJson,
+                        updatedAt = nowMs,
+                        lastAccessAt = nowMs,
+                    ),
+                )
+            }
+            cleanup(nowMs)
+        }
+    }
+
+    private fun cleanup(nowMs: Long) {
+        val cutoff = nowMs - CACHE_RETENTION_MS
+        val entries = dao.allEntries()
+        entries.filter { it.lastAccessAt <= cutoff }
+            .forEach { dao.delete(it.kind, it.cacheKey) }
+        entries.asSequence()
+            .filter { it.lastAccessAt > cutoff }
+            .drop(MAX_CACHE_ENTRIES)
+            .forEach { dao.delete(it.kind, it.cacheKey) }
+    }
+
+    private data class CacheHit<T>(val payload: T)
+
+    companion object {
+        internal fun identityKeys(
+            firstPrefix: String,
+            secondPrefix: String,
+            first: String?,
+            second: String?,
+        ): List<String> = buildList {
+            first?.trim()?.takeIf { it.isNotEmpty() }?.let { add("$firstPrefix:${normalize(it)}") }
+            second?.trim()?.takeIf { it.isNotEmpty() }?.let { add("$secondPrefix:${normalize(it)}") }
+        }.distinct()
+
+        internal fun gameIdentityKeys(gameId: String?, slug: String?, name: String?): List<String> = buildList {
+            gameId?.trim()?.takeIf { it.isNotEmpty() }?.let { add("id:${normalize(it)}") }
+            slug?.trim()?.takeIf { it.isNotEmpty() }?.let { add("slug:${normalize(it)}") }
+            name?.trim()?.takeIf { it.isNotEmpty() }?.let { add("name:${normalize(it)}") }
+        }.distinct()
+
+        private fun normalize(value: String): String = value.lowercase(Locale.ROOT)
+    }
+}
+
+@Serializable
+private data class AccountCachePayload(
+    val user: HelixUser? = null,
+    val scopes: List<String> = emptyList(),
+    val chatColor: String? = null,
+    val channel: ChannelInformation? = null,
+    val chatSettings: ChatSettings? = null,
+    val blockedUsers: List<BlockedUser> = emptyList(),
+    val blockedUsersCursor: String? = null,
+)
+
+@Serializable
+private data class ChannelPageCachePayload(
+    val user: CachedChannelUser? = null,
+    val stream: CachedChannelStream? = null,
+)
+
+@Serializable
+private data class CachedChannelUser(
+    val id: String? = null,
+    val login: String? = null,
+    val name: String? = null,
+    val profileImageURL: String? = null,
+    val type: String? = null,
+    val broadcasterType: String? = null,
+    val createdAt: String? = null,
+    val followerCount: Int? = null,
+    val bannerImageURL: String? = null,
+    val lastBroadcast: String? = null,
+)
+
+@Serializable
+private data class CachedChannelStream(
+    val id: String? = null,
+    val channelId: String? = null,
+    val channelLogin: String? = null,
+    val channelName: String? = null,
+    val channelImageURL: String? = null,
+    val gameId: String? = null,
+    val gameSlug: String? = null,
+    val gameName: String? = null,
+    val title: String? = null,
+    val thumbnailURL: String? = null,
+    val createdAt: String? = null,
+    val viewerCount: Int? = null,
+    val tags: List<String>? = null,
+)
+
+@Serializable
+private data class GamePageCachePayload(
+    val game: CachedGame? = null,
+)
+
+@Serializable
+private data class CachedGame(
+    val id: String? = null,
+    val slug: String? = null,
+    val name: String? = null,
+    val boxArtURL: String? = null,
+    val viewerCount: Int? = null,
+    val broadcasterCount: Int? = null,
+    val followerCount: Int? = null,
+    val tags: List<CachedTag>? = null,
+)
+
+@Serializable
+private data class CachedTag(
+    val id: String? = null,
+    val name: String? = null,
+)
+
+private fun User.toCacheUser() = CachedChannelUser(
+    id = id,
+    login = login,
+    name = name,
+    profileImageURL = profileImageURL,
+    type = type,
+    broadcasterType = broadcasterType,
+    createdAt = createdAt,
+    followerCount = followerCount,
+    bannerImageURL = bannerImageURL,
+    lastBroadcast = lastBroadcast,
+)
+
+private fun CachedChannelUser.toUiUser() = User(
+    id = id,
+    login = login,
+    name = name,
+    profileImageURL = profileImageURL,
+    type = type,
+    broadcasterType = broadcasterType,
+    createdAt = createdAt,
+    followerCount = followerCount,
+    bannerImageURL = bannerImageURL,
+    lastBroadcast = lastBroadcast,
+)
+
+private fun Stream.toCacheStream() = CachedChannelStream(
+    id = id,
+    channelId = channelId,
+    channelLogin = channelLogin,
+    channelName = channelName,
+    channelImageURL = channelImageURL,
+    gameId = gameId,
+    gameSlug = gameSlug,
+    gameName = gameName,
+    title = title,
+    thumbnailURL = thumbnailURL,
+    createdAt = createdAt,
+    viewerCount = viewerCount,
+    tags = tags,
+)
+
+private fun CachedChannelStream.toUiStream() = Stream(
+    id = id,
+    channelId = channelId,
+    channelLogin = channelLogin,
+    channelName = channelName,
+    channelImageURL = channelImageURL,
+    gameId = gameId,
+    gameSlug = gameSlug,
+    gameName = gameName,
+    title = title,
+    thumbnailURL = thumbnailURL,
+    createdAt = createdAt,
+    viewerCount = viewerCount,
+    tags = tags,
+)
+
+private fun Game.toCacheGame() = CachedGame(
+    id = id,
+    slug = slug,
+    name = name,
+    boxArtURL = boxArtURL,
+    viewerCount = viewerCount,
+    broadcasterCount = broadcasterCount,
+    followerCount = followerCount,
+    tags = tags?.map { CachedTag(it.id, it.name) },
+)
+
+private fun CachedGame.toUiGame() = Game(
+    id = id,
+    slug = slug,
+    name = name,
+    boxArtURL = boxArtURL,
+    viewerCount = viewerCount,
+    broadcasterCount = broadcasterCount,
+    followerCount = followerCount,
+    tags = tags?.map { Tag(it.id, it.name) },
+)

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/MetadataCache.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/MetadataCache.kt
@@ -56,7 +56,12 @@ class MetadataCache(
 ) {
 
     suspend fun readAccount(userId: String?, login: String?): AccountCacheSnapshot? = withContext(Dispatchers.IO) {
-        val hit = readPayload<AccountCachePayload>(ACCOUNT_KIND, identityKeys("id", "login", userId, login))
+        val hit = readPayload<AccountCachePayload>(
+            kind = ACCOUNT_KIND,
+            keys = identityKeys("id", "login", userId, login),
+            expectedStableId = userId,
+            identity = { it.user?.id },
+        )
             ?: return@withContext null
         AccountCacheSnapshot(
             user = hit.payload.user,
@@ -87,6 +92,8 @@ class MetadataCache(
                 blockedUsers = snapshot.blockedUsers,
                 blockedUsersCursor = snapshot.blockedUsersCursor,
             ),
+            stableId = userId ?: snapshot.user?.id,
+            identity = { it.user?.id },
             nowMs = nowMs,
         )
     }
@@ -98,7 +105,12 @@ class MetadataCache(
     }
 
     suspend fun readChannel(channelId: String?, login: String?): ChannelPageCacheSnapshot? = withContext(Dispatchers.IO) {
-        val hit = readPayload<ChannelPageCachePayload>(CHANNEL_KIND, identityKeys("id", "login", channelId, login))
+        val hit = readPayload<ChannelPageCachePayload>(
+            kind = CHANNEL_KIND,
+            keys = identityKeys("id", "login", channelId, login),
+            expectedStableId = channelId,
+            identity = { it.user?.id ?: it.stream?.channelId },
+        )
             ?: return@withContext null
         val user = hit.payload.user?.toUiUser() ?: return@withContext null
         ChannelPageCacheSnapshot(user = user, stream = hit.payload.stream?.toUiStream())
@@ -117,12 +129,19 @@ class MetadataCache(
                 user = snapshot.user.toCacheUser(),
                 stream = snapshot.stream?.toCacheStream(),
             ),
+            stableId = channelId ?: snapshot.user.id,
+            identity = { it.user?.id ?: it.stream?.channelId },
             nowMs = nowMs,
         )
     }
 
     suspend fun readGame(gameId: String?, slug: String?, name: String?): GamePageCacheSnapshot? = withContext(Dispatchers.IO) {
-        val hit = readPayload<GamePageCachePayload>(GAME_KIND, gameIdentityKeys(gameId, slug, name))
+        val hit = readPayload<GamePageCachePayload>(
+            kind = GAME_KIND,
+            keys = gameIdentityKeys(gameId, slug, name),
+            expectedStableId = gameId,
+            identity = { it.game?.id },
+        )
             ?: return@withContext null
         hit.payload.game?.let { GamePageCacheSnapshot(it.toUiGame()) }
     }
@@ -138,11 +157,19 @@ class MetadataCache(
             kind = GAME_KIND,
             keys = gameIdentityKeys(gameId ?: snapshot.game.id, slug ?: snapshot.game.slug, name ?: snapshot.game.name),
             payload = GamePageCachePayload(snapshot.game.toCacheGame()),
+            stableId = gameId ?: snapshot.game.id,
+            identity = { it.game?.id },
             nowMs = nowMs,
         )
     }
 
-    private inline fun <reified T> readPayload(kind: String, keys: List<String>): CacheHit<T>? {
+    private inline fun <reified T> readPayload(
+        kind: String,
+        keys: List<String>,
+        expectedStableId: String?,
+        noinline identity: (T) -> String?,
+    ): CacheHit<T>? {
+        val expectedIdentity = normalizeIdentity(expectedStableId)
         for (key in keys) {
             val entry = dao.entry(kind, key) ?: continue
             val nowMs = System.currentTimeMillis()
@@ -155,17 +182,41 @@ class MetadataCache(
                 dao.delete(kind, key)
                 continue
             }
+            val payloadIdentity = normalizeIdentity(identity(payload))
+            if (expectedIdentity != null && payloadIdentity != null && expectedIdentity != payloadIdentity) {
+                dao.delete(kind, key)
+                continue
+            }
             dao.touch(kind, key, nowMs)
             return CacheHit(payload)
         }
         return null
     }
 
-    private inline fun <reified T> writePayload(kind: String, keys: List<String>, payload: T, nowMs: Long) {
+    private inline fun <reified T> writePayload(
+        kind: String,
+        keys: List<String>,
+        payload: T,
+        stableId: String?,
+        noinline identity: (T) -> String?,
+        nowMs: Long,
+    ) {
         if (keys.isEmpty()) return
         database.runInTransaction {
+            val distinctKeys = keys.distinct()
+            normalizeIdentity(stableId)?.let { stableIdentity ->
+                dao.entries(kind)
+                    .filter { it.cacheKey !in distinctKeys }
+                    .filter { entry ->
+                        runCatching { json.decodeFromString<T>(entry.payload) }
+                            .getOrNull()
+                            ?.let { normalizeIdentity(identity(it)) == stableIdentity }
+                            ?: false
+                    }
+                    .forEach { dao.delete(kind, it.cacheKey) }
+            }
             val payloadJson = json.encodeToString(payload)
-            keys.distinct().forEach { key ->
+            distinctKeys.forEach { key ->
                 dao.insert(
                     MetadataCacheEntry(
                         kind = kind,
@@ -192,6 +243,11 @@ class MetadataCache(
     }
 
     private data class CacheHit<T>(val payload: T)
+
+    private fun normalizeIdentity(value: String?): String? = value
+        ?.trim()
+        ?.takeIf { it.isNotEmpty() }
+        ?.lowercase(Locale.ROOT)
 
     companion object {
         internal fun identityKeys(

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/PageMetadataFallbacks.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/PageMetadataFallbacks.kt
@@ -19,11 +19,25 @@ internal fun resolveChannelFallback(
     streamResult: Result<Stream?>,
     userResult: Result<User?>,
 ): ChannelFallbackResolution {
+    val freshStream = streamResult.getOrNull()
     val stream = streamResult.getOrElse { cached?.stream }
-    val user = userResult.getOrNull() ?: cached?.user
+    val user = userResult.getOrNull()
+        ?: cached?.user
+        ?: freshStream?.let {
+            User(
+                id = it.channelId,
+                login = it.channelLogin,
+                name = it.channelName,
+                profileImageURL = it.channelImageURL,
+            )
+        }
     val snapshot = user?.let { ChannelPageCacheSnapshot(user = it, stream = stream) }
     val hasFreshUser = userResult.getOrNull() != null
-    val shouldPersist = snapshot != null && (streamResult.isSuccess || (hasFreshUser && cached != null))
+    val shouldPersist = snapshot != null && when {
+        freshStream != null -> true
+        streamResult.isSuccess -> hasFreshUser || cached != null
+        else -> hasFreshUser && cached != null
+    }
     return ChannelFallbackResolution(snapshot = snapshot, shouldPersist = shouldPersist)
 }
 

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/PageMetadataFallbacks.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/PageMetadataFallbacks.kt
@@ -1,0 +1,46 @@
+package com.github.andreyasadchy.xtra.repository
+
+import com.github.andreyasadchy.xtra.model.ui.Game
+import com.github.andreyasadchy.xtra.model.ui.Stream
+import com.github.andreyasadchy.xtra.model.ui.User
+
+internal data class ChannelFallbackResolution(
+    val snapshot: ChannelPageCacheSnapshot?,
+    val shouldPersist: Boolean,
+)
+
+/**
+ * Keeps a failed stream request distinct from a successful offline response.
+ * A channel snapshot cannot encode that distinction, so failed stream loads
+ * may only be persisted when an existing snapshot is available to preserve.
+ */
+internal fun resolveChannelFallback(
+    cached: ChannelPageCacheSnapshot?,
+    streamResult: Result<Stream?>,
+    userResult: Result<User?>,
+): ChannelFallbackResolution {
+    val stream = streamResult.getOrElse { cached?.stream }
+    val user = userResult.getOrNull() ?: cached?.user
+    val snapshot = user?.let { ChannelPageCacheSnapshot(user = it, stream = stream) }
+    val hasFreshUser = userResult.getOrNull() != null
+    val shouldPersist = snapshot != null && (streamResult.isSuccess || (hasFreshUser && cached != null))
+    return ChannelFallbackResolution(snapshot = snapshot, shouldPersist = shouldPersist)
+}
+
+internal fun mergeGameFallback(cached: Game?, helixGame: Game): Game {
+    if (cached == null) return helixGame
+    return Game(
+        id = helixGame.id ?: cached.id,
+        slug = cached.slug ?: helixGame.slug,
+        name = helixGame.name ?: cached.name,
+        boxArtURL = helixGame.boxArtURL ?: cached.boxArtURL,
+        viewerCount = cached.viewerCount,
+        broadcasterCount = cached.broadcasterCount,
+        followerCount = cached.followerCount,
+        tags = cached.tags,
+        vodPosition = cached.vodPosition,
+        vodDuration = cached.vodDuration,
+        accountFollow = cached.accountFollow,
+        localFollow = cached.localFollow,
+    )
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/account/AccountViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/account/AccountViewModel.kt
@@ -10,6 +10,7 @@ import com.github.andreyasadchy.xtra.model.helix.chat.ChatSettings
 import com.github.andreyasadchy.xtra.model.helix.game.Game
 import com.github.andreyasadchy.xtra.model.helix.user.BlockedUser
 import com.github.andreyasadchy.xtra.model.helix.user.User
+import com.github.andreyasadchy.xtra.repository.AccountCacheSnapshot
 import com.github.andreyasadchy.xtra.repository.TwitchApiException
 import com.github.andreyasadchy.xtra.util.C
 import com.github.andreyasadchy.xtra.util.TwitchApiHelper
@@ -89,22 +90,6 @@ class AccountViewModel(application: Application) : AndroidViewModel(application)
     }
 
     private suspend fun loadAccount() {
-        _uiState.update {
-            it.copy(
-                loading = true,
-                error = null,
-                scopes = emptySet(),
-                capabilities = AccountCapabilities(),
-                chatColor = null,
-                chatColorLoadError = null,
-                channel = null,
-                channelLoadError = null,
-                chatSettings = null,
-                chatSettingsLoadError = null,
-                actionError = null,
-                actionMessage = null,
-            )
-        }
         val headers = TwitchApiHelper.getHelixHeaders(context)
         val token = headers[C.HEADER_TOKEN]
         if (token.isNullOrBlank()) {
@@ -130,6 +115,36 @@ class AccountViewModel(application: Application) : AndroidViewModel(application)
             return
         }
 
+        val tokenUserId = context.tokenPrefs().getString(C.USER_ID, null)
+        val tokenLogin = context.tokenPrefs().getString(C.USERNAME, null)
+        val cached = try {
+            module.metadataCache.readAccount(tokenUserId, tokenLogin)
+        } catch (_: Exception) {
+            null
+        }
+        val cachedScopes = cached?.scopes.orEmpty()
+        _uiState.update {
+            it.copy(
+                loading = true,
+                error = null,
+                user = cached?.user ?: cachedUser(),
+                scopes = cachedScopes,
+                capabilities = AccountCapabilities.from(cachedScopes),
+                chatColor = cached?.chatColor,
+                chatColorLoadError = null,
+                channel = cached?.channel,
+                channelLoadError = null,
+                chatSettings = cached?.chatSettings,
+                chatSettingsLoadError = null,
+                blockedUsers = cached?.blockedUsers.orEmpty(),
+                blockedUsersCursor = cached?.blockedUsersCursor,
+                blockedUsersLoading = false,
+                blockedUsersLoadError = null,
+                actionError = null,
+                actionMessage = null,
+            )
+        }
+
         try {
             val networkLibrary = context.prefs().getString(C.NETWORK_LIBRARY, C.OKHTTP)
             val validation = try {
@@ -143,14 +158,6 @@ class AccountViewModel(application: Application) : AndroidViewModel(application)
                         loading = false,
                         scopes = emptySet(),
                         capabilities = AccountCapabilities(),
-                        chatColor = null,
-                        chatColorLoadError = null,
-                        channel = null,
-                        channelLoadError = null,
-                        chatSettings = null,
-                        chatSettingsLoadError = null,
-                        blockedUsers = emptyList(),
-                        blockedUsersCursor = null,
                         blockedUsersLoading = false,
                         blockedUsersLoadError = null,
                         error = readableError(error),
@@ -171,27 +178,28 @@ class AccountViewModel(application: Application) : AndroidViewModel(application)
                 headers = headers,
                 ids = userId?.let { listOf(it) },
                 logins = if (userId.isNullOrBlank()) login?.let { listOf(it) } else null,
-            ).data.firstOrNull() ?: cachedUser()
+            ).data.firstOrNull() ?: cached?.user ?: cachedUser()
+            val resolvedUserId = userId ?: user?.id
 
             supervisorScope {
-                val color = if (capabilities.editChatColor && userId != null) {
+                val color = if (capabilities.editChatColor && resolvedUserId != null) {
                     async {
                         runCatching {
-                            module.helixRepository.getChatColor(networkLibrary, headers, userId)
+                            module.helixRepository.getChatColor(networkLibrary, headers, resolvedUserId)
                         }
                     }
                 } else null
-                val channel = if (capabilities.editChannel && userId != null) {
+                val channel = if (capabilities.editChannel && resolvedUserId != null) {
                     async {
                         runCatching {
-                            module.helixRepository.getChannelInformation(networkLibrary, headers, userId)
+                            module.helixRepository.getChannelInformation(networkLibrary, headers, resolvedUserId)
                         }
                     }
                 } else null
-                val chatSettings = if (capabilities.editChatSettings && userId != null) {
+                val chatSettings = if (capabilities.editChatSettings && resolvedUserId != null) {
                     async {
                         runCatching {
-                            module.helixRepository.getChatSettings(networkLibrary, headers, userId, userId)
+                            module.helixRepository.getChatSettings(networkLibrary, headers, resolvedUserId, resolvedUserId)
                         }
                     }
                 } else null
@@ -199,9 +207,9 @@ class AccountViewModel(application: Application) : AndroidViewModel(application)
                 val colorResult = color?.await()
                 val channelResult = channel?.await()
                 val chatSettingsResult = chatSettings?.await()
-                val loadedColor = colorResult?.getOrNull()?.takeIf(::isCanonicalChatColor)
-                val loadedChannel = channelResult?.getOrNull()
-                val loadedChatSettings = chatSettingsResult?.getOrNull()
+                val loadedColor = colorResult?.getOrNull()?.takeIf(::isCanonicalChatColor) ?: cached?.chatColor
+                val loadedChannel = channelResult?.getOrNull() ?: cached?.channel
+                val loadedChatSettings = chatSettingsResult?.getOrNull() ?: cached?.chatSettings
                 _uiState.update {
                     it.copy(
                         loading = false,
@@ -210,19 +218,20 @@ class AccountViewModel(application: Application) : AndroidViewModel(application)
                         capabilities = capabilities,
                         chatColor = loadedColor,
                         chatColorLoadError = colorResult?.let {
-                            if (it.isFailure) context.getString(R.string.account_load_failed) else null
+                            if (it.isFailure && loadedColor == null) context.getString(R.string.account_load_failed) else null
                         },
                         channel = loadedChannel,
                         channelLoadError = channelResult?.let {
-                            if (it.isFailure || loadedChannel == null) context.getString(R.string.account_load_failed) else null
+                            if ((it.isFailure || loadedChannel == null) && cached?.channel == null) context.getString(R.string.account_load_failed) else null
                         },
                         chatSettings = loadedChatSettings,
                         chatSettingsLoadError = chatSettingsResult?.let {
-                            if (it.isFailure || loadedChatSettings == null) context.getString(R.string.account_load_failed) else null
+                            if ((it.isFailure || loadedChatSettings == null) && cached?.chatSettings == null) context.getString(R.string.account_load_failed) else null
                         },
                         error = null,
                     )
                 }
+                persistAccountCache(resolvedUserId, login)
             }
         } catch (error: Exception) {
             _uiState.update {
@@ -256,6 +265,7 @@ class AccountViewModel(application: Application) : AndroidViewModel(application)
                     chatColorLoadError = canonicalColor.exceptionOrNull()?.let { context.getString(R.string.account_load_failed) },
                 )
             }
+            persistAccountCache()
         }
     }
 
@@ -265,6 +275,7 @@ class AccountViewModel(application: Application) : AndroidViewModel(application)
             require(description.length <= 300) { context.getString(R.string.account_bio_too_long) }
             val user = module.helixRepository.updateUserDescription(networkLibrary(), helixHeaders(), description)
             _uiState.update { state -> state.copy(user = user ?: state.user) }
+            persistAccountCache()
         }
     }
 
@@ -302,6 +313,7 @@ class AccountViewModel(application: Application) : AndroidViewModel(application)
                     )
                 )
             }
+            persistAccountCache()
         }
     }
 
@@ -358,6 +370,7 @@ class AccountViewModel(application: Application) : AndroidViewModel(application)
                     ),
                 )
             }
+            persistAccountCache()
         }
     }
 
@@ -410,6 +423,7 @@ class AccountViewModel(application: Application) : AndroidViewModel(application)
                         blockedUsersLoadError = null,
                     )
                 }
+                persistAccountCache()
             } catch (error: Exception) {
                 val message = readableError(error)
                 _uiState.update {
@@ -429,6 +443,7 @@ class AccountViewModel(application: Application) : AndroidViewModel(application)
             requireCapability { it.manageBlockedUsers }
             module.helixRepository.unblockUser(networkLibrary(), helixHeaders(), id)
             _uiState.update { state -> state.copy(blockedUsers = state.blockedUsers.filterNot { it.id == id }) }
+            persistAccountCache()
         }
     }
 
@@ -465,6 +480,33 @@ class AccountViewModel(application: Application) : AndroidViewModel(application)
     private fun currentUserId(): String = _uiState.value.user?.id
         ?: context.tokenPrefs().getString(C.USER_ID, null)
         ?: error(context.getString(R.string.account_missing_user))
+
+    private suspend fun persistAccountCache(userId: String? = null, login: String? = null) {
+        val state = _uiState.value
+        val resolvedUserId = userId
+            ?: state.user?.id
+            ?: context.tokenPrefs().getString(C.USER_ID, null)
+        val resolvedLogin = login
+            ?: state.user?.login
+            ?: context.tokenPrefs().getString(C.USERNAME, null)
+        if (resolvedUserId.isNullOrBlank() && resolvedLogin.isNullOrBlank()) return
+        try {
+            module.metadataCache.writeAccount(
+                userId = resolvedUserId,
+                login = resolvedLogin,
+                snapshot = AccountCacheSnapshot(
+                    user = state.user,
+                    scopes = state.scopes,
+                    chatColor = state.chatColor,
+                    channel = state.channel,
+                    chatSettings = state.chatSettings,
+                    blockedUsers = state.blockedUsers,
+                    blockedUsersCursor = state.blockedUsersCursor,
+                ),
+            )
+        } catch (_: Exception) {
+        }
+    }
 
     private fun cachedUser(): User? {
         val id = context.tokenPrefs().getString(C.USER_ID, null)

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/channel/ChannelPagerFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/channel/ChannelPagerFragment.kt
@@ -152,6 +152,7 @@ class ChannelPagerFragment : BaseNetworkFragment(), Scrollable, FragmentHost, In
                 if (it != null) {
                     userLayout.visibility = View.VISIBLE
                     userImage.visibility = View.VISIBLE
+                    userImage.tag = it
                     requireContext().imageLoader.enqueue(
                         ImageRequest.Builder(requireContext()).apply {
                             data(it)
@@ -164,6 +165,7 @@ class ChannelPagerFragment : BaseNetworkFragment(), Scrollable, FragmentHost, In
                     )
                 } else {
                     userImage.visibility = View.GONE
+                    userImage.tag = null
                 }
             }
             val isLoggedIn = !TwitchApiHelper.getGQLHeaders(requireContext(), true)[C.HEADER_TOKEN].isNullOrBlank() ||
@@ -572,19 +574,23 @@ class ChannelPagerFragment : BaseNetworkFragment(), Scrollable, FragmentHost, In
                 if (it != null) {
                     userLayout.visibility = View.VISIBLE
                     userImage.visibility = View.VISIBLE
-                    requireContext().imageLoader.enqueue(
-                        ImageRequest.Builder(requireContext()).apply {
-                            data(it)
-                            if (requireContext().prefs().getBoolean(C.UI_ROUND_USER_IMAGE, true)) {
-                                transformations(CircleCropTransformation())
-                            }
-                            crossfade(true)
-                            target(userImage)
-                        }.build()
-                    )
+                    if (userImage.tag != it || userImage.drawable == null) {
+                        userImage.tag = it
+                        requireContext().imageLoader.enqueue(
+                            ImageRequest.Builder(requireContext()).apply {
+                                data(it)
+                                if (requireContext().prefs().getBoolean(C.UI_ROUND_USER_IMAGE, true)) {
+                                    transformations(CircleCropTransformation())
+                                }
+                                crossfade(true)
+                                target(userImage)
+                            }.build()
+                        )
+                    }
                     requireArguments().putString(C.CHANNEL_IMAGE, it)
                 } else {
                     userImage.visibility = View.GONE
+                    userImage.tag = null
                 }
             }
             stream?.channelName.let {
@@ -683,19 +689,22 @@ class ChannelPagerFragment : BaseNetworkFragment(), Scrollable, FragmentHost, In
                     lastBroadcast.visibility = View.GONE
                 }
             }
-            if (!userImage.isVisible && user.profileImage != null) {
+            if (!user.profileImage.isNullOrBlank()) {
                 userLayout.visibility = View.VISIBLE
                 userImage.visibility = View.VISIBLE
-                requireContext().imageLoader.enqueue(
-                    ImageRequest.Builder(requireContext()).apply {
-                        data(user.profileImage)
-                        if (requireContext().prefs().getBoolean(C.UI_ROUND_USER_IMAGE, true)) {
-                            transformations(CircleCropTransformation())
-                        }
-                        crossfade(true)
-                        target(userImage)
-                    }.build()
-                )
+                if (userImage.tag != user.profileImage || userImage.drawable == null) {
+                    userImage.tag = user.profileImage
+                    requireContext().imageLoader.enqueue(
+                        ImageRequest.Builder(requireContext()).apply {
+                            data(user.profileImage)
+                            if (requireContext().prefs().getBoolean(C.UI_ROUND_USER_IMAGE, true)) {
+                                transformations(CircleCropTransformation())
+                            }
+                            crossfade(true)
+                            target(userImage)
+                        }.build()
+                    )
+                }
                 requireArguments().putString(C.CHANNEL_IMAGE, user.profileImage)
             }
             if (user.bannerImageURL != null) {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/channel/ChannelPagerFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/channel/ChannelPagerFragment.kt
@@ -73,6 +73,8 @@ import kotlin.time.Instant
 
 class ChannelPagerFragment : BaseNetworkFragment(), Scrollable, FragmentHost, IntegrityDialog.Listener {
 
+    override val initializeWithoutNetwork = true
+
     private var _binding: FragmentChannelBinding? = null
     private val binding get() = _binding!!
     private val args: ChannelPagerFragmentArgs by navArgs()
@@ -588,9 +590,6 @@ class ChannelPagerFragment : BaseNetworkFragment(), Scrollable, FragmentHost, In
                         )
                     }
                     requireArguments().putString(C.CHANNEL_IMAGE, it)
-                } else {
-                    userImage.visibility = View.GONE
-                    userImage.tag = null
                 }
             }
             stream?.channelName.let {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/channel/ChannelPagerFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/channel/ChannelPagerFragment.kt
@@ -782,6 +782,7 @@ class ChannelPagerFragment : BaseNetworkFragment(), Scrollable, FragmentHost, In
             TwitchApiHelper.getGQLHeaders(requireContext()),
             TwitchApiHelper.getHelixHeaders(requireContext()),
             requireContext().prefs().getBoolean(C.ENABLE_INTEGRITY, false),
+            revalidate = true,
         )
     }
 
@@ -793,6 +794,7 @@ class ChannelPagerFragment : BaseNetworkFragment(), Scrollable, FragmentHost, In
                     TwitchApiHelper.getGQLHeaders(requireContext()),
                     TwitchApiHelper.getHelixHeaders(requireContext()),
                     requireContext().prefs().getBoolean(C.ENABLE_INTEGRITY, false),
+                    revalidate = true,
                 )
                 viewModel.isFollowingChannel(
                     requireContext().tokenPrefs().getString(C.USER_ID, null),

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/channel/ChannelPagerViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/channel/ChannelPagerViewModel.kt
@@ -16,9 +16,11 @@ import com.github.andreyasadchy.xtra.model.ui.LocalChannelFollow
 import com.github.andreyasadchy.xtra.model.ui.Stream
 import com.github.andreyasadchy.xtra.model.ui.User
 import com.github.andreyasadchy.xtra.repository.BookmarksRepository
+import com.github.andreyasadchy.xtra.repository.ChannelPageCacheSnapshot
 import com.github.andreyasadchy.xtra.repository.GraphQLRepository
 import com.github.andreyasadchy.xtra.repository.HelixRepository
 import com.github.andreyasadchy.xtra.repository.LocalChannelFollowsRepository
+import com.github.andreyasadchy.xtra.repository.MetadataCache
 import com.github.andreyasadchy.xtra.repository.NotificationsRepository
 import com.github.andreyasadchy.xtra.repository.OfflineVideosRepository
 import com.github.andreyasadchy.xtra.repository.streamfeed.StreamFeedRefreshCoordinator
@@ -51,6 +53,7 @@ class ChannelPagerViewModel(
     private val cronetExecutor: Lazy<ExecutorService>,
     private val okHttpClient: Lazy<OkHttpClient>,
     private val streamFeedRefreshCoordinator: StreamFeedRefreshCoordinator,
+    private val metadataCache: MetadataCache,
     savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
 
@@ -73,6 +76,12 @@ class ChannelPagerViewModel(
     fun loadStream(networkLibrary: String?, gqlHeaders: Map<String, String>, helixHeaders: Map<String, String>, enableIntegrity: Boolean) {
         if (_stream.value == null) {
             viewModelScope.launch {
+                val cached = try {
+                    metadataCache.readChannel(args.channelId, args.channelLogin)
+                } catch (_: Exception) {
+                    null
+                }
+                cached?.let(::applyChannelSnapshot)
                 try {
                     val response = graphQLRepository.loadQueryUserChannelPage(networkLibrary, gqlHeaders, args.channelId, if (args.channelId.isNullOrBlank()) args.channelLogin else null)
                     if (enableIntegrity) {
@@ -82,54 +91,66 @@ class ChannelPagerViewModel(
                         }
                     }
                     response.data!!.user?.let {
-                        _stream.value = Stream(
-                            id = it.stream?.id,
-                            channelId = it.id,
-                            channelLogin = it.login,
-                            channelName = it.displayName,
-                            channelImageURL = it.profileImageURL,
-                            gameId = it.stream?.game?.id,
-                            gameSlug = it.stream?.game?.slug,
-                            gameName = it.stream?.game?.displayName,
-                            title = it.stream?.title,
-                            thumbnailURL = it.stream?.previewImageURL,
-                            createdAt = it.stream?.createdAt?.toString(),
-                            viewerCount = it.stream?.viewersCount,
+                        val snapshot = ChannelPageCacheSnapshot(
+                            stream = Stream(
+                                id = it.stream?.id,
+                                channelId = it.id,
+                                channelLogin = it.login,
+                                channelName = it.displayName,
+                                channelImageURL = it.profileImageURL,
+                                gameId = it.stream?.game?.id,
+                                gameSlug = it.stream?.game?.slug,
+                                gameName = it.stream?.game?.displayName,
+                                title = it.stream?.title,
+                                thumbnailURL = it.stream?.previewImageURL,
+                                createdAt = it.stream?.createdAt?.toString(),
+                                viewerCount = it.stream?.viewersCount,
+                            ),
+                            user = User(
+                                id = it.id,
+                                login = it.login,
+                                name = it.displayName,
+                                profileImageURL = it.profileImageURL,
+                                type = when {
+                                    it.roles?.isStaff == true -> "staff"
+                                    else -> null
+                                },
+                                broadcasterType = when {
+                                    it.roles?.isPartner == true -> "partner"
+                                    it.roles?.isAffiliate == true -> "affiliate"
+                                    else -> null
+                                },
+                                createdAt = it.createdAt?.toString(),
+                                followerCount = it.followers?.totalCount,
+                                bannerImageURL = it.bannerImageURL,
+                                lastBroadcast = it.lastBroadcast?.startedAt?.toString(),
+                            ),
                         )
-                        _user.value = User(
-                            id = it.id,
-                            login = it.login,
-                            name = it.displayName,
-                            profileImageURL = it.profileImageURL,
-                            type = when {
-                                it.roles?.isStaff == true -> "staff"
-                                else -> null
-                            },
-                            broadcasterType = when {
-                                it.roles?.isPartner == true -> "partner"
-                                it.roles?.isAffiliate == true -> "affiliate"
-                                else -> null
-                            },
-                            createdAt = it.createdAt?.toString(),
-                            followerCount = it.followers?.totalCount,
-                            bannerImageURL = it.bannerImageURL,
-                            lastBroadcast = it.lastBroadcast?.startedAt?.toString(),
-                        )
+                        applyChannelSnapshot(snapshot)
+                        try {
+                            metadataCache.writeChannel(
+                                channelId = args.channelId ?: snapshot.user.id,
+                                login = args.channelLogin ?: snapshot.user.login,
+                                snapshot = snapshot,
+                            )
+                        } catch (_: Exception) {
+                        }
                     }
                 } catch (e: Exception) {
                     if (!helixHeaders[C.HEADER_TOKEN].isNullOrBlank()) {
-                        try {
+                        val fallbackStream = try {
                             helixRepository.getStreams(
                                 networkLibrary = networkLibrary,
                                 headers = helixHeaders,
                                 ids = args.channelId?.let { listOf(it) },
                                 logins = if (args.channelId.isNullOrBlank()) args.channelLogin?.let { listOf(it) } else null
                             ).data.firstOrNull()?.let {
-                                _stream.value = Stream(
+                                Stream(
                                     id = it.id,
                                     channelId = it.channelId,
                                     channelLogin = it.channelLogin,
                                     channelName = it.channelName,
+                                    channelImageURL = cached?.user?.profileImageURL,
                                     gameId = it.gameId,
                                     gameName = it.gameName,
                                     title = it.title,
@@ -139,13 +160,17 @@ class ChannelPagerViewModel(
                                     tags = it.tags,
                                 )
                             }
+                        } catch (_: Exception) {
+                            null
+                        }
+                        val fallbackUser = try {
                             helixRepository.getUsers(
                                 networkLibrary = networkLibrary,
                                 headers = helixHeaders,
                                 ids = args.channelId?.let { listOf(it) },
                                 logins = if (args.channelId.isNullOrBlank()) args.channelLogin?.let { listOf(it) } else null
                             ).data.firstOrNull()?.let {
-                                _user.value = User(
+                                User(
                                     id = it.id,
                                     login = it.login,
                                     name = it.displayName,
@@ -155,13 +180,34 @@ class ChannelPagerViewModel(
                                     createdAt = it.createdAt,
                                 )
                             }
-                        } catch (e: Exception) {
-
+                        } catch (_: Exception) {
+                            null
+                        }
+                        val snapshot = fallbackUser?.let { user ->
+                            ChannelPageCacheSnapshot(user = user, stream = fallbackStream)
+                        } ?: fallbackStream?.let { stream ->
+                            cached?.user?.let { user -> ChannelPageCacheSnapshot(user = user, stream = stream) }
+                        }
+                        snapshot?.let {
+                            applyChannelSnapshot(it)
+                            try {
+                                metadataCache.writeChannel(
+                                    channelId = args.channelId ?: it.user.id,
+                                    login = args.channelLogin ?: it.user.login,
+                                    snapshot = it,
+                                )
+                            } catch (_: Exception) {
+                            }
                         }
                     }
                 }
             }
         }
+    }
+
+    private fun applyChannelSnapshot(snapshot: ChannelPageCacheSnapshot) {
+        _stream.value = snapshot.stream
+        _user.value = snapshot.user
     }
 
     fun enableNotifications(userId: String?, channelId: String?, setting: Int, notificationsEnabled: Boolean, networkLibrary: String?, gqlHeaders: Map<String, String>, enableIntegrity: Boolean) {
@@ -473,7 +519,7 @@ class ChannelPagerViewModel(
                 val savedStateHandle = createSavedStateHandle()
                 val application = (this[APPLICATION_KEY] as XtraApp)
                 val xtraModule = application.xtraModule
-                ChannelPagerViewModel(xtraModule.localChannelFollowsRepository, xtraModule.offlineVideosRepository, xtraModule.bookmarksRepository, xtraModule.notificationsRepository, xtraModule.graphQLRepository, xtraModule.helixRepository, xtraModule.httpEngine, xtraModule.cronetEngine, xtraModule.cronetExecutor, xtraModule.okHttpClient, xtraModule.streamFeedRefreshCoordinator, savedStateHandle)
+                ChannelPagerViewModel(xtraModule.localChannelFollowsRepository, xtraModule.offlineVideosRepository, xtraModule.bookmarksRepository, xtraModule.notificationsRepository, xtraModule.graphQLRepository, xtraModule.helixRepository, xtraModule.httpEngine, xtraModule.cronetEngine, xtraModule.cronetExecutor, xtraModule.okHttpClient, xtraModule.streamFeedRefreshCoordinator, xtraModule.metadataCache, savedStateHandle)
             }
         }
     }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/channel/ChannelPagerViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/channel/ChannelPagerViewModel.kt
@@ -29,6 +29,7 @@ import com.github.andreyasadchy.xtra.util.C
 import com.github.andreyasadchy.xtra.util.NetworkUtils
 import com.github.andreyasadchy.xtra.util.NetworkUtils.executeAsync
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -73,10 +74,11 @@ class ChannelPagerViewModel(
     val stream: StateFlow<Stream?> = _stream
     private val _user = MutableStateFlow<User?>(null)
     val user: StateFlow<User?> = _user
+    private var loadJob: Job? = null
 
     fun loadStream(networkLibrary: String?, gqlHeaders: Map<String, String>, helixHeaders: Map<String, String>, enableIntegrity: Boolean) {
-        if (_stream.value == null) {
-            viewModelScope.launch {
+        if (loadJob?.isActive == true) return
+        loadJob = viewModelScope.launch {
                 val cached = try {
                     metadataCache.readChannel(args.channelId, args.channelLogin)
                 } catch (_: Exception) {
@@ -205,7 +207,6 @@ class ChannelPagerViewModel(
                         }
                     }
                 }
-            }
         }
     }
 

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/channel/ChannelPagerViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/channel/ChannelPagerViewModel.kt
@@ -23,6 +23,7 @@ import com.github.andreyasadchy.xtra.repository.LocalChannelFollowsRepository
 import com.github.andreyasadchy.xtra.repository.MetadataCache
 import com.github.andreyasadchy.xtra.repository.NotificationsRepository
 import com.github.andreyasadchy.xtra.repository.OfflineVideosRepository
+import com.github.andreyasadchy.xtra.repository.resolveChannelFallback
 import com.github.andreyasadchy.xtra.repository.streamfeed.StreamFeedRefreshCoordinator
 import com.github.andreyasadchy.xtra.util.C
 import com.github.andreyasadchy.xtra.util.NetworkUtils
@@ -138,65 +139,68 @@ class ChannelPagerViewModel(
                     }
                 } catch (e: Exception) {
                     if (!helixHeaders[C.HEADER_TOKEN].isNullOrBlank()) {
-                        val fallbackStream = try {
-                            helixRepository.getStreams(
-                                networkLibrary = networkLibrary,
-                                headers = helixHeaders,
-                                ids = args.channelId?.let { listOf(it) },
-                                logins = if (args.channelId.isNullOrBlank()) args.channelLogin?.let { listOf(it) } else null
-                            ).data.firstOrNull()?.let {
-                                Stream(
-                                    id = it.id,
-                                    channelId = it.channelId,
-                                    channelLogin = it.channelLogin,
-                                    channelName = it.channelName,
-                                    channelImageURL = cached?.user?.profileImageURL,
-                                    gameId = it.gameId,
-                                    gameName = it.gameName,
-                                    title = it.title,
-                                    thumbnailURL = it.thumbnailURL,
-                                    createdAt = it.startedAt,
-                                    viewerCount = it.viewerCount,
-                                    tags = it.tags,
-                                )
-                            }
-                        } catch (_: Exception) {
-                            null
+                        val streamResult: Result<Stream?> = try {
+                            Result.success(
+                                helixRepository.getStreams(
+                                    networkLibrary = networkLibrary,
+                                    headers = helixHeaders,
+                                    ids = args.channelId?.let { listOf(it) },
+                                    logins = if (args.channelId.isNullOrBlank()) args.channelLogin?.let { listOf(it) } else null
+                                ).data.firstOrNull()?.let {
+                                    Stream(
+                                        id = it.id,
+                                        channelId = it.channelId,
+                                        channelLogin = it.channelLogin,
+                                        channelName = it.channelName,
+                                        channelImageURL = cached?.user?.profileImageURL,
+                                        gameId = it.gameId,
+                                        gameName = it.gameName,
+                                        title = it.title,
+                                        thumbnailURL = it.thumbnailURL,
+                                        createdAt = it.startedAt,
+                                        viewerCount = it.viewerCount,
+                                        tags = it.tags,
+                                    )
+                                }
+                            )
+                        } catch (e: Exception) {
+                            Result.failure(e)
                         }
-                        val fallbackUser = try {
-                            helixRepository.getUsers(
-                                networkLibrary = networkLibrary,
-                                headers = helixHeaders,
-                                ids = args.channelId?.let { listOf(it) },
-                                logins = if (args.channelId.isNullOrBlank()) args.channelLogin?.let { listOf(it) } else null
-                            ).data.firstOrNull()?.let {
-                                User(
-                                    id = it.id,
-                                    login = it.login,
-                                    name = it.displayName,
-                                    profileImageURL = it.profileImageURL,
-                                    type = it.type,
-                                    broadcasterType = it.broadcasterType,
-                                    createdAt = it.createdAt,
-                                )
-                            }
-                        } catch (_: Exception) {
-                            null
+                        val userResult: Result<User?> = try {
+                            Result.success(
+                                helixRepository.getUsers(
+                                    networkLibrary = networkLibrary,
+                                    headers = helixHeaders,
+                                    ids = args.channelId?.let { listOf(it) },
+                                    logins = if (args.channelId.isNullOrBlank()) args.channelLogin?.let { listOf(it) } else null
+                                ).data.firstOrNull()?.let {
+                                    User(
+                                        id = it.id,
+                                        login = it.login,
+                                        name = it.displayName,
+                                        profileImageURL = it.profileImageURL,
+                                        type = it.type,
+                                        broadcasterType = it.broadcasterType,
+                                        createdAt = it.createdAt,
+                                    )
+                                }
+                            )
+                        } catch (e: Exception) {
+                            Result.failure(e)
                         }
-                        val snapshot = fallbackUser?.let { user ->
-                            ChannelPageCacheSnapshot(user = user, stream = fallbackStream)
-                        } ?: fallbackStream?.let { stream ->
-                            cached?.user?.let { user -> ChannelPageCacheSnapshot(user = user, stream = stream) }
-                        }
-                        snapshot?.let {
-                            applyChannelSnapshot(it)
-                            try {
-                                metadataCache.writeChannel(
-                                    channelId = args.channelId ?: it.user.id,
-                                    login = args.channelLogin ?: it.user.login,
-                                    snapshot = it,
-                                )
-                            } catch (_: Exception) {
+                        resolveChannelFallback(cached, streamResult, userResult).let { resolution ->
+                            resolution.snapshot?.let {
+                                applyChannelSnapshot(it)
+                                if (resolution.shouldPersist) {
+                                    try {
+                                        metadataCache.writeChannel(
+                                            channelId = args.channelId ?: it.user.id,
+                                            login = args.channelLogin ?: it.user.login,
+                                            snapshot = it,
+                                        )
+                                    } catch (_: Exception) {
+                                    }
+                                }
                             }
                         }
                     }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/channel/ChannelPagerViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/channel/ChannelPagerViewModel.kt
@@ -25,11 +25,11 @@ import com.github.andreyasadchy.xtra.repository.NotificationsRepository
 import com.github.andreyasadchy.xtra.repository.OfflineVideosRepository
 import com.github.andreyasadchy.xtra.repository.resolveChannelFallback
 import com.github.andreyasadchy.xtra.repository.streamfeed.StreamFeedRefreshCoordinator
+import com.github.andreyasadchy.xtra.ui.common.LoadRequestCoalescer
 import com.github.andreyasadchy.xtra.util.C
 import com.github.andreyasadchy.xtra.util.NetworkUtils
 import com.github.andreyasadchy.xtra.util.NetworkUtils.executeAsync
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -74,11 +74,42 @@ class ChannelPagerViewModel(
     val stream: StateFlow<Stream?> = _stream
     private val _user = MutableStateFlow<User?>(null)
     val user: StateFlow<User?> = _user
-    private var loadJob: Job? = null
 
-    fun loadStream(networkLibrary: String?, gqlHeaders: Map<String, String>, helixHeaders: Map<String, String>, enableIntegrity: Boolean) {
-        if (loadJob?.isActive == true) return
-        loadJob = viewModelScope.launch {
+    private data class LoadRequest(
+        val networkLibrary: String?,
+        val gqlHeaders: Map<String, String>,
+        val helixHeaders: Map<String, String>,
+        val enableIntegrity: Boolean,
+    )
+
+    private val loadCoordinator: LoadRequestCoalescer<LoadRequest>
+
+    init {
+        loadCoordinator = LoadRequestCoalescer { request ->
+            viewModelScope.launch {
+                try {
+                    loadStream(request)
+                } finally {
+                    loadCoordinator.complete()
+                }
+            }
+        }
+    }
+
+    fun loadStream(
+        networkLibrary: String?,
+        gqlHeaders: Map<String, String>,
+        helixHeaders: Map<String, String>,
+        enableIntegrity: Boolean,
+        revalidate: Boolean = false,
+    ) {
+        loadCoordinator.request(
+            LoadRequest(networkLibrary, gqlHeaders, helixHeaders, enableIntegrity),
+            revalidate = revalidate,
+        )
+    }
+
+    private suspend fun loadStream(request: LoadRequest) {
                 val cached = try {
                     metadataCache.readChannel(args.channelId, args.channelLogin)
                 } catch (_: Exception) {
@@ -86,11 +117,11 @@ class ChannelPagerViewModel(
                 }
                 cached?.let(::applyChannelSnapshot)
                 try {
-                    val response = graphQLRepository.loadQueryUserChannelPage(networkLibrary, gqlHeaders, args.channelId, if (args.channelId.isNullOrBlank()) args.channelLogin else null)
-                    if (enableIntegrity) {
+                    val response = graphQLRepository.loadQueryUserChannelPage(request.networkLibrary, request.gqlHeaders, args.channelId, if (args.channelId.isNullOrBlank()) args.channelLogin else null)
+                    if (request.enableIntegrity) {
                         response.errors?.find { it.message == C.FAILED_INTEGRITY_CHECK }?.let {
                             integrity.emit("refresh")
-                            return@launch
+                            return
                         }
                     }
                     response.data!!.user?.let {
@@ -140,12 +171,12 @@ class ChannelPagerViewModel(
                         }
                     }
                 } catch (e: Exception) {
-                    if (!helixHeaders[C.HEADER_TOKEN].isNullOrBlank()) {
+                    if (!request.helixHeaders[C.HEADER_TOKEN].isNullOrBlank()) {
                         val streamResult: Result<Stream?> = try {
                             Result.success(
                                 helixRepository.getStreams(
-                                    networkLibrary = networkLibrary,
-                                    headers = helixHeaders,
+                                    networkLibrary = request.networkLibrary,
+                                    headers = request.helixHeaders,
                                     ids = args.channelId?.let { listOf(it) },
                                     logins = if (args.channelId.isNullOrBlank()) args.channelLogin?.let { listOf(it) } else null
                                 ).data.firstOrNull()?.let {
@@ -171,8 +202,8 @@ class ChannelPagerViewModel(
                         val userResult: Result<User?> = try {
                             Result.success(
                                 helixRepository.getUsers(
-                                    networkLibrary = networkLibrary,
-                                    headers = helixHeaders,
+                                    networkLibrary = request.networkLibrary,
+                                    headers = request.helixHeaders,
                                     ids = args.channelId?.let { listOf(it) },
                                     logins = if (args.channelId.isNullOrBlank()) args.channelLogin?.let { listOf(it) } else null
                                 ).data.firstOrNull()?.let {
@@ -207,7 +238,6 @@ class ChannelPagerViewModel(
                         }
                     }
                 }
-        }
     }
 
     private fun applyChannelSnapshot(snapshot: ChannelPageCacheSnapshot) {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/LoadRequestCoalescer.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/LoadRequestCoalescer.kt
@@ -1,0 +1,31 @@
+package com.github.andreyasadchy.xtra.ui.common
+
+internal class LoadRequestCoalescer<Request>(
+    private val start: (Request) -> Unit,
+) {
+
+    private var active = false
+    private var pending: Request? = null
+
+    fun request(request: Request, revalidate: Boolean = false) {
+        if (active) {
+            if (revalidate) {
+                pending = request
+            }
+            return
+        }
+        active = true
+        start(request)
+    }
+
+    fun complete() {
+        if (!active) return
+        val next = pending
+        pending = null
+        if (next == null) {
+            active = false
+        } else {
+            start(next)
+        }
+    }
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/game/GameMediaFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/game/GameMediaFragment.kt
@@ -109,6 +109,7 @@ class GameMediaFragment : BaseNetworkFragment(), Scrollable, FragmentHost, Integ
             if (args.boxArt != null) {
                 gameLayout.visibility = View.VISIBLE
                 gameImage.visibility = View.VISIBLE
+                gameImage.tag = args.boxArt
                 requireContext().imageLoader.enqueue(
                     ImageRequest.Builder(requireContext()).apply {
                         data(args.boxArt)
@@ -118,6 +119,7 @@ class GameMediaFragment : BaseNetworkFragment(), Scrollable, FragmentHost, Integ
                 )
             } else {
                 gameImage.visibility = View.GONE
+                gameImage.tag = null
             }
             val isLoggedIn = !TwitchApiHelper.getGQLHeaders(requireContext(), true)[C.HEADER_TOKEN].isNullOrBlank() ||
                     !TwitchApiHelper.getHelixHeaders(requireContext())[C.HEADER_TOKEN].isNullOrBlank()
@@ -351,16 +353,23 @@ class GameMediaFragment : BaseNetworkFragment(), Scrollable, FragmentHost, Integ
 
     private fun updateGameLayout(game: Game?) {
         with(binding) {
-            if (!gameImage.isVisible && game?.boxArt != null) {
+            val boxArt = game?.boxArt
+            if (!boxArt.isNullOrBlank()) {
                 gameLayout.visibility = View.VISIBLE
                 gameImage.visibility = View.VISIBLE
-                requireContext().imageLoader.enqueue(
-                    ImageRequest.Builder(requireContext()).apply {
-                        data(game.boxArt)
-                        crossfade(true)
-                        target(gameImage)
-                    }.build()
-                )
+                if (gameImage.tag != boxArt || gameImage.drawable == null) {
+                    gameImage.tag = boxArt
+                    requireContext().imageLoader.enqueue(
+                        ImageRequest.Builder(requireContext()).apply {
+                            data(boxArt)
+                            crossfade(true)
+                            target(gameImage)
+                        }.build()
+                    )
+                }
+            } else {
+                gameImage.visibility = View.GONE
+                gameImage.tag = null
             }
             if (game?.name != null && game.name != args.gameName) {
                 gameLayout.visibility = View.VISIBLE

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/game/GameMediaFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/game/GameMediaFragment.kt
@@ -65,6 +65,8 @@ import kotlinx.coroutines.launch
 
 class GameMediaFragment : BaseNetworkFragment(), Scrollable, FragmentHost, IntegrityDialog.Listener {
 
+    override val initializeWithoutNetwork = true
+
     private var _binding: FragmentGameBinding? = null
     private val binding get() = _binding!!
     private val args: GamePagerFragmentArgs by navArgs()
@@ -353,7 +355,9 @@ class GameMediaFragment : BaseNetworkFragment(), Scrollable, FragmentHost, Integ
 
     private fun updateGameLayout(game: Game?) {
         with(binding) {
-            val boxArt = game?.boxArt
+            val boxArt = game?.boxArtURL
+                ?.takeIf { it.isNotBlank() }
+                ?.let(TwitchApiHelper::getGameBoxArt)
             if (!boxArt.isNullOrBlank()) {
                 gameLayout.visibility = View.VISIBLE
                 gameImage.visibility = View.VISIBLE
@@ -367,9 +371,6 @@ class GameMediaFragment : BaseNetworkFragment(), Scrollable, FragmentHost, Integ
                         }.build()
                     )
                 }
-            } else {
-                gameImage.visibility = View.GONE
-                gameImage.tag = null
             }
             if (game?.name != null && game.name != args.gameName) {
                 gameLayout.visibility = View.VISIBLE

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/game/GameMediaFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/game/GameMediaFragment.kt
@@ -481,6 +481,7 @@ class GameMediaFragment : BaseNetworkFragment(), Scrollable, FragmentHost, Integ
             TwitchApiHelper.getGQLHeaders(requireContext()),
             TwitchApiHelper.getHelixHeaders(requireContext()),
             requireContext().prefs().getBoolean(C.ENABLE_INTEGRITY, false),
+            revalidate = true,
         )
     }
 
@@ -492,6 +493,7 @@ class GameMediaFragment : BaseNetworkFragment(), Scrollable, FragmentHost, Integ
                     TwitchApiHelper.getGQLHeaders(requireContext()),
                     TwitchApiHelper.getHelixHeaders(requireContext()),
                     requireContext().prefs().getBoolean(C.ENABLE_INTEGRITY, false),
+                    revalidate = true,
                 )
                 val setting = requireContext().prefs().getString(C.UI_FOLLOW_BUTTON, "0")?.toIntOrNull() ?: 0
                 if (setting < 2) {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/game/GamePagerFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/game/GamePagerFragment.kt
@@ -107,6 +107,7 @@ class GamePagerFragment : BaseNetworkFragment(), Scrollable, FragmentHost, Integ
             if (args.boxArt != null) {
                 gameLayout.visibility = View.VISIBLE
                 gameImage.visibility = View.VISIBLE
+                gameImage.tag = args.boxArt
                 requireContext().imageLoader.enqueue(
                     ImageRequest.Builder(requireContext()).apply {
                         data(args.boxArt)
@@ -116,6 +117,7 @@ class GamePagerFragment : BaseNetworkFragment(), Scrollable, FragmentHost, Integ
                 )
             } else {
                 gameImage.visibility = View.GONE
+                gameImage.tag = null
             }
             val isLoggedIn = !TwitchApiHelper.getGQLHeaders(requireContext(), true)[C.HEADER_TOKEN].isNullOrBlank() ||
                     !TwitchApiHelper.getHelixHeaders(requireContext())[C.HEADER_TOKEN].isNullOrBlank()
@@ -353,16 +355,23 @@ class GamePagerFragment : BaseNetworkFragment(), Scrollable, FragmentHost, Integ
 
     private fun updateGameLayout(game: Game?) {
         with(binding) {
-            if (!gameImage.isVisible && game?.boxArt != null) {
+            val boxArt = game?.boxArt
+            if (!boxArt.isNullOrBlank()) {
                 gameLayout.visibility = View.VISIBLE
                 gameImage.visibility = View.VISIBLE
-                requireContext().imageLoader.enqueue(
-                    ImageRequest.Builder(requireContext()).apply {
-                        data(game.boxArt)
-                        crossfade(true)
-                        target(gameImage)
-                    }.build()
-                )
+                if (gameImage.tag != boxArt || gameImage.drawable == null) {
+                    gameImage.tag = boxArt
+                    requireContext().imageLoader.enqueue(
+                        ImageRequest.Builder(requireContext()).apply {
+                            data(boxArt)
+                            crossfade(true)
+                            target(gameImage)
+                        }.build()
+                    )
+                }
+            } else {
+                gameImage.visibility = View.GONE
+                gameImage.tag = null
             }
             if (game?.name != null && game.name != args.gameName) {
                 gameLayout.visibility = View.VISIBLE

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/game/GamePagerFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/game/GamePagerFragment.kt
@@ -64,6 +64,8 @@ import kotlinx.coroutines.launch
 
 class GamePagerFragment : BaseNetworkFragment(), Scrollable, FragmentHost, IntegrityDialog.Listener {
 
+    override val initializeWithoutNetwork = true
+
     private var _binding: FragmentGamePagerBinding? = null
     private val binding get() = _binding!!
     private val args: GamePagerFragmentArgs by navArgs()
@@ -355,7 +357,9 @@ class GamePagerFragment : BaseNetworkFragment(), Scrollable, FragmentHost, Integ
 
     private fun updateGameLayout(game: Game?) {
         with(binding) {
-            val boxArt = game?.boxArt
+            val boxArt = game?.boxArtURL
+                ?.takeIf { it.isNotBlank() }
+                ?.let(TwitchApiHelper::getGameBoxArt)
             if (!boxArt.isNullOrBlank()) {
                 gameLayout.visibility = View.VISIBLE
                 gameImage.visibility = View.VISIBLE
@@ -369,9 +373,6 @@ class GamePagerFragment : BaseNetworkFragment(), Scrollable, FragmentHost, Integ
                         }.build()
                     )
                 }
-            } else {
-                gameImage.visibility = View.GONE
-                gameImage.tag = null
             }
             if (game?.name != null && game.name != args.gameName) {
                 gameLayout.visibility = View.VISIBLE

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/game/GamePagerFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/game/GamePagerFragment.kt
@@ -469,6 +469,7 @@ class GamePagerFragment : BaseNetworkFragment(), Scrollable, FragmentHost, Integ
             TwitchApiHelper.getGQLHeaders(requireContext()),
             TwitchApiHelper.getHelixHeaders(requireContext()),
             requireContext().prefs().getBoolean(C.ENABLE_INTEGRITY, false),
+            revalidate = true,
         )
     }
 
@@ -480,6 +481,7 @@ class GamePagerFragment : BaseNetworkFragment(), Scrollable, FragmentHost, Integ
                     TwitchApiHelper.getGQLHeaders(requireContext()),
                     TwitchApiHelper.getHelixHeaders(requireContext()),
                     requireContext().prefs().getBoolean(C.ENABLE_INTEGRITY, false),
+                    revalidate = true,
                 )
                 val setting = requireContext().prefs().getString(C.UI_FOLLOW_BUTTON, "0")?.toIntOrNull() ?: 0
                 if (setting < 2) {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/game/GamePagerViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/game/GamePagerViewModel.kt
@@ -24,6 +24,7 @@ import com.github.andreyasadchy.xtra.util.NetworkUtils
 import com.github.andreyasadchy.xtra.util.NetworkUtils.executeAsync
 import com.github.andreyasadchy.xtra.util.TwitchApiHelper
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -58,10 +59,11 @@ class GamePagerViewModel(
 
     private val _game = MutableStateFlow<Game?>(null)
     val game: StateFlow<Game?> = _game
+    private var loadJob: Job? = null
 
     fun loadGame(networkLibrary: String?, gqlHeaders: Map<String, String>, helixHeaders: Map<String, String>, enableIntegrity: Boolean) {
-        if (_game.value == null) {
-            viewModelScope.launch {
+        if (loadJob?.isActive == true) return
+        loadJob = viewModelScope.launch {
                 val cached = try {
                     metadataCache.readGame(args.gameId, args.gameSlug, args.gameName)
                 } catch (_: Exception) {
@@ -139,7 +141,6 @@ class GamePagerViewModel(
                         }
                     }
                 }
-            }
         }
     }
 

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/game/GamePagerViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/game/GamePagerViewModel.kt
@@ -13,9 +13,11 @@ import com.github.andreyasadchy.xtra.XtraApp
 import com.github.andreyasadchy.xtra.model.ui.Game
 import com.github.andreyasadchy.xtra.model.ui.LocalGameFollow
 import com.github.andreyasadchy.xtra.model.ui.Tag
+import com.github.andreyasadchy.xtra.repository.GamePageCacheSnapshot
 import com.github.andreyasadchy.xtra.repository.GraphQLRepository
 import com.github.andreyasadchy.xtra.repository.HelixRepository
 import com.github.andreyasadchy.xtra.repository.LocalGameFollowsRepository
+import com.github.andreyasadchy.xtra.repository.MetadataCache
 import com.github.andreyasadchy.xtra.util.C
 import com.github.andreyasadchy.xtra.util.NetworkUtils
 import com.github.andreyasadchy.xtra.util.NetworkUtils.executeAsync
@@ -41,6 +43,7 @@ class GamePagerViewModel(
     private val cronetEngine: Lazy<CronetEngine?>,
     private val cronetExecutor: Lazy<ExecutorService>,
     private val okHttpClient: Lazy<OkHttpClient>,
+    private val metadataCache: MetadataCache,
     savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
 
@@ -58,7 +61,13 @@ class GamePagerViewModel(
     fun loadGame(networkLibrary: String?, gqlHeaders: Map<String, String>, helixHeaders: Map<String, String>, enableIntegrity: Boolean) {
         if (_game.value == null) {
             viewModelScope.launch {
-                _game.value = try {
+                val cached = try {
+                    metadataCache.readGame(args.gameId, args.gameSlug, args.gameName)
+                } catch (_: Exception) {
+                    null
+                }
+                cached?.let { _game.value = it.game }
+                try {
                     val response = graphQLRepository.loadQueryGame(
                         networkLibrary = networkLibrary,
                         headers = gqlHeaders,
@@ -73,7 +82,7 @@ class GamePagerViewModel(
                         }
                     }
                     response.data!!.game?.let {
-                        Game(
+                        val game = Game(
                             id = it.id,
                             slug = it.slug,
                             name = it.displayName,
@@ -88,6 +97,16 @@ class GamePagerViewModel(
                                 )
                             }
                         )
+                        _game.value = game
+                        try {
+                            metadataCache.writeGame(
+                                gameId = args.gameId ?: game.id,
+                                slug = args.gameSlug ?: game.slug,
+                                name = args.gameName ?: game.name,
+                                snapshot = GamePageCacheSnapshot(game),
+                            )
+                        } catch (_: Exception) {
+                        }
                     }
                 } catch (e: Exception) {
                     if (!helixHeaders[C.HEADER_TOKEN].isNullOrBlank()) {
@@ -98,16 +117,25 @@ class GamePagerViewModel(
                                 ids = args.gameId?.let { listOf(it) },
                                 names = if (args.gameId.isNullOrBlank()) args.gameName?.let { listOf(it) } else null
                             ).data.firstOrNull()?.let {
-                                Game(
+                                val game = Game(
                                     id = it.id,
                                     name = it.name,
                                     boxArtURL = it.boxArtURL
                                 )
+                                _game.value = game
+                                try {
+                                    metadataCache.writeGame(
+                                        gameId = args.gameId ?: game.id,
+                                        slug = args.gameSlug ?: game.slug,
+                                        name = args.gameName ?: game.name,
+                                        snapshot = GamePageCacheSnapshot(game),
+                                    )
+                                } catch (_: Exception) {
+                                }
                             }
                         } catch (e: Exception) {
-                            null
                         }
-                    } else null
+                    }
                 }
             }
         }
@@ -369,7 +397,7 @@ class GamePagerViewModel(
                 val savedStateHandle = createSavedStateHandle()
                 val application = (this[APPLICATION_KEY] as XtraApp)
                 val xtraModule = application.xtraModule
-                GamePagerViewModel(xtraModule.graphQLRepository, xtraModule.helixRepository, xtraModule.localGameFollowsRepository, xtraModule.httpEngine, xtraModule.cronetEngine, xtraModule.cronetExecutor, xtraModule.okHttpClient, savedStateHandle)
+                GamePagerViewModel(xtraModule.graphQLRepository, xtraModule.helixRepository, xtraModule.localGameFollowsRepository, xtraModule.httpEngine, xtraModule.cronetEngine, xtraModule.cronetExecutor, xtraModule.okHttpClient, xtraModule.metadataCache, savedStateHandle)
             }
         }
     }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/game/GamePagerViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/game/GamePagerViewModel.kt
@@ -18,6 +18,7 @@ import com.github.andreyasadchy.xtra.repository.GraphQLRepository
 import com.github.andreyasadchy.xtra.repository.HelixRepository
 import com.github.andreyasadchy.xtra.repository.LocalGameFollowsRepository
 import com.github.andreyasadchy.xtra.repository.MetadataCache
+import com.github.andreyasadchy.xtra.repository.mergeGameFallback
 import com.github.andreyasadchy.xtra.util.C
 import com.github.andreyasadchy.xtra.util.NetworkUtils
 import com.github.andreyasadchy.xtra.util.NetworkUtils.executeAsync
@@ -117,11 +118,12 @@ class GamePagerViewModel(
                                 ids = args.gameId?.let { listOf(it) },
                                 names = if (args.gameId.isNullOrBlank()) args.gameName?.let { listOf(it) } else null
                             ).data.firstOrNull()?.let {
-                                val game = Game(
+                                val helixGame = Game(
                                     id = it.id,
                                     name = it.name,
                                     boxArtURL = it.boxArtURL
                                 )
+                                val game = mergeGameFallback(cached?.game, helixGame)
                                 _game.value = game
                                 try {
                                     metadataCache.writeGame(

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/game/GamePagerViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/game/GamePagerViewModel.kt
@@ -23,8 +23,8 @@ import com.github.andreyasadchy.xtra.util.C
 import com.github.andreyasadchy.xtra.util.NetworkUtils
 import com.github.andreyasadchy.xtra.util.NetworkUtils.executeAsync
 import com.github.andreyasadchy.xtra.util.TwitchApiHelper
+import com.github.andreyasadchy.xtra.ui.common.LoadRequestCoalescer
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -59,11 +59,42 @@ class GamePagerViewModel(
 
     private val _game = MutableStateFlow<Game?>(null)
     val game: StateFlow<Game?> = _game
-    private var loadJob: Job? = null
 
-    fun loadGame(networkLibrary: String?, gqlHeaders: Map<String, String>, helixHeaders: Map<String, String>, enableIntegrity: Boolean) {
-        if (loadJob?.isActive == true) return
-        loadJob = viewModelScope.launch {
+    private data class LoadRequest(
+        val networkLibrary: String?,
+        val gqlHeaders: Map<String, String>,
+        val helixHeaders: Map<String, String>,
+        val enableIntegrity: Boolean,
+    )
+
+    private val loadCoordinator: LoadRequestCoalescer<LoadRequest>
+
+    init {
+        loadCoordinator = LoadRequestCoalescer { request ->
+            viewModelScope.launch {
+                try {
+                    loadGame(request)
+                } finally {
+                    loadCoordinator.complete()
+                }
+            }
+        }
+    }
+
+    fun loadGame(
+        networkLibrary: String?,
+        gqlHeaders: Map<String, String>,
+        helixHeaders: Map<String, String>,
+        enableIntegrity: Boolean,
+        revalidate: Boolean = false,
+    ) {
+        loadCoordinator.request(
+            LoadRequest(networkLibrary, gqlHeaders, helixHeaders, enableIntegrity),
+            revalidate = revalidate,
+        )
+    }
+
+    private suspend fun loadGame(request: LoadRequest) {
                 val cached = try {
                     metadataCache.readGame(args.gameId, args.gameSlug, args.gameName)
                 } catch (_: Exception) {
@@ -72,16 +103,16 @@ class GamePagerViewModel(
                 cached?.let { _game.value = it.game }
                 try {
                     val response = graphQLRepository.loadQueryGame(
-                        networkLibrary = networkLibrary,
-                        headers = gqlHeaders,
+                        networkLibrary = request.networkLibrary,
+                        headers = request.gqlHeaders,
                         id = args.gameId,
                         slug = args.gameSlug.takeIf { args.gameId.isNullOrBlank() },
                         name = args.gameName.takeIf { args.gameId.isNullOrBlank() && args.gameSlug.isNullOrBlank() },
                     )
-                    if (enableIntegrity) {
+                    if (request.enableIntegrity) {
                         response.errors?.find { it.message == C.FAILED_INTEGRITY_CHECK }?.let {
                             integrity.emit("refresh")
-                            return@launch
+                            return
                         }
                     }
                     response.data!!.game?.let {
@@ -112,11 +143,11 @@ class GamePagerViewModel(
                         }
                     }
                 } catch (e: Exception) {
-                    if (!helixHeaders[C.HEADER_TOKEN].isNullOrBlank()) {
+                    if (!request.helixHeaders[C.HEADER_TOKEN].isNullOrBlank()) {
                         try {
                             helixRepository.getGames(
-                                networkLibrary = networkLibrary,
-                                headers = helixHeaders,
+                                networkLibrary = request.networkLibrary,
+                                headers = request.helixHeaders,
                                 ids = args.gameId?.let { listOf(it) },
                                 names = if (args.gameId.isNullOrBlank()) args.gameName?.let { listOf(it) } else null
                             ).data.firstOrNull()?.let {
@@ -141,7 +172,6 @@ class GamePagerViewModel(
                         }
                     }
                 }
-        }
     }
 
     fun isFollowingGame(gameId: String?, setting: Int, networkLibrary: String?, gqlHeaders: Map<String, String>) {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/login/LoginActivity.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/login/LoginActivity.kt
@@ -116,6 +116,7 @@ class LoginActivity : AppCompatActivity() {
     private var previousGqlWebClientId: String? = null
     private var previousGqlWebToken: String? = null
     private var previousUserId: String? = null
+    private var previousUserLogin: String? = null
     private var reauthorizationIdentityMismatch = false
     private var reauthorizationHelixValidationFailed = false
     private var reauthorizationHelixScopes: Set<String> = emptySet()
@@ -131,6 +132,7 @@ class LoginActivity : AppCompatActivity() {
         setContentView(binding.root)
         reauthorize = intent.getBooleanExtra(EXTRA_REAUTHORIZE, false)
         previousUserId = tokenPrefs().getString(C.USER_ID, null)
+        previousUserLogin = tokenPrefs().getString(C.USERNAME, null)
         if (reauthorize && previousUserId.isNullOrBlank()) {
             Toast.makeText(this, R.string.account_reauthorize_identity_unknown, Toast.LENGTH_LONG).show()
             setResult(RESULT_CANCELED)
@@ -166,6 +168,7 @@ class LoginActivity : AppCompatActivity() {
                 LiveNotificationScheduler.disable(this@LoginActivity)
                 lifecycleScope.launch(Dispatchers.IO) {
                     xtraModule.notificationsRepository.clearNotificationState()
+                    xtraModule.metadataCache.clearAccount(previousUserId, previousUserLogin)
                 }
                 TwitchApiHelper.checkedValidation = false
                 prefs().edit { putBoolean(C.LIVE_NOTIFICATIONS_ENABLED, false) }

--- a/app/src/test/java/com/github/andreyasadchy/xtra/repository/MetadataCacheKeyTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/repository/MetadataCacheKeyTest.kt
@@ -1,0 +1,31 @@
+package com.github.andreyasadchy.xtra.repository
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class MetadataCacheKeyTest {
+
+    @Test
+    fun `account identity keeps id and login aliases deterministic`() {
+        assertEquals(
+            listOf("id:123", "login:somebody"),
+            MetadataCache.identityKeys("id", "login", " 123 ", "SomeBody"),
+        )
+    }
+
+    @Test
+    fun `game identity prefers stable id but retains slug and name aliases`() {
+        assertEquals(
+            listOf("id:42", "slug:some-game", "name:some game"),
+            MetadataCache.gameIdentityKeys("42", "Some-Game", "Some Game"),
+        )
+    }
+
+    @Test
+    fun `blank identity values are not cached`() {
+        assertEquals(
+            emptyList<String>(),
+            MetadataCache.identityKeys("id", "login", " ", null),
+        )
+    }
+}

--- a/app/src/test/java/com/github/andreyasadchy/xtra/repository/PageMetadataFallbacksTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/repository/PageMetadataFallbacksTest.kt
@@ -1,0 +1,88 @@
+package com.github.andreyasadchy.xtra.repository
+
+import com.github.andreyasadchy.xtra.model.ui.Game
+import com.github.andreyasadchy.xtra.model.ui.Stream
+import com.github.andreyasadchy.xtra.model.ui.Tag
+import com.github.andreyasadchy.xtra.model.ui.User
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PageMetadataFallbacksTest {
+
+    @Test
+    fun `failed stream request preserves cached live stream and allows user refresh`() {
+        val cached = ChannelPageCacheSnapshot(
+            user = User(id = "42", login = "channel", name = "Old name"),
+            stream = Stream(id = "stream", channelId = "42", title = "Still live"),
+        )
+
+        val resolution = resolveChannelFallback(
+            cached = cached,
+            streamResult = Result.failure(IllegalStateException("temporary failure")),
+            userResult = Result.success(User(id = "42", login = "channel", name = "New name")),
+        )
+
+        assertEquals("New name", resolution.snapshot?.user?.name)
+        assertEquals("stream", resolution.snapshot?.stream?.id)
+        assertTrue(resolution.shouldPersist)
+    }
+
+    @Test
+    fun `successful empty stream response confirms offline and can be persisted`() {
+        val resolution = resolveChannelFallback(
+            cached = ChannelPageCacheSnapshot(
+                user = User(id = "42", login = "channel", name = "Channel"),
+                stream = Stream(id = "stream", channelId = "42"),
+            ),
+            streamResult = Result.success(null),
+            userResult = Result.success(null),
+        )
+
+        assertNotNull(resolution.snapshot)
+        assertNull(resolution.snapshot?.stream)
+        assertTrue(resolution.shouldPersist)
+    }
+
+    @Test
+    fun `failed stream request without cache does not persist an offline snapshot`() {
+        val resolution = resolveChannelFallback(
+            cached = null,
+            streamResult = Result.failure(IllegalStateException("temporary failure")),
+            userResult = Result.success(User(id = "42", login = "channel", name = "Channel")),
+        )
+
+        assertNotNull(resolution.snapshot)
+        assertNull(resolution.snapshot?.stream)
+        assertFalse(resolution.shouldPersist)
+    }
+
+    @Test
+    fun `Helix game fallback retains rich cached metadata`() {
+        val cached = Game(
+            id = "7",
+            slug = "rich-game",
+            name = "Rich Game",
+            boxArtURL = "cached-box-art",
+            viewerCount = 120,
+            broadcasterCount = 8,
+            followerCount = 900,
+            tags = listOf(Tag(id = "tag", name = "Tag")),
+        )
+        val helixGame = Game(id = "7", name = "Updated Game", boxArtURL = "fresh-box-art")
+
+        val merged = mergeGameFallback(cached, helixGame)
+
+        assertEquals("7", merged.id)
+        assertEquals("rich-game", merged.slug)
+        assertEquals("Updated Game", merged.name)
+        assertEquals("fresh-box-art", merged.boxArtURL)
+        assertEquals(120, merged.viewerCount)
+        assertEquals(8, merged.broadcasterCount)
+        assertEquals(900, merged.followerCount)
+        assertEquals("Tag", merged.tags?.single()?.name)
+    }
+}

--- a/app/src/test/java/com/github/andreyasadchy/xtra/repository/PageMetadataFallbacksTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/repository/PageMetadataFallbacksTest.kt
@@ -48,6 +48,63 @@ class PageMetadataFallbacksTest {
     }
 
     @Test
+    fun `fresh live stream builds a minimal user when user request fails`() {
+        val stream = Stream(
+            id = "stream",
+            channelId = "42",
+            channelLogin = "channel",
+            channelName = "Channel",
+            channelImageURL = "profile",
+            title = "Live",
+        )
+
+        val resolution = resolveChannelFallback(
+            cached = null,
+            streamResult = Result.success(stream),
+            userResult = Result.failure(IllegalStateException("temporary failure")),
+        )
+
+        assertEquals("42", resolution.snapshot?.user?.id)
+        assertEquals("channel", resolution.snapshot?.user?.login)
+        assertEquals("Channel", resolution.snapshot?.user?.name)
+        assertEquals("profile", resolution.snapshot?.user?.profileImageURL)
+        assertEquals("stream", resolution.snapshot?.stream?.id)
+        assertTrue(resolution.shouldPersist)
+    }
+
+    @Test
+    fun `fresh live stream builds a minimal user when user response is empty`() {
+        val stream = Stream(
+            id = "stream",
+            channelId = "42",
+            channelLogin = "channel",
+            channelName = "Channel",
+        )
+
+        val resolution = resolveChannelFallback(
+            cached = null,
+            streamResult = Result.success(stream),
+            userResult = Result.success(null),
+        )
+
+        assertEquals("42", resolution.snapshot?.user?.id)
+        assertEquals("stream", resolution.snapshot?.stream?.id)
+        assertTrue(resolution.shouldPersist)
+    }
+
+    @Test
+    fun `successful offline response without user or cache has no snapshot`() {
+        val resolution = resolveChannelFallback(
+            cached = null,
+            streamResult = Result.success(null),
+            userResult = Result.failure(IllegalStateException("temporary failure")),
+        )
+
+        assertNull(resolution.snapshot)
+        assertFalse(resolution.shouldPersist)
+    }
+
+    @Test
     fun `failed stream request without cache does not persist an offline snapshot`() {
         val resolution = resolveChannelFallback(
             cached = null,

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/common/LoadRequestCoalescerTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/common/LoadRequestCoalescerTest.kt
@@ -1,0 +1,28 @@
+package com.github.andreyasadchy.xtra.ui.common
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class LoadRequestCoalescerTest {
+
+    @Test
+    fun `queued revalidation starts once after active load completes`() {
+        val started = mutableListOf<String>()
+        val coalescer = LoadRequestCoalescer<String> { started += it }
+
+        coalescer.request("offline-load")
+        coalescer.request("ordinary-duplicate")
+        coalescer.request("restored-load-1", revalidate = true)
+        coalescer.request("restored-load-2", revalidate = true)
+
+        assertEquals(listOf("offline-load"), started)
+
+        coalescer.complete()
+
+        assertEquals(listOf("offline-load", "restored-load-2"), started)
+
+        coalescer.complete()
+
+        assertEquals(listOf("offline-load", "restored-load-2"), started)
+    }
+}


### PR DESCRIPTION
## What changed

- Remember account settings, channel profiles, and game details locally.
- Show saved information immediately while refreshing it in the background.
- Keep saved account data separated when the signed-in account changes.

## Why

Popular pages and profile settings feel ready sooner, even when the network is slow.

## Validation

- Debug build and unit tests passed.
- 8 connected Android tests passed.
- Emulator smoke check passed.
- Full-project lint still reports existing unrelated issues.
