### PR TITLE
Fix stale stream-feed auto-refresh

### DIFF
--- a/app/src/androidTest/java/com/github/andreyasadchy/xtra/repository/streamfeed/StreamFeedCacheTest.kt
+++ b/app/src/androidTest/java/com/github/andreyasadchy/xtra/repository/streamfeed/StreamFeedCacheTest.kt
@@ -1,6 +1,7 @@
 package com.github.andreyasadchy.xtra.repository.streamfeed
 
 import androidx.room.Room
+import androidx.paging.PagingSource
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.github.andreyasadchy.xtra.db.AppDatabase
@@ -94,6 +95,46 @@ class StreamFeedCacheTest {
             feedKey,
             expectedKeys = listOf("a", "b", "x", "d", "y", "f"),
             activeCount = 6,
+        )
+    }
+
+    @Test
+    fun automaticRefreshDoesNotRenderEndedRowsRetainedForCacheFallback() = runBlocking {
+        val cache = StreamFeedCache(database)
+        val feedKey = StreamFeedKey("top:visible-generation")
+
+        cache.replaceAfterRefresh(
+            feedKey,
+            StreamFeedPage(
+                streams("ended", "still-live"),
+                StreamFeedCursor("gql", "old-page-2"),
+            ),
+            nowMs = 1L,
+            preserveTail = false,
+            pruneStaleOnEnd = true,
+        )
+        cache.replaceAfterRefresh(
+            feedKey,
+            StreamFeedPage(streams("still-live"), nextCursor = null),
+            nowMs = 2L,
+            preserveTail = true,
+            pruneStaleOnEnd = false,
+        )
+
+        val allCachedRows = database.streamFeedDao().itemsForFeed(feedKey.value)
+        assertTrue(allCachedRows.any { it.itemKey == "channel:ended" })
+
+        val result = cache.pagingSource(feedKey).load(
+            PagingSource.LoadParams.Refresh(
+                key = null,
+                loadSize = 30,
+                placeholdersEnabled = false,
+            )
+        )
+        assertTrue(result is PagingSource.LoadResult.Page)
+        assertEquals(
+            listOf("channel:still-live"),
+            (result as PagingSource.LoadResult.Page).data.map { it.itemKey },
         )
     }
 

--- a/app/src/androidTest/java/com/github/andreyasadchy/xtra/repository/streamfeed/StreamFeedPagingIntegrationTest.kt
+++ b/app/src/androidTest/java/com/github/andreyasadchy/xtra/repository/streamfeed/StreamFeedPagingIntegrationTest.kt
@@ -24,7 +24,6 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 import org.junit.After
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -48,7 +47,7 @@ class StreamFeedPagingIntegrationTest {
     }
 
     @Test
