### PR TITLE
Fix emote picker scrolling in compact chat

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatFragment.kt
@@ -199,6 +199,7 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        setupEmotePickerSizing()
         viewLifecycleOwner.lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.connectionState.collectLatest { state ->
@@ -938,6 +939,7 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
     fun toggleEmoteMenu(enable: Boolean) {
         if (enable) {
             binding.emoteMenu.visibility = View.VISIBLE
+            binding.emoteMenu.post { updateEmotePickerHeight() }
         } else {
             binding.emoteMenu.visibility = View.GONE
         }
@@ -1070,6 +1072,70 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
         if (_binding == null || binding.messageView.width <= 0) return
         val compactWidth = (320 * resources.displayMetrics.density).toInt()
         binding.channelPointsText.isVisible = binding.channelPoints.isVisible && binding.messageView.width >= compactWidth
+    }
+
+    private fun setupEmotePickerSizing() {
+        listOf(
+            binding.root,
+            binding.chatContentColumn,
+            binding.emoteMenu,
+            binding.tabLayout,
+            binding.viewPager,
+            binding.messageView,
+            binding.replyView,
+            binding.channelPointRewardOverlay,
+        ).forEach { view ->
+            view.addOnLayoutChangeListener { _, _, _, _, _, _, _, _, _ ->
+                updateEmotePickerHeight()
+            }
+        }
+    }
+
+    private fun updateEmotePickerHeight() {
+        val currentBinding = _binding ?: return
+        if (!currentBinding.emoteMenu.isVisible) return
+
+        val contentColumn = currentBinding.chatContentColumn
+        val tabHeight = currentBinding.tabLayout.measuredHeight
+        if (contentColumn.measuredHeight <= 0 || tabHeight <= 0) return
+
+        val historyContainer = currentBinding.recyclerView.parent as? View
+        var fixedContentHeight = contentColumn.paddingTop + contentColumn.paddingBottom
+        for (index in 0 until contentColumn.childCount) {
+            val child = contentColumn.getChildAt(index)
+            val childMargins = verticalMargins(child)
+            if (child === currentBinding.emoteMenu) continue
+            if (child === historyContainer) {
+                // The history area has a weight and can shrink, but its margins cannot.
+                fixedContentHeight += childMargins
+                continue
+            }
+            if (child.visibility != View.GONE) {
+                fixedContentHeight += child.measuredHeight + childMargins
+            }
+        }
+
+        val pickerMargins = verticalMargins(currentBinding.emoteMenu) +
+            verticalMargins(currentBinding.tabLayout) +
+            verticalMargins(currentBinding.viewPager)
+        val targetHeight = calculateEmotePickerPagerHeight(
+            hostHeight = contentColumn.measuredHeight,
+            fixedContentHeight = fixedContentHeight,
+            tabHeight = tabHeight,
+            pickerMargins = pickerMargins,
+            maxHeight = resources.getDimensionPixelSize(R.dimen.emote_picker_max_height),
+        )
+        if (currentBinding.viewPager.layoutParams.height != targetHeight) {
+            currentBinding.viewPager.updateLayoutParams<ViewGroup.LayoutParams> {
+                height = targetHeight
+            }
+        }
+    }
+
+    private fun verticalMargins(view: View): Int {
+        return (view.layoutParams as? ViewGroup.MarginLayoutParams)?.let { params ->
+            params.topMargin + params.bottomMargin
+        } ?: 0
     }
 
     private fun showComposerOverlay(state: ComposerOverlayState) {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/EmotePickerSizing.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/EmotePickerSizing.kt
@@ -1,0 +1,11 @@
+package com.github.andreyasadchy.xtra.ui.chat
+
+internal fun calculateEmotePickerPagerHeight(
+    hostHeight: Int,
+    fixedContentHeight: Int,
+    tabHeight: Int,
+    pickerMargins: Int,
+    maxHeight: Int,
+): Int {
+    return (hostHeight - fixedContentHeight - tabHeight - pickerMargins).coerceIn(0, maxHeight)
+}

--- a/app/src/main/res/layout/fragment_chat.xml
+++ b/app/src/main/res/layout/fragment_chat.xml
@@ -6,6 +6,7 @@
     android:layout_height="match_parent">
 
     <LinearLayout
+        android:id="@+id/chatContentColumn"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:orientation="vertical"
@@ -271,7 +272,7 @@
             <androidx.viewpager2.widget.ViewPager2
                 android:id="@+id/viewPager"
                 android:layout_width="match_parent"
-                android:layout_height="300dp" />
+                android:layout_height="@dimen/emote_picker_max_height" />
         </LinearLayout>
 
     </LinearLayout>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -2,4 +2,5 @@
 <resources>
     <dimen name="divider_margin">5dp</dimen>
     <dimen name="settings_section_spacing">8dp</dimen>
+    <dimen name="emote_picker_max_height">300dp</dimen>
 </resources>

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/EmotePickerSizingTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/EmotePickerSizingTest.kt
@@ -1,0 +1,63 @@
+package com.github.andreyasadchy.xtra.ui.chat
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class EmotePickerSizingTest {
+
+    @Test
+    fun largeHostKeepsTheMaximumHeight() {
+        assertEquals(
+            300,
+            calculateEmotePickerPagerHeight(
+                hostHeight = 800,
+                fixedContentHeight = 48,
+                tabHeight = 48,
+                pickerMargins = 0,
+                maxHeight = 300,
+            ),
+        )
+    }
+
+    @Test
+    fun constrainedHostUsesAllAvailableSpace() {
+        assertEquals(
+            215,
+            calculateEmotePickerPagerHeight(
+                hostHeight = 311,
+                fixedContentHeight = 48,
+                tabHeight = 48,
+                pickerMargins = 0,
+                maxHeight = 300,
+            ),
+        )
+    }
+
+    @Test
+    fun fixedComposerAndReplySpaceReducesThePager() {
+        assertEquals(
+            167,
+            calculateEmotePickerPagerHeight(
+                hostHeight = 311,
+                fixedContentHeight = 96,
+                tabHeight = 48,
+                pickerMargins = 0,
+                maxHeight = 300,
+            ),
+        )
+    }
+
+    @Test
+    fun resultNeverBecomesNegative() {
+        assertEquals(
+            0,
+            calculateEmotePickerPagerHeight(
+                hostHeight = 100,
+                fixedContentHeight = 96,
+                tabHeight = 48,
+                pickerMargins = 12,
+                maxHeight = 300,
+            ),
+        )
+    }
+}


### PR DESCRIPTION
## What changed

The shared emote picker now uses the space available in its chat pane, up to the existing 300dp size.

## Why
Multiview can provide less room than the fixed picker height. The picker was clipped while its list still used the larger viewport, making the final emotes unreachable.

## Checks
- Debug unit suite
- Debug APK build
- Emulator smoke check in normal player and multiview portrait