### PR TITLE
Add reorderable favorite emotes

### DIFF
--- a/.github/scripts/translation-baseline.json
+++ b/.github/scripts/translation-baseline.json
@@ -1,15 +1,15 @@
 {
-  "values-ar": 740,
-  "values-de": 740,
-  "values-es": 740,
-  "values-fr": 740,
-  "values-gl": 740,
-  "values-in": 740,
-  "values-it": 740,
-  "values-ja": 740,
-  "values-pt-rBR": 740,
-  "values-ru": 740,
-  "values-tr": 740,
-  "values-zh-rCN": 740,
-  "values-zh-rTW": 740
+  "values-ar": 742,
+  "values-de": 742,
+  "values-es": 742,
+  "values-fr": 742,
+  "values-gl": 742,
+  "values-in": 742,
+  "values-it": 742,
+  "values-ja": 742,
+  "values-pt-rBR": 742,
+  "values-ru": 742,
+  "values-tr": 742,
+  "values-zh-rCN": 742,
+  "values-zh-rTW": 742
 }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/XtraModule.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/XtraModule.kt
@@ -385,6 +385,9 @@ class XtraModule(application: Application) {
                 Migration(45, 46) { db ->
                     db.execSQL("CREATE TABLE IF NOT EXISTS favorite_emotes (provider TEXT NOT NULL, emote_id TEXT NOT NULL, favorited_at INTEGER NOT NULL, PRIMARY KEY (provider, emote_id))")
                 },
+                Migration(46, 47) { db ->
+                    db.execSQL("ALTER TABLE favorite_emotes ADD COLUMN sort_order INTEGER NOT NULL DEFAULT 0")
+                },
             )
         }.build()
     }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/db/AppDatabase.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/db/AppDatabase.kt
@@ -47,7 +47,7 @@ import com.github.andreyasadchy.xtra.model.ui.TranslatedChannel
         StreamFeedState::class,
         MetadataCacheEntry::class,
     ],