-    fun retainedTailGetsOneFreshPageWithoutPagingWalkingTheWholeStaleTail() = runBlocking {
+    fun refreshShowsOnlyFreshPagesWhileKeepingStaleTailOutOfTheList() = runBlocking {
         val cache = StreamFeedCache(database)
         val feedKey = StreamFeedKey("top:paging-tail")
         cache.replaceAfterRefresh(
@@ -124,8 +123,7 @@ class StreamFeedPagingIntegrationTest {
             listOf(null, StreamFeedCursor(C.GQL, "fresh-page-2")),
             cursors,
         )
-        assertTrue(differ.itemCount >= 90)
-        assertTrue(database.streamFeedDao().itemsForFeed(feedKey.value).any { it.itemKey == "channel:old-80" })
+        assertEquals(60, differ.itemCount)
         assertEquals(null, database.streamFeedDao().state(feedKey.value)?.nextCursor)
 
         collectionJob.cancel()

--- a/app/src/main/java/com/github/andreyasadchy/xtra/db/StreamFeedDao.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/db/StreamFeedDao.kt
@@ -9,11 +9,47 @@ import androidx.room.Query
 @Dao
 interface StreamFeedDao {
 
-    @Query("SELECT * FROM stream_feed_items WHERE feedKey = :feedKey ORDER BY position ASC, itemKey ASC")
+    @Query(
+        """
+        SELECT items.*
+        FROM stream_feed_items AS items
+        WHERE items.feedKey = :feedKey
+          AND (
+            NOT EXISTS (
+                SELECT 1 FROM stream_feed_states
+                WHERE feedKey = :feedKey
+            )
+            OR items.generation = (
+                SELECT activeGeneration FROM stream_feed_states
+                WHERE feedKey = :feedKey
+            )
+          )
+        ORDER BY items.position ASC, items.itemKey ASC
+        """
+    )
     fun pagingSource(feedKey: String): PagingSource<Int, CachedStreamFeedItem>
 
     @Query("SELECT * FROM stream_feed_items WHERE feedKey = :feedKey ORDER BY position ASC, itemKey ASC")
     fun itemsForFeed(feedKey: String): List<CachedStreamFeedItem>
+
+    @Query(
+        """
+        SELECT COUNT(*)
+        FROM stream_feed_items AS items
+        WHERE items.feedKey = :feedKey
+          AND (
+            NOT EXISTS (
+                SELECT 1 FROM stream_feed_states
+                WHERE feedKey = :feedKey
+            )
+            OR items.generation = (
+                SELECT activeGeneration FROM stream_feed_states
+                WHERE feedKey = :feedKey
+            )
+          )
+        """
+    )
+    fun activeItemCount(feedKey: String): Int
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     fun insertItems(items: List<CachedStreamFeedItem>)

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/streamfeed/StreamFeedCache.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/streamfeed/StreamFeedCache.kt
@@ -217,7 +217,7 @@ class StreamFeedCache(
     }
 
     override suspend fun itemCount(feedKey: StreamFeedKey): Int = withContext(Dispatchers.IO) {
-        dao.itemsForFeed(feedKey.value).size
+        dao.activeItemCount(feedKey.value)
     }
 
     override suspend fun touchAccess(feedKey: StreamFeedKey, nowMs: Long) = withContext(Dispatchers.IO) {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/streamfeed/StreamFeedPolicy.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/streamfeed/StreamFeedPolicy.kt
@@ -163,7 +163,8 @@ internal class StreamFeedSingleFlight<T>(private val scope: CoroutineScope) {
 /** Central policy for volatile live-stream metadata. */
 object StreamFeedFreshnessPolicy {
     const val LIVE_STREAM_SOFT_TTL_MS = 90_000L
-    const val VISIBLE_REVALIDATION_INTERVAL_MS = 2 * 60_000L
+    /** Revalidate at the same cadence as the live-list freshness window. */
+    const val VISIBLE_REVALIDATION_INTERVAL_MS = LIVE_STREAM_SOFT_TTL_MS
     const val APP_BACKGROUND_THRESHOLD_MS = 30_000L
     const val PLAYBACK_RETURN_THRESHOLD_MS = 45_000L
     const val AUTO_REFRESH_DEBOUNCE_MS = 20_000L

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/StreamFeedScreenController.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/StreamFeedScreenController.kt
@@ -50,6 +50,14 @@ class StreamFeedScreenController(
         // player-return signal. A newly resumed screen replaces it.
     }
 
+    fun onDestroyView() {
+        tickerJob?.cancel()
+        tickerJob = null
+        if (!coordinator.isPlayerFullscreen) {
+            specProvider()?.key?.let(coordinator::clearVisibleFeed)
+        }
+    }
+
     fun onSpecChanged(force: Boolean, reason: RefreshReason = RefreshReason.FILTER_CHANGED) {
         val spec = specProvider() ?: return
         coordinator.setVisibleFeed(spec)

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/streams/FollowedStreamsFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/streams/FollowedStreamsFragment.kt
@@ -127,6 +127,9 @@ class FollowedStreamsFragment : PagedListFragment(), Scrollable {
     }
 
     override fun onDestroyView() {
+        if (::streamFeedScreenController.isInitialized) {
+            streamFeedScreenController.onDestroyView()
+        }
         super.onDestroyView()
         _binding = null
     }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/game/streams/GameStreamsFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/game/streams/GameStreamsFragment.kt
@@ -316,6 +316,9 @@ class GameStreamsFragment : PagedListFragment(), Scrollable, Sortable, StreamsSo
     }
 
     override fun onDestroyView() {
+        if (::streamFeedScreenController.isInitialized) {
+            streamFeedScreenController.onDestroyView()
+        }
         super.onDestroyView()
         _binding = null
     }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/top/TopStreamsFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/top/TopStreamsFragment.kt
@@ -358,6 +358,9 @@ class TopStreamsFragment : PagedListFragment(), Scrollable, StreamsSortDialog.On
     }
 
     override fun onDestroyView() {
+        if (::streamFeedScreenController.isInitialized) {
+            streamFeedScreenController.onDestroyView()
+        }
         super.onDestroyView()
         _binding = null
     }

--- a/app/src/test/java/com/github/andreyasadchy/xtra/repository/streamfeed/StreamFeedRefreshCoordinatorTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/repository/streamfeed/StreamFeedRefreshCoordinatorTest.kt
@@ -398,6 +398,55 @@ class StreamFeedRefreshCoordinatorTest {
     }
 
     @Test
+    fun consecutiveAutomaticRefreshesCountOnlyActiveGenerationRows() = runBlocking {
+        val key = StreamFeedKey("top:active-item-count")
+        val cache = FakeCache(
+            key = key,
+            rows = refreshCachedItems(
+                key.value,
+                listOf(Stream(channelId = "active-old")),
+                generation = 1L,
+            ) + refreshCachedItems(
+                key.value,
+                (0 until 4).map { Stream(channelId = "stale-$it") },
+                generation = 0L,
+            ),
+            currentState = StreamFeedState(
+                feedKey = key.value,
+                lastSuccessAt = 0L,
+                activeGeneration = 1L,
+            ),
+        )
+        var now = 1_000_000L
+        var refreshes = 0
+        val loader = object : StreamFeedPageLoader {
+            override suspend fun load(cursor: StreamFeedCursor?): StreamFeedPage {
+                assertEquals(null, cursor)
+                return StreamFeedPage(
+                    listOf(Stream(channelId = "fresh-${refreshes++}")),
+                    nextCursor = null,
+                )
+            }
+        }
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val coordinator = StreamFeedRefreshCoordinator(cache, scope, { now }, { 1_000L }, false)
+        val spec = StreamFeedSpec(key, loader)
+
+        coordinator.maybeRefresh(spec, RefreshReason.APP_FOREGROUND)
+        now += StreamFeedFreshnessPolicy.LIVE_STREAM_SOFT_TTL_MS
+        coordinator.maybeRefresh(spec, RefreshReason.APP_FOREGROUND)
+
+        assertEquals(listOf(1, 1), cache.itemCounts)
+        assertEquals(
+            listOf("channel:fresh-1"),
+            cache.rows
+                .filter { it.generation == cache.currentState?.activeGeneration }
+                .map { it.itemKey },
+        )
+        scope.cancel()
+    }
+
+    @Test
     fun speculativeTailPrefetchFailureDoesNotBackoffImmediateAppend() = runBlocking {
         val key = StreamFeedKey("top:speculative-prefetch-failure")
         val cache = FakeCache(
@@ -639,6 +688,7 @@ class StreamFeedRefreshCoordinatorTest {
         var currentState: StreamFeedState?,
     ) : StreamFeedCacheStore {
         var replacementCount = 0
+        val itemCounts = mutableListOf<Int>()
         var appendCommitted: CompletableDeferred<Unit>? = null
         var failureRecorded: CompletableDeferred<Unit>? = null
 
@@ -646,7 +696,10 @@ class StreamFeedRefreshCoordinatorTest {
 
         override suspend fun state(feedKey: StreamFeedKey): StreamFeedState? = currentState
 
-        override suspend fun itemCount(feedKey: StreamFeedKey): Int = rows.size
+        override suspend fun itemCount(feedKey: StreamFeedKey): Int {
+            val generation = currentState?.activeGeneration ?: 0L
+            return rows.count { it.generation == generation }.also(itemCounts::add)
+        }
 
         override suspend fun touchAccess(feedKey: StreamFeedKey, nowMs: Long) {
             currentState = (currentState ?: StreamFeedState(feedKey.value)).copy(lastAccessAt = nowMs)


### PR DESCRIPTION
## What changed

- Show only the active refresh generation in live stream lists.
- Keep stale rows only as private cache fallback data.
- Align visible revalidation with the 90-second live-stream freshness window.
- Stop refresh tickers and unregister destroyed stream screens.
- Add regressions for ended stream removal and stale-tail visibility.

## Why

Automatic refresh retained old rows for cache fallback, but Paging also rendered those rows as live streams. A streamer who stopped broadcasting could therefore remain in the list after refresh.

## Validation

- Debug Kotlin compilation
- Stream-feed unit tests
- Stream-feed Android instrumentation tests
- Debug APK build and emulator launch
