### PR TITLE
Harden cache-first thumbnail freshness

### DIFF
--- a/app/src/androidTest/java/com/github/andreyasadchy/xtra/db/AppDatabaseMigrationTest.kt
+++ b/app/src/androidTest/java/com/github/andreyasadchy/xtra/db/AppDatabaseMigrationTest.kt
@@ -4,6 +4,10 @@ import androidx.room.Room
 import androidx.sqlite.db.SupportSQLiteDatabase
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import com.github.andreyasadchy.xtra.repository.streamfeed.StreamFeedCache
+import com.github.andreyasadchy.xtra.repository.streamfeed.StreamFeedFreshnessPolicy
+import com.github.andreyasadchy.xtra.repository.streamfeed.StreamFeedKey
+import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -23,7 +27,7 @@ class AppDatabaseMigrationTest {
     }
 
     @Test
-    fun migrateCurrentVersion38To42CreatesStatisticsAndStreamFeedSchema() {
+    fun migrateCurrentVersion38To44CreatesStatisticsAndStreamFeedSchema() {
         val name = "migration-v38.db"
         prepareDatabase(name, version = 38, historicalVersion39 = false)
 
@@ -48,6 +52,33 @@ class AppDatabaseMigrationTest {
         database.close()
     }
 
+    @Test
+    fun migrateInvalidatedV43RetainedTailUsesLastAccessForExpiry() = runBlocking {
+        val name = "migration-v43-invalidated-tail.db"
+        val feedKey = StreamFeedKey("top:migration-invalidated")
+        prepareInvalidatedV43Feed(name, feedKey.value)
+
+        val database = openMigratedDatabase(name)
+        val state = database.streamFeedDao().state(feedKey.value)
+        assertEquals(null, state?.lastSuccessAt)
+        assertEquals(1_000L, state?.staleTailRetainedAt)
+        assertEquals(
+            listOf("channel:active", "channel:old"),
+            database.streamFeedDao().itemsForFeed(feedKey.value).map { it.itemKey },
+        )
+
+        StreamFeedCache(database).touchAccess(
+            feedKey,
+            nowMs = 1_000L + StreamFeedFreshnessPolicy.MAX_RETAINED_STALE_TAIL_AGE_MS + 1L,
+        )
+
+        assertEquals(
+            listOf("channel:active"),
+            database.streamFeedDao().itemsForFeed(feedKey.value).map { it.itemKey },
+        )
+        database.close()
+    }
+
     private fun openMigratedDatabase(name: String): AppDatabase {
         return Room.databaseBuilder(context, AppDatabase::class.java, name)
             .addMigrations(
@@ -56,6 +87,7 @@ class AppDatabaseMigrationTest {
                 StreamFeedMigrations.FROM_40,
                 StreamFeedMigrations.FROM_41,
                 MetadataCacheMigrations.FROM_42,
+                StreamFeedMigrations.FROM_43,
             )
             .build()
             .also { it.openHelper.writableDatabase }
@@ -93,8 +125,53 @@ class AppDatabaseMigrationTest {
         database.close()
     }
 
+    private fun prepareInvalidatedV43Feed(name: String, feedKey: String) {
+        context.deleteDatabase(name)
+        databaseNames += name
+        val database = Room.databaseBuilder(context, AppDatabase::class.java, name).build()
+        val sqlite = database.openHelper.writableDatabase
+        sqlite.execSQL("DROP INDEX IF EXISTS index_stream_feed_items_feedKey_position")
+        sqlite.execSQL("DROP INDEX IF EXISTS index_stream_feed_items_feedKey_channelId")
+        sqlite.execSQL("DROP TABLE IF EXISTS stream_feed_items")
+        sqlite.execSQL("DROP TABLE IF EXISTS stream_feed_states")
+        sqlite.execSQL(
+            "CREATE TABLE stream_feed_items (" +
+                    "feedKey TEXT NOT NULL, itemKey TEXT NOT NULL, position INTEGER NOT NULL, " +
+                    "streamId TEXT, channelId TEXT, channelLogin TEXT, channelName TEXT, " +
+                    "channelImageURL TEXT, gameId TEXT, gameSlug TEXT, gameName TEXT, title TEXT, " +
+                    "thumbnailURL TEXT, createdAt TEXT, viewerCount INTEGER, tags TEXT, " +
+                    "generation INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(feedKey, itemKey))"
+        )
+        sqlite.execSQL("CREATE INDEX index_stream_feed_items_feedKey_position ON stream_feed_items(feedKey, position)")
+        sqlite.execSQL("CREATE INDEX index_stream_feed_items_feedKey_channelId ON stream_feed_items(feedKey, channelId)")
+        sqlite.execSQL(
+            "CREATE TABLE stream_feed_states (" +
+                    "feedKey TEXT NOT NULL PRIMARY KEY, nextCursor TEXT, lastSuccessAt INTEGER, " +
+                    "lastAttemptAt INTEGER, lastAccessAt INTEGER NOT NULL, " +
+                    "failureBackoffUntil INTEGER, rateLimitUntil INTEGER, nextCursorApi TEXT, " +
+                    "activeGeneration INTEGER NOT NULL DEFAULT 0)"
+        )
+        sqlite.execSQL(
+            "INSERT INTO stream_feed_items (feedKey, itemKey, position, channelId, generation) " +
+                    "VALUES (?, ?, ?, ?, ?)",
+            arrayOf<Any?>(feedKey, "channel:active", 0, "active", 2),
+        )
+        sqlite.execSQL(
+            "INSERT INTO stream_feed_items (feedKey, itemKey, position, channelId, generation) " +
+                    "VALUES (?, ?, ?, ?, ?)",
+            arrayOf<Any?>(feedKey, "channel:old", 1, "old", 1),
+        )
+        sqlite.execSQL(
+            "INSERT INTO stream_feed_states (" +
+                    "feedKey, lastSuccessAt, lastAccessAt, activeGeneration) VALUES (?, NULL, ?, ?)",
+            arrayOf<Any?>(feedKey, 1_000L, 2),
+        )
+        sqlite.execSQL("PRAGMA user_version = 43")
+        database.close()
+    }
+
     private fun assertStatisticsSchema(database: SupportSQLiteDatabase) {
-        assertEquals(43, scalarInt(database, "PRAGMA user_version"))
+        assertEquals(44, scalarInt(database, "PRAGMA user_version"))
         assertTrue(tableExists(database, "viewing_sessions"))
         assertTrue(tableExists(database, "viewing_intervals"))
         assertTrue(indexExists(database, "index_viewing_sessions_started_at"))
@@ -109,6 +186,7 @@ class AppDatabaseMigrationTest {
         assertTrue(columnExists(database, "stream_feed_items", "generation"))
         assertTrue(columnExists(database, "stream_feed_states", "nextCursorApi"))
         assertTrue(columnExists(database, "stream_feed_states", "activeGeneration"))
+        assertTrue(columnExists(database, "stream_feed_states", "staleTailRetainedAt"))
         assertTrue(tableExists(database, "metadata_cache"))
         assertTrue(indexExists(database, "index_metadata_cache_lastAccessAt"))
     }

--- a/app/src/androidTest/java/com/github/andreyasadchy/xtra/repository/MetadataCacheTest.kt
+++ b/app/src/androidTest/java/com/github/andreyasadchy/xtra/repository/MetadataCacheTest.kt
@@ -52,6 +52,11 @@ class MetadataCacheTest {
                 blockedUsersCursor = "next",
             ),
             nowMs = now,
+            scopesValidated = true,
+            chatColorValidated = true,
+            channelValidated = true,
+            chatSettingsValidated = true,
+            blockedUsersValidated = true,
         )
 
         val account = cache.readAccount(null, "STREAMER")
@@ -92,7 +97,13 @@ class MetadataCacheTest {
             user = User(id = "99", login = "channel", name = "Old name"),
             stream = Stream(id = "stream", channelId = "99", title = "Still live"),
         )
-        cache.writeChannel("99", "channel", liveSnapshot, now)
+        cache.writeChannel(
+            channelId = "99",
+            login = "channel",
+            snapshot = liveSnapshot,
+            nowMs = now,
+            streamValidated = true,
+        )
 
         val resolution = resolveChannelFallback(
             cached = cache.readChannel("99", "channel"),
@@ -131,5 +142,179 @@ class MetadataCacheTest {
         assertNull(cache.readAccount(null, "new-login"))
         assertEquals("New", cache.readAccount(null, "renamed-login")?.user?.displayName)
         assertNull(cache.readAccount(null, "old-login"))
+    }
+
+    @Test
+    fun durableMetadataRetentionDoesNotMakeVolatileFieldsLookFresh() = runBlocking {
+        val now = maxOf(
+            MetadataCachePolicy.CURRENT_STREAM_BOOTSTRAP_MAX_AGE_MS,
+            MetadataCachePolicy.FOLLOWER_COUNT_BOOTSTRAP_MAX_AGE_MS,
+        ) + 1L
+        val clockedCache = MetadataCache(
+            database = database,
+            json = Json { ignoreUnknownKeys = true },
+            clockMs = { now },
+        )
+        clockedCache.writeChannel(
+            channelId = "99",
+            login = "channel",
+            snapshot = ChannelPageCacheSnapshot(
+                user = User(id = "99", login = "channel", name = "Channel", followerCount = 321),
+                stream = Stream(
+                    id = "stream",
+                    channelId = "99",
+                    title = "Still useful title",
+                    viewerCount = 123,
+                ),
+            ),
+            nowMs = 0L,
+        )
+
+        val snapshot = clockedCache.readChannel("99", "channel")
+        assertEquals("Still useful title", snapshot?.stream?.title)
+        assertNull(snapshot?.stream?.viewerCount)
+        assertNull(snapshot?.user?.followerCount)
+    }
+
+    @Test
+    fun partialFallbackWriteDoesNotRejuvenateChannelLiveState() = runBlocking {
+        var nowMs = 0L
+        val clockedCache = MetadataCache(
+            database = database,
+            json = Json { ignoreUnknownKeys = true },
+            clockMs = { nowMs },
+        )
+        val original = ChannelPageCacheSnapshot(
+            user = User(id = "99", login = "channel", name = "Old name", followerCount = 321),
+            stream = Stream(
+                id = "stream",
+                channelId = "99",
+                title = "Old title",
+                viewerCount = 123,
+            ),
+        )
+        clockedCache.writeChannel(
+            channelId = "99",
+            login = "channel",
+            snapshot = original,
+            nowMs = nowMs,
+            streamValidated = true,
+            followerCountValidated = true,
+        )
+
+        nowMs = MetadataCachePolicy.CURRENT_STREAM_BOOTSTRAP_MAX_AGE_MS - 1L
+        clockedCache.writeChannel(
+            channelId = "99",
+            login = "channel",
+            snapshot = ChannelPageCacheSnapshot(
+                user = User(id = "99", login = "channel", name = "Fresh static name", followerCount = 321),
+                stream = original.stream,
+            ),
+            nowMs = nowMs,
+        )
+
+        nowMs = MetadataCachePolicy.CURRENT_STREAM_BOOTSTRAP_MAX_AGE_MS + 1L
+        val snapshot = clockedCache.readChannel("99", "channel")
+        assertEquals("Fresh static name", snapshot?.user?.name)
+        assertEquals("Old title", snapshot?.stream?.title)
+        assertNull(snapshot?.stream?.viewerCount)
+    }
+
+    @Test
+    fun partialAccountMutationsDoNotRejuvenateUntouchedComponents() = runBlocking {
+        var nowMs = 0L
+        val clockedCache = MetadataCache(
+            database = database,
+            json = Json { ignoreUnknownKeys = true },
+            clockMs = { nowMs },
+        )
+        val original = AccountCacheSnapshot(
+            user = HelixUser(id = "42", login = "streamer", displayName = "Streamer"),
+            channel = ChannelInformation(
+                broadcasterId = "42",
+                title = "Old title",
+                delay = 3,
+                tags = listOf("old"),
+            ),
+            chatSettings = ChatSettings(
+                broadcasterId = "42",
+                followerMode = true,
+                followerModeDuration = 10,
+                slowMode = false,
+                slowModeWaitTime = 30,
+                subscriberMode = true,
+                emoteMode = true,
+                uniqueChatMode = true,
+            ),
+        )
+        clockedCache.writeAccount(
+            userId = "42",
+            login = "streamer",
+            snapshot = original,
+            nowMs = nowMs,
+            channelValidated = true,
+            chatSettingsValidated = true,
+        )
+
+        nowMs = MetadataCachePolicy.ACCOUNT_SETTINGS_BOOTSTRAP_MAX_AGE_MS - 1L
+        clockedCache.writeAccount(
+            userId = "42",
+            login = "streamer",
+            snapshot = original.copy(
+                channel = original.channel?.copy(title = "Mutated title"),
+                chatSettings = original.chatSettings?.copy(slowMode = true),
+            ),
+            nowMs = nowMs,
+            // Simulates a successful one-field PATCH while the full GETs
+            // failed: copied fields retain their original validation times.
+        )
+
+        nowMs = MetadataCachePolicy.ACCOUNT_SETTINGS_BOOTSTRAP_MAX_AGE_MS + 1L
+        val cached = clockedCache.readAccount("42", "streamer")
+        assertNull(cached?.channel)
+        assertNull(cached?.chatSettings)
+    }
+
+    @Test
+    fun appendingBlockedUsersPageDoesNotRejuvenateTheOriginalPage() = runBlocking {
+        var nowMs = 0L
+        val clockedCache = MetadataCache(
+            database = database,
+            json = Json { ignoreUnknownKeys = true },
+            clockMs = { nowMs },
+        )
+        val firstPage = AccountCacheSnapshot(
+            user = HelixUser(id = "42", login = "streamer", displayName = "Streamer"),
+            blockedUsers = listOf(BlockedUser(id = "1", login = "first", displayName = "First")),
+            blockedUsersCursor = "page-2",
+        )
+        clockedCache.writeAccount(
+            userId = "42",
+            login = "streamer",
+            snapshot = firstPage,
+            nowMs = nowMs,
+            blockedUsersValidated = true,
+        )
+
+        nowMs = MetadataCachePolicy.ACCOUNT_SENSITIVE_BOOTSTRAP_MAX_AGE_MS - 1L
+        clockedCache.writeAccount(
+            userId = "42",
+            login = "streamer",
+            snapshot = firstPage.copy(
+                blockedUsers = firstPage.blockedUsers + BlockedUser(
+                    id = "2",
+                    login = "second",
+                    displayName = "Second",
+                ),
+                blockedUsersCursor = null,
+            ),
+            nowMs = nowMs,
+            // Appending page two does not revalidate page one.
+        )
+
+        nowMs = MetadataCachePolicy.ACCOUNT_SENSITIVE_BOOTSTRAP_MAX_AGE_MS + 1L
+        val cached = clockedCache.readAccount("42", "streamer")
+        assertTrue(cached?.blockedUsers.isNullOrEmpty())
+        assertNull(cached?.blockedUsersCursor)
     }
 }

--- a/app/src/androidTest/java/com/github/andreyasadchy/xtra/repository/streamfeed/StreamFeedCacheTest.kt
+++ b/app/src/androidTest/java/com/github/andreyasadchy/xtra/repository/streamfeed/StreamFeedCacheTest.kt
@@ -98,6 +98,79 @@ class StreamFeedCacheTest {
     }
 
     @Test
+    fun successfulRefreshReplacesAllMutableFieldsForAnExistingChannel() = runBlocking {
+        val cache = StreamFeedCache(database)
+        val feedKey = StreamFeedKey("top:mutable-fields")
+        cache.replaceAfterRefresh(
+            feedKey,
+            StreamFeedPage(
+                listOf(
+                    Stream(
+                        id = "broadcast-1",
+                        channelId = "channel-42",
+                        channelLogin = "old-login",
+                        channelName = "Old name",
+                        channelImageURL = "old-avatar",
+                        gameId = "game-old",
+                        gameSlug = "old-game",
+                        gameName = "Old game",
+                        title = "Old title",
+                        thumbnailURL = "old-thumbnail",
+                        createdAt = "old-created",
+                        viewerCount = 10,
+                        tags = listOf("old-tag"),
+                    ),
+                ),
+                nextCursor = null,
+            ),
+            nowMs = 1L,
+            preserveTail = false,
+            pruneStaleOnEnd = true,
+        )
+        cache.replaceAfterRefresh(
+            feedKey,
+            StreamFeedPage(
+                listOf(
+                    Stream(
+                        id = "broadcast-2",
+                        channelId = "channel-42",
+                        channelLogin = "new-login",
+                        channelName = "New name",
+                        channelImageURL = "new-avatar",
+                        gameId = "game-new",
+                        gameSlug = "new-game",
+                        gameName = "New game",
+                        title = "New title",
+                        thumbnailURL = "new-thumbnail",
+                        createdAt = "new-created",
+                        viewerCount = 20,
+                        tags = listOf("new-tag"),
+                    ),
+                ),
+                nextCursor = null,
+            ),
+            nowMs = 2L,
+            preserveTail = false,
+            pruneStaleOnEnd = true,
+        )
+
+        val stream = database.streamFeedDao().itemsForFeed(feedKey.value).single().toStream()
+        assertEquals("broadcast-2", stream.id)
+        assertEquals("new-login", stream.channelLogin)
+        assertEquals("New name", stream.channelName)
+        assertEquals("new-avatar", stream.channelImageURL)
+        assertEquals("game-new", stream.gameId)
+        assertEquals("new-game", stream.gameSlug)
+        assertEquals("New game", stream.gameName)
+        assertEquals("New title", stream.title)
+        assertEquals("new-thumbnail", stream.thumbnailURL)
+        assertEquals("new-created", stream.createdAt)
+        assertEquals(20, stream.viewerCount)
+        assertEquals(listOf("new-tag"), stream.tags)
+        assertEquals(2L, stream.thumbnailGeneration)
+    }
+
+    @Test
     fun automaticRefreshEofDefersStalePruningUntilExplicitFinalization() = runBlocking {
         val cache = StreamFeedCache(database)
         val feedKey = StreamFeedKey("top:cache-automatic-eof")
@@ -121,6 +194,119 @@ class StreamFeedCacheTest {
         assertEquals(listOf("channel:fresh-0", "channel:fresh-1"), rows.map { it.itemKey })
         assertFalse(rows.any { it.itemKey == "channel:old-80" })
         assertContiguousLayout(feedKey, activeCount = 2)
+    }
+
+    @Test
+    fun retainedStaleTailExpiresAfterItsBoundedBootstrapWindow() = runBlocking {
+        val cache = StreamFeedCache(database)
+        val feedKey = StreamFeedKey("top:cache-tail-expiry")
+        cache.replaceAfterRefresh(
+            feedKey,
+            StreamFeedPage(streams("old"), nextCursor = StreamFeedCursor("gql", "old-next")),
+            nowMs = 1L,
+            preserveTail = false,
+            pruneStaleOnEnd = true,
+        )
+        cache.replaceAfterRefresh(
+            feedKey,
+            StreamFeedPage(streams("fresh"), nextCursor = StreamFeedCursor("gql", "fresh-next")),
+            nowMs = 2L,
+            preserveTail = true,
+            pruneStaleOnEnd = false,
+        )
+        assertEquals(
+            listOf("channel:fresh", "channel:old"),
+            database.streamFeedDao().itemsForFeed(feedKey.value).map { it.itemKey },
+        )
+
+        cache.touchAccess(
+            feedKey,
+            nowMs = 2L + StreamFeedFreshnessPolicy.MAX_RETAINED_STALE_TAIL_AGE_MS + 1L,
+        )
+
+        assertEquals(
+            listOf("channel:fresh"),
+            database.streamFeedDao().itemsForFeed(feedKey.value).map { it.itemKey },
+        )
+    }
+
+    @Test
+    fun invalidationDoesNotDisableStaleTailExpiry() = runBlocking {
+        val cache = StreamFeedCache(database)
+        val feedKey = StreamFeedKey("top:cache-tail-invalidation")
+        cache.replaceAfterRefresh(
+            feedKey,
+            StreamFeedPage(streams("old"), StreamFeedCursor("gql", "old-next")),
+            nowMs = 1L,
+            preserveTail = false,
+            pruneStaleOnEnd = true,
+        )
+        cache.replaceAfterRefresh(
+            feedKey,
+            StreamFeedPage(streams("fresh"), StreamFeedCursor("gql", "fresh-next")),
+            nowMs = 2L,
+            preserveTail = true,
+            pruneStaleOnEnd = false,
+        )
+
+        cache.invalidatePrefix("top:", nowMs = 3L)
+        assertEquals(null, database.streamFeedDao().state(feedKey.value)?.lastSuccessAt)
+        assertEquals(
+            listOf("channel:fresh", "channel:old"),
+            database.streamFeedDao().itemsForFeed(feedKey.value).map { it.itemKey },
+        )
+
+        cache.touchAccess(
+            feedKey,
+            nowMs = 2L + StreamFeedFreshnessPolicy.MAX_RETAINED_STALE_TAIL_AGE_MS + 1L,
+        )
+
+        assertEquals(
+            listOf("channel:fresh"),
+            database.streamFeedDao().itemsForFeed(feedKey.value).map { it.itemKey },
+        )
+        assertEquals(null, database.streamFeedDao().state(feedKey.value)?.staleTailRetainedAt)
+    }
+
+    @Test
+    fun expiryDuringRefreshPreservesThePreviousActiveGenerationAsTheNewTail() = runBlocking {
+        val cache = StreamFeedCache(database)
+        val feedKey = StreamFeedKey("top:cache-tail-refresh-race")
+        cache.replaceAfterRefresh(
+            feedKey,
+            StreamFeedPage(streams("old"), StreamFeedCursor("gql", "old-next")),
+            nowMs = 1L,
+            preserveTail = false,
+            pruneStaleOnEnd = true,
+        )
+        cache.replaceAfterRefresh(
+            feedKey,
+            StreamFeedPage(streams("active"), StreamFeedCursor("gql", "active-next")),
+            nowMs = 2L,
+            preserveTail = true,
+            pruneStaleOnEnd = false,
+        )
+
+        val justBeforeExpiry = 2L + StreamFeedFreshnessPolicy.MAX_RETAINED_STALE_TAIL_AGE_MS - 1L
+        cache.markAttempt(feedKey, nowMs = justBeforeExpiry)
+        cache.replaceAfterRefresh(
+            feedKey,
+            StreamFeedPage(streams("fresh"), StreamFeedCursor("gql", "fresh-next")),
+            nowMs = justBeforeExpiry + 2L,
+            preserveTail = true,
+            pruneStaleOnEnd = false,
+        )
+
+        val rows = database.streamFeedDao().itemsForFeed(feedKey.value)
+        assertEquals(
+            listOf("channel:fresh", "channel:active"),
+            rows.map { it.itemKey },
+        )
+        assertEquals(rows.first().generation - 1L, rows.last().generation)
+        assertEquals(
+            justBeforeExpiry + 2L,
+            database.streamFeedDao().state(feedKey.value)?.staleTailRetainedAt,
+        )
     }
 
     @Test

--- a/app/src/main/java/com/github/andreyasadchy/xtra/XtraModule.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/XtraModule.kt
@@ -346,6 +346,7 @@ class XtraModule(application: Application) {
                 StreamFeedMigrations.FROM_40,
                 StreamFeedMigrations.FROM_41,
                 MetadataCacheMigrations.FROM_42,
+                StreamFeedMigrations.FROM_43,
             )
         }.build()
     }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/db/AppDatabase.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/db/AppDatabase.kt
@@ -45,7 +45,7 @@ import com.github.andreyasadchy.xtra.model.ui.TranslatedChannel
         StreamFeedState::class,
         MetadataCacheEntry::class,
     ],
-    version = 43,
+    version = 44,
     exportSchema = false
 )
 abstract class AppDatabase : RoomDatabase() {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/db/StreamFeedMigrations.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/db/StreamFeedMigrations.kt
@@ -28,4 +28,15 @@ object StreamFeedMigrations {
         db.execSQL("ALTER TABLE stream_feed_states ADD COLUMN nextCursorApi TEXT")
         db.execSQL("ALTER TABLE stream_feed_states ADD COLUMN activeGeneration INTEGER NOT NULL DEFAULT 0")
     }
+
+    val FROM_43 = Migration(43, 44) { db ->
+        db.execSQL("ALTER TABLE stream_feed_states ADD COLUMN staleTailRetainedAt INTEGER")
+        // Existing rows predate the separate tail clock. lastSuccessAt is the
+        // preferred value, while lastAccessAt covers feeds invalidated before
+        // this column existed.
+        db.execSQL(
+            "UPDATE stream_feed_states SET staleTailRetainedAt = COALESCE(lastSuccessAt, lastAccessAt) " +
+                    "WHERE activeGeneration != 0"
+        )
+    }
 }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/db/StreamFeedState.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/db/StreamFeedState.kt
@@ -17,4 +17,6 @@ data class StreamFeedState(
     val nextCursorApi: String? = null,
     /** Generation currently being refreshed/appended for this feed. */
     val activeGeneration: Long = 0L,
+    /** When the retained stale tail started being kept behind the active generation. */
+    val staleTailRetainedAt: Long? = null,
 )

--- a/app/src/main/java/com/github/andreyasadchy/xtra/model/ui/Stream.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/model/ui/Stream.kt
@@ -2,6 +2,7 @@ package com.github.andreyasadchy.xtra.model.ui
 
 import android.os.Parcelable
 import com.github.andreyasadchy.xtra.util.TwitchApiHelper
+import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
@@ -19,6 +20,9 @@ class Stream(
     var createdAt: String? = null,
     var viewerCount: Int? = null,
     val tags: List<String>? = null,
+    /** Feed refresh generation used to revalidate live preview pixels. */
+    @IgnoredOnParcel
+    val thumbnailGeneration: Long = 0L,
 ) : Parcelable {
 
     val channelImage: String?

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/MetadataCache.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/MetadataCache.kt
@@ -22,8 +22,22 @@ import java.util.Locale
 private const val ACCOUNT_KIND = "account"
 private const val CHANNEL_KIND = "channel"
 private const val GAME_KIND = "game"
-private const val CACHE_RETENTION_MS = 30L * 24 * 60 * 60 * 1_000L
 private const val MAX_CACHE_ENTRIES = 240
+private const val METADATA_CACHE_FRESHNESS_VERSION = 1
+
+/**
+ * Freshness is deliberately separate from durable retention. A cached object
+ * can remain useful for bootstrap while its volatile fields must be treated as
+ * stale and revalidated immediately by the owning screen.
+ */
+internal object MetadataCachePolicy {
+    const val DURABLE_RETENTION_MS = 30L * 24 * 60 * 60 * 1_000L
+    const val CURRENT_STREAM_BOOTSTRAP_MAX_AGE_MS = 2L * 60 * 60 * 1_000L
+    const val GAME_STATS_BOOTSTRAP_MAX_AGE_MS = 15L * 60 * 1_000L
+    const val FOLLOWER_COUNT_BOOTSTRAP_MAX_AGE_MS = 6L * 60 * 60 * 1_000L
+    const val ACCOUNT_SENSITIVE_BOOTSTRAP_MAX_AGE_MS = 10L * 60 * 1_000L
+    const val ACCOUNT_SETTINGS_BOOTSTRAP_MAX_AGE_MS = 6L * 60 * 60 * 1_000L
+}
 
 data class AccountCacheSnapshot(
     val user: HelixUser? = null,
@@ -53,6 +67,7 @@ class MetadataCache(
     private val database: AppDatabase,
     private val json: Json,
     private val dao: MetadataCacheDao = database.metadataCache(),
+    private val clockMs: () -> Long = { System.currentTimeMillis() },
 ) {
 
     suspend fun readAccount(userId: String?, login: String?): AccountCacheSnapshot? = withContext(Dispatchers.IO) {
@@ -63,14 +78,48 @@ class MetadataCache(
             identity = { it.user?.id },
         )
             ?: return@withContext null
+        val sensitiveFresh = hit.isFresh(
+            freshnessVersion = hit.payload.freshnessVersion,
+            validatedAt = hit.payload.scopesValidatedAt,
+            maxAgeMs = MetadataCachePolicy.ACCOUNT_SENSITIVE_BOOTSTRAP_MAX_AGE_MS,
+        )
+        val settingsFresh = hit.isFresh(
+            freshnessVersion = hit.payload.freshnessVersion,
+            validatedAt = hit.payload.chatSettingsValidatedAt,
+            maxAgeMs = MetadataCachePolicy.ACCOUNT_SETTINGS_BOOTSTRAP_MAX_AGE_MS,
+        )
         AccountCacheSnapshot(
             user = hit.payload.user,
-            scopes = hit.payload.scopes.toSet(),
-            chatColor = hit.payload.chatColor,
-            channel = hit.payload.channel,
-            chatSettings = hit.payload.chatSettings,
-            blockedUsers = hit.payload.blockedUsers,
-            blockedUsersCursor = hit.payload.blockedUsersCursor,
+            scopes = hit.payload.scopes.takeIf { sensitiveFresh }?.toSet().orEmpty(),
+            chatColor = hit.payload.chatColor.takeIf {
+                hit.isFresh(
+                    freshnessVersion = hit.payload.freshnessVersion,
+                    validatedAt = hit.payload.chatColorValidatedAt,
+                    maxAgeMs = MetadataCachePolicy.ACCOUNT_SETTINGS_BOOTSTRAP_MAX_AGE_MS,
+                )
+            },
+            channel = hit.payload.channel.takeIf {
+                hit.isFresh(
+                    freshnessVersion = hit.payload.freshnessVersion,
+                    validatedAt = hit.payload.channelValidatedAt,
+                    maxAgeMs = MetadataCachePolicy.ACCOUNT_SETTINGS_BOOTSTRAP_MAX_AGE_MS,
+                )
+            },
+            chatSettings = hit.payload.chatSettings.takeIf { settingsFresh },
+            blockedUsers = hit.payload.blockedUsers.takeIf {
+                hit.isFresh(
+                    freshnessVersion = hit.payload.freshnessVersion,
+                    validatedAt = hit.payload.blockedUsersValidatedAt,
+                    maxAgeMs = MetadataCachePolicy.ACCOUNT_SENSITIVE_BOOTSTRAP_MAX_AGE_MS,
+                )
+            }.orEmpty(),
+            blockedUsersCursor = hit.payload.blockedUsersCursor.takeIf {
+                hit.isFresh(
+                    freshnessVersion = hit.payload.freshnessVersion,
+                    validatedAt = hit.payload.blockedUsersValidatedAt,
+                    maxAgeMs = MetadataCachePolicy.ACCOUNT_SENSITIVE_BOOTSTRAP_MAX_AGE_MS,
+                )
+            },
         )
     }
 
@@ -78,23 +127,69 @@ class MetadataCache(
         userId: String?,
         login: String?,
         snapshot: AccountCacheSnapshot,
-        nowMs: Long = System.currentTimeMillis(),
+        nowMs: Long = clockMs(),
+        scopesValidated: Boolean = false,
+        chatColorValidated: Boolean = false,
+        channelValidated: Boolean = false,
+        chatSettingsValidated: Boolean = false,
+        blockedUsersValidated: Boolean = false,
     ) = withContext(Dispatchers.IO) {
+        val payload = AccountCachePayload(
+            freshnessVersion = METADATA_CACHE_FRESHNESS_VERSION,
+            user = snapshot.user,
+            scopes = snapshot.scopes.sorted(),
+            chatColor = snapshot.chatColor,
+            channel = snapshot.channel,
+            chatSettings = snapshot.chatSettings,
+            blockedUsers = snapshot.blockedUsers,
+            blockedUsersCursor = snapshot.blockedUsersCursor,
+        )
         writePayload(
             kind = ACCOUNT_KIND,
             keys = identityKeys("id", "login", userId ?: snapshot.user?.id, login ?: snapshot.user?.login),
-            payload = AccountCachePayload(
-                user = snapshot.user,
-                scopes = snapshot.scopes.sorted(),
-                chatColor = snapshot.chatColor,
-                channel = snapshot.channel,
-                chatSettings = snapshot.chatSettings,
-                blockedUsers = snapshot.blockedUsers,
-                blockedUsersCursor = snapshot.blockedUsersCursor,
-            ),
+            payload = payload,
             stableId = userId ?: snapshot.user?.id,
             identity = { it.user?.id },
             nowMs = nowMs,
+            mergePayload = { previous, previousUpdatedAt ->
+                payload.copy(
+                    scopesValidatedAt = fieldValidationTimestamp(
+                        validated = scopesValidated,
+                        nowMs = nowMs,
+                        previousVersion = previous?.freshnessVersion,
+                        previousTimestamp = previous?.scopesValidatedAt,
+                        previousUpdatedAt = previousUpdatedAt,
+                    ),
+                    chatColorValidatedAt = fieldValidationTimestamp(
+                        validated = chatColorValidated,
+                        nowMs = nowMs,
+                        previousVersion = previous?.freshnessVersion,
+                        previousTimestamp = previous?.chatColorValidatedAt,
+                        previousUpdatedAt = previousUpdatedAt,
+                    ),
+                    channelValidatedAt = fieldValidationTimestamp(
+                        validated = channelValidated,
+                        nowMs = nowMs,
+                        previousVersion = previous?.freshnessVersion,
+                        previousTimestamp = previous?.channelValidatedAt,
+                        previousUpdatedAt = previousUpdatedAt,
+                    ),
+                    chatSettingsValidatedAt = fieldValidationTimestamp(
+                        validated = chatSettingsValidated,
+                        nowMs = nowMs,
+                        previousVersion = previous?.freshnessVersion,
+                        previousTimestamp = previous?.chatSettingsValidatedAt,
+                        previousUpdatedAt = previousUpdatedAt,
+                    ),
+                    blockedUsersValidatedAt = fieldValidationTimestamp(
+                        validated = blockedUsersValidated,
+                        nowMs = nowMs,
+                        previousVersion = previous?.freshnessVersion,
+                        previousTimestamp = previous?.blockedUsersValidatedAt,
+                        previousUpdatedAt = previousUpdatedAt,
+                    ),
+                )
+            },
         )
     }
 
@@ -112,26 +207,63 @@ class MetadataCache(
             identity = { it.user?.id ?: it.stream?.channelId },
         )
             ?: return@withContext null
-        val user = hit.payload.user?.toUiUser() ?: return@withContext null
-        ChannelPageCacheSnapshot(user = user, stream = hit.payload.stream?.toUiStream())
+        val user = hit.payload.user?.toUiUser(
+            includeFollowerCount = hit.isFresh(
+                freshnessVersion = hit.payload.freshnessVersion,
+                validatedAt = hit.payload.followerCountValidatedAt,
+                maxAgeMs = MetadataCachePolicy.FOLLOWER_COUNT_BOOTSTRAP_MAX_AGE_MS,
+            ),
+        ) ?: return@withContext null
+        ChannelPageCacheSnapshot(
+            user = user,
+            stream = hit.payload.stream?.toUiStream(
+                includeLiveState = hit.isFresh(
+                    freshnessVersion = hit.payload.freshnessVersion,
+                    validatedAt = hit.payload.streamValidatedAt,
+                    maxAgeMs = MetadataCachePolicy.CURRENT_STREAM_BOOTSTRAP_MAX_AGE_MS,
+                ),
+            ),
+        )
     }
 
     suspend fun writeChannel(
         channelId: String?,
         login: String?,
         snapshot: ChannelPageCacheSnapshot,
-        nowMs: Long = System.currentTimeMillis(),
+        nowMs: Long = clockMs(),
+        streamValidated: Boolean = false,
+        followerCountValidated: Boolean = false,
     ) = withContext(Dispatchers.IO) {
+        val payload = ChannelPageCachePayload(
+            freshnessVersion = METADATA_CACHE_FRESHNESS_VERSION,
+            user = snapshot.user.toCacheUser(),
+            stream = snapshot.stream?.toCacheStream(),
+        )
         writePayload(
             kind = CHANNEL_KIND,
             keys = identityKeys("id", "login", channelId ?: snapshot.user.id, login ?: snapshot.user.login),
-            payload = ChannelPageCachePayload(
-                user = snapshot.user.toCacheUser(),
-                stream = snapshot.stream?.toCacheStream(),
-            ),
+            payload = payload,
             stableId = channelId ?: snapshot.user.id,
             identity = { it.user?.id ?: it.stream?.channelId },
             nowMs = nowMs,
+            mergePayload = { previous, previousUpdatedAt ->
+                payload.copy(
+                    streamValidatedAt = fieldValidationTimestamp(
+                        validated = streamValidated,
+                        nowMs = nowMs,
+                        previousVersion = previous?.freshnessVersion,
+                        previousTimestamp = previous?.streamValidatedAt,
+                        previousUpdatedAt = previousUpdatedAt,
+                    ),
+                    followerCountValidatedAt = fieldValidationTimestamp(
+                        validated = followerCountValidated,
+                        nowMs = nowMs,
+                        previousVersion = previous?.freshnessVersion,
+                        previousTimestamp = previous?.followerCountValidatedAt,
+                        previousUpdatedAt = previousUpdatedAt,
+                    ),
+                )
+            },
         )
     }
 
@@ -143,7 +275,22 @@ class MetadataCache(
             identity = { it.game?.id },
         )
             ?: return@withContext null
-        hit.payload.game?.let { GamePageCacheSnapshot(it.toUiGame()) }
+        hit.payload.game?.let {
+            GamePageCacheSnapshot(
+                it.toUiGame(
+                    includeLiveStats = hit.isFresh(
+                        freshnessVersion = hit.payload.freshnessVersion,
+                        validatedAt = hit.payload.liveStatsValidatedAt,
+                        maxAgeMs = MetadataCachePolicy.GAME_STATS_BOOTSTRAP_MAX_AGE_MS,
+                    ),
+                    includeFollowerCount = hit.isFresh(
+                        freshnessVersion = hit.payload.freshnessVersion,
+                        validatedAt = hit.payload.followerCountValidatedAt,
+                        maxAgeMs = MetadataCachePolicy.FOLLOWER_COUNT_BOOTSTRAP_MAX_AGE_MS,
+                    ),
+                ),
+            )
+        }
     }
 
     suspend fun writeGame(
@@ -151,15 +298,39 @@ class MetadataCache(
         slug: String?,
         name: String?,
         snapshot: GamePageCacheSnapshot,
-        nowMs: Long = System.currentTimeMillis(),
+        nowMs: Long = clockMs(),
+        liveStatsValidated: Boolean = false,
+        followerCountValidated: Boolean = false,
     ) = withContext(Dispatchers.IO) {
+        val payload = GamePageCachePayload(
+            freshnessVersion = METADATA_CACHE_FRESHNESS_VERSION,
+            game = snapshot.game.toCacheGame(),
+        )
         writePayload(
             kind = GAME_KIND,
             keys = gameIdentityKeys(gameId ?: snapshot.game.id, slug ?: snapshot.game.slug, name ?: snapshot.game.name),
-            payload = GamePageCachePayload(snapshot.game.toCacheGame()),
+            payload = payload,
             stableId = gameId ?: snapshot.game.id,
             identity = { it.game?.id },
             nowMs = nowMs,
+            mergePayload = { previous, previousUpdatedAt ->
+                payload.copy(
+                    liveStatsValidatedAt = fieldValidationTimestamp(
+                        validated = liveStatsValidated,
+                        nowMs = nowMs,
+                        previousVersion = previous?.freshnessVersion,
+                        previousTimestamp = previous?.liveStatsValidatedAt,
+                        previousUpdatedAt = previousUpdatedAt,
+                    ),
+                    followerCountValidatedAt = fieldValidationTimestamp(
+                        validated = followerCountValidated,
+                        nowMs = nowMs,
+                        previousVersion = previous?.freshnessVersion,
+                        previousTimestamp = previous?.followerCountValidatedAt,
+                        previousUpdatedAt = previousUpdatedAt,
+                    ),
+                )
+            },
         )
     }
 
@@ -172,8 +343,8 @@ class MetadataCache(
         val expectedIdentity = normalizeIdentity(expectedStableId)
         for (key in keys) {
             val entry = dao.entry(kind, key) ?: continue
-            val nowMs = System.currentTimeMillis()
-            if (entry.updatedAt <= nowMs - CACHE_RETENTION_MS) {
+            val nowMs = clockMs()
+            if (entry.updatedAt <= nowMs - MetadataCachePolicy.DURABLE_RETENTION_MS) {
                 dao.delete(kind, key)
                 continue
             }
@@ -188,7 +359,11 @@ class MetadataCache(
                 continue
             }
             dao.touch(kind, key, nowMs)
-            return CacheHit(payload)
+            return CacheHit(
+                payload = payload,
+                updatedAt = entry.updatedAt,
+                readAtMs = nowMs,
+            )
         }
         return null
     }
@@ -200,6 +375,7 @@ class MetadataCache(
         stableId: String?,
         noinline identity: (T) -> String?,
         nowMs: Long,
+        noinline mergePayload: (T?, Long?) -> T,
     ) {
         if (keys.isEmpty()) return
         database.runInTransaction {
@@ -215,7 +391,20 @@ class MetadataCache(
                     }
                     .forEach { dao.delete(kind, it.cacheKey) }
             }
-            val payloadJson = json.encodeToString(payload)
+            val stableIdentity = normalizeIdentity(stableId)
+            val previous = distinctKeys.asSequence()
+                .mapNotNull { key ->
+                    dao.entry(kind, key)?.let { entry ->
+                        runCatching { json.decodeFromString<T>(entry.payload) }
+                            .getOrNull()
+                            ?.takeIf { previousPayload ->
+                                stableIdentity == null || normalizeIdentity(identity(previousPayload)) == stableIdentity
+                            }
+                            ?.let { previousPayload -> ExistingPayload(previousPayload, entry.updatedAt) }
+                    }
+                }
+                .firstOrNull()
+            val payloadJson = json.encodeToString(mergePayload(previous?.payload, previous?.updatedAt))
             distinctKeys.forEach { key ->
                 dao.insert(
                     MetadataCacheEntry(
@@ -232,7 +421,7 @@ class MetadataCache(
     }
 
     private fun cleanup(nowMs: Long) {
-        val cutoff = nowMs - CACHE_RETENTION_MS
+        val cutoff = nowMs - MetadataCachePolicy.DURABLE_RETENTION_MS
         val entries = dao.allEntries()
         entries.filter { it.lastAccessAt <= cutoff }
             .forEach { dao.delete(it.kind, it.cacheKey) }
@@ -242,7 +431,42 @@ class MetadataCache(
             .forEach { dao.delete(it.kind, it.cacheKey) }
     }
 
-    private data class CacheHit<T>(val payload: T)
+    private data class CacheHit<T>(
+        val payload: T,
+        val updatedAt: Long,
+        val readAtMs: Long,
+    )
+
+    private data class ExistingPayload<T>(
+        val payload: T,
+        val updatedAt: Long,
+    )
+
+    private fun CacheHit<*>.isFresh(
+        freshnessVersion: Int,
+        validatedAt: Long?,
+        maxAgeMs: Long,
+    ): Boolean {
+        val effectiveValidatedAt = validatedAt
+            ?: updatedAt.takeIf { freshnessVersion < METADATA_CACHE_FRESHNESS_VERSION }
+        return effectiveValidatedAt?.let {
+            (readAtMs - it).coerceAtLeast(0L) <= maxAgeMs
+        } == true
+    }
+
+    private fun fieldValidationTimestamp(
+        validated: Boolean,
+        nowMs: Long,
+        previousVersion: Int?,
+        previousTimestamp: Long?,
+        previousUpdatedAt: Long?,
+    ): Long? {
+        if (validated) return nowMs
+        return previousTimestamp
+            ?: previousUpdatedAt?.takeIf {
+                (previousVersion ?: 0) < METADATA_CACHE_FRESHNESS_VERSION
+            }
+    }
 
     private fun normalizeIdentity(value: String?): String? = value
         ?.trim()
@@ -272,6 +496,7 @@ class MetadataCache(
 
 @Serializable
 private data class AccountCachePayload(
+    val freshnessVersion: Int = 0,
     val user: HelixUser? = null,
     val scopes: List<String> = emptyList(),
     val chatColor: String? = null,
@@ -279,12 +504,20 @@ private data class AccountCachePayload(
     val chatSettings: ChatSettings? = null,
     val blockedUsers: List<BlockedUser> = emptyList(),
     val blockedUsersCursor: String? = null,
+    val scopesValidatedAt: Long? = null,
+    val chatColorValidatedAt: Long? = null,
+    val channelValidatedAt: Long? = null,
+    val chatSettingsValidatedAt: Long? = null,
+    val blockedUsersValidatedAt: Long? = null,
 )
 
 @Serializable
 private data class ChannelPageCachePayload(
+    val freshnessVersion: Int = 0,
     val user: CachedChannelUser? = null,
     val stream: CachedChannelStream? = null,
+    val streamValidatedAt: Long? = null,
+    val followerCountValidatedAt: Long? = null,
 )
 
 @Serializable
@@ -320,7 +553,10 @@ private data class CachedChannelStream(
 
 @Serializable
 private data class GamePageCachePayload(
+    val freshnessVersion: Int = 0,
     val game: CachedGame? = null,
+    val liveStatsValidatedAt: Long? = null,
+    val followerCountValidatedAt: Long? = null,
 )
 
 @Serializable
@@ -354,7 +590,7 @@ private fun User.toCacheUser() = CachedChannelUser(
     lastBroadcast = lastBroadcast,
 )
 
-private fun CachedChannelUser.toUiUser() = User(
+private fun CachedChannelUser.toUiUser(includeFollowerCount: Boolean) = User(
     id = id,
     login = login,
     name = name,
@@ -362,7 +598,7 @@ private fun CachedChannelUser.toUiUser() = User(
     type = type,
     broadcasterType = broadcasterType,
     createdAt = createdAt,
-    followerCount = followerCount,
+    followerCount = followerCount.takeIf { includeFollowerCount },
     bannerImageURL = bannerImageURL,
     lastBroadcast = lastBroadcast,
 )
@@ -383,7 +619,7 @@ private fun Stream.toCacheStream() = CachedChannelStream(
     tags = tags,
 )
 
-private fun CachedChannelStream.toUiStream() = Stream(
+private fun CachedChannelStream.toUiStream(includeLiveState: Boolean) = Stream(
     id = id,
     channelId = channelId,
     channelLogin = channelLogin,
@@ -395,7 +631,7 @@ private fun CachedChannelStream.toUiStream() = Stream(
     title = title,
     thumbnailURL = thumbnailURL,
     createdAt = createdAt,
-    viewerCount = viewerCount,
+    viewerCount = viewerCount.takeIf { includeLiveState },
     tags = tags,
 )
 
@@ -410,13 +646,16 @@ private fun Game.toCacheGame() = CachedGame(
     tags = tags?.map { CachedTag(it.id, it.name) },
 )
 
-private fun CachedGame.toUiGame() = Game(
+private fun CachedGame.toUiGame(
+    includeLiveStats: Boolean,
+    includeFollowerCount: Boolean,
+) = Game(
     id = id,
     slug = slug,
     name = name,
     boxArtURL = boxArtURL,
-    viewerCount = viewerCount,
-    broadcasterCount = broadcasterCount,
-    followerCount = followerCount,
+    viewerCount = viewerCount.takeIf { includeLiveStats },
+    broadcasterCount = broadcasterCount.takeIf { includeLiveStats },
+    followerCount = followerCount.takeIf { includeFollowerCount },
     tags = tags?.map { Tag(it.id, it.name) },
 )

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/PageMetadataFallbacks.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/PageMetadataFallbacks.kt
@@ -7,6 +7,8 @@ import com.github.andreyasadchy.xtra.model.ui.User
 internal data class ChannelFallbackResolution(
     val snapshot: ChannelPageCacheSnapshot?,
     val shouldPersist: Boolean,
+    val streamValidated: Boolean = false,
+    val followerCountValidated: Boolean = false,
 )
 
 /**
@@ -38,7 +40,13 @@ internal fun resolveChannelFallback(
         streamResult.isSuccess -> hasFreshUser || cached != null
         else -> hasFreshUser && cached != null
     }
-    return ChannelFallbackResolution(snapshot = snapshot, shouldPersist = shouldPersist)
+    return ChannelFallbackResolution(
+        snapshot = snapshot,
+        shouldPersist = shouldPersist,
+        streamValidated = streamResult.isSuccess,
+        // Helix user fallback does not include the channel follower count.
+        followerCountValidated = false,
+    )
 }
 
 internal fun mergeGameFallback(cached: Game?, helixGame: Game): Game {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/streamfeed/StreamFeedCache.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/streamfeed/StreamFeedCache.kt
@@ -87,6 +87,7 @@ internal fun CachedStreamFeedItem.toStream(): Stream {
         createdAt = createdAt,
         viewerCount = viewerCount,
         tags = tags?.let(::decodeTags),
+        thumbnailGeneration = generation,
     )
 }
 
@@ -126,13 +127,32 @@ internal fun refreshCachedItemsPreservingTail(
 ): List<CachedStreamFeedItem> {
     val refreshed = refreshCachedItems(feedKey, streams, generation)
     val refreshedKeys = refreshed.map { it.itemKey }.toSet()
+    // Keep at most one previously verified generation as a useful stale tail.
+    // Without this bound, every successful first-page refresh could retain rows
+    // from an arbitrarily old feed snapshot until the feed's long retention
+    // cleanup ran.
+    val retainedGenerations = existing.asSequence()
+        .map { it.generation }
+        .distinct()
+        .sortedDescending()
+        .take(StreamFeedFreshnessPolicy.MAX_RETAINED_STALE_GENERATIONS)
+        .toSet()
     val staleTail = existing
+        .filter { it.generation in retainedGenerations }
         .filterNot { it.itemKey in refreshedKeys }
         .sortedBy { it.position }
         .mapIndexed { index, item ->
             item.copy(position = refreshed.size + index)
         }
     return refreshed + staleTail
+}
+
+internal fun staleTailExpired(state: StreamFeedState?, nowMs: Long): Boolean {
+    return state != null &&
+            state.activeGeneration != 0L &&
+            state.staleTailRetainedAt?.let {
+                nowMs - it >= StreamFeedFreshnessPolicy.MAX_RETAINED_STALE_TAIL_AGE_MS
+            } == true
 }
 
 /**
@@ -203,8 +223,15 @@ class StreamFeedCache(
     override suspend fun touchAccess(feedKey: StreamFeedKey, nowMs: Long) = withContext(Dispatchers.IO) {
         database.runInTransaction {
             val current = dao.state(feedKey.value)
+            val expiredTail = staleTailExpired(current, nowMs)
+            if (expiredTail) {
+                dao.deleteItemsExceptGeneration(feedKey.value, current!!.activeGeneration)
+            }
             dao.insertState(
-                (current ?: StreamFeedState(feedKey.value)).copy(lastAccessAt = nowMs)
+                (current ?: StreamFeedState(feedKey.value)).copy(
+                    lastAccessAt = nowMs,
+                    staleTailRetainedAt = if (expiredTail) null else current?.staleTailRetainedAt,
+                )
             )
         }
     }
@@ -212,10 +239,15 @@ class StreamFeedCache(
     override suspend fun markAttempt(feedKey: StreamFeedKey, nowMs: Long) = withContext(Dispatchers.IO) {
         database.runInTransaction {
             val current = dao.state(feedKey.value)
+            val expiredTail = staleTailExpired(current, nowMs)
+            if (expiredTail) {
+                dao.deleteItemsExceptGeneration(feedKey.value, current!!.activeGeneration)
+            }
             dao.insertState(
                 (current ?: StreamFeedState(feedKey.value)).copy(
                     lastAttemptAt = nowMs,
                     lastAccessAt = nowMs,
+                    staleTailRetainedAt = if (expiredTail) null else current?.staleTailRetainedAt,
                 )
             )
         }
@@ -232,6 +264,13 @@ class StreamFeedCache(
         database.runInTransaction {
             val current = dao.state(feedKey.value)
             val generation = (current?.activeGeneration ?: 0L) + 1L
+            val expiredTail = staleTailExpired(current, nowMs)
+            if (expiredTail && current != null) {
+                // The expired rows are the generations behind the active one.
+                // Keep the active generation available to become the next
+                // stale tail even when expiry is crossed during the request.
+                dao.deleteItemsExceptGeneration(feedKey.value, current.activeGeneration)
+            }
             val items = if (preserveTail) {
                 refreshCachedItemsPreservingTail(
                     feedKey = feedKey.value,
@@ -251,6 +290,9 @@ class StreamFeedCache(
             if (page.nextCursor == null && pruneStaleOnEnd) {
                 dao.deleteItemsExceptGeneration(feedKey.value, generation)
             }
+            val retainsStaleTail = preserveTail &&
+                    !(page.nextCursor == null && pruneStaleOnEnd) &&
+                    items.any { it.generation != generation }
             dao.insertState(
                 StreamFeedState(
                     feedKey = feedKey.value,
@@ -262,6 +304,11 @@ class StreamFeedCache(
                     rateLimitUntil = null,
                     nextCursorApi = page.nextCursor?.api,
                     activeGeneration = generation,
+                    staleTailRetainedAt = if (retainsStaleTail) {
+                        current?.staleTailRetainedAt?.takeUnless { expiredTail } ?: nowMs
+                    } else {
+                        null
+                    },
                 )
             )
         }
@@ -276,6 +323,10 @@ class StreamFeedCache(
     ) = withContext(Dispatchers.IO) {
         database.runInTransaction {
             val current = dao.state(feedKey.value) ?: StreamFeedState(feedKey.value)
+            val expiredTail = staleTailExpired(current, nowMs)
+            if (expiredTail) {
+                dao.deleteItemsExceptGeneration(feedKey.value, current.activeGeneration)
+            }
             val existing = dao.itemsForFeed(feedKey.value)
             val items = appendCachedPage(feedKey.value, existing, page.items, current.activeGeneration)
             if (items.isNotEmpty()) {
@@ -284,6 +335,9 @@ class StreamFeedCache(
             if (page.nextCursor == null && pruneStaleOnEnd) {
                 dao.deleteItemsExceptGeneration(feedKey.value, current.activeGeneration)
             }
+            val retainsStaleTail =
+                !(page.nextCursor == null && pruneStaleOnEnd) &&
+                        items.any { it.generation != current.activeGeneration }
             dao.insertState(
                 current.copy(
                     nextCursor = page.nextCursor?.value,
@@ -293,6 +347,11 @@ class StreamFeedCache(
                     failureBackoffUntil = null,
                     rateLimitUntil = null,
                     nextCursorApi = page.nextCursor?.api,
+                    staleTailRetainedAt = if (retainsStaleTail) {
+                        current.staleTailRetainedAt?.takeUnless { expiredTail } ?: nowMs
+                    } else {
+                        null
+                    },
                 )
             )
         }
@@ -302,6 +361,7 @@ class StreamFeedCache(
         database.runInTransaction {
             dao.state(feedKey.value)?.let { state ->
                 dao.deleteItemsExceptGeneration(feedKey.value, state.activeGeneration)
+                dao.insertState(state.copy(staleTailRetainedAt = null))
             }
         }
     }
@@ -315,12 +375,17 @@ class StreamFeedCache(
     ) = withContext(Dispatchers.IO) {
         database.runInTransaction {
             val current = dao.state(feedKey.value) ?: StreamFeedState(feedKey.value)
+            val expiredTail = staleTailExpired(current, nowMs)
+            if (expiredTail) {
+                dao.deleteItemsExceptGeneration(feedKey.value, current.activeGeneration)
+            }
             dao.insertState(
                 current.copy(
                     lastAttemptAt = nowMs,
                     lastAccessAt = nowMs,
                     failureBackoffUntil = failureBackoffUntil,
                     rateLimitUntil = rateLimitUntil,
+                    staleTailRetainedAt = if (expiredTail) null else current.staleTailRetainedAt,
                 )
             )
         }
@@ -345,6 +410,11 @@ class StreamFeedCache(
         database.runInTransaction {
             val cutoff = nowMs - FEED_RETENTION_MS
             val states = dao.allStates()
+            states.filter { staleTailExpired(it, nowMs) }
+                .forEach { state ->
+                    dao.deleteItemsExceptGeneration(state.feedKey, state.activeGeneration)
+                    dao.insertState(state.copy(staleTailRetainedAt = null))
+                }
             states.filter { it.lastAccessAt <= cutoff }
                 .forEach { state ->
                     dao.deleteItems(state.feedKey)

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/streamfeed/StreamFeedPolicy.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/streamfeed/StreamFeedPolicy.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.async
 import java.util.Locale
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicLong
 
 /** A stable, credential-free identity for one stream feed variant. */
 data class StreamFeedKey(val value: String) {
@@ -91,6 +92,17 @@ enum class RefreshDecision {
     JOIN,
 }
 
+/** Process-local signal for image loaders that must bypass the current preview bucket. */
+internal object StreamThumbnailRefreshSignal {
+    private val forceEpoch = AtomicLong(0L)
+
+    fun requestForceRefresh() {
+        forceEpoch.incrementAndGet()
+    }
+
+    fun currentForceEpoch(): Long = forceEpoch.get()
+}
+
 internal fun refreshDecision(
     nowMs: Long,
     lastSuccessAt: Long?,
@@ -161,6 +173,10 @@ object StreamFeedFreshnessPolicy {
     const val PREWARM_LEAD_TIME_MS = 2 * 60_000L
     const val PREWARM_MIN_DELAY_MS = 10 * 60_000L
     const val PREWARM_MAX_DELAY_MS = 6 * 60 * 60_000L
+    /** Keep one verified stale generation useful without retaining old tails forever. */
+    const val MAX_RETAINED_STALE_GENERATIONS = 1
+    /** A retained tail is bootstrap data, not a permanent offline feed snapshot. */
+    const val MAX_RETAINED_STALE_TAIL_AGE_MS = 24 * 60 * 60_000L
     /** Keep the retained tail useful without eagerly refetching a deep feed. */
     const val MAX_AUTOMATIC_TAIL_PREFETCH_PAGES = 1
 

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/streamfeed/StreamFeedRefreshCoordinator.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/streamfeed/StreamFeedRefreshCoordinator.kt
@@ -80,6 +80,9 @@ class StreamFeedRefreshCoordinator(
         reason: RefreshReason,
         force: Boolean,
     ): StreamRefreshResult {
+        if (force) {
+            StreamThumbnailRefreshSignal.requestForceRefresh()
+        }
         val result = refreshFlights.run(spec.key.value) {
             executeRefresh(spec, reason, force)
         }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/account/AccountViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/account/AccountViewModel.kt
@@ -231,7 +231,14 @@ class AccountViewModel(application: Application) : AndroidViewModel(application)
                         error = null,
                     )
                 }
-                persistAccountCache(resolvedUserId, login)
+                persistAccountCache(
+                    userId = resolvedUserId,
+                    login = login,
+                    scopesValidated = true,
+                    chatColorValidated = colorResult?.getOrNull()?.let(::isCanonicalChatColor) == true,
+                    channelValidated = channelResult?.getOrNull() != null,
+                    chatSettingsValidated = chatSettingsResult?.getOrNull() != null,
+                )
             }
         } catch (error: Exception) {
             _uiState.update {
@@ -265,7 +272,9 @@ class AccountViewModel(application: Application) : AndroidViewModel(application)
                     chatColorLoadError = canonicalColor.exceptionOrNull()?.let { context.getString(R.string.account_load_failed) },
                 )
             }
-            persistAccountCache()
+            persistAccountCache(
+                chatColorValidated = canonicalColor.getOrNull()?.let(::isCanonicalChatColor) == true,
+            )
         }
     }
 
@@ -423,7 +432,7 @@ class AccountViewModel(application: Application) : AndroidViewModel(application)
                         blockedUsersLoadError = null,
                     )
                 }
-                persistAccountCache()
+                persistAccountCache(blockedUsersValidated = reset)
             } catch (error: Exception) {
                 val message = readableError(error)
                 _uiState.update {
@@ -481,7 +490,15 @@ class AccountViewModel(application: Application) : AndroidViewModel(application)
         ?: context.tokenPrefs().getString(C.USER_ID, null)
         ?: error(context.getString(R.string.account_missing_user))
 
-    private suspend fun persistAccountCache(userId: String? = null, login: String? = null) {
+    private suspend fun persistAccountCache(
+        userId: String? = null,
+        login: String? = null,
+        scopesValidated: Boolean = false,
+        chatColorValidated: Boolean = false,
+        channelValidated: Boolean = false,
+        chatSettingsValidated: Boolean = false,
+        blockedUsersValidated: Boolean = false,
+    ) {
         val state = _uiState.value
         val resolvedUserId = userId
             ?: state.user?.id
@@ -503,6 +520,11 @@ class AccountViewModel(application: Application) : AndroidViewModel(application)
                     blockedUsers = state.blockedUsers,
                     blockedUsersCursor = state.blockedUsersCursor,
                 ),
+                scopesValidated = scopesValidated,
+                chatColorValidated = chatColorValidated,
+                channelValidated = channelValidated,
+                chatSettingsValidated = chatSettingsValidated,
+                blockedUsersValidated = blockedUsersValidated,
             )
         } catch (_: Exception) {
         }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/channel/ChannelPagerViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/channel/ChannelPagerViewModel.kt
@@ -166,6 +166,8 @@ class ChannelPagerViewModel(
                                 channelId = args.channelId ?: snapshot.user.id,
                                 login = args.channelLogin ?: snapshot.user.login,
                                 snapshot = snapshot,
+                                streamValidated = true,
+                                followerCountValidated = true,
                             )
                         } catch (_: Exception) {
                         }
@@ -230,6 +232,8 @@ class ChannelPagerViewModel(
                                             channelId = args.channelId ?: it.user.id,
                                             login = args.channelLogin ?: it.user.login,
                                             snapshot = it,
+                                            streamValidated = resolution.streamValidated,
+                                            followerCountValidated = resolution.followerCountValidated,
                                         )
                                     } catch (_: Exception) {
                                     }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/ThumbnailImageRequest.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/ThumbnailImageRequest.kt
@@ -1,11 +1,13 @@
 package com.github.andreyasadchy.xtra.ui.common
 
 import android.content.Context
+import android.util.Log
 import android.widget.ImageView
 import coil3.Image
+import coil3.decode.DataSource
 import coil3.imageLoader
-import coil3.request.ImageRequest
 import coil3.request.CachePolicy
+import coil3.request.ImageRequest
 import coil3.request.crossfade
 import coil3.request.error
 import coil3.request.fallback
@@ -14,10 +16,13 @@ import coil3.request.target
 import coil3.request.transformations
 import coil3.target.ImageViewTarget
 import coil3.transform.CircleCropTransformation
-import com.github.andreyasadchy.xtra.model.ui.Stream
+import com.github.andreyasadchy.xtra.BuildConfig
 import com.github.andreyasadchy.xtra.R
+import com.github.andreyasadchy.xtra.model.ui.Stream
+import com.github.andreyasadchy.xtra.repository.streamfeed.StreamThumbnailRefreshSignal
 import com.github.andreyasadchy.xtra.util.C
 import com.github.andreyasadchy.xtra.util.prefs
+import java.util.concurrent.ConcurrentHashMap
 
 internal fun ImageRequest.Builder.thumbnailState(): ImageRequest.Builder = apply {
     placeholder(R.drawable.bg_thumbnail_placeholder)
@@ -30,6 +35,22 @@ internal fun Stream.streamIdentity(): String {
         ?: id?.takeIf { it.isNotBlank() }?.let { "stream:$it" }
         ?: channelLogin?.takeIf { it.isNotBlank() }?.let { "login:${it.lowercase()}" }
         ?: "unknown:${channelName.orEmpty()}"
+}
+
+/**
+ * Identity for image bytes, which is intentionally different from the stable
+ * channel identity used by RecyclerView rows.
+ */
+internal fun Stream.thumbnailIdentity(): String {
+    val created = createdAt?.trim()?.takeIf { it.isNotEmpty() }
+    return id?.trim()?.takeIf { it.isNotEmpty() }?.let { "stream:$it" }
+        ?: channelId?.trim()?.takeIf { it.isNotEmpty() }?.let { channel ->
+            created?.let { "channel:$channel:created:$it" }
+        }
+        ?: channelLogin?.trim()?.takeIf { it.isNotEmpty() }?.let { login ->
+            created?.let { "login:${login.lowercase()}:created:$it" }
+        }
+        ?: "fallback:${streamIdentity()}:thumbnail-hash:${thumbnailURL.orEmpty().hashCode().toString(16)}"
 }
 
 internal fun streamContentsSame(oldItem: Stream, newItem: Stream): Boolean {
@@ -45,7 +66,8 @@ internal fun streamContentsSame(oldItem: Stream, newItem: Stream): Boolean {
             oldItem.thumbnailURL == newItem.thumbnailURL &&
             oldItem.createdAt == newItem.createdAt &&
             oldItem.viewerCount == newItem.viewerCount &&
-            oldItem.tags == newItem.tags
+            oldItem.tags == newItem.tags &&
+            oldItem.thumbnailGeneration == newItem.thumbnailGeneration
 }
 
 /**
@@ -72,7 +94,12 @@ private class StreamImageTarget(
 
     override fun onError(error: Image?) {
         if (view.tag != identity) return
-        if (preserveCurrentImage && view.drawable != null) return
+        if (shouldPreserveThumbnailOnFreshFailure(
+                identityMatches = true,
+                preserveCurrentImage = preserveCurrentImage,
+                hasDisplayedImage = view.drawable != null,
+            )
+        ) return
         super.onError(error)
     }
 }
@@ -80,10 +107,7 @@ private class StreamImageTarget(
 private class StreamThumbnailCacheTarget(
     imageView: ImageView,
     private val identity: String,
-    private val onCacheSettled: () -> Unit,
 ) : ImageViewTarget(imageView) {
-
-    private var settled = false
 
     override fun onStart(placeholder: Image?) {
         // The cache-only stage is intentionally silent. It must never replace
@@ -93,38 +117,154 @@ private class StreamThumbnailCacheTarget(
     override fun onSuccess(result: Image) {
         if (view.tag == identity) {
             super.onSuccess(result)
-            settle()
         }
     }
 
     override fun onError(error: Image?) {
         if (view.tag == identity) {
             // Preserve whatever was already displayed, including a previous
-            // cached image, and continue to the network stage.
-            settle()
-        }
-    }
-
-    private fun settle() {
-        if (!settled) {
-            settled = true
-            onCacheSettled()
+            // cached image. The request listener starts the fresh stage after
+            // this target callback has completed.
         }
     }
 }
 
 internal data class StreamThumbnailRequestPlan(
     val diskCacheKey: String,
+    val memoryCacheKey: String,
     val networkUrl: String,
 )
+
+internal object StreamThumbnailPolicy {
+    const val REFRESH_INTERVAL_MS = 5 * 60_000L
+    const val FRESH_RETRY_INTERVAL_MS = 30_000L
+
+    fun bucket(nowMs: Long): Long = nowMs / REFRESH_INTERVAL_MS
+}
+
+internal class StreamThumbnailFetchGate(
+    private val maxTrackedSessions: Int = 512,
+    private val retryIntervalMs: Long = StreamThumbnailPolicy.FRESH_RETRY_INTERVAL_MS,
+) {
+    private data class State(
+        var successfulBucket: Long? = null,
+        var successfulForceEpoch: Long = 0L,
+        var attemptedBucket: Long? = null,
+        var attemptedForceEpoch: Long = 0L,
+        var attemptedAtMs: Long = 0L,
+    )
+
+    private val states = ConcurrentHashMap<String, State>()
+
+    @Synchronized
+    fun forcePending(identity: String, bucket: Long, forceEpoch: Long): Boolean {
+        if (forceEpoch == 0L) return false
+        val state = states[identity] ?: return true
+        return state.successfulBucket != bucket || state.successfulForceEpoch < forceEpoch
+    }
+
+    @Synchronized
+    fun shouldFetch(identity: String, bucket: Long, forceEpoch: Long, nowMs: Long): Boolean {
+        val state = state(identity)
+        if (state.successfulBucket == bucket && state.successfulForceEpoch >= forceEpoch) {
+            return false
+        }
+        return state.attemptedBucket != bucket ||
+                state.attemptedForceEpoch != forceEpoch ||
+                nowMs - state.attemptedAtMs >= retryIntervalMs
+    }
+
+    @Synchronized
+    fun markAttempt(identity: String, bucket: Long, forceEpoch: Long, nowMs: Long) {
+        state(identity).apply {
+            attemptedBucket = bucket
+            attemptedForceEpoch = forceEpoch
+            attemptedAtMs = nowMs
+        }
+    }
+
+    @Synchronized
+    fun markSuccess(identity: String, bucket: Long, forceEpoch: Long) {
+        state(identity).apply {
+            successfulBucket = bucket
+            successfulForceEpoch = forceEpoch
+        }
+    }
+
+    private fun state(identity: String): State {
+        return states[identity] ?: run {
+            if (states.size >= maxTrackedSessions) {
+                states.keys.firstOrNull()?.let(states::remove)
+            }
+            State().also { states[identity] = it }
+        }
+    }
+}
+
+private val streamThumbnailFetchGate = StreamThumbnailFetchGate()
+
+internal data class ThumbnailCachePolicies(
+    val memory: CachePolicy,
+    val disk: CachePolicy,
+    val network: CachePolicy,
+)
+
+internal fun thumbnailCachePolicies(fresh: Boolean): ThumbnailCachePolicies {
+    return if (fresh) {
+        ThumbnailCachePolicies(
+            memory = CachePolicy.WRITE_ONLY,
+            disk = CachePolicy.WRITE_ONLY,
+            network = CachePolicy.ENABLED,
+        )
+    } else {
+        ThumbnailCachePolicies(
+            memory = CachePolicy.READ_ONLY,
+            disk = CachePolicy.READ_ONLY,
+            network = CachePolicy.DISABLED,
+        )
+    }
+}
+
+internal fun shouldRefreshThumbnailAfterCache(
+    cacheSource: DataSource?,
+    forceRefresh: Boolean,
+): Boolean = cacheSource != DataSource.MEMORY_CACHE || forceRefresh
+
+internal fun shouldPreserveThumbnailOnFreshFailure(
+    identityMatches: Boolean,
+    preserveCurrentImage: Boolean,
+    hasDisplayedImage: Boolean,
+): Boolean = identityMatches && preserveCurrentImage && hasDisplayedImage
+
+private fun ImageRequest.Builder.thumbnailDebugDiagnostics(
+    stage: String,
+    identity: String,
+    bucket: Long,
+    onSuccess: (DataSource) -> Unit = {},
+    onError: () -> Unit = {},
+): ImageRequest.Builder = apply {
+    listener(
+        onError = { _, _ -> onError() },
+        onSuccess = { _, result ->
+            onSuccess(result.dataSource)
+            if (BuildConfig.DEBUG) {
+                Log.d(
+                    "StreamThumbnail",
+                    "stage=$stage source=${result.dataSource} sessionHash=${identity.hashCode().toString(16)} bucket=$bucket",
+                )
+            }
+        },
+    )
+}
 
 internal fun streamThumbnailRequestPlan(stream: Stream, bucket: Long): StreamThumbnailRequestPlan? {
     if (stream.thumbnailURL.isNullOrBlank()) return null
     val thumbnail = stream.thumbnail ?: return null
-    val identity = stream.streamIdentity()
+    val identity = stream.thumbnailIdentity()
     val separator = if ('?' in thumbnail) '&' else '?'
     return StreamThumbnailRequestPlan(
         diskCacheKey = "xtra:stream-thumbnail:$identity",
+        memoryCacheKey = "xtra:stream-thumbnail-memory:$identity:bucket:$bucket",
         networkUrl = "$thumbnail${separator}xtra_preview_bucket=$bucket",
     )
 }
@@ -154,12 +294,13 @@ internal fun loadStreamProfileImage(context: Context, imageView: ImageView, stre
 }
 
 internal fun loadStreamThumbnail(context: Context, imageView: ImageView, stream: Stream) {
-    val identity = stream.streamIdentity()
+    val identity = stream.thumbnailIdentity()
     if (imageView.tag != identity) {
         imageView.setImageDrawable(null)
     }
     imageView.tag = identity
-    val bucket = System.currentTimeMillis() / (5 * 60_000L)
+    val bucket = StreamThumbnailPolicy.bucket(System.currentTimeMillis())
+    val forceEpoch = StreamThumbnailRefreshSignal.currentForceEpoch()
     val plan = streamThumbnailRequestPlan(stream, bucket)
     if (plan == null) {
         imageView.setImageDrawable(null)
@@ -167,18 +308,30 @@ internal fun loadStreamThumbnail(context: Context, imageView: ImageView, stream:
     }
 
     fun enqueueFreshRequest() {
+        val nowMs = System.currentTimeMillis()
+        if (!streamThumbnailFetchGate.shouldFetch(identity, bucket, forceEpoch, nowMs)) return
+        streamThumbnailFetchGate.markAttempt(identity, bucket, forceEpoch, nowMs)
         val preserveCurrentImage = imageView.tag == identity && imageView.drawable != null
+        val policies = thumbnailCachePolicies(fresh = true)
         ImageRequest.Builder(context).apply {
             data(plan.networkUrl)
-            // WRITE_ONLY deliberately bypasses the stable stale image while
-            // retaining the new response under that same stable disk key.
-            diskCachePolicy(CachePolicy.WRITE_ONLY)
+            // The fresh stage must bypass both stale memory and disk reads while
+            // retaining the new response in both caches.
+            memoryCachePolicy(policies.memory)
+            memoryCacheKey(plan.memoryCacheKey)
+            diskCachePolicy(policies.disk)
             diskCacheKey(plan.diskCacheKey)
-            networkCachePolicy(CachePolicy.ENABLED)
+            networkCachePolicy(policies.network)
             crossfade(false)
             if (!preserveCurrentImage) {
                 thumbnailState()
             }
+            thumbnailDebugDiagnostics(
+                stage = "fresh",
+                identity = identity,
+                bucket = bucket,
+                onSuccess = { streamThumbnailFetchGate.markSuccess(identity, bucket, forceEpoch) },
+            )
             target(StreamImageTarget(imageView, identity, preserveCurrentImage))
         }.build().let(context.imageLoader::enqueue)
     }
@@ -186,11 +339,39 @@ internal fun loadStreamThumbnail(context: Context, imageView: ImageView, stream:
     // Stage one renders the stable last-known image without touching the
     // network. Stage two then revalidates the preview and atomically replaces
     // the displayed image and the same stable disk entry if successful.
+    val policies = thumbnailCachePolicies(fresh = false)
     ImageRequest.Builder(context).apply {
         data(plan.networkUrl)
-        diskCachePolicy(CachePolicy.READ_ONLY)
+        // READ_ONLY prevents this stale stage from populating the memory entry
+        // that the fresh stage deliberately bypasses.
+        memoryCachePolicy(policies.memory)
+        memoryCacheKey(plan.memoryCacheKey)
+        diskCachePolicy(policies.disk)
         diskCacheKey(plan.diskCacheKey)
-        networkCachePolicy(CachePolicy.DISABLED)
-        target(StreamThumbnailCacheTarget(imageView, identity, ::enqueueFreshRequest))
+        networkCachePolicy(policies.network)
+        thumbnailDebugDiagnostics(
+            stage = "stale",
+            identity = identity,
+            bucket = bucket,
+            onSuccess = { source ->
+                val forceRefresh = streamThumbnailFetchGate.forcePending(identity, bucket, forceEpoch)
+                val retryFreshRequest = source == DataSource.MEMORY_CACHE &&
+                        streamThumbnailFetchGate.shouldFetch(
+                            identity = identity,
+                            bucket = bucket,
+                            forceEpoch = forceEpoch,
+                            nowMs = System.currentTimeMillis(),
+                        )
+                if (shouldRefreshThumbnailAfterCache(
+                        cacheSource = source,
+                        forceRefresh = forceRefresh || retryFreshRequest,
+                    )
+                ) {
+                    enqueueFreshRequest()
+                }
+            },
+            onError = { enqueueFreshRequest() },
+        )
+        target(StreamThumbnailCacheTarget(imageView, identity))
     }.build().let(context.imageLoader::enqueue)
 }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/game/GamePagerViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/game/GamePagerViewModel.kt
@@ -138,6 +138,8 @@ class GamePagerViewModel(
                                 slug = args.gameSlug ?: game.slug,
                                 name = args.gameName ?: game.name,
                                 snapshot = GamePageCacheSnapshot(game),
+                                liveStatsValidated = true,
+                                followerCountValidated = true,
                             )
                         } catch (_: Exception) {
                         }

--- a/app/src/test/java/com/github/andreyasadchy/xtra/repository/streamfeed/StreamFeedKeyTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/repository/streamfeed/StreamFeedKeyTest.kt
@@ -25,4 +25,35 @@ class StreamFeedKeyTest {
         assertEquals(StreamFeedKey.followed("100"), StreamFeedKey.followed(" 100 "))
         assertEquals("followed:account:100", StreamFeedKey.followed("100").value)
     }
+
+    @Test
+    fun gameIdentityAndFiltersCannotCollide() {
+        val first = StreamFeedKey.game(
+            gameId = "1",
+            gameSlug = "same-slug",
+            gameName = "Same name",
+            sort = "VIEWER_COUNT",
+            tags = listOf("fps"),
+            languages = listOf("en"),
+        )
+        val second = StreamFeedKey.game(
+            gameId = "2",
+            gameSlug = "same-slug",
+            gameName = "Same name",
+            sort = "VIEWER_COUNT",
+            tags = listOf("fps"),
+            languages = listOf("en"),
+        )
+        val differentFilters = StreamFeedKey.game(
+            gameId = "1",
+            gameSlug = "same-slug",
+            gameName = "Same name",
+            sort = "VIEWER_COUNT",
+            tags = listOf("rpg"),
+            languages = listOf("en"),
+        )
+
+        assertNotEquals(first, second)
+        assertNotEquals(first, differentFilters)
+    }
 }

--- a/app/src/test/java/com/github/andreyasadchy/xtra/repository/streamfeed/StreamFeedSnapshotTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/repository/streamfeed/StreamFeedSnapshotTest.kt
@@ -89,4 +89,95 @@ class StreamFeedSnapshotTest {
         assertTrue(afterAppend.take(6).all { it.generation == 2L })
         assertTrue(afterAppend.drop(6).all { it.generation == 1L })
     }
+
+    @Test
+    fun refreshingAnExistingChannelReplacesEveryCachedStreamField() {
+        val key = "top:v2"
+        val existing = refreshCachedItems(
+            feedKey = key,
+            streams = listOf(
+                Stream(
+                    id = "broadcast-1",
+                    channelId = "channel-42",
+                    channelLogin = "old-login",
+                    channelName = "Old name",
+                    channelImageURL = "old-avatar",
+                    gameId = "game-old",
+                    gameSlug = "old-game",
+                    gameName = "Old game",
+                    title = "Old title",
+                    thumbnailURL = "old-thumbnail",
+                    createdAt = "old-created",
+                    viewerCount = 10,
+                    tags = listOf("old-tag"),
+                ),
+            ),
+            generation = 1L,
+        )
+        val refreshed = refreshCachedItemsPreservingTail(
+            feedKey = key,
+            existing = existing,
+            streams = listOf(
+                Stream(
+                    id = "broadcast-2",
+                    channelId = "channel-42",
+                    channelLogin = "new-login",
+                    channelName = "New name",
+                    channelImageURL = "new-avatar",
+                    gameId = "game-new",
+                    gameSlug = "new-game",
+                    gameName = "New game",
+                    title = "New title",
+                    thumbnailURL = "new-thumbnail",
+                    createdAt = "new-created",
+                    viewerCount = 20,
+                    tags = listOf("new-tag"),
+                ),
+            ),
+            generation = 2L,
+        )
+
+        val stream = refreshed.single().toStream()
+        assertEquals("broadcast-2", stream.id)
+        assertEquals("channel-42", stream.channelId)
+        assertEquals("new-login", stream.channelLogin)
+        assertEquals("New name", stream.channelName)
+        assertEquals("new-avatar", stream.channelImageURL)
+        assertEquals("game-new", stream.gameId)
+        assertEquals("new-game", stream.gameSlug)
+        assertEquals("New game", stream.gameName)
+        assertEquals("New title", stream.title)
+        assertEquals("new-thumbnail", stream.thumbnailURL)
+        assertEquals("new-created", stream.createdAt)
+        assertEquals(20, stream.viewerCount)
+        assertEquals(listOf("new-tag"), stream.tags)
+        assertEquals(2L, stream.thumbnailGeneration)
+    }
+
+    @Test
+    fun staleTailIsBoundToOnePreviouslyVerifiedGeneration() {
+        val first = refreshCachedItems(
+            "top:bounded-tail",
+            listOf(Stream(channelId = "old")),
+            generation = 1L,
+        )
+        val second = refreshCachedItemsPreservingTail(
+            "top:bounded-tail",
+            first,
+            listOf(Stream(channelId = "middle")),
+            generation = 2L,
+        )
+        val third = refreshCachedItemsPreservingTail(
+            "top:bounded-tail",
+            second,
+            listOf(Stream(channelId = "new")),
+            generation = 3L,
+        )
+
+        assertEquals(
+            listOf("channel:new", "channel:middle"),
+            third.map { it.itemKey },
+        )
+        assertTrue(third.all { it.generation >= 2L })
+    }
 }

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/common/ThumbnailImageRequestTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/common/ThumbnailImageRequestTest.kt
@@ -1,9 +1,13 @@
 package com.github.andreyasadchy.xtra.ui.common
 
 import com.github.andreyasadchy.xtra.model.ui.Stream
+import coil3.decode.DataSource
+import coil3.request.CachePolicy
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class ThumbnailImageRequestTest {
@@ -19,8 +23,159 @@ class ThumbnailImageRequestTest {
         val second = streamThumbnailRequestPlan(stream, bucket = 11L)
 
         assertEquals(first!!.diskCacheKey, second!!.diskCacheKey)
+        assertNotEquals(first.memoryCacheKey, second.memoryCacheKey)
         assertNotEquals(first.networkUrl, second.networkUrl)
-        assertEquals("xtra:stream-thumbnail:channel:channel-42", first.diskCacheKey)
+        assertFalse(first.diskCacheKey.contains("https://"))
+    }
+
+    @Test
+    fun broadcastSessionIdentityDoesNotReusePreviousChannelThumbnail() {
+        val first = streamThumbnailRequestPlan(
+            Stream(
+                id = "broadcast-1",
+                channelId = "channel-42",
+                createdAt = "2026-08-16T10:00:00Z",
+                thumbnailURL = "https://static-cdn.jtvnw.net/previews/{width}x{height}.jpg",
+            ),
+            bucket = 10L,
+        )
+        val second = streamThumbnailRequestPlan(
+            Stream(
+                id = "broadcast-2",
+                channelId = "channel-42",
+                createdAt = "2026-08-16T11:00:00Z",
+                thumbnailURL = "https://static-cdn.jtvnw.net/previews/{width}x{height}.jpg",
+            ),
+            bucket = 10L,
+        )
+
+        assertNotEquals(first!!.diskCacheKey, second!!.diskCacheKey)
+    }
+
+    @Test
+    fun loginAndCreatedAtProvideSessionIdentityWhenStreamIdIsMissing() {
+        val first = streamThumbnailRequestPlan(
+            Stream(
+                channelId = "channel-42",
+                channelLogin = "Streamer",
+                createdAt = "2026-08-16T10:00:00Z",
+                thumbnailURL = "https://cdn.example/preview.jpg",
+            ),
+            bucket = 10L,
+        )
+        val second = streamThumbnailRequestPlan(
+            Stream(
+                channelId = "channel-42",
+                channelLogin = "Streamer",
+                createdAt = "2026-08-16T11:00:00Z",
+                thumbnailURL = "https://cdn.example/preview.jpg",
+            ),
+            bucket = 10L,
+        )
+
+        assertNotEquals(first!!.diskCacheKey, second!!.diskCacheKey)
+    }
+
+    @Test
+    fun staleStageCannotPoisonFreshMemoryRead() {
+        val stale = thumbnailCachePolicies(fresh = false)
+        val fresh = thumbnailCachePolicies(fresh = true)
+
+        assertEquals(CachePolicy.READ_ONLY, stale.memory)
+        assertEquals(CachePolicy.READ_ONLY, stale.disk)
+        assertEquals(CachePolicy.DISABLED, stale.network)
+        assertEquals(CachePolicy.WRITE_ONLY, fresh.memory)
+        assertEquals(CachePolicy.WRITE_ONLY, fresh.disk)
+        assertEquals(CachePolicy.ENABLED, fresh.network)
+    }
+
+    @Test
+    fun currentBucketMemoryHitSkipsRepeatedFreshRequestUnlessForced() {
+        assertEquals(false, shouldRefreshThumbnailAfterCache(DataSource.MEMORY_CACHE, forceRefresh = false))
+        assertEquals(true, shouldRefreshThumbnailAfterCache(DataSource.MEMORY_CACHE, forceRefresh = true))
+        assertEquals(true, shouldRefreshThumbnailAfterCache(DataSource.DISK, forceRefresh = false))
+        assertEquals(true, shouldRefreshThumbnailAfterCache(null, forceRefresh = false))
+    }
+
+    @Test
+    fun fetchGateRateLimitsRepeatedBindsWithinOneBucket() {
+        val gate = StreamThumbnailFetchGate(retryIntervalMs = 100L)
+
+        assertTrue(gate.shouldFetch("session", bucket = 7L, forceEpoch = 0L, nowMs = 0L))
+        gate.markAttempt("session", bucket = 7L, forceEpoch = 0L, nowMs = 0L)
+        assertFalse(gate.shouldFetch("session", bucket = 7L, forceEpoch = 0L, nowMs = 99L))
+        assertTrue(gate.shouldFetch("session", bucket = 7L, forceEpoch = 0L, nowMs = 100L))
+
+        gate.markSuccess("session", bucket = 7L, forceEpoch = 0L)
+        assertFalse(gate.shouldFetch("session", bucket = 7L, forceEpoch = 0L, nowMs = 101L))
+    }
+
+    @Test
+    fun forceEpochRequestsFreshThumbnailEvenInsideCurrentBucket() {
+        val gate = StreamThumbnailFetchGate()
+        gate.markSuccess("session", bucket = 7L, forceEpoch = 0L)
+
+        assertFalse(gate.forcePending("session", bucket = 7L, forceEpoch = 0L))
+        assertTrue(gate.forcePending("session", bucket = 7L, forceEpoch = 1L))
+
+        gate.markSuccess("session", bucket = 7L, forceEpoch = 1L)
+        assertFalse(gate.forcePending("session", bucket = 7L, forceEpoch = 1L))
+    }
+
+    @Test
+    fun freshFailurePreservesOnlyTheMatchingDisplayedThumbnail() {
+        assertTrue(
+            shouldPreserveThumbnailOnFreshFailure(
+                identityMatches = true,
+                preserveCurrentImage = true,
+                hasDisplayedImage = true,
+            ),
+        )
+        assertFalse(
+            shouldPreserveThumbnailOnFreshFailure(
+                identityMatches = true,
+                preserveCurrentImage = false,
+                hasDisplayedImage = true,
+            ),
+        )
+        assertFalse(
+            shouldPreserveThumbnailOnFreshFailure(
+                identityMatches = false,
+                preserveCurrentImage = true,
+                hasDisplayedImage = true,
+            ),
+        )
+    }
+
+    @Test
+    fun thumbnailRefreshBucketsAreDeterministicAndNamedByPolicy() {
+        assertEquals(0L, StreamThumbnailPolicy.bucket(0L))
+        assertEquals(1L, StreamThumbnailPolicy.bucket(StreamThumbnailPolicy.REFRESH_INTERVAL_MS))
+        assertEquals(
+            1L,
+            StreamThumbnailPolicy.bucket(StreamThumbnailPolicy.REFRESH_INTERVAL_MS + 1L),
+        )
+    }
+
+    @Test
+    fun refreshGenerationMakesIdenticalStreamMetadataChangedForDiffUtil() {
+        val oldItem = Stream(
+            id = "broadcast-1",
+            channelId = "channel-42",
+            title = "Same title",
+            thumbnailURL = "https://cdn.example/preview.jpg",
+            thumbnailGeneration = 10L,
+        )
+        val newItem = Stream(
+            id = "broadcast-1",
+            channelId = "channel-42",
+            title = "Same title",
+            thumbnailURL = "https://cdn.example/preview.jpg",
+            thumbnailGeneration = 11L,
+        )
+
+        assertEquals(oldItem.streamIdentity(), newItem.streamIdentity())
+        org.junit.Assert.assertFalse(streamContentsSame(oldItem, newItem))
     }
 
     @Test


### PR DESCRIPTION
## What changed

Keeps cache-first stream feeds responsive while making live thumbnails and cached metadata refresh predictably.

## Review fixes

- Volatile metadata fields keep independent validation timestamps, and partial account mutations no longer renew untouched channel, chat settings, or blocked-user pages.
- Retained feed tails have their own expiry clock that survives invalidation, migration, and refresh completion races.
- Coil memory-cache handling uses the actual `MEMORY_CACHE` data source.

## Validation

- :app:testDebugUnitTest — 307 tests
- :app:connectedDebugAndroidTest — 19 tests on xtra-api35