-    version = 46,
+    version = 47,
     exportSchema = false
 )
 abstract class AppDatabase : RoomDatabase() {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/db/FavoriteEmotesDao.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/db/FavoriteEmotesDao.kt
@@ -4,17 +4,37 @@ import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
+import androidx.room.Transaction
 import com.github.andreyasadchy.xtra.model.chat.FavoriteEmote
+import com.github.andreyasadchy.xtra.model.chat.FavoriteEmoteKey
 import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface FavoriteEmotesDao {
 
-    @Query("SELECT * FROM favorite_emotes ORDER BY favorited_at DESC")
+    @Query("SELECT * FROM favorite_emotes ORDER BY sort_order ASC, favorited_at DESC")
     fun getAllFlow(): Flow<List<FavoriteEmote>>
+
+    @Query("SELECT COALESCE(MAX(sort_order), -1) + 1 FROM favorite_emotes")
+    suspend fun getNextSortOrder(): Int
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insert(favorite: FavoriteEmote)
+
+    @Transaction
+    suspend fun insertAtEnd(favorite: FavoriteEmote) {
+        insert(favorite.copy(sortOrder = getNextSortOrder()))
+    }
+
+    @Query("UPDATE favorite_emotes SET sort_order = :sortOrder WHERE provider = :provider AND emote_id = :emoteId")
+    suspend fun updateSortOrder(provider: String, emoteId: String, sortOrder: Int)
+
+    @Transaction
+    suspend fun updateOrder(order: List<FavoriteEmoteKey>) {
+        order.forEachIndexed { index, key ->
+            updateSortOrder(key.provider.name, key.emoteId, index)
+        }
+    }
 
     @Query("DELETE FROM favorite_emotes WHERE provider = :provider AND emote_id = :emoteId")
     suspend fun delete(provider: String, emoteId: String)

--- a/app/src/main/java/com/github/andreyasadchy/xtra/model/chat/FavoriteEmote.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/model/chat/FavoriteEmote.kt
@@ -13,4 +13,6 @@ data class FavoriteEmote(
     val emoteId: String,
     @ColumnInfo(name = "favorited_at")
     val favoritedAt: Long,
+    @ColumnInfo(name = "sort_order", defaultValue = "0")
+    val sortOrder: Int = 0,
 )

--- a/app/src/main/java/com/github/andreyasadchy/xtra/model/chat/FavoriteEmoteKey.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/model/chat/FavoriteEmoteKey.kt
@@ -68,6 +68,31 @@ object FavoriteEmoteCatalog {
         }
     }
 
+    /**
+     * Reorders the currently available favorites while keeping unavailable
+     * favorites in their existing global slots.
+     */
+    fun reorderAvailableFavorites(
+        currentOrder: List<FavoriteEmoteKey>,
+        availableOrder: List<FavoriteEmoteKey>,
+    ): List<FavoriteEmoteKey> {
+        val currentKeys = currentOrder.toSet()
+        val reorderedAvailable = availableOrder
+            .filter(currentKeys::contains)
+            .distinct()
+        if (reorderedAvailable.isEmpty()) return currentOrder
+
+        val reorderedKeys = reorderedAvailable.toSet()
+        var nextAvailableIndex = 0
+        return currentOrder.map { key ->
+            if (key in reorderedKeys) {
+                reorderedAvailable[nextAvailableIndex++]
+            } else {
+                key
+            }
+        }
+    }
+
     fun removeMatchingScope(
         emotes: MutableList<Emote>,
         removed: List<Emote>,

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/PlayerRepository.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/PlayerRepository.kt
@@ -2092,13 +2092,17 @@ class PlayerRepository(
     fun loadFavoriteEmotesFlow() = favoriteEmotes.getAllFlow()
 
     suspend fun addFavoriteEmote(key: FavoriteEmoteKey) = withContext(Dispatchers.IO) {
-        favoriteEmotes.insert(
+        favoriteEmotes.insertAtEnd(
             FavoriteEmote(
                 provider = key.provider.name,
                 emoteId = key.emoteId,
                 favoritedAt = System.currentTimeMillis(),
             ),
         )
+    }
+
+    suspend fun reorderFavoriteEmotes(order: List<FavoriteEmoteKey>) = withContext(Dispatchers.IO) {
+        favoriteEmotes.updateOrder(order)
     }
 
     suspend fun removeFavoriteEmote(key: FavoriteEmoteKey) = withContext(Dispatchers.IO) {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatViewModel.kt
@@ -1740,6 +1740,17 @@ class ChatViewModel(
         return adding
     }
 
+    fun reorderFavorites(emotes: List<Emote>): Boolean {
+        val currentOrder = favoriteEmotes.value.mapNotNull { it.key() }
+        val availableOrder = emotes.mapNotNull { it.favoriteKey() }
+        val reordered = FavoriteEmoteCatalog.reorderAvailableFavorites(currentOrder, availableOrder)
+        if (reordered == currentOrder) return false
+        viewModelScope.launch {
+            playerRepository.reorderFavoriteEmotes(reordered)
+        }
+        return true
+    }
+
     fun startLiveChat(channelId: String?, channelLogin: String) {
         stopLiveChat()
         val sessionToken = predictionSessionToken

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/EmotesAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/EmotesAdapter.kt
@@ -1,13 +1,17 @@
 package com.github.andreyasadchy.xtra.ui.chat
 
+import android.annotation.SuppressLint
 import android.view.HapticFeedbackConstants
 import android.view.LayoutInflater
+import android.view.MotionEvent
+import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.core.view.ViewCompat
 import androidx.core.view.accessibility.AccessibilityViewCommand
+import androidx.recyclerview.widget.AsyncListDiffer
 import androidx.recyclerview.widget.DiffUtil
-import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.ItemTouchHelper
 import androidx.recyclerview.widget.RecyclerView
 import coil3.imageLoader
 import coil3.network.NetworkHeaders
@@ -26,6 +30,13 @@ import com.github.andreyasadchy.xtra.model.chat.Emote
 import com.github.andreyasadchy.xtra.model.chat.FavoriteEmoteKey
 import com.github.andreyasadchy.xtra.model.chat.favoriteKey
 
+internal fun <T> moveListItem(items: MutableList<T>, from: Int, to: Int): Boolean {
+    if (from !in items.indices || to !in items.indices || from == to) return false
+    val item = items.removeAt(from)
+    items.add(to, item)
+    return true
+}
+
 class EmotesAdapter(
     private val fragment: Fragment,
     private val clickListener: (Emote) -> Unit,
@@ -33,30 +44,38 @@ class EmotesAdapter(
     private val imageLibrary: String?,
     private val favoriteToggleListener: ((Emote) -> Unit)? = null,
     private val consumeLongPress: Boolean = false,
-) : ListAdapter<Emote, EmotesAdapter.ViewHolder>(
-    object : DiffUtil.ItemCallback<Emote>() {
-        override fun areItemsTheSame(oldItem: Emote, newItem: Emote): Boolean {
-            val oldKey = oldItem.favoriteKey()
-            val newKey = newItem.favoriteKey()
-            return if (oldKey != null || newKey != null) {
-                oldKey == newKey
-            } else {
-                oldItem.name == newItem.name
-            }
-        }
+    private val reorderable: Boolean = false,
+) : RecyclerView.Adapter<EmotesAdapter.ViewHolder>() {
 
-        override fun areContentsTheSame(oldItem: Emote, newItem: Emote): Boolean {
-            return oldItem.name == newItem.name &&
-                    oldItem.url1x == newItem.url1x &&
-                    oldItem.url2x == newItem.url2x &&
-                    oldItem.url3x == newItem.url3x &&
-                    oldItem.url4x == newItem.url4x &&
-                    oldItem.format == newItem.format
+    private val differ = AsyncListDiffer(this, EMOTE_DIFF_CALLBACK)
+    private val items = mutableListOf<Emote>()
+    private var favoriteKeys: Set<FavoriteEmoteKey> = emptySet()
+    var itemTouchHelper: ItemTouchHelper? = null
+    var accessibilityMoveListener: ((Int, Int) -> Boolean)? = null
+
+    override fun getItemCount(): Int = if (reorderable) items.size else differ.currentList.size
+
+    /**
+     * Copies the list so an active drag can update the adapter's data without
+     * mutating a list owned by a caller or by RecyclerView.
+     */
+    fun submitList(newItems: List<Emote>) {
+        if (reorderable) {
+            items.clear()
+            items.addAll(newItems)
+            notifyDataSetChanged()
+        } else {
+            differ.submitList(newItems.toList())
         }
     }
-) {
 
-    private var favoriteKeys: Set<FavoriteEmoteKey> = emptySet()
+    fun moveItem(from: Int, to: Int): Boolean {
+        if (!moveListItem(items, from, to)) return false
+        notifyItemMoved(from, to)
+        return true
+    }
+
+    fun currentItems(): List<Emote> = items.toList()
 
     fun setFavoriteKeys(keys: Set<FavoriteEmoteKey>) {
         if (favoriteKeys != keys) {
@@ -73,25 +92,41 @@ class EmotesAdapter(
     }
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
-        holder.bind(getItem(position))
+        val currentItems = if (reorderable) items else differ.currentList
+        holder.bind(currentItems.getOrNull(position))
     }
 
     inner class ViewHolder(
         private val binding: FragmentEmotesListItemBinding,
     ) : RecyclerView.ViewHolder(binding.root) {
         private var favoriteAccessibilityActionId: Int? = null
+        private val reorderAccessibilityActionIds = mutableListOf<Int>()
 
+        @SuppressLint("ClickableViewAccessibility")
         fun bind(item: Emote?) {
             with(binding) {
                 favoriteAccessibilityActionId?.let {
-                    ViewCompat.removeAccessibilityAction(root, it)
+                    ViewCompat.removeAccessibilityAction(emote, it)
                     favoriteAccessibilityActionId = null
                 }
-                root.setOnClickListener(null)
-                root.setOnLongClickListener(null)
+                reorderAccessibilityActionIds.forEach { actionId ->
+                    ViewCompat.removeAccessibilityAction(emote, actionId)
+                }
+                reorderAccessibilityActionIds.clear()
+                emote.setOnClickListener(null)
+                emote.setOnLongClickListener(null)
+                dragHandle.visibility = if (reorderable) View.VISIBLE else View.GONE
+                dragHandle.setOnTouchListener(if (reorderable) {
+                    { _, event ->
+                        if (event.actionMasked == MotionEvent.ACTION_DOWN) {
+                            itemTouchHelper?.startDrag(this@ViewHolder)
+                        }
+                        true
+                    }
+                } else null)
                 if (item != null) {
-                    root.contentDescription = fragment.getString(R.string.use_emote, item.name)
-                    root.isFocusable = true
+                    emote.contentDescription = fragment.getString(R.string.use_emote, item.name)
+                    emote.isFocusable = true
                     if (imageLibrary == "0" || (imageLibrary == "1" && !item.format.equals("webp", true))) {
                         fragment.requireContext().imageLoader.enqueue(
                             ImageRequest.Builder(fragment.requireContext()).apply {
@@ -109,7 +144,7 @@ class EmotesAdapter(
                                     }.build())
                                 }
                                 crossfade(true)
-                                target(root)
+                                target(emote)
                             }.build()
                         )
                     } else {
@@ -128,19 +163,19 @@ class EmotesAdapter(
                             )
                             .diskCacheStrategy(DiskCacheStrategy.DATA)
                             .transition(DrawableTransitionOptions.withCrossFade())
-                            .into(root)
+                            .into(emote)
                     }
-                    root.setOnClickListener { clickListener(item) }
+                    emote.setOnClickListener { clickListener(item) }
                     val key = item.favoriteKey()
                     if (favoriteToggleListener != null && key != null) {
                         val isFavorite = key in favoriteKeys
-                        root.setOnLongClickListener {
+                        emote.setOnLongClickListener {
                             it.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS)
                             favoriteToggleListener.invoke(item)
                             true
                         }
                         favoriteAccessibilityActionId = ViewCompat.addAccessibilityAction(
-                            root,
+                            emote,
                             fragment.getString(
                                 if (isFavorite) R.string.remove_emote_from_favorites else R.string.add_emote_to_favorites,
                             ),
@@ -150,9 +185,50 @@ class EmotesAdapter(
                             },
                         )
                     } else if (consumeLongPress) {
-                        root.setOnLongClickListener { true }
+                        emote.setOnLongClickListener { true }
+                    }
+                    if (reorderable) {
+                        reorderAccessibilityActionIds += ViewCompat.addAccessibilityAction(
+                            emote,
+                            fragment.getString(R.string.move_favorite_emote_before),
+                            AccessibilityViewCommand { _, _ ->
+                                val position = bindingAdapterPosition
+                                accessibilityMoveListener?.invoke(position, position - 1) == true
+                            },
+                        )
+                        reorderAccessibilityActionIds += ViewCompat.addAccessibilityAction(
+                            emote,
+                            fragment.getString(R.string.move_favorite_emote_after),
+                            AccessibilityViewCommand { _, _ ->
+                                val position = bindingAdapterPosition
+                                accessibilityMoveListener?.invoke(position, position + 1) == true
+                            },
+                        )
                     }
                 }
+            }
+        }
+    }
+
+    private companion object {
+        val EMOTE_DIFF_CALLBACK = object : DiffUtil.ItemCallback<Emote>() {
+            override fun areItemsTheSame(oldItem: Emote, newItem: Emote): Boolean {
+                val oldKey = oldItem.favoriteKey()
+                val newKey = newItem.favoriteKey()
+                return if (oldKey != null || newKey != null) {
+                    oldKey == newKey
+                } else {
+                    oldItem.name == newItem.name
+                }
+            }
+
+            override fun areContentsTheSame(oldItem: Emote, newItem: Emote): Boolean {
+                return oldItem.name == newItem.name &&
+                        oldItem.url1x == newItem.url1x &&
+                        oldItem.url2x == newItem.url2x &&
+                        oldItem.url3x == newItem.url3x &&
+                        oldItem.url4x == newItem.url4x &&
+                        oldItem.format == newItem.format
             }
         }
     }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/EmotesFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/EmotesFragment.kt
@@ -12,6 +12,8 @@ import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
+import androidx.recyclerview.widget.ItemTouchHelper
+import androidx.recyclerview.widget.RecyclerView
 import com.github.andreyasadchy.xtra.R
 import com.github.andreyasadchy.xtra.databinding.FragmentEmotesBinding
 import com.github.andreyasadchy.xtra.model.chat.Emote
@@ -22,6 +24,11 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
+
+internal fun pendingFavoriteItemsToApply(
+    pendingItems: List<Emote>?,
+    orderChanged: Boolean,
+): List<Emote>? = if (orderChanged) null else pendingItems
 
 enum class EmotePickerSection {
     FAVORITES,
@@ -47,6 +54,8 @@ class EmotesFragment : Fragment() {
     private val binding get() = _binding!!
     private val viewModel by viewModels<ChatViewModel>(ownerProducer = { requireParentFragment() }, factoryProducer = { ChatViewModelFactory })
     private var recentEmotes = emptyList<RecentEmote>()
+    private var favoriteDragActive = false
+    private var pendingFavoriteItems: List<Emote>? = null
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         _binding = FragmentEmotesBinding.inflate(inflater, container, false)
@@ -65,13 +74,67 @@ class EmotesFragment : Fragment() {
             "0",
             if (section.supportsFavoriteToggle) ::toggleFavorite else null,
             consumeLongPress = section == EmotePickerSection.RECENTS,
+            reorderable = section == EmotePickerSection.FAVORITES,
         )
+        val itemTouchHelper = if (section == EmotePickerSection.FAVORITES) {
+            ItemTouchHelper(
+                object : ItemTouchHelper.SimpleCallback(
+                    ItemTouchHelper.UP or ItemTouchHelper.DOWN or ItemTouchHelper.LEFT or ItemTouchHelper.RIGHT,
+                    0,
+                ) {
+                    override fun onSelectedChanged(viewHolder: RecyclerView.ViewHolder?, actionState: Int) {
+                        super.onSelectedChanged(viewHolder, actionState)
+                        if (actionState == ItemTouchHelper.ACTION_STATE_DRAG) {
+                            favoriteDragActive = true
+                        }
+                    }
+
+                    override fun onMove(
+                        recyclerView: RecyclerView,
+                        viewHolder: RecyclerView.ViewHolder,
+                        target: RecyclerView.ViewHolder,
+                    ): Boolean {
+                        val from = viewHolder.bindingAdapterPosition
+                        val to = target.bindingAdapterPosition
+                        if (from == RecyclerView.NO_POSITION || to == RecyclerView.NO_POSITION) return false
+                        return adapter.moveItem(from, to)
+                    }
+
+                    override fun onSwiped(viewHolder: RecyclerView.ViewHolder, direction: Int) = Unit
+
+                    override fun clearView(recyclerView: RecyclerView, viewHolder: RecyclerView.ViewHolder) {
+                        super.clearView(recyclerView, viewHolder)
+                        val orderChanged = viewModel.reorderFavorites(adapter.currentItems())
+                        favoriteDragActive = false
+                        pendingFavoriteItemsToApply(pendingFavoriteItems, orderChanged)?.let { pendingItems ->
+                            adapter.submitList(pendingItems)
+                            updateEmptyState(section, pendingItems)
+                        }
+                        pendingFavoriteItems = null
+                    }
+
+                    override fun isLongPressDragEnabled(): Boolean = false
+                },
+            )
+        } else {
+            null
+        }
+        adapter.itemTouchHelper = itemTouchHelper
+        adapter.accessibilityMoveListener = { from, to ->
+            if (!adapter.moveItem(from, to)) {
+                false
+            } else {
+                viewModel.reorderFavorites(adapter.currentItems())
+                true
+            }
+        }
         with(binding.emotesRecyclerView) {
             itemAnimator = null
             this.adapter = adapter
             val columnWidth = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 50f, resources.displayMetrics).toInt()
             layoutManager = GridAutofitLayoutManager(requireContext(), columnWidth)
         }
+        itemTouchHelper?.attachToRecyclerView(binding.emotesRecyclerView)
         viewLifecycleOwner.lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
                 launch {
@@ -123,7 +186,16 @@ class EmotesFragment : Fragment() {
             }
             EmotePickerSection.THIRD_PARTY -> viewModel.thirdPartyPickerEmotes()
         }
+        if (section == EmotePickerSection.FAVORITES && favoriteDragActive) {
+            pendingFavoriteItems = list.toList()
+            updateEmptyState(section, list)
+            return
+        }
         adapter.submitList(list)
+        updateEmptyState(section, list)
+    }
+
+    private fun updateEmptyState(section: EmotePickerSection, list: List<Emote>) {
         if (section == EmotePickerSection.FAVORITES && list.isEmpty()) {
             binding.emptyState.setText(
                 if (viewModel.favoriteEmotes.value.isEmpty()) {

--- a/app/src/main/res/layout/fragment_emotes_list_item.xml
+++ b/app/src/main/res/layout/fragment_emotes_list_item.xml
@@ -1,15 +1,33 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ImageButton xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="48dp"
     android:layout_height="48dp"
-    android:background="?android:selectableItemBackgroundBorderless"
-    android:contentDescription="@string/room_emote"
-    android:padding="8dp"
-    android:scaleType="fitCenter"
     android:layout_marginTop="5dp"
     android:layout_marginBottom="5dp"
     android:layout_marginLeft="10dp"
     android:layout_marginStart="10dp"
     android:layout_marginRight="10dp"
-    android:layout_marginEnd="10dp" />
+    android:layout_marginEnd="10dp">
+
+    <ImageButton
+        android:id="@+id/emote"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="?android:selectableItemBackgroundBorderless"
+        android:contentDescription="@string/room_emote"
+        android:padding="8dp"
+        android:scaleType="fitCenter" />
+
+    <ImageView
+        android:id="@+id/dragHandle"
+        android:layout_width="24dp"
+        android:layout_height="24dp"
+        android:layout_gravity="top|end"
+        android:alpha="0.8"
+        android:importantForAccessibility="no"
+        android:padding="2dp"
+        android:src="@drawable/outline_drag_handle_black_24"
+        android:visibility="gone"
+        app:tint="?attr/colorControlNormal" />
+</FrameLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1028,6 +1028,8 @@
     <string name="removed_emote_from_favorites">Removed %1$s from favorites</string>
     <string name="favorite_emotes_empty">No favorite emotes here yet\nLong-press an emote to add it to Favorites.</string>
     <string name="favorite_emotes_unavailable">None of your favorite emotes are available in this channel.</string>
+    <string name="move_favorite_emote_before">Move favorite emote before</string>
+    <string name="move_favorite_emote_after">Move favorite emote after</string>
     <string name="watch_stream">Watch stream</string>
     <string name="select_stream">Select stream</string>
     <string name="channel_stv_emote">Channel 7TV emote</string>

--- a/app/src/test/java/com/github/andreyasadchy/xtra/model/chat/FavoriteEmoteKeyTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/model/chat/FavoriteEmoteKeyTest.kt
@@ -94,6 +94,35 @@ class FavoriteEmoteKeyTest {
         assertEquals(listOf("bttv", "renamed_7tv"), result.map { it.name })
     }
 
+    @Test
+    fun reorderingAvailableFavoritesKeepsUnavailableSlots() {
+        val hidden = FavoriteEmoteKey(EmoteProvider.FFZ, "hidden")
+        val first = FavoriteEmoteKey(EmoteProvider.TWITCH, "first")
+        val second = FavoriteEmoteKey(EmoteProvider.TWITCH, "second")
+        val third = FavoriteEmoteKey(EmoteProvider.TWITCH, "third")
+
+        val result = FavoriteEmoteCatalog.reorderAvailableFavorites(
+            currentOrder = listOf(first, hidden, second, third),
+            availableOrder = listOf(third, first, second),
+        )
+
+        assertEquals(listOf(third, hidden, first, second), result)
+    }
+
+    @Test
+    fun reorderingIgnoresStaleAvailableKeys() {
+        val first = FavoriteEmoteKey(EmoteProvider.TWITCH, "first")
+        val second = FavoriteEmoteKey(EmoteProvider.TWITCH, "second")
+        val stale = FavoriteEmoteKey(EmoteProvider.BTTV, "stale")
+
+        val result = FavoriteEmoteCatalog.reorderAvailableFavorites(
+            currentOrder = listOf(first, second),
+            availableOrder = listOf(stale, second, first),
+        )
+
+        assertEquals(listOf(second, first), result)
+    }
+
     private fun emote(source: Int, id: String, name: String = "emote") = Emote(
         source = source,
         id = id,

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/EmotePickerSectionTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/EmotePickerSectionTest.kt
@@ -1,0 +1,12 @@
+package com.github.andreyasadchy.xtra.ui.chat
+
+import org.junit.Assert.assertFalse
+import org.junit.Test
+
+class EmotePickerSectionTest {
+
+    @Test
+    fun recentEmotesCannotBeAddedToFavoritesWithoutProviderIdentity() {
+        assertFalse(EmotePickerSection.RECENTS.supportsFavoriteToggle)
+    }
+}

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/EmotesAdapterTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/EmotesAdapterTest.kt
@@ -1,0 +1,16 @@
+package com.github.andreyasadchy.xtra.ui.chat
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class EmotesAdapterTest {
+
+    @Test
+    fun moveListItemMovesNonAdjacentItem() {
+        val items = mutableListOf("A", "B", "C", "D")
+
+        assertTrue(moveListItem(items, 0, 3))
+        assertEquals(listOf("B", "C", "D", "A"), items)
+    }
+}

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/EmotesFragmentTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/EmotesFragmentTest.kt
@@ -1,0 +1,30 @@
+package com.github.andreyasadchy.xtra.ui.chat
+
+import com.github.andreyasadchy.xtra.model.chat.Emote
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class EmotesFragmentTest {
+
+    @Test
+    fun pendingRefreshDoesNotReplaceChangedDragOrder() {
+        val pendingRefresh = listOf(
+            Emote(name = "A"),
+            Emote(name = "B"),
+            Emote(name = "C"),
+        )
+
+        assertNull(pendingFavoriteItemsToApply(pendingRefresh, orderChanged = true))
+    }
+
+    @Test
+    fun pendingRefreshAppliesWhenDragDidNotChangeOrder() {
+        val pendingRefresh = listOf(Emote(name = "A"))
+
+        assertEquals(
+            pendingRefresh,
+            pendingFavoriteItemsToApply(pendingRefresh, orderChanged = false),
+        )
+    }
+}


### PR DESCRIPTION
Lets users arrange the global Favorites tab with drag and drop and keep that order across restarts.

Favorites now stays stable while emotes refresh, and unavailable favorites keep their saved positions. Recent emotes remain insertion-only until their saved entries include provider identity, so a same-name emote can never favorite the wrong provider.

Chat width and badge settings are intentionally kept in a separate PR.