### PR TITLE
Polish favorite emote interactions

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatViewModel.kt
@@ -1719,6 +1719,14 @@ class ChatViewModel(
         return emote.favoriteKey()?.let { it in favoriteKeys.value } == true
     }
 
+    fun removeFavorite(emote: Emote): Boolean? {
+        val key = emote.favoriteKey() ?: return null
+        viewModelScope.launch {
+            playerRepository.removeFavoriteEmote(key)
+        }
+        return true
+    }
+
     fun toggleFavorite(emote: Emote): Boolean? {
         val key = emote.favoriteKey() ?: return null
         val adding = key !in favoriteKeys.value

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/EmotesAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/EmotesAdapter.kt
@@ -32,6 +32,7 @@ class EmotesAdapter(
     private val emoteQuality: String,
     private val imageLibrary: String?,
     private val favoriteToggleListener: ((Emote) -> Unit)? = null,
+    private val consumeLongPress: Boolean = false,
 ) : ListAdapter<Emote, EmotesAdapter.ViewHolder>(
     object : DiffUtil.ItemCallback<Emote>() {
         override fun areItemsTheSame(oldItem: Emote, newItem: Emote): Boolean {
@@ -148,6 +149,8 @@ class EmotesAdapter(
                                 true
                             },
                         )
+                    } else if (consumeLongPress) {
+                        root.setOnLongClickListener { true }
                     }
                 }
             }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/EmotesFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/EmotesFragment.kt
@@ -18,6 +18,7 @@ import com.github.andreyasadchy.xtra.model.chat.Emote
 import com.github.andreyasadchy.xtra.model.chat.RecentEmote
 import com.github.andreyasadchy.xtra.ui.chat.ChatViewModel.Companion.ChatViewModelFactory
 import com.github.andreyasadchy.xtra.ui.view.GridAutofitLayoutManager
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
@@ -63,6 +64,7 @@ class EmotesFragment : Fragment() {
             "4",
             "0",
             if (section.supportsFavoriteToggle) ::toggleFavorite else null,
+            consumeLongPress = section == EmotePickerSection.RECENTS,
         )
         with(binding.emotesRecyclerView) {
             itemAnimator = null
@@ -137,6 +139,29 @@ class EmotesFragment : Fragment() {
     }
 
     private fun toggleFavorite(emote: Emote) {
+        if (viewModel.isFavorite(emote)) {
+            MaterialAlertDialogBuilder(requireContext())
+                .setTitle(R.string.remove_emote_from_favorites)
+                .setNegativeButton(android.R.string.cancel, null)
+                .setPositiveButton(R.string.remove_emote_from_favorites) { _, _ ->
+                    removeFavoriteImmediately(emote)
+                }
+                .show()
+            return
+        }
+        toggleFavoriteImmediately(emote)
+    }
+
+    private fun removeFavoriteImmediately(emote: Emote) {
+        if (viewModel.removeFavorite(emote) == null) return
+        Snackbar.make(
+            binding.root,
+            getString(R.string.removed_emote_from_favorites, emote.name.orEmpty()),
+            Snackbar.LENGTH_SHORT,
+        ).show()
+    }
+
+    private fun toggleFavoriteImmediately(emote: Emote) {
         val added = viewModel.toggleFavorite(emote) ?: return
         Snackbar.make(
             binding.root,


### PR DESCRIPTION
Favorites now ask for confirmation before removal, and long-pressing a Recent emote no longer inserts it accidentally. Normal Recent taps still work as before.

Verified with the debug build and the shared Android AVD.