### PR TITLE
Fix lint issues and speed up Gradle builds

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -64,6 +64,11 @@ android {
     androidResources {
         generateLocaleConfig = true
     }
+    bundle {
+        language {
+            enableSplit = false
+        }
+    }
     lint {
         disable += "ContentDescription"
     }
@@ -147,14 +152,5 @@ apollo {
     @Suppress("ApolloEndpointNotConfigured")
     service("service") {
         packageName.set("com.github.andreyasadchy.xtra.graphql")
-    }
-}
-
-// Delete large build log files from ~/.gradle/daemon/X.X/daemon-XXX.out.log
-// Source: https://discuss.gradle.org/t/gradle-daemon-produces-a-lot-of-logs/9905
-File("${project.gradle.gradleUserHomeDir.absolutePath}/daemon/${project.gradle.gradleVersion}").listFiles()?.forEach {
-    if (it.name.endsWith(".out.log")) {
-        // println("Deleting gradle log file: $it") // Optional debug output
-        it.delete()
     }
 }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/PlayerRepository.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/PlayerRepository.kt
@@ -6,7 +6,9 @@ import android.net.http.HttpEngine
 import android.net.http.ProxyOptions
 import android.util.Base64
 import android.util.Log
+import androidx.annotation.OptIn
 import androidx.core.net.toUri
+import androidx.media3.common.util.UnstableApi
 import com.apollographql.apollo.api.CustomScalarAdapters
 import com.apollographql.apollo.api.json.buildJsonString
 import com.apollographql.apollo.api.json.jsonReader
@@ -75,6 +77,7 @@ import kotlin.uuid.Uuid
 
 private const val AD_TAG = "XtraAd"
 
+@OptIn(UnstableApi::class)
 class PlayerRepository(
     private val httpEngine: Lazy<HttpEngine?>,
     private val cronetEngine: Lazy<CronetEngine?>,

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatFragment.kt
@@ -942,7 +942,7 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
 
     fun toggleBackPressedCallback(enable: Boolean) {
         if (enable) {
-            requireActivity().onBackPressedDispatcher.addCallback(this, backPressedCallback)
+            requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner, backPressedCallback)
         } else {
             backPressedCallback.remove()
         }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatViewModel.kt
@@ -298,7 +298,6 @@ class ChatViewModel(
 
     override fun onCleared() {
         releaseSession()
-        super.onCleared()
     }
 
     /** Releases a session owned by a non-Fragment chat surface such as multiview. */

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/main/MainActivity.kt
@@ -758,6 +758,7 @@ class MainActivity : AppCompatActivity() {
 
     fun minimizeMultiview() {
         if (!canMinimizeMultiview()) return
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
         runCatching {
             enterPictureInPictureMode(PictureInPictureParams.Builder().build())
         }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/multiview/CombinedChatFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/multiview/CombinedChatFragment.kt
@@ -11,6 +11,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
+import androidx.core.content.withStyledAttributes
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
@@ -358,8 +359,9 @@ private class CombinedChatAdapter(
             val context = fragment.requireContext()
             val preferences = context.prefs()
             val sizeModifier = (preferences.getInt(C.CHAT_SIZE_MODIFIER, 100).toFloat() / 100f)
-            val isLightTheme = context.obtainStyledAttributes(intArrayOf(androidx.appcompat.R.attr.isLightTheme)).use {
-                it.getBoolean(0, false)
+            var isLightTheme = false
+            context.withStyledAttributes(attrs = intArrayOf(androidx.appcompat.R.attr.isLightTheme)) {
+                isLightTheme = getBoolean(0, false)
             }
             adapter = ChatAdapter(
                 messages = singleMessage,

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/multiview/MultiviewViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/multiview/MultiviewViewModel.kt
@@ -295,7 +295,6 @@ class MultiviewViewModel(
 
     override fun onCleared() {
         playbackCoordinator.releaseAll()
-        super.onCleared()
     }
 
     private fun updatePlaybackSnapshot(identity: String, snapshot: MultiviewPlaybackSnapshot) {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/multiview/chat/CombinedChatViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/multiview/chat/CombinedChatViewModel.kt
@@ -81,7 +81,6 @@ class CombinedChatViewModel(
     override fun onCleared() {
         sessions.values.forEach(ChannelSession::release)
         sessions.clear()
-        super.onCleared()
     }
 
     private fun observe(session: ChannelSession) {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/multiview/playback/MultiviewPlaybackCoordinator.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/multiview/playback/MultiviewPlaybackCoordinator.kt
@@ -6,6 +6,7 @@ import android.net.NetworkCapabilities
 import android.util.Log
 import android.annotation.SuppressLint
 import com.github.andreyasadchy.xtra.BuildConfig
+import androidx.annotation.OptIn
 import androidx.media3.common.AudioAttributes
 import androidx.media3.common.Format
 import androidx.media3.common.MediaItem
@@ -58,6 +59,7 @@ import java.net.SocketAddress
 import java.net.URI
 import com.github.andreyasadchy.xtra.repository.PlayerRepository
 
+@OptIn(UnstableApi::class)
 class MultiviewPlaybackCoordinator(
     context: Context,
     private val loadPlaylist: suspend (String, Boolean) -> String,

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/multiview/ui/MultiviewPickerAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/multiview/ui/MultiviewPickerAdapter.kt
@@ -7,6 +7,7 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
 import com.github.andreyasadchy.xtra.databinding.MultiviewPickerListItemBinding
 import com.github.andreyasadchy.xtra.model.ui.Stream
+import com.github.andreyasadchy.xtra.ui.common.streamContentsSame
 
 class MultiviewPickerAdapter(
     private val isExcluded: (Stream) -> Boolean,
@@ -58,7 +59,7 @@ class MultiviewPickerAdapter(
             }
 
             override fun areContentsTheSame(oldItem: Stream, newItem: Stream): Boolean {
-                return oldItem == newItem
+                return streamContentsSame(oldItem, newItem)
             }
         }
 

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/multiview/ui/MultiviewSlotView.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/multiview/ui/MultiviewSlotView.kt
@@ -1,5 +1,6 @@
 package com.github.andreyasadchy.xtra.ui.multiview.ui
 
+import android.annotation.SuppressLint
 import android.content.Context
 import android.graphics.Color
 import android.graphics.drawable.GradientDrawable
@@ -8,8 +9,10 @@ import android.view.LayoutInflater
 import android.view.MotionEvent
 import android.view.View
 import android.widget.FrameLayout
+import androidx.annotation.OptIn
 import androidx.core.view.ViewCompat
 import androidx.core.view.isVisible
+import androidx.media3.common.util.UnstableApi
 import androidx.media3.ui.AspectRatioFrameLayout
 import androidx.media3.ui.PlayerView
 import com.github.andreyasadchy.xtra.R
@@ -20,13 +23,14 @@ import com.github.andreyasadchy.xtra.ui.multiview.playback.MultiviewSlotStatus
 import com.google.android.material.color.MaterialColors
 
 /** A stable tile shell. The coordinator owns the player; this view only owns presentation and gestures. */
+@OptIn(UnstableApi::class)
 class MultiviewSlotView(context: Context) : FrameLayout(context) {
     private val binding = MultiviewSlotBinding.inflate(LayoutInflater.from(context), this, true)
     private val gestureDetector = GestureDetector(context, object : GestureDetector.SimpleOnGestureListener() {
         override fun onDown(event: MotionEvent): Boolean = true
 
         override fun onSingleTapConfirmed(event: MotionEvent): Boolean {
-            onTap?.invoke()
+            this@MultiviewSlotView.performClick()
             return true
         }
 
@@ -62,14 +66,19 @@ class MultiviewSlotView(context: Context) : FrameLayout(context) {
         isClickable = true
         isFocusable = true
         setOnClickListener { onTap?.invoke() }
-        binding.playerView.setOnTouchListener { _, event ->
-            gestureDetector.onTouchEvent(event)
-            true
-        }
+        installPlayerTouchListener()
         binding.overflowButton.setOnClickListener { onOverflow?.invoke() }
         binding.audioIcon.setOnClickListener { onAudioClick?.invoke() }
         binding.statusMessage.setOnClickListener { onRetry?.invoke() }
         setControlsVisible(false)
+    }
+
+    @SuppressLint("ClickableViewAccessibility") // GestureDetector forwards confirmed clicks to the outer slot.
+    private fun installPlayerTouchListener() {
+        binding.playerView.setOnTouchListener { _, event ->
+            gestureDetector.onTouchEvent(event)
+            true
+        }
     }
 
     fun bind(

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/Media3PlayerFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/Media3PlayerFragment.kt
@@ -2275,7 +2275,7 @@ abstract class Media3PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFr
             if (isInPictureInPictureMode) {
                 if (!isMaximized) {
                     isMaximized = true
-                    requireActivity().onBackPressedDispatcher.addCallback(this@Media3PlayerFragment, backPressedCallback)
+                    requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner, backPressedCallback)
                     if (videoType == STREAM && chatFragment?.emoteMenuIsVisible() == true) {
                         chatFragment?.toggleBackPressedCallback(true)
                     }
@@ -2410,7 +2410,7 @@ abstract class Media3PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFr
         with(binding) {
             isMaximized = true
             (activity as? MainActivity)?.onPlayerEnteredPlayback(isLive = videoType == STREAM)
-            requireActivity().onBackPressedDispatcher.addCallback(this@Media3PlayerFragment, backPressedCallback)
+            requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner, backPressedCallback)
             if (videoType == STREAM && chatFragment?.emoteMenuIsVisible() == true) {
                 chatFragment?.toggleBackPressedCallback(true)
             }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/Media3PlayerViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/Media3PlayerViewModel.kt
@@ -4,11 +4,13 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.net.Uri
 import android.net.http.HttpEngine
+import androidx.annotation.OptIn
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider.AndroidViewModelFactory.Companion.APPLICATION_KEY
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
+import androidx.media3.common.util.UnstableApi
 import com.github.andreyasadchy.xtra.XtraApp
 import com.github.andreyasadchy.xtra.model.NotificationUser
 import com.github.andreyasadchy.xtra.model.ShownNotification
@@ -55,6 +57,7 @@ import java.util.concurrent.ExecutorService
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Instant
 
+@OptIn(UnstableApi::class)
 class Media3PlayerViewModel(
     private val applicationContext: Context,
     private val httpEngine: Lazy<HttpEngine?>,

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/PlayerFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/PlayerFragment.kt
@@ -648,11 +648,12 @@ abstract class PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFragment
         }
     }
 
+    @SuppressLint("RepeatOnLifecycleWrongUsage") // start() runs once after service binding and resets with the view lifecycle.
     fun start() {
         with(binding) {
             clearPlayerError()
             viewLifecycleOwner.lifecycleScope.launch {
-                repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                     playbackService?.integrity?.collect {
                         (requireActivity() as? MainActivity)?.getNewIntegrityToken(it, childFragmentManager)
                     }
@@ -840,7 +841,7 @@ abstract class PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFragment
                         }
                     }
                     viewLifecycleOwner.lifecycleScope.launch {
-                        repeatOnLifecycle(Lifecycle.State.STARTED) {
+                        viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                             viewModel.stream.collectLatest { stream ->
                                 if (stream != null) {
                                     stream.id?.let {
@@ -925,7 +926,7 @@ abstract class PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFragment
                 if (playbackService?.type == BasePlaybackService.VIDEO) {
                     if (requireContext().prefs().getBoolean(C.PLAYER_MENU_BOOKMARK, true)) {
                         viewLifecycleOwner.lifecycleScope.launch {
-                            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                                 viewModel.isBookmarked.collectLatest {
                                     if (it != null) {
                                         (childFragmentManager.findFragmentByTag("closeOnPip") as? PlayerSettingsDialog?)?.setBookmarkText(it)
@@ -937,7 +938,7 @@ abstract class PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFragment
                     }
                     if (!playbackService?.videoId.isNullOrBlank() && (requireContext().prefs().getBoolean(C.PLAYER_GAMES_BUTTON, true) || requireContext().prefs().getBoolean(C.PLAYER_MENU_GAMES, false))) {
                         viewLifecycleOwner.lifecycleScope.launch {
-                            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                                 viewModel.gamesList.collectLatest { list ->
                                     if (!list.isNullOrEmpty()) {
                                         if (requireContext().prefs().getBoolean(C.PLAYER_GAMES_BUTTON, true)) {
@@ -1051,7 +1052,7 @@ abstract class PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFragment
                             }
                         }
                         viewLifecycleOwner.lifecycleScope.launch {
-                            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                                 viewModel.isFollowing.collectLatest {
                                     if (it != null) {
                                         if (it) {
@@ -1066,7 +1067,7 @@ abstract class PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFragment
                             }
                         }
                         viewLifecycleOwner.lifecycleScope.launch {
-                            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                                 viewModel.follow.collectLatest { pair ->
                                     if (pair != null) {
                                         val following = pair.first
@@ -2053,7 +2054,7 @@ abstract class PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFragment
             if (isInPictureInPictureMode) {
                 if (!isMaximized) {
                     isMaximized = true
-                    requireActivity().onBackPressedDispatcher.addCallback(this@PlayerFragment, backPressedCallback)
+                    requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner, backPressedCallback)
                     if (playbackService?.type == BasePlaybackService.STREAM && chatFragment?.emoteMenuIsVisible() == true) {
                         chatFragment?.toggleBackPressedCallback(true)
                     }
@@ -2173,7 +2174,7 @@ abstract class PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFragment
             (activity as? com.github.andreyasadchy.xtra.ui.main.MainActivity)?.onPlayerEnteredPlayback(
                 isLive = playbackService?.type == BasePlaybackService.STREAM,
             )
-            requireActivity().onBackPressedDispatcher.addCallback(this@PlayerFragment, backPressedCallback)
+            requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner, backPressedCallback)
             if (playbackService?.type == BasePlaybackService.STREAM && chatFragment?.emoteMenuIsVisible() == true) {
                 chatFragment?.toggleBackPressedCallback(true)
             }
@@ -2422,6 +2423,7 @@ abstract class PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFragment
     }
 
     override fun onDestroyView() {
+        started = false
         super.onDestroyView()
         _binding = null
     }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/statistics/ViewingActivityChartView.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/statistics/ViewingActivityChartView.kt
@@ -1,6 +1,8 @@
 package com.github.andreyasadchy.xtra.ui.statistics
 
+import android.annotation.SuppressLint
 import android.content.Context
+import android.content.res.TypedArray
 import android.graphics.Canvas
 import android.graphics.Paint
 import android.graphics.RectF
@@ -30,7 +32,7 @@ class ViewingActivityChartView @JvmOverloads constructor(
     init {
         context.withStyledAttributes(attrs, intArrayOf(android.R.attr.colorAccent, android.R.attr.textColorSecondary)) {
             bars.color = getColor(0, 0xff6750a4.toInt())
-            baseline.color = getColor(1, 0xff777777.toInt())
+            baseline.color = getBaselineColor(0xff777777.toInt())
             label.color = baseline.color
         }
         setWillNotDraw(false)
@@ -116,3 +118,6 @@ class ViewingActivityChartView @JvmOverloads constructor(
         private const val MAX_POINTS = 30
     }
 }
+
+@SuppressLint("ResourceType") // 1 is a TypedArray index, not a resource ID.
+private fun TypedArray.getBaselineColor(defaultColor: Int): Int = getColor(1, defaultColor)

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,6 +9,8 @@
 org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 # Reuse task outputs across local and Docker builds.
 org.gradle.caching=true
+# Reuse the configured build model between Gradle invocations.
+org.gradle.configuration-cache=true
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. For more details, visit
 # https://developer.android.com/r/tools/gradle-multi-project-decoupled-projects


### PR DESCRIPTION
## Why

Keep the app safer while reducing repeated build overhead during active development.

## Changes

- Clean up real lint, lifecycle, and API issues.
- Keep in-app language switching reliable.
- Make repeated Gradle builds faster.
- Review the test suite; no empty tests were found to remove.

## Checks

- JVM tests pass.
- Debug APK build passes.
- Remaining Lint findings are the existing translation/resource backlog.