### PR TITLE
Add favorite emotes

### DIFF
--- a/app/src/androidTest/java/com/github/andreyasadchy/xtra/db/AppDatabaseMigrationTest.kt
+++ b/app/src/androidTest/java/com/github/andreyasadchy/xtra/db/AppDatabaseMigrationTest.kt
@@ -2,13 +2,16 @@ package com.github.andreyasadchy.xtra.db
 
 import android.database.sqlite.SQLiteDatabase
 import androidx.room.Room
+import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.github.andreyasadchy.xtra.repository.streamfeed.StreamFeedCache
 import com.github.andreyasadchy.xtra.repository.streamfeed.StreamFeedFreshnessPolicy
 import com.github.andreyasadchy.xtra.repository.streamfeed.StreamFeedKey
+import com.github.andreyasadchy.xtra.model.chat.FavoriteEmote
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.flow.first
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -28,7 +31,7 @@ class AppDatabaseMigrationTest {
     }
 
     @Test
-    fun migrateCurrentVersion38To45CreatesStatisticsAndStreamFeedSchema() {
+    fun migrateCurrentVersion38To46CreatesStatisticsAndStreamFeedSchema() {
         val name = "migration-v38.db"
         prepareDatabase(name, version = 38, historicalVersion39 = false)
 
@@ -95,15 +98,31 @@ class AppDatabaseMigrationTest {
     }
 
     @Test
-    fun migrateVersion44To45RetainsExistingViewingStats() {
+    fun migrateVersion44To46RetainsExistingViewingStats() {
         val name = "migration-v44-stats.db"
         prepareVersion44Database(name)
         insertLegacyViewingStats(name)
 
         val database = openMigratedDatabase(name)
         val sqlite = database.openHelper.readableDatabase
-        assertEquals(45, scalarInt(sqlite, "PRAGMA user_version"))
+        assertEquals(46, scalarInt(sqlite, "PRAGMA user_version"))
         assertRetainedViewingStats(sqlite)
+        database.close()
+    }
+
+    @Test
+    fun migrateVersion45To46CreatesFavoritesWithoutChangingExistingData() = runBlocking {
+        val name = "migration-v45-favorites.db"
+        prepareVersion45WithoutFavorites(name)
+
+        val database = openMigratedDatabase(name)
+        val sqlite = database.openHelper.readableDatabase
+        assertEquals(46, scalarInt(sqlite, "PRAGMA user_version"))
+        assertTrue(tableExists(sqlite, "favorite_emotes"))
+        assertEquals("legacy", database.recentEmotes().getAll().single().name)
+
+        database.favoriteEmotes().insert(FavoriteEmote("BTTV", "emote-id", 123L))
+        assertEquals("emote-id", database.favoriteEmotes().getAllFlow().first().single().emoteId)
         database.close()
     }
 
@@ -117,6 +136,9 @@ class AppDatabaseMigrationTest {
                 MetadataCacheMigrations.FROM_42,
                 StreamFeedMigrations.FROM_43,
                 ViewingStatsMigrations.FROM_44,
+                Migration(45, 46) { db ->
+                    db.execSQL("CREATE TABLE IF NOT EXISTS favorite_emotes (provider TEXT NOT NULL, emote_id TEXT NOT NULL, favorited_at INTEGER NOT NULL, PRIMARY KEY (provider, emote_id))")
+                },
             )
             .build()
             .also { it.openHelper.writableDatabase }
@@ -241,6 +263,17 @@ class AppDatabaseMigrationTest {
         database.close()
     }
 
+    private fun prepareVersion45WithoutFavorites(name: String) {
+        context.deleteDatabase(name)
+        databaseNames += name
+        val database = Room.databaseBuilder(context, AppDatabase::class.java, name).build()
+        val sqlite = database.openHelper.writableDatabase
+        sqlite.execSQL("DROP TABLE IF EXISTS favorite_emotes")
+        sqlite.execSQL("INSERT INTO recent_emotes (name, used_at) VALUES ('legacy', 1000)")
+        sqlite.execSQL("PRAGMA user_version = 45")
+        database.close()
+    }
+
     private fun dropViewingStatsTables(sqlite: SupportSQLiteDatabase) {
         sqlite.execSQL("DROP INDEX IF EXISTS index_viewing_intervals_session_id")
         sqlite.execSQL("DROP INDEX IF EXISTS index_viewing_intervals_content_type_start_at")
@@ -315,7 +348,7 @@ class AppDatabaseMigrationTest {
     }
 
     private fun assertStatisticsSchema(database: SupportSQLiteDatabase) {
-        assertEquals(45, scalarInt(database, "PRAGMA user_version"))
+        assertEquals(46, scalarInt(database, "PRAGMA user_version"))
         assertTrue(tableExists(database, "viewing_sessions"))
         assertTrue(tableExists(database, "viewing_intervals"))
         assertTrue(indexExists(database, "index_viewing_sessions_started_at"))

--- a/app/src/main/java/com/github/andreyasadchy/xtra/XtraModule.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/XtraModule.kt
@@ -382,6 +382,9 @@ class XtraModule(application: Application) {
                 MetadataCacheMigrations.FROM_42,
                 StreamFeedMigrations.FROM_43,
                 ViewingStatsMigrations.FROM_44,
+                Migration(45, 46) { db ->
+                    db.execSQL("CREATE TABLE IF NOT EXISTS favorite_emotes (provider TEXT NOT NULL, emote_id TEXT NOT NULL, favorited_at INTEGER NOT NULL, PRIMARY KEY (provider, emote_id))")
+                },
             )
         }.build()
     }
@@ -432,7 +435,7 @@ class XtraModule(application: Application) {
     }
 
     val playerRepository by lazy {
-        PlayerRepository(httpEngine, cronetEngine, cronetExecutor, okHttpClient, json, database.recentEmotes(), database.translatedChannels(), database.videoPositions(), database.playbackStates(), graphQLRepository, helixRepository)
+        PlayerRepository(httpEngine, cronetEngine, cronetExecutor, okHttpClient, json, database.recentEmotes(), database.favoriteEmotes(), database.translatedChannels(), database.videoPositions(), database.playbackStates(), graphQLRepository, helixRepository)
     }
 
     val recentSearchesRepository by lazy {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/db/AppDatabase.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/db/AppDatabase.kt
@@ -7,6 +7,7 @@ import com.github.andreyasadchy.xtra.model.NotificationEvent
 import com.github.andreyasadchy.xtra.model.PlaybackState
 import com.github.andreyasadchy.xtra.model.ShownNotification
 import com.github.andreyasadchy.xtra.model.VideoPosition
+import com.github.andreyasadchy.xtra.model.chat.FavoriteEmote
 import com.github.andreyasadchy.xtra.model.chat.RecentEmote
 import com.github.andreyasadchy.xtra.model.stats.ViewingInterval
 import com.github.andreyasadchy.xtra.model.stats.ViewingSession
@@ -25,6 +26,7 @@ import com.github.andreyasadchy.xtra.model.ui.TranslatedChannel
     entities = [
         OfflineVideo::class,
         RecentEmote::class,
+        FavoriteEmote::class,
         VideoPosition::class,
         LocalChannelFollow::class,
         LocalGameFollow::class,
@@ -45,13 +47,14 @@ import com.github.andreyasadchy.xtra.model.ui.TranslatedChannel
         StreamFeedState::class,
         MetadataCacheEntry::class,
     ],
-    version = 45,
+    version = 46,
     exportSchema = false
 )
 abstract class AppDatabase : RoomDatabase() {
 
     abstract fun offlineVideos(): OfflineVideosDao
     abstract fun recentEmotes(): RecentEmotesDao
+    abstract fun favoriteEmotes(): FavoriteEmotesDao
     abstract fun videoPositions(): VideoPositionsDao
     abstract fun localChannelFollows(): LocalChannelFollowsDao
     abstract fun localGameFollows(): LocalGameFollowsDao

--- a/app/src/main/java/com/github/andreyasadchy/xtra/db/FavoriteEmotesDao.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/db/FavoriteEmotesDao.kt
@@ -1,0 +1,21 @@
+package com.github.andreyasadchy.xtra.db
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.github.andreyasadchy.xtra.model.chat.FavoriteEmote
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface FavoriteEmotesDao {
+
+    @Query("SELECT * FROM favorite_emotes ORDER BY favorited_at DESC")
+    fun getAllFlow(): Flow<List<FavoriteEmote>>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(favorite: FavoriteEmote)
+
+    @Query("DELETE FROM favorite_emotes WHERE provider = :provider AND emote_id = :emoteId")
+    suspend fun delete(provider: String, emoteId: String)
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/model/chat/FavoriteEmote.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/model/chat/FavoriteEmote.kt
@@ -1,0 +1,16 @@
+package com.github.andreyasadchy.xtra.model.chat
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+
+@Entity(
+    tableName = "favorite_emotes",
+    primaryKeys = ["provider", "emote_id"],
+)
+data class FavoriteEmote(
+    val provider: String,
+    @ColumnInfo(name = "emote_id")
+    val emoteId: String,
+    @ColumnInfo(name = "favorited_at")
+    val favoritedAt: Long,
+)

--- a/app/src/main/java/com/github/andreyasadchy/xtra/model/chat/FavoriteEmoteKey.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/model/chat/FavoriteEmoteKey.kt
@@ -1,0 +1,94 @@
+package com.github.andreyasadchy.xtra.model.chat
+
+enum class EmoteProvider {
+    TWITCH,
+    SEVENTV,
+    BTTV,
+    FFZ,
+}
+
+data class FavoriteEmoteKey(
+    val provider: EmoteProvider,
+    val emoteId: String,
+)
+
+fun Emote.favoriteKey(): FavoriteEmoteKey? {
+    val normalizedId = id?.trim()?.takeIf { it.isNotEmpty() } ?: return null
+    val provider = when (source) {
+        null -> EmoteProvider.TWITCH
+        Emote.PERSONAL_STV, Emote.CHANNEL_STV, Emote.GLOBAL_STV -> EmoteProvider.SEVENTV
+        Emote.CHANNEL_BTTV, Emote.GLOBAL_BTTV -> EmoteProvider.BTTV
+        Emote.CHANNEL_FFZ, Emote.GLOBAL_FFZ -> EmoteProvider.FFZ
+        else -> return null
+    }
+    return FavoriteEmoteKey(provider, normalizedId)
+}
+
+fun FavoriteEmote.key(): FavoriteEmoteKey? {
+    val normalizedId = emoteId.trim().takeIf { it.isNotEmpty() } ?: return null
+    val parsedProvider = runCatching { EmoteProvider.valueOf(provider) }.getOrNull() ?: return null
+    return FavoriteEmoteKey(parsedProvider, normalizedId)
+}
+
+/**
+ * Keeps the live emote instance, including its current name and URLs, as the
+ * source of truth for Favorites.
+ */
+object FavoriteEmoteCatalog {
+
+    fun deduplicate(emotes: List<Emote>): List<Emote> {
+        val result = mutableListOf<Emote>()
+        val indexesByKey = mutableMapOf<FavoriteEmoteKey, Int>()
+        emotes.forEach { emote ->
+            val key = emote.favoriteKey()
+            if (key == null) {
+                result += emote
+            } else {
+                val existingIndex = indexesByKey[key]
+                if (existingIndex == null) {
+                    indexesByKey[key] = result.size
+                    result += emote
+                } else if (scopePriority(emote) < scopePriority(result[existingIndex])) {
+                    result[existingIndex] = emote
+                }
+            }
+        }
+        return result
+    }
+
+    fun availableFavorites(
+        favorites: List<FavoriteEmote>,
+        emotes: List<Emote>,
+    ): List<Emote> {
+        val availableByKey = deduplicate(emotes).mapNotNull { emote ->
+            emote.favoriteKey()?.let { it to emote }
+        }.toMap()
+        return favorites.mapNotNull { favorite ->
+            favorite.key()?.let(availableByKey::get)
+        }
+    }
+
+    fun removeMatchingScope(
+        emotes: MutableList<Emote>,
+        removed: List<Emote>,
+        source: Int,
+    ) {
+        val removedKeys = removed.mapNotNull { it.favoriteKey() }.toSet()
+        val removedNames = removed.map { it.name }.toSet()
+        emotes.removeAll { emote ->
+            val key = emote.favoriteKey()
+            emote.source == source &&
+                    ((key != null && key in removedKeys) ||
+                            (key == null && emote.name in removedNames))
+        }
+    }
+
+    private fun scopePriority(emote: Emote): Int {
+        return when (emote.source) {
+            Emote.CHANNEL_STV, Emote.CHANNEL_BTTV, Emote.CHANNEL_FFZ -> 0
+            Emote.PERSONAL_STV -> 1
+            Emote.GLOBAL_STV, Emote.GLOBAL_BTTV, Emote.GLOBAL_FFZ -> 2
+            else -> 0
+        }
+    }
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/model/misc/FFZResponse.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/model/misc/FFZResponse.kt
@@ -9,6 +9,7 @@ class FFZResponse(
 ) {
     @Serializable
     class Emote(
+        val id: Int? = null,
         val name: String? = null,
         val animated: Urls? = null,
         val urls: Urls? = null,

--- a/app/src/main/java/com/github/andreyasadchy/xtra/model/misc/STVEmoteSetResponse.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/model/misc/STVEmoteSetResponse.kt
@@ -9,6 +9,7 @@ class STVEmoteSetResponse(
 ) {
     @Serializable
     class Emote(
+        val id: String? = null,
         val name: String? = null,
         val flags: Int? = null,
         val data: Data? = null,

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/PlayerRepository.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/PlayerRepository.kt
@@ -15,6 +15,7 @@ import com.apollographql.apollo.api.json.jsonReader
 import com.apollographql.apollo.api.json.writeObject
 import com.apollographql.apollo.api.parseResponse
 import com.github.andreyasadchy.xtra.BuildConfig
+import com.github.andreyasadchy.xtra.db.FavoriteEmotesDao
 import com.github.andreyasadchy.xtra.db.PlaybackStatesDao
 import com.github.andreyasadchy.xtra.db.RecentEmotesDao
 import com.github.andreyasadchy.xtra.db.TranslatedChannelsDao
@@ -27,6 +28,8 @@ import com.github.andreyasadchy.xtra.model.VideoPosition
 import com.github.andreyasadchy.xtra.model.VideoQuality
 import com.github.andreyasadchy.xtra.model.chat.CheerEmote
 import com.github.andreyasadchy.xtra.model.chat.Emote
+import com.github.andreyasadchy.xtra.model.chat.FavoriteEmote
+import com.github.andreyasadchy.xtra.model.chat.FavoriteEmoteKey
 import com.github.andreyasadchy.xtra.model.chat.RecentEmote
 import com.github.andreyasadchy.xtra.model.chat.TwitchBadge
 import com.github.andreyasadchy.xtra.model.chat.TwitchEmote
@@ -85,6 +88,7 @@ class PlayerRepository(
     private val okHttpClient: Lazy<OkHttpClient>,
     private val json: Json,
     private val recentEmotes: RecentEmotesDao,
+    private val favoriteEmotes: FavoriteEmotesDao,
     private val translatedChannelsDao: TranslatedChannelsDao,
     private val videoPositions: VideoPositionsDao,
     private val playbackStatesDao: PlaybackStatesDao,
@@ -1189,6 +1193,7 @@ class PlayerRepository(
                             }
                             Emote(
                                 name = name,
+                                id = emote.id,
                                 url1x = urls?.getOrNull(0) ?: "https:${template}/1x.webp",
                                 url2x = urls?.getOrNull(1) ?: if (urls.isNullOrEmpty()) "https:${template}/2x.webp" else null,
                                 url3x = urls?.getOrNull(2) ?: if (urls.isNullOrEmpty()) "https:${template}/3x.webp" else null,
@@ -1448,6 +1453,7 @@ class PlayerRepository(
                 emote.id?.takeIf { it.isNotBlank() }?.let { id ->
                     Emote(
                         name = name,
+                        id = id,
                         url1x = if (useWebp) "https://cdn.betterttv.net/emote/$id/1x.webp" else "https://cdn.betterttv.net/emote/$id/1x",
                         url2x = if (useWebp) "https://cdn.betterttv.net/emote/$id/2x.webp" else "https://cdn.betterttv.net/emote/$id/2x",
                         url3x = if (useWebp) "https://cdn.betterttv.net/emote/$id/2x.webp" else "https://cdn.betterttv.net/emote/$id/2x",
@@ -1599,6 +1605,7 @@ class PlayerRepository(
                 }?.let { urls ->
                     Emote(
                         name = name,
+                        id = emote.id?.toString(),
                         url1x = urls.url1x,
                         url2x = urls.url2x,
                         url3x = urls.url2x,
@@ -2081,6 +2088,22 @@ class PlayerRepository(
     }
 
     fun loadRecentEmotesFlow() = recentEmotes.getAllFlow()
+
+    fun loadFavoriteEmotesFlow() = favoriteEmotes.getAllFlow()
+
+    suspend fun addFavoriteEmote(key: FavoriteEmoteKey) = withContext(Dispatchers.IO) {
+        favoriteEmotes.insert(
+            FavoriteEmote(
+                provider = key.provider.name,
+                emoteId = key.emoteId,
+                favoritedAt = System.currentTimeMillis(),
+            ),
+        )
+    }
+
+    suspend fun removeFavoriteEmote(key: FavoriteEmoteKey) = withContext(Dispatchers.IO) {
+        favoriteEmotes.delete(key.provider.name, key.emoteId)
+    }
 
     suspend fun loadRecentEmotes(): List<RecentEmote> = withContext(Dispatchers.IO) {
         recentEmotes.getAll()

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatFragment.kt
@@ -106,7 +106,6 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
 
     private var isChatTouched = false
     private var showChatStatus = false
-    private var hasRecentEmotes = false
     private var messagingEnabled = false
     private var channelPointsIconUrl: String? = null
     private var channelPointsIconRequest: Disposable? = null
@@ -380,16 +379,6 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
                         }
                     }
                     if (enableMessaging) {
-                        viewModel.loadRecentEmotes()
-                        viewLifecycleOwner.lifecycleScope.launch {
-                            repeatOnLifecycle(Lifecycle.State.STARTED) {
-                                viewModel.hasRecentEmotes.collectLatest {
-                                    if (it) {
-                                        hasRecentEmotes = true
-                                    }
-                                }
-                            }
-                        }
                         viewLifecycleOwner.lifecycleScope.launch {
                             repeatOnLifecycle(Lifecycle.State.STARTED) {
                                 viewModel.channelPoints.collectLatest { points ->
@@ -470,27 +459,31 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
                         }
                         updateComposerDensity()
                         viewPager.adapter = object : FragmentStateAdapter(this@ChatFragment) {
-                            override fun getItemCount(): Int = 3
+                            override fun getItemCount(): Int = EmotePickerSection.entries.size
 
                             override fun createFragment(position: Int): Fragment {
-                                return EmotesFragment.newInstance(position)
+                                return EmotesFragment.newInstance(EmotePickerSection.fromPosition(position))
                             }
                         }
                         viewPager.offscreenPageLimit = 2
                         viewPager.reduceDragSensitivity()
                         TabLayoutMediator(tabLayout, viewPager) { tab, position ->
-                            tab.text = when (position) {
-                                0 -> getString(R.string.recent_emotes)
-                                1 -> "Twitch"
-                                else -> "7TV/BTTV/FFZ"
+                            tab.text = when (EmotePickerSection.fromPosition(position)) {
+                                EmotePickerSection.FAVORITES -> getString(R.string.favorite_emotes)
+                                EmotePickerSection.RECENTS -> getString(R.string.recent_emotes)
+                                EmotePickerSection.TWITCH -> "Twitch"
+                                EmotePickerSection.THIRD_PARTY -> "7TV/BTTV/FFZ"
                             }
                         }.attach()
                         emotes.setOnClickListener {
                             //TODO add animation
                             if (emoteMenu.isGone) {
-                                if (!hasRecentEmotes && viewPager.currentItem == 0) {
-                                    viewPager.setCurrentItem(1, false)
+                                val defaultSection = when {
+                                    viewModel.hasAvailableFavoriteEmotes.value -> EmotePickerSection.FAVORITES
+                                    viewModel.hasRecentEmotes.value -> EmotePickerSection.RECENTS
+                                    else -> EmotePickerSection.TWITCH
                                 }
+                                viewPager.setCurrentItem(defaultSection.position, false)
                                 toggleEmoteMenu(true)
                             } else {
                                 toggleEmoteMenu(false)

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatViewModel.kt
@@ -21,6 +21,11 @@ import com.github.andreyasadchy.xtra.model.chat.ChatMessage
 import com.github.andreyasadchy.xtra.model.chat.Chatter
 import com.github.andreyasadchy.xtra.model.chat.CheerEmote
 import com.github.andreyasadchy.xtra.model.chat.Emote
+import com.github.andreyasadchy.xtra.model.chat.FavoriteEmote
+import com.github.andreyasadchy.xtra.model.chat.FavoriteEmoteCatalog
+import com.github.andreyasadchy.xtra.model.chat.FavoriteEmoteKey
+import com.github.andreyasadchy.xtra.model.chat.key
+import com.github.andreyasadchy.xtra.model.chat.favoriteKey
 import com.github.andreyasadchy.xtra.model.chat.NamePaint
 import com.github.andreyasadchy.xtra.model.chat.Poll
 import com.github.andreyasadchy.xtra.model.chat.PollVoteState
@@ -83,8 +88,13 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
@@ -173,8 +183,6 @@ class ChatViewModel(
     private var chatReplayManager: ChatReplayManager? = null
     private var chatReplayManagerLocal: ChatReplayManagerLocal? = null
 
-    val recentEmotes by lazy { playerRepository.loadRecentEmotesFlow() }
-    val hasRecentEmotes = MutableStateFlow(false)
     val userEmotes = mutableListOf<Emote>()
     private val channelEmotes = mutableListOf<Emote>()
     private val channelPointModifiedEmotes = mutableListOf<Emote>()
@@ -222,6 +230,42 @@ class ChatViewModel(
     val stvUsers = mutableListOf<STVUser>()
     var channelSTVEmoteSetId: String? = null
     var userSTVEmoteSetId: String? = null
+
+    private val pickerCatalogRevision = MutableStateFlow(0L)
+    val recentEmotes: StateFlow<List<RecentEmote>> = playerRepository.loadRecentEmotesFlow().stateIn(
+        viewModelScope,
+        SharingStarted.Eagerly,
+        emptyList(),
+    )
+    val hasRecentEmotes: StateFlow<Boolean> = recentEmotes.map { it.isNotEmpty() }.stateIn(
+        viewModelScope,
+        SharingStarted.Eagerly,
+        false,
+    )
+    val favoriteEmotes: StateFlow<List<FavoriteEmote>> = playerRepository.loadFavoriteEmotesFlow().stateIn(
+        viewModelScope,
+        SharingStarted.Eagerly,
+        emptyList(),
+    )
+    val favoriteKeys: StateFlow<Set<FavoriteEmoteKey>> = favoriteEmotes.map { favorites ->
+        favorites.mapNotNull { it.key() }.toSet()
+    }.stateIn(
+        viewModelScope,
+        SharingStarted.Eagerly,
+        emptySet(),
+    )
+    val availableFavoriteEmotes: StateFlow<List<Emote>> = combine(favoriteEmotes, pickerCatalogRevision) { favorites, _ ->
+        FavoriteEmoteCatalog.availableFavorites(favorites, currentPickerEmotes())
+    }.stateIn(
+        viewModelScope,
+        SharingStarted.Eagerly,
+        emptyList(),
+    )
+    val hasAvailableFavoriteEmotes: StateFlow<Boolean> = availableFavoriteEmotes.map { it.isNotEmpty() }.stateIn(
+        viewModelScope,
+        SharingStarted.Eagerly,
+        false,
+    )
     val translateAllMessages = MutableStateFlow<Boolean?>(null)
     val channelPoints = MutableStateFlow<ChannelPoints?>(null)
     val watchStreak = MutableStateFlow<WatchStreak?>(null)
@@ -245,6 +289,20 @@ class ChatViewModel(
     val chatMessages = mutableListOf<ChatMessage>()
     val autoCompleteList = mutableListOf<Any?>()
     private val chatters = ConcurrentHashMap<String, Chatter>()
+
+    private fun markPickerCatalogChanged() {
+        pickerCatalogRevision.update { it + 1 }
+    }
+
+    private suspend fun emitUserEmotesUpdated() {
+        markPickerCatalogChanged()
+        userEmotesUpdated.emit(Unit)
+    }
+
+    private suspend fun emitThirdPartyEmotesUpdated() {
+        markPickerCatalogChanged()
+        thirdPartyEmotesUpdated.emit(Unit)
+    }
 
     fun startLive(networkLibrary: String?, recentMessagesUrl: String?, channelId: String?, channelLogin: String?, channelName: String?, streamId: String?) {
         if (chatReadIRCSocket == null && chatReadWebSocket == null && eventSub == null && channelLogin != null) {
@@ -322,9 +380,11 @@ class ChatViewModel(
         val animateGifs = applicationContext.prefs().getBoolean(C.ANIMATED_EMOTES, true)
         val useWebp = true
         val enableIntegrity = applicationContext.prefs().getBoolean(C.ENABLE_INTEGRITY, false)
+        // Twitch user emotes are refreshed separately; keep them during third-party reloads.
         synchronized(thirdPartyEmotes) {
             thirdPartyEmotes.clear()
         }
+        markPickerCatalogChanged()
         val saved = savedGlobalBadges
         if (!saved.isNullOrEmpty()) {
             synchronized(globalBadges) {
@@ -371,7 +431,7 @@ class ChatViewModel(
                     reloadMessages.value = true
                 }
                 viewModelScope.launch {
-                    thirdPartyEmotesUpdated.emit(Unit)
+                    emitThirdPartyEmotesUpdated()
                 }
                 synchronized(autoCompleteList) {
                     autoCompleteList.addAll(saved.filter { it !in autoCompleteList })
@@ -400,7 +460,7 @@ class ChatViewModel(
                                 if (!reloadMessages.value) {
                                     reloadMessages.value = true
                                 }
-                                thirdPartyEmotesUpdated.emit(Unit)
+                                emitThirdPartyEmotesUpdated()
                                 synchronized(autoCompleteList) {
                                     autoCompleteList.addAll(emotes.filter { it !in autoCompleteList })
                                 }
@@ -500,7 +560,7 @@ class ChatViewModel(
                                 if (!reloadMessages.value) {
                                     reloadMessages.value = true
                                 }
-                                thirdPartyEmotesUpdated.emit(Unit)
+                                emitThirdPartyEmotesUpdated()
                                 synchronized(autoCompleteList) {
                                     autoCompleteList.addAll(emotes.filter { it !in autoCompleteList })
                                 }
@@ -548,7 +608,7 @@ class ChatViewModel(
                     reloadMessages.value = true
                 }
                 viewModelScope.launch {
-                    thirdPartyEmotesUpdated.emit(Unit)
+                    emitThirdPartyEmotesUpdated()
                 }
                 synchronized(autoCompleteList) {
                     autoCompleteList.addAll(saved.filter { it !in autoCompleteList })
@@ -577,7 +637,7 @@ class ChatViewModel(
                                 if (!reloadMessages.value) {
                                     reloadMessages.value = true
                                 }
-                                thirdPartyEmotesUpdated.emit(Unit)
+                                emitThirdPartyEmotesUpdated()
                                 synchronized(autoCompleteList) {
                                     autoCompleteList.addAll(emotes.filter { it !in autoCompleteList })
                                 }
@@ -625,7 +685,7 @@ class ChatViewModel(
                                 if (!reloadMessages.value) {
                                     reloadMessages.value = true
                                 }
-                                thirdPartyEmotesUpdated.emit(Unit)
+                                emitThirdPartyEmotesUpdated()
                                 synchronized(autoCompleteList) {
                                     autoCompleteList.addAll(emotes.filter { it !in autoCompleteList })
                                 }
@@ -673,7 +733,7 @@ class ChatViewModel(
                     reloadMessages.value = true
                 }
                 viewModelScope.launch {
-                    thirdPartyEmotesUpdated.emit(Unit)
+                    emitThirdPartyEmotesUpdated()
                 }
                 synchronized(autoCompleteList) {
                     autoCompleteList.addAll(saved.filter { it !in autoCompleteList })
@@ -702,7 +762,7 @@ class ChatViewModel(
                                 if (!reloadMessages.value) {
                                     reloadMessages.value = true
                                 }
-                                thirdPartyEmotesUpdated.emit(Unit)
+                                emitThirdPartyEmotesUpdated()
                                 synchronized(autoCompleteList) {
                                     autoCompleteList.addAll(emotes.filter { it !in autoCompleteList })
                                 }
@@ -748,7 +808,7 @@ class ChatViewModel(
                                 if (!reloadMessages.value) {
                                     reloadMessages.value = true
                                 }
-                                thirdPartyEmotesUpdated.emit(Unit)
+                                emitThirdPartyEmotesUpdated()
                                 synchronized(autoCompleteList) {
                                     autoCompleteList.addAll(emotes.filter { it !in autoCompleteList })
                                 }
@@ -842,7 +902,7 @@ class ChatViewModel(
                 )
             }
             viewModelScope.launch {
-                userEmotesUpdated.emit(Unit)
+                emitUserEmotesUpdated()
             }
             synchronized(allEmotes) {
                 allEmotes.addAll(saved.filter { it.name !in allEmotes }.mapNotNull { it.name })
@@ -871,7 +931,7 @@ class ChatViewModel(
                                     sorted.sortedByDescending { it.ownerId == currentChannelId }.map { it.toPickerEmote() },
                                 )
                             }
-                            userEmotesUpdated.emit(Unit)
+                            emitUserEmotesUpdated()
                             synchronized(allEmotes) {
                                 allEmotes.addAll(sorted.filter { it.name !in allEmotes }.mapNotNull { it.name })
                             }
@@ -884,12 +944,6 @@ class ChatViewModel(
                     }
                 }
             }
-        }
-    }
-
-    fun loadRecentEmotes() {
-        viewModelScope.launch {
-            hasRecentEmotes.value = playerRepository.loadRecentEmotes().isNotEmpty()
         }
     }
 
@@ -1629,16 +1683,53 @@ class ChatViewModel(
         }
     }
 
-    fun emotePickerItems(): List<Emote> {
+    fun thirdPartyPickerEmotes(): List<Emote> {
         val personalEmotes = userSTVEmoteSetId?.let { setId ->
             synchronized(personalEmoteSets) { personalEmoteSets[setId].orEmpty() }
         }.orEmpty()
-        return (synchronized(userEmotes) { userEmotes.toList() } +
-                personalEmotes +
+        return FavoriteEmoteCatalog.deduplicate(personalEmotes +
                 synchronized(thirdPartyEmotes) { thirdPartyEmotes.toList() })
-            .filter { !it.name.isNullOrBlank() }
-            .distinctBy { it.name }
+            .filter { !it.name.isNullOrBlank() && isPickerProviderEnabled(it) }
+    }
+
+    fun currentPickerEmotes(): List<Emote> {
+        return FavoriteEmoteCatalog.deduplicate(synchronized(userEmotes) { userEmotes.toList() } +
+                thirdPartyPickerEmotes())
+            .filter { !it.name.isNullOrBlank() && isPickerProviderEnabled(it) }
+    }
+
+    private fun isPickerProviderEnabled(emote: Emote): Boolean {
+        return when (emote.source) {
+            Emote.PERSONAL_STV, Emote.CHANNEL_STV, Emote.GLOBAL_STV ->
+                applicationContext.prefs().getBoolean(C.CHAT_ENABLE_STV, true)
+            Emote.CHANNEL_BTTV, Emote.GLOBAL_BTTV ->
+                applicationContext.prefs().getBoolean(C.CHAT_ENABLE_BTTV, true)
+            Emote.CHANNEL_FFZ, Emote.GLOBAL_FFZ ->
+                applicationContext.prefs().getBoolean(C.CHAT_ENABLE_FFZ, true)
+            else -> true
+        }
+    }
+
+    fun emotePickerItems(): List<Emote> {
+        return currentPickerEmotes()
             .sortedBy { it.name.orEmpty().lowercase() }
+    }
+
+    fun isFavorite(emote: Emote): Boolean {
+        return emote.favoriteKey()?.let { it in favoriteKeys.value } == true
+    }
+
+    fun toggleFavorite(emote: Emote): Boolean? {
+        val key = emote.favoriteKey() ?: return null
+        val adding = key !in favoriteKeys.value
+        viewModelScope.launch {
+            if (adding) {
+                playerRepository.addFavoriteEmote(key)
+            } else {
+                playerRepository.removeFavoriteEmote(key)
+            }
+        }
+        return adding
     }
 
     fun startLiveChat(channelId: String?, channelLogin: String) {
@@ -2732,35 +2823,42 @@ class ChatViewModel(
             if (result != null) {
                 if (result.channelSet) {
                     if (stvLiveUpdates) {
-                        val removedEmotes = (result.removed + result.updated.map { it.first }).map { it.name }
+                        val removedItems = result.removed + result.updated.map { it.first }
+                        val removedEmoteNames = removedItems.map { it.name }.toSet()
                         val newEmotes = result.added + result.updated.map { it.second }
                         synchronized(thirdPartyEmotes) {
-                            thirdPartyEmotes.removeAll { it.name in removedEmotes }
+                            FavoriteEmoteCatalog.removeMatchingScope(thirdPartyEmotes, removedItems, Emote.CHANNEL_STV)
                             thirdPartyEmotes.addAll(newEmotes)
                         }
                         if (!reloadMessages.value) {
                             reloadMessages.value = true
                         }
                         viewModelScope.launch {
-                            thirdPartyEmotesUpdated.emit(Unit)
+                            emitThirdPartyEmotesUpdated()
                         }
                         synchronized(allEmotes) {
-                            allEmotes.removeAll { it in removedEmotes }
+                            allEmotes.removeAll { it in removedEmoteNames }
                             allEmotes.addAll(newEmotes.filter { it.name !in allEmotes }.mapNotNull { it.name })
                         }
                     }
                 } else {
                     if (showPersonalEmotes) {
-                        val removedEmotes = (result.removed + result.updated.map { it.first }).map { it.name }
+                        val removedItems = result.removed + result.updated.map { it.first }
+                        val removedEmoteKeys = removedItems.mapNotNull { it.favoriteKey() }.toSet()
+                        val removedEmoteNames = removedItems.map { it.name }.toSet()
                         synchronized(personalEmoteSets) {
-                            val existingSet = personalEmoteSets[result.setId]?.filter { it.name !in removedEmotes } ?: emptyList()
+                            val existingSet = personalEmoteSets[result.setId]?.filter { emote ->
+                                val key = emote.favoriteKey()
+                                !((key != null && key in removedEmoteKeys) ||
+                                        (key == null && emote.name in removedEmoteNames))
+                            } ?: emptyList()
                             personalEmoteSets.remove(result.setId)
                             val set = existingSet + result.added + result.updated.map { it.second }
                             personalEmoteSets[result.setId] = set
                         }
                         if (isLoggedIn && !accountId.isNullOrBlank() && result.setId == userSTVEmoteSetId) {
                             viewModelScope.launch {
-                                thirdPartyEmotesUpdated.emit(Unit)
+                                emitThirdPartyEmotesUpdated()
                             }
                         }
                     }
@@ -2866,7 +2964,7 @@ class ChatViewModel(
                             if (isLoggedIn && !accountId.isNullOrBlank() && result.userId == accountId) {
                                 userSTVEmoteSetId = result.setId
                                 viewModelScope.launch {
-                                    thirdPartyEmotesUpdated.emit(Unit)
+                                    emitThirdPartyEmotesUpdated()
                                 }
                             }
                         }
@@ -2993,7 +3091,7 @@ class ChatViewModel(
                                 sorted.sortedByDescending { it.ownerId == currentChannelId }.map { it.toPickerEmote() },
                             )
                         }
-                        userEmotesUpdated.emit(Unit)
+                        emitUserEmotesUpdated()
                         synchronized(allEmotes) {
                             allEmotes.addAll(sorted.filter { it.name !in allEmotes }.mapNotNull { it.name })
                         }
@@ -4432,6 +4530,7 @@ class ChatViewModel(
                     thirdPartyEmotes.clear()
                     thirdPartyEmotes.addAll(emotes)
                 }
+                markPickerCatalogChanged()
                 if (emotes.isEmpty()) {
                     viewModelScope.launch {
                         loadEmotes(channelId, channelLogin)

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/EmotesAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/EmotesAdapter.kt
@@ -1,8 +1,11 @@
 package com.github.andreyasadchy.xtra.ui.chat
 
+import android.view.HapticFeedbackConstants
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.core.view.ViewCompat
+import androidx.core.view.accessibility.AccessibilityViewCommand
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
@@ -20,23 +23,48 @@ import com.github.andreyasadchy.xtra.BuildConfig
 import com.github.andreyasadchy.xtra.R
 import com.github.andreyasadchy.xtra.databinding.FragmentEmotesListItemBinding
 import com.github.andreyasadchy.xtra.model.chat.Emote
+import com.github.andreyasadchy.xtra.model.chat.FavoriteEmoteKey
+import com.github.andreyasadchy.xtra.model.chat.favoriteKey
 
 class EmotesAdapter(
     private val fragment: Fragment,
     private val clickListener: (Emote) -> Unit,
     private val emoteQuality: String,
     private val imageLibrary: String?,
+    private val favoriteToggleListener: ((Emote) -> Unit)? = null,
 ) : ListAdapter<Emote, EmotesAdapter.ViewHolder>(
     object : DiffUtil.ItemCallback<Emote>() {
         override fun areItemsTheSame(oldItem: Emote, newItem: Emote): Boolean {
-            return oldItem.name == newItem.name
+            val oldKey = oldItem.favoriteKey()
+            val newKey = newItem.favoriteKey()
+            return if (oldKey != null || newKey != null) {
+                oldKey == newKey
+            } else {
+                oldItem.name == newItem.name
+            }
         }
 
         override fun areContentsTheSame(oldItem: Emote, newItem: Emote): Boolean {
-            return true
+            return oldItem.name == newItem.name &&
+                    oldItem.url1x == newItem.url1x &&
+                    oldItem.url2x == newItem.url2x &&
+                    oldItem.url3x == newItem.url3x &&
+                    oldItem.url4x == newItem.url4x &&
+                    oldItem.format == newItem.format
         }
     }
 ) {
+
+    private var favoriteKeys: Set<FavoriteEmoteKey> = emptySet()
+
+    fun setFavoriteKeys(keys: Set<FavoriteEmoteKey>) {
+        if (favoriteKeys != keys) {
+            favoriteKeys = keys
+            if (itemCount > 0) {
+                notifyItemRangeChanged(0, itemCount)
+            }
+        }
+    }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
         val binding = FragmentEmotesListItemBinding.inflate(LayoutInflater.from(parent.context), parent, false)
@@ -50,8 +78,16 @@ class EmotesAdapter(
     inner class ViewHolder(
         private val binding: FragmentEmotesListItemBinding,
     ) : RecyclerView.ViewHolder(binding.root) {
+        private var favoriteAccessibilityActionId: Int? = null
+
         fun bind(item: Emote?) {
             with(binding) {
+                favoriteAccessibilityActionId?.let {
+                    ViewCompat.removeAccessibilityAction(root, it)
+                    favoriteAccessibilityActionId = null
+                }
+                root.setOnClickListener(null)
+                root.setOnLongClickListener(null)
                 if (item != null) {
                     root.contentDescription = fragment.getString(R.string.use_emote, item.name)
                     root.isFocusable = true
@@ -94,6 +130,25 @@ class EmotesAdapter(
                             .into(root)
                     }
                     root.setOnClickListener { clickListener(item) }
+                    val key = item.favoriteKey()
+                    if (favoriteToggleListener != null && key != null) {
+                        val isFavorite = key in favoriteKeys
+                        root.setOnLongClickListener {
+                            it.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS)
+                            favoriteToggleListener.invoke(item)
+                            true
+                        }
+                        favoriteAccessibilityActionId = ViewCompat.addAccessibilityAction(
+                            root,
+                            fragment.getString(
+                                if (isFavorite) R.string.remove_emote_from_favorites else R.string.add_emote_to_favorites,
+                            ),
+                            AccessibilityViewCommand { _, _ ->
+                                favoriteToggleListener.invoke(item)
+                                true
+                            },
+                        )
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/EmotesFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/EmotesFragment.kt
@@ -6,19 +6,39 @@ import android.util.TypedValue
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
+import com.github.andreyasadchy.xtra.R
 import com.github.andreyasadchy.xtra.databinding.FragmentEmotesBinding
+import com.github.andreyasadchy.xtra.model.chat.Emote
 import com.github.andreyasadchy.xtra.model.chat.RecentEmote
 import com.github.andreyasadchy.xtra.ui.chat.ChatViewModel.Companion.ChatViewModelFactory
 import com.github.andreyasadchy.xtra.ui.view.GridAutofitLayoutManager
-import com.github.andreyasadchy.xtra.util.C
-import com.github.andreyasadchy.xtra.util.prefs
+import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
+
+enum class EmotePickerSection {
+    FAVORITES,
+    RECENTS,
+    TWITCH,
+    THIRD_PARTY,
+    ;
+
+    val position: Int
+        get() = ordinal
+
+    val supportsFavoriteToggle: Boolean
+        get() = this != RECENTS
+
+    companion object {
+        fun fromPosition(position: Int): EmotePickerSection = entries.getOrElse(position) { THIRD_PARTY }
+    }
+}
 
 class EmotesFragment : Fragment() {
 
@@ -34,106 +54,103 @@ class EmotesFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        with(binding) {
-            val position = requireArguments().getInt(KEY_POSITION)
-            val adapter = EmotesAdapter(
-                this@EmotesFragment,
-                { (parentFragment as? ChatFragment)?.appendEmote(it) },
-                "4",
-                "0"
-            )
-            root.itemAnimator = null
-            root.adapter = adapter
+        val section = requireArguments().getString(KEY_SECTION)
+            ?.let { runCatching { EmotePickerSection.valueOf(it) }.getOrNull() }
+            ?: EmotePickerSection.THIRD_PARTY
+        val adapter = EmotesAdapter(
+            this,
+            { (parentFragment as? ChatFragment)?.appendEmote(it) },
+            "4",
+            "0",
+            if (section.supportsFavoriteToggle) ::toggleFavorite else null,
+        )
+        with(binding.emotesRecyclerView) {
+            itemAnimator = null
+            this.adapter = adapter
             val columnWidth = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 50f, resources.displayMetrics).toInt()
-            root.layoutManager = GridAutofitLayoutManager(requireContext(), columnWidth)
-            when (position) {
-                0 -> {
-                    viewLifecycleOwner.lifecycleScope.launch {
-                        repeatOnLifecycle(Lifecycle.State.STARTED) {
-                            viewModel.recentEmotes.collectLatest {
-                                if (it.isNotEmpty()) {
-                                    recentEmotes = it
-                                    updateList(position, adapter)
-                                }
-                            }
-                        }
+            layoutManager = GridAutofitLayoutManager(requireContext(), columnWidth)
+        }
+        viewLifecycleOwner.lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                launch {
+                    viewModel.recentEmotes.collectLatest {
+                        recentEmotes = it
+                        updateList(section, adapter)
                     }
-                    viewLifecycleOwner.lifecycleScope.launch {
-                        repeatOnLifecycle(Lifecycle.State.STARTED) {
-                            viewModel.userEmotesUpdated.collectLatest {
-                                updateList(position, adapter)
-                            }
-                        }
+                }
+                launch {
+                    viewModel.userEmotesUpdated.collectLatest {
+                        updateList(section, adapter)
                     }
-                    viewLifecycleOwner.lifecycleScope.launch {
-                        repeatOnLifecycle(Lifecycle.State.STARTED) {
-                            viewModel.thirdPartyEmotesUpdated.collectLatest {
-                                updateList(position, adapter)
-                            }
+                }
+                launch {
+                    viewModel.thirdPartyEmotesUpdated.collectLatest {
+                        updateList(section, adapter)
+                    }
+                }
+                launch {
+                    viewModel.availableFavoriteEmotes.collectLatest {
+                        if (section == EmotePickerSection.FAVORITES) {
+                            updateList(section, adapter)
                         }
                     }
                 }
-                1 -> {
-                    viewLifecycleOwner.lifecycleScope.launch {
-                        repeatOnLifecycle(Lifecycle.State.STARTED) {
-                            viewModel.userEmotesUpdated.collectLatest {
-                                updateList(position, adapter)
-                            }
+                launch {
+                    viewModel.favoriteKeys.collectLatest {
+                        adapter.setFavoriteKeys(it)
+                        if (section == EmotePickerSection.FAVORITES) {
+                            updateList(section, adapter)
                         }
                     }
-                    updateList(position, adapter)
-                }
-                else -> {
-                    viewLifecycleOwner.lifecycleScope.launch {
-                        repeatOnLifecycle(Lifecycle.State.STARTED) {
-                            viewModel.thirdPartyEmotesUpdated.collectLatest {
-                                updateList(position, adapter)
-                            }
-                        }
-                    }
-                    updateList(position, adapter)
                 }
             }
+        }
+        adapter.setFavoriteKeys(viewModel.favoriteKeys.value)
+        updateList(section, adapter)
+    }
+
+    private fun updateList(section: EmotePickerSection, adapter: EmotesAdapter) {
+        val list = when (section) {
+            EmotePickerSection.FAVORITES -> viewModel.availableFavoriteEmotes.value
+            EmotePickerSection.RECENTS -> {
+                val current = viewModel.currentPickerEmotes()
+                recentEmotes.mapNotNull { recent -> current.find { it.name == recent.name } }
+            }
+            EmotePickerSection.TWITCH -> synchronized(viewModel.userEmotes) {
+                viewModel.userEmotes.toList()
+            }
+            EmotePickerSection.THIRD_PARTY -> viewModel.thirdPartyPickerEmotes()
+        }
+        adapter.submitList(list)
+        if (section == EmotePickerSection.FAVORITES && list.isEmpty()) {
+            binding.emptyState.setText(
+                if (viewModel.favoriteEmotes.value.isEmpty()) {
+                    R.string.favorite_emotes_empty
+                } else {
+                    R.string.favorite_emotes_unavailable
+                },
+            )
+            binding.emptyState.isVisible = true
+        } else {
+            binding.emptyState.isVisible = false
         }
     }
 
-    private fun updateList(position: Int, adapter: EmotesAdapter) {
-        when (position) {
-            0 -> {
-                if (recentEmotes.isNotEmpty()) {
-                    val personalEmotes = viewModel.userSTVEmoteSetId?.let { setId ->
-                        synchronized(viewModel.personalEmoteSets) {
-                            viewModel.personalEmoteSets[setId]
-                        }
-                    } ?: emptyList()
-                    val list = synchronized(viewModel.userEmotes) { viewModel.userEmotes } +
-                            personalEmotes +
-                            synchronized(viewModel.thirdPartyEmotes) { viewModel.thirdPartyEmotes }
-                    adapter.submitList(recentEmotes.mapNotNull { emote -> list.find { it.name == emote.name } })
-                }
-            }
-            1 -> {
-                synchronized(viewModel.userEmotes) {
-                    adapter.submitList(viewModel.userEmotes)
-                }
-            }
-            else -> {
-                val personalEmotes = viewModel.userSTVEmoteSetId?.let { setId ->
-                    synchronized(viewModel.personalEmoteSets) {
-                        viewModel.personalEmoteSets[setId]
-                    }
-                } ?: emptyList()
-                val list = personalEmotes + synchronized(viewModel.thirdPartyEmotes) {
-                    viewModel.thirdPartyEmotes
-                }
-                adapter.submitList(list)
-            }
-        }
+    private fun toggleFavorite(emote: Emote) {
+        val added = viewModel.toggleFavorite(emote) ?: return
+        Snackbar.make(
+            binding.root,
+            getString(
+                if (added) R.string.added_emote_to_favorites else R.string.removed_emote_from_favorites,
+                emote.name.orEmpty(),
+            ),
+            Snackbar.LENGTH_SHORT,
+        ).show()
     }
 
     override fun onConfigurationChanged(newConfig: Configuration) {
         super.onConfigurationChanged(newConfig)
-        (binding.root.layoutManager as? GridAutofitLayoutManager)?.updateWidth()
+        (binding.emotesRecyclerView.layoutManager as? GridAutofitLayoutManager)?.updateWidth()
     }
 
     override fun onDestroyView() {
@@ -142,12 +159,12 @@ class EmotesFragment : Fragment() {
     }
 
     companion object {
-        private const val KEY_POSITION = "position"
+        private const val KEY_SECTION = "section"
 
-        fun newInstance(position: Int): EmotesFragment {
+        fun newInstance(section: EmotePickerSection): EmotesFragment {
             return EmotesFragment().apply {
                 arguments = Bundle().apply {
-                    putInt(KEY_POSITION, position)
+                    putString(KEY_SECTION, section.name)
                 }
             }
         }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/chat/STVEventApiUtils.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/chat/STVEventApiUtils.kt
@@ -64,9 +64,11 @@ object STVEventApiUtils {
     }
 
     private fun parseEmote(value: JSONObject?, useWebp: Boolean, channelSet: Boolean): Emote? {
+        val emoteId = value?.optString("id")?.takeIf { it.isNotBlank() }
         val objectData = value?.optJSONObject("data")
         return if (objectData != null) {
-            val name = if (!objectData.isNull("name")) objectData.optString("name").takeIf { it.isNotBlank() } else null
+            val name = value.optString("name").takeIf { it.isNotBlank() }
+                ?: objectData.optString("name").takeIf { it.isNotBlank() }
             val host = objectData.optJSONObject("host")
             if (name != null && host != null) {
                 val template = if (!host.isNull("url")) host.optString("url").takeIf { it.isNotBlank() } else null
@@ -91,6 +93,7 @@ object STVEventApiUtils {
                     }
                     Emote(
                         name = name,
+                        id = emoteId,
                         url1x = urls.getOrNull(0) ?: "https:${template}/1x.webp",
                         url2x = urls.getOrNull(1) ?: if (urls.isEmpty()) "https:${template}/2x.webp" else null,
                         url3x = urls.getOrNull(2) ?: if (urls.isEmpty()) "https:${template}/3x.webp" else null,

--- a/app/src/main/res/layout/fragment_emotes.xml
+++ b/app/src/main/res/layout/fragment_emotes.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.recyclerview.widget.RecyclerView xmlns:android="http://schemas.android.com/apk/res/android"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent" />
+    android:layout_height="match_parent">
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/emotesRecyclerView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
+    <TextView
+        android:id="@+id/emptyState"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:gravity="center"
+        android:padding="24dp"
+        android:textAlignment="center"
+        android:visibility="gone" />
+</FrameLayout>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -93,6 +93,13 @@
     <string name="view_profile">عَرض الصفحة الشخصية</string>
     <string name="chat">الدردشة</string>
     <string name="recent_emotes">الأخيرة</string>
+    <string name="favorite_emotes">★ المفضلة</string>
+    <string name="add_emote_to_favorites">إضافة إلى المفضلة</string>
+    <string name="remove_emote_from_favorites">إزالة من المفضلة</string>
+    <string name="added_emote_to_favorites">تمت إضافة %1$s إلى المفضلة</string>
+    <string name="removed_emote_from_favorites">تمت إزالة %1$s من المفضلة</string>
+    <string name="favorite_emotes_empty">لا توجد رموز مفضلة هنا بعد\nاضغط مطولًا على رمز لإضافته إلى المفضلة.</string>
+    <string name="favorite_emotes_unavailable">لا تتوفر أي من رموزك المفضلة في هذه القناة.</string>
     <string name="notification_playback_channel_title">تشغيل</string>
     <string name="channels">القنوات</string>
     <string name="watch_video">مشاهدة الفيديو بأكمله</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -93,6 +93,13 @@
     <string name="view_profile">Profil ansehen</string>
     <string name="chat">Chat</string>
     <string name="recent_emotes">Letzte</string>
+    <string name="favorite_emotes">★ Favoriten</string>
+    <string name="add_emote_to_favorites">Zu Favoriten hinzufügen</string>
+    <string name="remove_emote_from_favorites">Aus Favoriten entfernen</string>
+    <string name="added_emote_to_favorites">%1$s zu Favoriten hinzugefügt</string>
+    <string name="removed_emote_from_favorites">%1$s aus Favoriten entfernt</string>
+    <string name="favorite_emotes_empty">Noch keine Favoriten\nHalte ein Emote gedrückt, um es zu den Favoriten hinzuzufügen.</string>
+    <string name="favorite_emotes_unavailable">Keines deiner Favoriten ist in diesem Kanal verfügbar.</string>
     <string name="notification_playback_channel_title">Wiedergabe</string>
     <string name="channels">Kanäle</string>
     <string name="watch_video">Vollständiges Video abspielen</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -98,6 +98,13 @@
     <string name="view_profile">Ver perfil</string>
     <string name="chat">Chat</string>
     <string name="recent_emotes">Recientes</string>
+    <string name="favorite_emotes">★ Favoritos</string>
+    <string name="add_emote_to_favorites">Añadir a favoritos</string>
+    <string name="remove_emote_from_favorites">Quitar de favoritos</string>
+    <string name="added_emote_to_favorites">Se añadió %1$s a favoritos</string>
+    <string name="removed_emote_from_favorites">Se quitó %1$s de favoritos</string>
+    <string name="favorite_emotes_empty">Aún no hay emotes favoritos\nMantén pulsado un emote para añadirlo a Favoritos.</string>
+    <string name="favorite_emotes_unavailable">Ninguno de tus emotes favoritos está disponible en este canal.</string>
     <string name="notification_playback_channel_title">Reproducción</string>
     <string name="channels">Canales</string>
     <string name="watch_video">Ver video completo</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -93,6 +93,13 @@
     <string name="view_profile">Voir le profil</string>
     <string name="chat">Chat</string>
     <string name="recent_emotes">Récent</string>
+    <string name="favorite_emotes">★ Favoris</string>
+    <string name="add_emote_to_favorites">Ajouter aux favoris</string>
+    <string name="remove_emote_from_favorites">Retirer des favoris</string>
+    <string name="added_emote_to_favorites">%1$s ajouté aux favoris</string>
+    <string name="removed_emote_from_favorites">%1$s retiré des favoris</string>
+    <string name="favorite_emotes_empty">Aucun emote favori pour le moment\nAppuyez longuement sur un emote pour l’ajouter aux favoris.</string>
+    <string name="favorite_emotes_unavailable">Aucun de vos emotes favoris n’est disponible dans cette chaîne.</string>
     <string name="notification_playback_channel_title">Lecture</string>
     <string name="channels">Chaînes</string>
     <string name="watch_video">Regarder la vidéo complète</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -93,6 +93,13 @@
     <string name="view_profile">Ver perfil</string>
     <string name="chat">Chat</string>
     <string name="recent_emotes">Recentes</string>
+    <string name="favorite_emotes">★ Favoritos</string>
+    <string name="add_emote_to_favorites">Engadir aos favoritos</string>
+    <string name="remove_emote_from_favorites">Eliminar dos favoritos</string>
+    <string name="added_emote_to_favorites">Engadiuse %1$s aos favoritos</string>
+    <string name="removed_emote_from_favorites">Eliminouse %1$s dos favoritos</string>
+    <string name="favorite_emotes_empty">Aínda non hai emotes favoritos\nMantén premido un emote para engadilo aos Favoritos.</string>
+    <string name="favorite_emotes_unavailable">Ningún dos teus emotes favoritos está dispoñible nesta canle.</string>
     <string name="notification_playback_channel_title">Reprodución</string>
     <string name="channels">Canles</string>
     <string name="watch_video">Ver vídeo completo</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -93,6 +93,13 @@
     <string name="view_profile">Lihat profil</string>
     <string name="chat">Chat</string>
     <string name="recent_emotes">Terakhir</string>
+    <string name="favorite_emotes">★ Favorit</string>
+    <string name="add_emote_to_favorites">Tambahkan ke favorit</string>
+    <string name="remove_emote_from_favorites">Hapus dari favorit</string>
+    <string name="added_emote_to_favorites">%1$s ditambahkan ke favorit</string>
+    <string name="removed_emote_from_favorites">%1$s dihapus dari favorit</string>
+    <string name="favorite_emotes_empty">Belum ada emote favorit\nTekan lama emote untuk menambahkannya ke Favorit.</string>
+    <string name="favorite_emotes_unavailable">Tidak ada emote favorit Anda yang tersedia di channel ini.</string>
     <string name="notification_playback_channel_title">Pemutar</string>
     <string name="channels">Channel</string>
     <string name="watch_video">Watch full video</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -93,6 +93,13 @@
     <string name="view_profile">Visualizza profilo</string>
     <string name="chat">Chat</string>
     <string name="recent_emotes">Emote recenti</string>
+    <string name="favorite_emotes">★ Preferiti</string>
+    <string name="add_emote_to_favorites">Aggiungi ai preferiti</string>
+    <string name="remove_emote_from_favorites">Rimuovi dai preferiti</string>
+    <string name="added_emote_to_favorites">%1$s aggiunto ai preferiti</string>
+    <string name="removed_emote_from_favorites">%1$s rimosso dai preferiti</string>
+    <string name="favorite_emotes_empty">Nessun emote preferito\nTieni premuto un emote per aggiungerlo ai Preferiti.</string>
+    <string name="favorite_emotes_unavailable">Nessuno dei tuoi emote preferiti è disponibile in questo canale.</string>
     <string name="notification_playback_channel_title">Riproduzione</string>
     <string name="channels">Canali</string>
     <string name="watch_video">Guarda il video completo</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -93,6 +93,13 @@
     <string name="view_profile">プロフィールを表示</string>
     <string name="chat">チャット</string>
     <string name="recent_emotes">最近</string>
+    <string name="favorite_emotes">★ お気に入り</string>
+    <string name="add_emote_to_favorites">お気に入りに追加</string>
+    <string name="remove_emote_from_favorites">お気に入りから削除</string>
+    <string name="added_emote_to_favorites">%1$sをお気に入りに追加しました</string>
+    <string name="removed_emote_from_favorites">%1$sをお気に入りから削除しました</string>
+    <string name="favorite_emotes_empty">お気に入りのエモートはまだありません\nエモートを長押ししてお気に入りに追加できます。</string>
+    <string name="favorite_emotes_unavailable">このチャンネルではお気に入りのエモートを利用できません。</string>
     <string name="notification_playback_channel_title">再生</string>
     <string name="channels">チャンネル</string>
     <string name="watch_video">フル動画を見る</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -93,6 +93,13 @@
     <string name="view_profile">Ver perfil</string>
     <string name="chat">Chat</string>
     <string name="recent_emotes">Recente</string>
+    <string name="favorite_emotes">★ Favoritos</string>
+    <string name="add_emote_to_favorites">Adicionar aos favoritos</string>
+    <string name="remove_emote_from_favorites">Remover dos favoritos</string>
+    <string name="added_emote_to_favorites">%1$s foi adicionado aos favoritos</string>
+    <string name="removed_emote_from_favorites">%1$s foi removido dos favoritos</string>
+    <string name="favorite_emotes_empty">Ainda não há emotes favoritos\nMantenha um emote pressionado para adicioná-lo aos Favoritos.</string>
+    <string name="favorite_emotes_unavailable">Nenhum dos seus emotes favoritos está disponível neste canal.</string>
     <string name="notification_playback_channel_title">Reproduzir</string>
     <string name="channels">Canais</string>
     <string name="watch_video">Assistir vídeo completo</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -93,6 +93,13 @@
     <string name="view_profile">Открыть профиль</string>
     <string name="chat">Чат</string>
     <string name="recent_emotes">Недавние</string>
+    <string name="favorite_emotes">★ Избранное</string>
+    <string name="add_emote_to_favorites">Добавить в избранное</string>
+    <string name="remove_emote_from_favorites">Удалить из избранного</string>
+    <string name="added_emote_to_favorites">%1$s добавлен в избранное</string>
+    <string name="removed_emote_from_favorites">%1$s удалён из избранного</string>
+    <string name="favorite_emotes_empty">Пока нет избранных эмоутов\nНажмите и удерживайте эмоут, чтобы добавить его в избранное.</string>
+    <string name="favorite_emotes_unavailable">Избранные эмоуты недоступны на этом канале.</string>
     <string name="notification_playback_channel_title">Воспроизведение</string>
     <string name="channels">Каналы</string>
     <string name="watch_video">Смотреть полное видео</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -94,6 +94,13 @@
     <string name="view_profile">Profili görüntüle</string>
     <string name="chat">Sohbet</string>
     <string name="recent_emotes">Son Kullanılanlar</string>
+    <string name="favorite_emotes">★ Favoriler</string>
+    <string name="add_emote_to_favorites">Favorilere ekle</string>
+    <string name="remove_emote_from_favorites">Favorilerden kaldır</string>
+    <string name="added_emote_to_favorites">%1$s favorilere eklendi</string>
+    <string name="removed_emote_from_favorites">%1$s favorilerden kaldırıldı</string>
+    <string name="favorite_emotes_empty">Henüz favori ifade yok\nBir ifadeyi Favorilere eklemek için uzun basın.</string>
+    <string name="favorite_emotes_unavailable">Favori ifadelerinizin hiçbiri bu kanalda kullanılamıyor.</string>
     <string name="notification_playback_channel_title">Oynatma</string>
     <string name="channels">Kanallar</string>
     <string name="watch_video">Videonun tamamını izle</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -93,6 +93,13 @@
     <string name="view_profile">查看个人档案</string>
     <string name="chat">聊天室</string>
     <string name="recent_emotes">最近的</string>
+    <string name="favorite_emotes">★ 收藏</string>
+    <string name="add_emote_to_favorites">添加到收藏</string>
+    <string name="remove_emote_from_favorites">从收藏中移除</string>
+    <string name="added_emote_to_favorites">已将 %1$s 添加到收藏</string>
+    <string name="removed_emote_from_favorites">已将 %1$s 从收藏中移除</string>
+    <string name="favorite_emotes_empty">还没有收藏的表情\n长按表情即可将其添加到收藏。</string>
+    <string name="favorite_emotes_unavailable">此频道中没有可用的收藏表情。</string>
     <string name="notification_playback_channel_title">播放</string>
     <string name="channels">频道</string>
     <string name="watch_video">观看完整视频</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -93,6 +93,13 @@
     <string name="view_profile">檢視個人檔案</string>
     <string name="chat">聊天室</string>
     <string name="recent_emotes">最近的</string>
+    <string name="favorite_emotes">★ 收藏</string>
+    <string name="add_emote_to_favorites">加入收藏</string>
+    <string name="remove_emote_from_favorites">從收藏中移除</string>
+    <string name="added_emote_to_favorites">已將 %1$s 加入收藏</string>
+    <string name="removed_emote_from_favorites">已將 %1$s 從收藏中移除</string>
+    <string name="favorite_emotes_empty">尚無收藏的表情\n長按表情即可將其加入收藏。</string>
+    <string name="favorite_emotes_unavailable">此頻道中沒有可用的收藏表情。</string>
     <string name="notification_playback_channel_title">播放</string>
     <string name="channels">頻道</string>
     <string name="watch_video">觀看完整影片</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -464,6 +464,7 @@
     <string name="copy_message">Copy message</string>
     <string name="view_profile">View profile</string>
     <string name="chat">Chat</string>
+    <string name="favorite_emotes">★ Favorites</string>
     <string name="recent_emotes">Recent</string>
     <string name="notification_playback_channel_title">Playback</string>
     <string name="channels">Channels</string>
@@ -1021,6 +1022,12 @@
     <string name="chat_close_prediction">Close prediction</string>
     <string name="chat_scroll_to_latest">Scroll to latest messages</string>
     <string name="use_emote">Use %1$s emote</string>
+    <string name="add_emote_to_favorites">Add to favorites</string>
+    <string name="remove_emote_from_favorites">Remove from favorites</string>
+    <string name="added_emote_to_favorites">Added %1$s to favorites</string>
+    <string name="removed_emote_from_favorites">Removed %1$s from favorites</string>
+    <string name="favorite_emotes_empty">No favorite emotes here yet\nLong-press an emote to add it to Favorites.</string>
+    <string name="favorite_emotes_unavailable">None of your favorite emotes are available in this channel.</string>
     <string name="watch_stream">Watch stream</string>
     <string name="select_stream">Select stream</string>
     <string name="channel_stv_emote">Channel 7TV emote</string>

--- a/app/src/test/java/com/github/andreyasadchy/xtra/model/chat/FavoriteEmoteKeyTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/model/chat/FavoriteEmoteKeyTest.kt
@@ -1,0 +1,102 @@
+package com.github.andreyasadchy.xtra.model.chat
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Test
+
+class FavoriteEmoteKeyTest {
+
+    @Test
+    fun providerScopesShareOneSevenTvKey() {
+        val expected = FavoriteEmoteKey(EmoteProvider.SEVENTV, "7tv-id")
+
+        assertEquals(expected, emote(Emote.PERSONAL_STV, "7tv-id").favoriteKey())
+        assertEquals(expected, emote(Emote.CHANNEL_STV, "7tv-id").favoriteKey())
+        assertEquals(expected, emote(Emote.GLOBAL_STV, "7tv-id").favoriteKey())
+    }
+
+    @Test
+    fun everyThirdPartyScopeMapsToItsProvider() {
+        assertEquals(EmoteProvider.BTTV, emote(Emote.CHANNEL_BTTV, "bttv-id").favoriteKey()?.provider)
+        assertEquals(EmoteProvider.BTTV, emote(Emote.GLOBAL_BTTV, "bttv-id").favoriteKey()?.provider)
+        assertEquals(EmoteProvider.FFZ, emote(Emote.CHANNEL_FFZ, "ffz-id").favoriteKey()?.provider)
+        assertEquals(EmoteProvider.FFZ, emote(Emote.GLOBAL_FFZ, "ffz-id").favoriteKey()?.provider)
+    }
+
+    @Test
+    fun providersWithTheSameNameAndIdRemainIndependent() {
+        val twitch = Emote(name = "OMEGALUL", id = "same")
+        val ffz = emote(Emote.CHANNEL_FFZ, "same", "OMEGALUL")
+
+        assertEquals(FavoriteEmoteKey(EmoteProvider.TWITCH, "same"), twitch.favoriteKey())
+        assertEquals(FavoriteEmoteKey(EmoteProvider.FFZ, "same"), ffz.favoriteKey())
+    }
+
+    @Test
+    fun renamedEmoteKeepsItsFavoriteKey() {
+        val before = emote(Emote.CHANNEL_BTTV, "bttv-id", "old_name")
+        val after = emote(Emote.CHANNEL_BTTV, "bttv-id", "new_name")
+
+        assertEquals(before.favoriteKey(), after.favoriteKey())
+    }
+
+    @Test
+    fun blankIdCannotBecomeANameBasedFavorite() {
+        assertNull(Emote(name = "PogChamp", id = null).favoriteKey())
+        assertNull(Emote(name = "PogChamp", id = "   ").favoriteKey())
+    }
+
+    @Test
+    fun scopeDuplicateUsesChannelInstance() {
+        val global = emote(Emote.GLOBAL_STV, "same", "global_alias")
+        val personal = emote(Emote.PERSONAL_STV, "same", "personal_alias")
+        val channel = emote(Emote.CHANNEL_STV, "same", "channel_alias")
+
+        val result = FavoriteEmoteCatalog.deduplicate(listOf(global, personal, channel))
+
+        assertEquals(1, result.size)
+        assertSame(channel, result.single())
+    }
+
+    @Test
+    fun removingChannelScopeKeepsGlobalFavoriteFallback() {
+        val global = emote(Emote.GLOBAL_STV, "same", "global_alias")
+        val channel = emote(Emote.CHANNEL_STV, "same", "channel_alias")
+        val catalog = mutableListOf(global, channel)
+
+        FavoriteEmoteCatalog.removeMatchingScope(catalog, listOf(channel), Emote.CHANNEL_STV)
+
+        assertEquals(listOf(global), catalog)
+        assertEquals(
+            listOf(global),
+            FavoriteEmoteCatalog.availableFavorites(
+                listOf(FavoriteEmote("SEVENTV", "same", 1L)),
+                catalog,
+            ),
+        )
+    }
+
+    @Test
+    fun projectionKeepsFavoriteOrderAndHidesUnavailableRows() {
+        val favorites = listOf(
+            FavoriteEmote("BTTV", "b", 30),
+            FavoriteEmote("SEVENTV", "s", 20),
+            FavoriteEmote("FFZ", "missing", 10),
+        )
+        val available = listOf(
+            emote(Emote.GLOBAL_STV, "s", "renamed_7tv"),
+            emote(Emote.CHANNEL_BTTV, "b", "bttv"),
+        )
+
+        val result = FavoriteEmoteCatalog.availableFavorites(favorites, available)
+
+        assertEquals(listOf("bttv", "renamed_7tv"), result.map { it.name })
+    }
+
+    private fun emote(source: Int, id: String, name: String = "emote") = Emote(
+        source = source,
+        id = id,
+        name = name,
+    )
+}

--- a/app/src/test/java/com/github/andreyasadchy/xtra/util/chat/STVEventApiUtilsTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/util/chat/STVEventApiUtilsTest.kt
@@ -1,0 +1,54 @@
+package com.github.andreyasadchy.xtra.util.chat
+
+import com.github.andreyasadchy.xtra.model.chat.EmoteProvider
+import com.github.andreyasadchy.xtra.model.chat.favoriteKey
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class STVEventApiUtilsTest {
+
+    @Test
+    fun emoteSetChangesKeepTheStableEmoteIdAcrossAliases() {
+        val body = JSONObject(
+            """
+            {
+              "id": "set-id",
+              "updated": [
+                {
+                  "key": "emotes",
+                  "old_value": {
+                    "id": "emote-id",
+                    "name": "old_alias",
+                    "data": {
+                      "name": "canonical_name",
+                      "animated": false,
+                      "host": { "url": "//cdn.example/emote", "files": [] }
+                    }
+                  },
+                  "value": {
+                    "id": "emote-id",
+                    "name": "new_alias",
+                    "data": {
+                      "name": "canonical_name",
+                      "animated": false,
+                      "host": { "url": "//cdn.example/emote", "files": [] }
+                    }
+                  }
+                }
+              ]
+            }
+            """.trimIndent(),
+        )
+
+        val result = STVEventApiUtils.parseEmoteSetUpdate(body, useWebp = true, channelSTVEmoteSetId = "set-id")
+
+        val update = result!!.updated.single()
+        assertEquals("emote-id", update.first.id)
+        assertEquals("emote-id", update.second.id)
+        assertEquals("old_alias", update.first.name)
+        assertEquals("new_alias", update.second.name)
+        assertEquals(update.first.favoriteKey(), update.second.favoriteKey())
+        assertEquals(EmoteProvider.SEVENTV, update.second.favoriteKey()?.provider)
+    }
+}


### PR DESCRIPTION
Adds a Favorites tab to the chat emote picker. Favorites persist across channels and reappear whenever the emote is available. Includes long-press controls and a safe database migration.