### PR TITLE
Restore Twitch watch credit tracking

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/PlayerRepository.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/PlayerRepository.kt
@@ -47,9 +47,13 @@ import com.github.andreyasadchy.xtra.util.NetworkUtils
 import com.github.andreyasadchy.xtra.util.NetworkUtils.executeAsync
 import com.github.andreyasadchy.xtra.util.m3u8.PlaylistUtils
 import com.github.andreyasadchy.xtra.util.m3u8.TwitchAdDetector
+import com.github.andreyasadchy.xtra.util.watch.WatchCreditSession
+import com.github.andreyasadchy.xtra.util.watch.WatchCreditTelemetry
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
@@ -101,6 +105,19 @@ class PlayerRepository(
         val url: String,
         val verifiedClean: Boolean = false,
     )
+
+    private data class CachedSpadeEndpoint(
+        val session: WatchCreditSession,
+        val url: String,
+    )
+
+    private data class WatchCreditHttpResponse(
+        val statusCode: Int,
+        val body: String,
+    )
+
+    private val watchCreditMutex = Mutex()
+    private var cachedSpadeEndpoint: CachedSpadeEndpoint? = null
 
     suspend fun loadStreamPlaylistUrl(context: Context, networkLibrary: String?, gqlHeaders: Map<String, String>, channelLogin: String, randomDeviceId: Boolean?, xDeviceId: String?, playerType: String?, supportedCodecs: String?, proxyPlaybackAccessToken: Boolean, proxyHost: String?, proxyPort: Int?, proxyUser: String?, proxyPassword: String?, enableIntegrity: Boolean): String = withContext(Dispatchers.IO) {
         val accessToken = loadStreamPlaybackAccessToken(context, networkLibrary, gqlHeaders, channelLogin, randomDeviceId, xDeviceId, playerType, proxyPlaybackAccessToken, proxyHost, proxyPort, proxyUser, proxyPassword, enableIntegrity).let { token ->
@@ -799,17 +816,109 @@ class PlayerRepository(
         }
     }
 
-    suspend fun sendMinuteWatched(networkLibrary: String?, userId: String?, streamId: String?, channelId: String?, channelLogin: String?) = withContext(Dispatchers.IO) {
-        val pageResponse = channelLogin?.let {
-            val pageUrl = "https://www.twitch.tv/${channelLogin}"
-            when {
-                networkLibrary == C.HTTP_ENGINE && httpEngine.value != null -> @SuppressLint("NewApi") {
+    suspend fun sendMinuteWatched(
+        networkLibrary: String?,
+        userId: String?,
+        streamId: String?,
+        channelId: String?,
+        channelLogin: String?,
+    ): Boolean = withContext(Dispatchers.IO) {
+        watchCreditMutex.withLock {
+            if (userId.isNullOrBlank() || streamId.isNullOrBlank() || channelId.isNullOrBlank() || channelLogin.isNullOrBlank()) {
+                Log.w(
+                    WatchCreditTelemetry.LOG_TAG,
+                    "watch heartbeat skipped: missing userId=${!userId.isNullOrBlank()} broadcastId=${!streamId.isNullOrBlank()} channelId=${!channelId.isNullOrBlank()} channelLogin=${!channelLogin.isNullOrBlank()}",
+                )
+                return@withLock false
+            }
+
+            val session = WatchCreditSession(
+                broadcastId = streamId,
+                channelId = channelId,
+                channelLogin = channelLogin,
+                userId = userId,
+            )
+            val cachedEndpoint = cachedSpadeEndpoint?.takeIf { it.session == session }
+            if (cachedSpadeEndpoint != null && cachedEndpoint == null) {
+                Log.d(WatchCreditTelemetry.LOG_TAG, "watch session changed; invalidating cached Spade URL")
+                cachedSpadeEndpoint = null
+            }
+
+            val spadeUrl = cachedEndpoint?.url ?: discoverSpadeUrl(networkLibrary, channelLogin)
+            if (spadeUrl.isNullOrBlank()) {
+                Log.w(WatchCreditTelemetry.LOG_TAG, "Spade URL discovery failed")
+                return@withLock false
+            }
+            if (cachedEndpoint == null) {
+                cachedSpadeEndpoint = CachedSpadeEndpoint(session, spadeUrl)
+                Log.d(WatchCreditTelemetry.LOG_TAG, "Spade URL discovered and cached host=${urlHost(spadeUrl)}")
+            }
+
+            val body = WatchCreditTelemetry.buildMinuteWatchedPayload(session)
+            val spadeRequest = "data=" + Base64.encodeToString(body.toByteArray(), Base64.NO_WRAP)
+            if (postMinuteWatched(networkLibrary, spadeUrl, spadeRequest)) {
+                return@withLock true
+            }
+
+            if (cachedEndpoint == null) {
+                cachedSpadeEndpoint = null
+                return@withLock false
+            }
+
+            cachedSpadeEndpoint = null
+            Log.w(WatchCreditTelemetry.LOG_TAG, "cached Spade URL failed; rediscovering and retrying once")
+            val retryUrl = discoverSpadeUrl(networkLibrary, channelLogin)
+            if (retryUrl.isNullOrBlank()) {
+                Log.w(WatchCreditTelemetry.LOG_TAG, "Spade URL rediscovery failed after heartbeat failure")
+                return@withLock false
+            }
+            cachedSpadeEndpoint = CachedSpadeEndpoint(session, retryUrl)
+            val retrySucceeded = postMinuteWatched(networkLibrary, retryUrl, spadeRequest)
+            if (!retrySucceeded) {
+                cachedSpadeEndpoint = null
+            }
+            retrySucceeded
+        }
+    }
+
+    private suspend fun discoverSpadeUrl(networkLibrary: String?, channelLogin: String): String? {
+        val pageUrl = "https://www.twitch.tv/$channelLogin"
+        val pageResponse = fetchWatchCreditText(networkLibrary, pageUrl, "Twitch page") ?: return null
+        WatchCreditTelemetry.extractSpadeUrl(pageResponse)?.let {
+            Log.d(WatchCreditTelemetry.LOG_TAG, "Spade URL found directly in Twitch page host=${urlHost(it)}")
+            return it
+        }
+
+        val settingsUrl = WatchCreditTelemetry.extractSettingsUrl(pageResponse)
+        if (settingsUrl.isNullOrBlank()) {
+            Log.w(WatchCreditTelemetry.LOG_TAG, "Twitch settings JS URL not found")
+            return null
+        }
+        val settingsResponse = fetchWatchCreditText(networkLibrary, settingsUrl, "Twitch settings") ?: return null
+        val spadeUrl = WatchCreditTelemetry.extractSpadeUrl(settingsResponse)
+        if (spadeUrl.isNullOrBlank()) {
+            Log.w(WatchCreditTelemetry.LOG_TAG, "Spade URL not found in Twitch settings")
+        } else {
+            Log.d(WatchCreditTelemetry.LOG_TAG, "Spade URL found in Twitch settings host=${urlHost(spadeUrl)}")
+        }
+        return spadeUrl
+    }
+
+    @SuppressLint("NewApi")
+    private suspend fun fetchWatchCreditText(
+        networkLibrary: String?,
+        url: String,
+        label: String,
+    ): String? {
+        return try {
+            val response = when {
+                networkLibrary == C.HTTP_ENGINE && httpEngine.value != null -> {
                     val response = suspendCancellableCoroutine { continuation ->
                         val timeout = NetworkUtils.HttpEngineTimeout()
                         val request = httpEngine.value!!.newUrlRequestBuilder(
-                            pageUrl,
+                            url,
                             cronetExecutor.value,
-                            NetworkUtils.ByteArrayUrlCallback(continuation, timeout)
+                            NetworkUtils.ByteArrayUrlCallback(continuation, timeout),
                         ).build()
                         timeout.start(request, continuation)
                         request.start()
@@ -818,15 +927,15 @@ class PlayerRepository(
                             timeout.stop()
                         }
                     }
-                    response.body.decodeToString()
+                    WatchCreditHttpResponse(response.info.httpStatusCode, response.body.decodeToString())
                 }
                 networkLibrary == C.CRONET && cronetEngine.value != null -> {
-                    val response = suspendCancellableCoroutine { continuation ->
+                    val response = suspendCancellableCoroutine<NetworkUtils.CronetResponse> { continuation ->
                         val timeout = NetworkUtils.CronetTimeout()
                         val request = cronetEngine.value!!.newUrlRequestBuilder(
-                            pageUrl,
+                            url,
                             NetworkUtils.ByteArrayCronetCallback(continuation, timeout),
-                            cronetExecutor.value
+                            cronetExecutor.value,
                         ).build()
                         timeout.start(request, continuation)
                         request.start()
@@ -835,126 +944,98 @@ class PlayerRepository(
                             timeout.stop()
                         }
                     }
-                    response.body.decodeToString()
+                    WatchCreditHttpResponse(response.info.httpStatusCode, response.body.decodeToString())
                 }
                 else -> {
-                    okHttpClient.value.newCall(Request.Builder().url(pageUrl).build()).executeAsync().use { response ->
-                        response.body.string()
+                    okHttpClient.value.newCall(Request.Builder().url(url).build()).executeAsync().use { response ->
+                        WatchCreditHttpResponse(response.code, response.body.string())
                     }
                 }
             }
-        }
-        if (!pageResponse.isNullOrBlank()) {
-            val settingsRegex = Regex("https://[\\w.]+/config/settings\\.\\w+?\\.js")
-            val settingsUrl = settingsRegex.find(pageResponse)?.value
-            val settingsResponse = settingsUrl?.let {
-                when {
-                    networkLibrary == C.HTTP_ENGINE && httpEngine.value != null -> @SuppressLint("NewApi") {
-                        val response = suspendCancellableCoroutine { continuation ->
-                            val timeout = NetworkUtils.HttpEngineTimeout()
-                            val request = httpEngine.value!!.newUrlRequestBuilder(
-                                settingsUrl,
-                                cronetExecutor.value,
-                                NetworkUtils.ByteArrayUrlCallback(continuation, timeout)
-                            ).build()
-                            timeout.start(request, continuation)
-                            request.start()
-                            continuation.invokeOnCancellation {
-                                request.cancel()
-                                timeout.stop()
-                            }
-                        }
-                        response.body.decodeToString()
-                    }
-                    networkLibrary == C.CRONET && cronetEngine.value != null -> {
-                        val response = suspendCancellableCoroutine { continuation ->
-                            val timeout = NetworkUtils.CronetTimeout()
-                            val request = cronetEngine.value!!.newUrlRequestBuilder(
-                                settingsUrl,
-                                NetworkUtils.ByteArrayCronetCallback(continuation, timeout),
-                                cronetExecutor.value
-                            ).build()
-                            timeout.start(request, continuation)
-                            request.start()
-                            continuation.invokeOnCancellation {
-                                request.cancel()
-                                timeout.stop()
-                            }
-                        }
-                        response.body.decodeToString()
-                    }
-                    else -> {
-                        okHttpClient.value.newCall(Request.Builder().url(settingsUrl).build()).executeAsync().use { response ->
-                            response.body.string()
-                        }
-                    }
-                }
-            }
-            if (!settingsResponse.isNullOrBlank()) {
-                val spadeRegex = Regex("\"(?:beacon_url|spade_url)\":\"(.*?)\"")
-                val spadeUrl = spadeRegex.find(settingsResponse)?.groups?.get(1)?.value
-                if (!spadeUrl.isNullOrBlank()) {
-                    val body = buildJsonObject {
-                        put("event", "minute-watched")
-                        putJsonObject("properties") {
-                            put("channel_id", channelId)
-                            put("broadcast_id", streamId)
-                            put("player", "site")
-                            put("user_id", userId?.toLong())
-                        }
-                    }.toString()
-                    val spadeRequest = "data=" + Base64.encodeToString(body.toByteArray(), Base64.NO_WRAP)
-                    when {
-                        networkLibrary == C.HTTP_ENGINE && httpEngine.value != null -> @SuppressLint("NewApi") {
-                            suspendCancellableCoroutine { continuation ->
-                                val timeout = NetworkUtils.HttpEngineTimeout()
-                                val request = httpEngine.value!!.newUrlRequestBuilder(
-                                    spadeUrl,
-                                    cronetExecutor.value,
-                                    NetworkUtils.ByteArrayUrlCallback(continuation, timeout)
-                                ).apply {
-                                    addHeader("Content-Type", "application/x-www-form-urlencoded")
-                                    setUploadDataProvider(NetworkUtils.ByteArrayUploadProvider(spadeRequest.toByteArray()), cronetExecutor.value)
-                                }.build()
-                                timeout.start(request, continuation)
-                                request.start()
-                                continuation.invokeOnCancellation {
-                                    request.cancel()
-                                    timeout.stop()
-                                }
-                            }
-                        }
-                        networkLibrary == C.CRONET && cronetEngine.value != null -> {
-                            suspendCancellableCoroutine<NetworkUtils.CronetResponse> { continuation ->
-                                val timeout = NetworkUtils.CronetTimeout()
-                                val request = cronetEngine.value!!.newUrlRequestBuilder(
-                                    spadeUrl,
-                                    NetworkUtils.ByteArrayCronetCallback(continuation, timeout),
-                                    cronetExecutor.value
-                                ).apply {
-                                    addHeader("Content-Type", "application/x-www-form-urlencoded")
-                                    setUploadDataProvider(UploadDataProviders.create(spadeRequest.toByteArray()), cronetExecutor.value)
-                                }.build()
-                                timeout.start(request, continuation)
-                                request.start()
-                                continuation.invokeOnCancellation {
-                                    request.cancel()
-                                    timeout.stop()
-                                }
-                            }
-                        }
-                        else -> {
-                            okHttpClient.value.newCall(Request.Builder().apply {
-                                url(spadeUrl)
-                                header("Content-Type", "application/x-www-form-urlencoded")
-                                post(spadeRequest.toRequestBody())
-                            }.build()).executeAsync()
-                        }
-                    }
-                }
-            }
+            Log.d(WatchCreditTelemetry.LOG_TAG, "$label GET status=${response.statusCode}")
+            response.body.takeIf { WatchCreditTelemetry.isSuccessfulStatus(response.statusCode) }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Log.e(WatchCreditTelemetry.LOG_TAG, "$label GET failed", e)
+            null
         }
     }
+
+    @SuppressLint("NewApi")
+    private suspend fun postMinuteWatched(
+        networkLibrary: String?,
+        spadeUrl: String,
+        spadeRequest: String,
+    ): Boolean {
+        return try {
+            val statusCode = when {
+                networkLibrary == C.HTTP_ENGINE && httpEngine.value != null -> {
+                    val response = suspendCancellableCoroutine { continuation ->
+                        val timeout = NetworkUtils.HttpEngineTimeout()
+                        val request = httpEngine.value!!.newUrlRequestBuilder(
+                            spadeUrl,
+                            cronetExecutor.value,
+                            NetworkUtils.ByteArrayUrlCallback(continuation, timeout),
+                        ).apply {
+                            addHeader("Content-Type", "application/x-www-form-urlencoded")
+                            setUploadDataProvider(NetworkUtils.ByteArrayUploadProvider(spadeRequest.toByteArray()), cronetExecutor.value)
+                        }.build()
+                        timeout.start(request, continuation)
+                        request.start()
+                        continuation.invokeOnCancellation {
+                            request.cancel()
+                            timeout.stop()
+                        }
+                    }
+                    response.info.httpStatusCode
+                }
+                networkLibrary == C.CRONET && cronetEngine.value != null -> {
+                    val response = suspendCancellableCoroutine<NetworkUtils.CronetResponse> { continuation ->
+                        val timeout = NetworkUtils.CronetTimeout()
+                        val request = cronetEngine.value!!.newUrlRequestBuilder(
+                            spadeUrl,
+                            NetworkUtils.ByteArrayCronetCallback(continuation, timeout),
+                            cronetExecutor.value,
+                        ).apply {
+                            addHeader("Content-Type", "application/x-www-form-urlencoded")
+                            setUploadDataProvider(UploadDataProviders.create(spadeRequest.toByteArray()), cronetExecutor.value)
+                        }.build()
+                        timeout.start(request, continuation)
+                        request.start()
+                        continuation.invokeOnCancellation {
+                            request.cancel()
+                            timeout.stop()
+                        }
+                    }
+                    response.info.httpStatusCode
+                }
+                else -> {
+                    okHttpClient.value.newCall(Request.Builder().apply {
+                        url(spadeUrl)
+                        header("Content-Type", "application/x-www-form-urlencoded")
+                        post(spadeRequest.toRequestBody())
+                    }.build()).executeAsync().use { response ->
+                        response.code
+                    }
+                }
+            }
+            val success = WatchCreditTelemetry.isSuccessfulStatus(statusCode)
+            if (success) {
+                Log.d(WatchCreditTelemetry.LOG_TAG, "Spade POST status=$statusCode host=${urlHost(spadeUrl)}")
+            } else {
+                Log.w(WatchCreditTelemetry.LOG_TAG, "Spade POST rejected status=$statusCode host=${urlHost(spadeUrl)}")
+            }
+            success
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Log.e(WatchCreditTelemetry.LOG_TAG, "Spade POST failed host=${urlHost(spadeUrl)}", e)
+            false
+        }
+    }
+
+    private fun urlHost(url: String): String = runCatching { URI(url).host }.getOrNull() ?: "unknown"
 
     suspend fun loadRecentMessages(networkLibrary: String?, recentMessagesUrl: String, channelLogin: String, limit: String): RecentMessagesResponse = withContext(Dispatchers.IO) {
         val url = recentMessagesUrl.replace("\$channel", channelLogin) + "?limit=${limit}"

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatViewModel.kt
@@ -6,6 +6,7 @@ import android.net.ConnectivityManager
 import android.util.Base64
 import android.util.JsonReader
 import android.util.JsonToken
+import android.util.Log
 import androidx.core.content.ContextCompat
 import androidx.core.net.toUri
 import androidx.lifecycle.ViewModel
@@ -78,6 +79,7 @@ import com.github.andreyasadchy.xtra.util.chat.STVEventApiUtils
 import com.github.andreyasadchy.xtra.util.chat.STVEventApiWebSocket
 import com.github.andreyasadchy.xtra.util.chat.ViewerParticipationCache
 import com.github.andreyasadchy.xtra.util.prefs
+import com.github.andreyasadchy.xtra.util.watch.WatchCreditTelemetry
 import kotlinx.coroutines.cancel
 import com.github.andreyasadchy.xtra.util.tokenPrefs
 import kotlinx.coroutines.CancellationException
@@ -154,6 +156,7 @@ class ChatViewModel(
     private var hermesWebSocket: HermesWebSocket? = null
     private var pubSubJob: Job? = null
     private var channelPointsJob: Job? = null
+    private var claimJob: Job? = null
     private var watchStreakJob: Job? = null
     private var watchStreakRetryJob: Job? = null
     private var watchStreakSession = 0L
@@ -1914,6 +1917,8 @@ class ChatViewModel(
         }
         channelPointsJob?.cancel()
         channelPointsJob = null
+        claimJob?.cancel()
+        claimJob = null
         watchStreakJob?.cancel()
         watchStreakJob = null
         watchStreakRetryJob?.cancel()
@@ -2650,6 +2655,9 @@ class ChatViewModel(
         private val showWebSocketDebugInfo: Boolean,
         private val sessionToken: Long,
     ) : HermesWebSocket.Listener {
+        @Volatile
+        private var watchCreditLive = true
+
         override suspend fun onConnect() {
             if (showWebSocketDebugInfo) {
                 onMessage(ChatMessage(systemMsg = ContextCompat.getString(applicationContext, R.string.websocket_connected).format("PubSub")))
@@ -2666,15 +2674,26 @@ class ChatViewModel(
         }
 
         override suspend fun onPlaybackMessage(message: JSONObject) {
+            if (!isActiveWatchCreditSession()) {
+                Log.d(WatchCreditTelemetry.LOG_TAG, "playback message ignored for inactive watch session")
+                return
+            }
             val playbackMessage = PubSubUtils.parsePlaybackMessage(message)
             if (playbackMessage != null) {
                 playbackMessage.live?.let {
                     if (it) {
+                        watchCreditLive = true
+                        this@ChatViewModel.streamId = null
+                        Log.d(WatchCreditTelemetry.LOG_TAG, "watch credit stream-up received; refreshing broadcastId")
+                        refreshWatchCreditStreamId("stream-up")
                         onMessage(ChatMessage(
                             type = ChatMessage.NOTICE_MESSAGE,
                             systemMsg = ContextCompat.getString(applicationContext, R.string.stream_live).format(channelLogin),
                         ))
                     } else {
+                        watchCreditLive = false
+                        this@ChatViewModel.streamId = null
+                        Log.d(WatchCreditTelemetry.LOG_TAG, "watch credit stream-down received; heartbeat paused")
                         onMessage(ChatMessage(
                             type = ChatMessage.NOTICE_MESSAGE,
                             systemMsg = ContextCompat.getString(applicationContext, R.string.stream_offline).format(channelLogin),
@@ -2718,43 +2737,145 @@ class ChatViewModel(
         }
 
         override suspend fun onClaimAvailable() {
-            if (collectPoints) {
-                if (!gqlHeaders[C.HEADER_TOKEN].isNullOrBlank()) {
-                    viewModelScope.launch {
-                        try {
-                            val response = graphQLRepository.loadChannelPointsContext(networkLibrary, gqlHeaders, channelLogin)
-                            if (enableIntegrity) {
-                                response.errors?.find { it.message == C.FAILED_INTEGRITY_CHECK }?.let {
-                                    integrity.emit("refresh")
-                                    return@launch
-                                }
-                            }
-                            updateChannelPoints(response)
-                            response.data?.community?.channel?.self?.communityPoints?.availableClaim?.id?.let { claimId ->
-                                val response = graphQLRepository.loadClaimPoints(networkLibrary, gqlHeaders, channelId, claimId)
-                                if (enableIntegrity) {
-                                    response.errors?.find { it.message == C.FAILED_INTEGRITY_CHECK }?.let {
-                                        integrity.emit("refresh")
-                                        return@launch
-                                    }
-                                }
-                                loadChannelPoints(networkLibrary, gqlHeaders, channelLogin, enableIntegrity)
-                            }
-                        } catch (e: Exception) {
-
-                        }
+            Log.d(
+                WatchCreditTelemetry.LOG_TAG,
+                "claim-available handler invoked collectPoints=$collectPoints gqlTokenPresent=${!gqlHeaders[C.HEADER_TOKEN].isNullOrBlank()}",
+            )
+            if (!collectPoints || gqlHeaders[C.HEADER_TOKEN].isNullOrBlank()) {
+                return
+            }
+            if (claimJob?.isActive == true) {
+                Log.d(WatchCreditTelemetry.LOG_TAG, "claim-available ignored while another claim is in flight")
+                return
+            }
+            val job = viewModelScope.launch {
+                try {
+                    val contextResponse = graphQLRepository.loadChannelPointsContext(networkLibrary, gqlHeaders, channelLogin)
+                    val contextError = contextResponse.errors?.firstOrNull()?.message
+                    val contextIntegrityError = contextResponse.errors?.find { it.message == C.FAILED_INTEGRITY_CHECK }
+                    val claimId = contextResponse.data?.community?.channel?.self?.communityPoints?.availableClaim?.id
+                    Log.d(
+                        WatchCreditTelemetry.LOG_TAG,
+                        "ChannelPointsContext result dataPresent=${contextResponse.data != null} claimPresent=${!claimId.isNullOrBlank()} error=${contextError ?: "none"}",
+                    )
+                    if (enableIntegrity && contextIntegrityError != null) {
+                        integrity.emit("refresh")
+                        return@launch
                     }
+                    updateChannelPoints(contextResponse)
+                    if (claimId.isNullOrBlank()) {
+                        return@launch
+                    }
+
+                    val claimResponse = graphQLRepository.loadClaimPoints(networkLibrary, gqlHeaders, channelId, claimId)
+                    val claimError = claimResponse.errors?.firstOrNull()?.message
+                    val claimIntegrityError = claimResponse.errors?.find { it.message == C.FAILED_INTEGRITY_CHECK }
+                    Log.d(
+                        WatchCreditTelemetry.LOG_TAG,
+                        "ClaimCommunityPoints result success=${claimError == null} error=${claimError ?: "none"}",
+                    )
+                    if (enableIntegrity && claimIntegrityError != null) {
+                        integrity.emit("refresh")
+                        return@launch
+                    }
+                    if (claimError == null) {
+                        loadChannelPoints(networkLibrary, gqlHeaders, channelLogin, enableIntegrity)
+                    }
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    Log.e(WatchCreditTelemetry.LOG_TAG, "Channel Points claim handling failed", e)
+                }
+            }
+            claimJob = job
+            job.invokeOnCompletion {
+                if (claimJob === job) {
+                    claimJob = null
                 }
             }
         }
 
-        override suspend fun onMinuteWatched() {
-            if (!streamId.isNullOrBlank()) {
-                try {
-                    playerRepository.sendMinuteWatched(networkLibrary, accountId, streamId, channelId, channelLogin)
-                } catch (e: Exception) {
+        private fun isActiveWatchCreditSession(): Boolean =
+            sessionToken == predictionSessionToken &&
+                    activeChannelLogin == channelLogin &&
+                    activeChannelId == channelId
 
+        private suspend fun refreshWatchCreditStreamId(reason: String): String? {
+            if (!isLoggedIn || accountId.isNullOrBlank()) {
+                Log.d(WatchCreditTelemetry.LOG_TAG, "broadcastId refresh skipped: authenticated user missing reason=$reason")
+                return null
+            }
+            if (!watchCreditLive || !isActiveWatchCreditSession()) {
+                Log.d(WatchCreditTelemetry.LOG_TAG, "broadcastId refresh skipped: inactive watch session reason=$reason")
+                return null
+            }
+            return try {
+                val response = graphQLRepository.loadQueryUsersStream(
+                    networkLibrary = networkLibrary,
+                    headers = gqlHeaders,
+                    ids = channelId?.let { listOf(it) },
+                    logins = if (channelId.isNullOrBlank()) listOf(channelLogin) else null,
+                )
+                val error = response.errors?.firstOrNull()?.message
+                val resolvedStreamId = response.data?.users?.firstOrNull()?.stream?.id
+                if (!watchCreditLive || !isActiveWatchCreditSession()) {
+                    return null
                 }
+                if (!resolvedStreamId.isNullOrBlank()) {
+                    val previousStreamId = this@ChatViewModel.streamId
+                    this@ChatViewModel.streamId = resolvedStreamId
+                    Log.d(
+                        WatchCreditTelemetry.LOG_TAG,
+                        "broadcastId refreshed reason=$reason changed=${previousStreamId != resolvedStreamId}",
+                    )
+                } else {
+                    Log.w(
+                        WatchCreditTelemetry.LOG_TAG,
+                        "broadcastId refresh returned no live stream reason=$reason error=${error ?: "none"}",
+                    )
+                }
+                resolvedStreamId
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Log.e(WatchCreditTelemetry.LOG_TAG, "broadcastId refresh failed reason=$reason", e)
+                null
+            }
+        }
+
+        override suspend fun onMinuteWatched() {
+            if (!isActiveWatchCreditSession()) {
+                Log.d(WatchCreditTelemetry.LOG_TAG, "watch heartbeat skipped: inactive watch session")
+                return
+            }
+            if (!watchCreditLive) {
+                Log.d(WatchCreditTelemetry.LOG_TAG, "watch heartbeat skipped: stream is offline")
+                return
+            }
+            var currentStreamId = streamId
+            Log.d(
+                WatchCreditTelemetry.LOG_TAG,
+                "watch heartbeat callback userIdPresent=${!accountId.isNullOrBlank()} channelIdPresent=${!channelId.isNullOrBlank()} channelLoginPresent=${!channelLogin.isNullOrBlank()} streamIdPresent=${!currentStreamId.isNullOrBlank()}",
+            )
+            if (currentStreamId.isNullOrBlank()) {
+                Log.d(WatchCreditTelemetry.LOG_TAG, "watch heartbeat missing broadcastId; refreshing current stream")
+                currentStreamId = refreshWatchCreditStreamId("heartbeat")
+                if (currentStreamId.isNullOrBlank()) {
+                    Log.w(WatchCreditTelemetry.LOG_TAG, "watch heartbeat skipped: missing broadcastId")
+                    return
+                }
+            }
+            if (!watchCreditLive) {
+                Log.d(WatchCreditTelemetry.LOG_TAG, "watch heartbeat skipped: stream went offline during refresh")
+                return
+            }
+            try {
+                val success = playerRepository.sendMinuteWatched(networkLibrary, accountId, currentStreamId, channelId, channelLogin)
+                Log.d(WatchCreditTelemetry.LOG_TAG, "watch heartbeat completed success=$success")
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Log.e(WatchCreditTelemetry.LOG_TAG, "watch heartbeat failed", e)
             }
         }
 

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/chat/HermesWebSocket.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/chat/HermesWebSocket.kt
@@ -1,6 +1,9 @@
 package com.github.andreyasadchy.xtra.util.chat
 
+import android.util.Log
 import com.github.andreyasadchy.xtra.util.WebSocket
+import com.github.andreyasadchy.xtra.util.watch.WatchCreditTelemetry
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -35,6 +38,7 @@ class HermesWebSocket(
     private val handledMessageIds = mutableListOf<String>()
 
     fun connect(coroutineScope: CoroutineScope): Job {
+        Log.d(WatchCreditTelemetry.LOG_TAG, "Hermes connect requested channelIdPresent=${channelId.isNotBlank()} userIdPresent=${!userId.isNullOrBlank()} collectPoints=$collectPoints listenForPoints=$listenForPoints")
         webSocket = WebSocket("wss://hermes.twitch.tv/v1?clientId=${gqlClientId}", trustManager, WebSocketListener())
         webSocket?.coroutineScope = coroutineScope
         return coroutineScope.launch(Dispatchers.IO) {
@@ -43,6 +47,7 @@ class HermesWebSocket(
     }
 
     suspend fun disconnect(job: Job?) = withContext(Dispatchers.IO) {
+        Log.d(WatchCreditTelemetry.LOG_TAG, "Hermes disconnect requested")
         pongTimer?.cancel()
         minuteWatchedTimer?.cancel()
         minuteWatchedTimer = null
@@ -61,6 +66,7 @@ class HermesWebSocket(
                 put("timestamp", Clock.System.now().toString())
             }.toString()
             webSocket?.write(authenticate)
+            Log.d(WatchCreditTelemetry.LOG_TAG, "Hermes authentication request sent")
         }
         topics = buildMap {
             put(Uuid.random().toHexString().substring(0, 21), "video-playback-by-id.$channelId")
@@ -95,7 +101,11 @@ class HermesWebSocket(
                 put("timestamp", Clock.System.now().toString())
             }.toString()
             webSocket?.write(subscribe)
+            if (it.value.startsWith("community-points-user")) {
+                Log.d(WatchCreditTelemetry.LOG_TAG, "Hermes community-points-user subscription sent")
+            }
         }
+        Log.d(WatchCreditTelemetry.LOG_TAG, "Hermes subscriptions sent count=${topics.size}")
         listener.onSubscriptionsSent()
     }
 
@@ -110,9 +120,12 @@ class HermesWebSocket(
     }
 
     private suspend fun startMinuteWatchedTimer() = withContext(Dispatchers.IO) {
+        Log.d(WatchCreditTelemetry.LOG_TAG, "Hermes minute-watched timer started intervalMs=60000")
         minuteWatchedTimer = Timer().apply {
             scheduleAtFixedRate(60000, 60000) {
-                webSocket?.coroutineScope?.launch {
+                val scope = webSocket?.coroutineScope
+                Log.d(WatchCreditTelemetry.LOG_TAG, "Hermes minute-watched timer fired scopePresent=${scope != null}")
+                scope?.launch {
                     listener.onMinuteWatched()
                 }
             }
@@ -137,6 +150,7 @@ class HermesWebSocket(
 
     private inner class WebSocketListener : WebSocket.Listener {
         override suspend fun onConnect(webSocket: WebSocket) {
+            Log.d(WatchCreditTelemetry.LOG_TAG, "Hermes connected")
             listener.onConnect()
         }
 
@@ -179,8 +193,14 @@ class HermesWebSocket(
                                 }
                                 topic.startsWith("community-points-user") -> {
                                     when {
-                                        messageType.startsWith("points-earned") -> listener.onPointsEarned(message)
-                                        messageType.startsWith("claim-available") -> listener.onClaimAvailable()
+                                        messageType.startsWith("points-earned") -> {
+                                            Log.d(WatchCreditTelemetry.LOG_TAG, "Hermes points-earned received")
+                                            listener.onPointsEarned(message)
+                                        }
+                                        messageType.startsWith("claim-available") -> {
+                                            Log.d(WatchCreditTelemetry.LOG_TAG, "Hermes claim-available received")
+                                            listener.onClaimAvailable()
+                                        }
                                     }
                                 }
                                 topic.startsWith("raid") -> {
@@ -198,6 +218,9 @@ class HermesWebSocket(
                         pongTimer?.cancel()
                         startPongTimer()
                     }
+                    "authenticated" -> {
+                        Log.d(WatchCreditTelemetry.LOG_TAG, "Hermes authentication accepted")
+                    }
                     "reconnect" -> {
                         //val reconnect = json.optJSONObject("reconnect")
                         //val reconnectUrl = if (reconnect?.isNull("url") == false) reconnect.optString("url").takeIf { it.isNotBlank() } else null
@@ -213,18 +236,24 @@ class HermesWebSocket(
                         }
                         pongTimer?.cancel()
                         startPongTimer()
+                        Log.d(WatchCreditTelemetry.LOG_TAG, "Hermes welcome received collectPoints=$collectPoints userIdPresent=${!userId.isNullOrBlank()} gqlTokenPresent=${!gqlToken.isNullOrBlank()}")
                         subscribe()
                         if (collectPoints && !userId.isNullOrBlank() && !gqlToken.isNullOrBlank() && minuteWatchedTimer == null) {
                             startMinuteWatchedTimer()
+                        } else if (collectPoints && minuteWatchedTimer == null) {
+                            Log.w(WatchCreditTelemetry.LOG_TAG, "Hermes minute-watched timer not started: missing userId or GQL token")
                         }
                     }
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
-
+                Log.e(WatchCreditTelemetry.LOG_TAG, "Hermes message handling failed", e)
             }
         }
 
         override suspend fun onDisconnect(webSocket: WebSocket, message: String, fullMsg: String?) {
+            Log.w(WatchCreditTelemetry.LOG_TAG, "Hermes disconnected message=$message")
             listener.onDisconnect(message, fullMsg)
         }
     }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/watch/WatchCreditTelemetry.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/watch/WatchCreditTelemetry.kt
@@ -1,0 +1,75 @@
+package com.github.andreyasadchy.xtra.util.watch
+
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonObject
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import java.util.TimeZone
+
+data class WatchCreditSession(
+    val broadcastId: String,
+    val channelId: String,
+    val channelLogin: String,
+    val userId: String,
+)
+
+object WatchCreditTelemetry {
+    const val LOG_TAG = "XtraWatchCredit"
+
+    private val spadeUrlRegex = Regex(
+        """(?i)[\"']?(?:spadeUrl|spade_url|beacon_url)[\"']?\s*:\s*[\"'](https?://[^\"'\s<>]+)[\"']""",
+    )
+    private val settingsUrlRegex = Regex(
+        """https://(?:static\.twitchcdn\.net|assets\.twitch\.tv)/config/settings[^\"'\\\s<>]*\.js(?:\?[^\"'\\\s<>]*)?""",
+        RegexOption.IGNORE_CASE,
+    )
+
+    fun buildMinuteWatchedPayload(
+        session: WatchCreditSession,
+        clientTimeMillis: Long = System.currentTimeMillis(),
+        game: String? = null,
+        gameId: String? = null,
+    ): String = buildJsonArray {
+        add(buildJsonObject {
+            put("event", "minute-watched")
+            putJsonObject("properties") {
+                put("broadcast_id", session.broadcastId)
+                put("channel_id", session.channelId)
+                put("channel", session.channelLogin)
+                put("client_time", formatClientTime(clientTimeMillis))
+                game?.let { put("game", it) }
+                gameId?.let { put("game_id", it) }
+                put("hidden", false)
+                put("is_live", true)
+                put("live", true)
+                put("location", "channel")
+                put("logged_in", true)
+                put("minutes_logged", 1)
+                put("muted", false)
+                put("player", "site")
+                put("user_id", session.userId)
+            }
+        })
+    }.toString()
+
+    fun extractSpadeUrl(content: String): String? = spadeUrlRegex
+        .find(content.replace("\\/", "/"))
+        ?.groupValues
+        ?.getOrNull(1)
+
+    fun extractSettingsUrl(content: String): String? = settingsUrlRegex
+        .find(content.replace("\\/", "/"))
+        ?.value
+
+    fun isSuccessfulStatus(statusCode: Int): Boolean = statusCode in 200..299
+
+    private fun formatClientTime(timeMillis: Long): String = SimpleDateFormat(
+        "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'",
+        Locale.US,
+    ).apply {
+        timeZone = TimeZone.getTimeZone("UTC")
+    }.format(Date(timeMillis))
+}

--- a/app/src/test/java/com/github/andreyasadchy/xtra/util/watch/WatchCreditTelemetryTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/util/watch/WatchCreditTelemetryTest.kt
@@ -1,0 +1,98 @@
+package com.github.andreyasadchy.xtra.util.watch
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class WatchCreditTelemetryTest {
+    @Test
+    fun minuteWatchedPayloadUsesAnEventArray() {
+        val payload = WatchCreditTelemetry.buildMinuteWatchedPayload(
+            WatchCreditSession(
+                broadcastId = "broadcast-1",
+                channelId = "channel-1",
+                channelLogin = "channel",
+                userId = "user-1",
+            ),
+            clientTimeMillis = 1_704_116_262_123L,
+        )
+
+        val root = Json.parseToJsonElement(payload)
+        assertTrue(root is JsonArray)
+        val event = (root as JsonArray).single().jsonObject
+        assertEquals("minute-watched", event["event"]?.jsonPrimitive?.content)
+        val properties = event["properties"]!!.jsonObject
+        assertEquals("broadcast-1", properties["broadcast_id"]?.jsonPrimitive?.content)
+        assertEquals("channel-1", properties["channel_id"]?.jsonPrimitive?.content)
+        assertEquals("channel", properties["channel"]?.jsonPrimitive?.content)
+        assertEquals("user-1", properties["user_id"]?.jsonPrimitive?.content)
+        assertEquals("2024-01-01T13:37:42.123Z", properties["client_time"]?.jsonPrimitive?.content)
+        assertEquals("channel", properties["location"]?.jsonPrimitive?.content)
+        assertEquals("site", properties["player"]?.jsonPrimitive?.content)
+        assertEquals("1", properties["minutes_logged"]?.jsonPrimitive?.content)
+        assertEquals("true", properties["live"]?.jsonPrimitive?.content)
+        assertEquals("true", properties["is_live"]?.jsonPrimitive?.content)
+        assertEquals("true", properties["logged_in"]?.jsonPrimitive?.content)
+        assertEquals("false", properties["hidden"]?.jsonPrimitive?.content)
+        assertEquals("false", properties["muted"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun directSpadeUrlParserSupportsAllKnownPropertyNames() {
+        assertEquals(
+            "https://spade.twitch.tv/track",
+            WatchCreditTelemetry.extractSpadeUrl("{\"spadeUrl\":\"https:\\/\\/spade.twitch.tv/track\"}"),
+        )
+        assertEquals(
+            "https://spade.twitch.tv/track",
+            WatchCreditTelemetry.extractSpadeUrl("{\"spade_url\":\"https://spade.twitch.tv/track\"}"),
+        )
+        assertEquals(
+            "https://spade.twitch.tv/track",
+            WatchCreditTelemetry.extractSpadeUrl("{\"beacon_url\":\"https://spade.twitch.tv/track\"}"),
+        )
+    }
+
+    @Test
+    fun settingsUrlParserSupportsStaticTwitchCdnPath() {
+        assertEquals(
+            "https://static.twitchcdn.net/config/settings.a-b_c.123.js",
+            WatchCreditTelemetry.extractSettingsUrl(
+                "<script src=\"https://static.twitchcdn.net/config/settings.a-b_c.123.js\"></script>",
+            ),
+        )
+    }
+
+    @Test
+    fun settingsUrlParserSupportsAssetsTwitchPath() {
+        assertEquals(
+            "https://assets.twitch.tv/config/settings.abc-def.js",
+            WatchCreditTelemetry.extractSettingsUrl(
+                "<script src=\"https://assets.twitch.tv/config/settings.abc-def.js\"></script>",
+            ),
+        )
+    }
+
+    @Test
+    fun settingsUrlParserNormalizesEscapedSlashes() {
+        assertEquals(
+            "https://static.twitchcdn.net/config/settings.escaped-name.js",
+            WatchCreditTelemetry.extractSettingsUrl(
+                """<script src="https:\/\/static.twitchcdn.net\/config\/settings.escaped-name.js"></script>""",
+            ),
+        )
+    }
+
+    @Test
+    fun statusPolicyAcceptsSuccessfulResponsesIncludingNoContent() {
+        assertTrue(WatchCreditTelemetry.isSuccessfulStatus(200))
+        assertTrue(WatchCreditTelemetry.isSuccessfulStatus(204))
+        assertFalse(WatchCreditTelemetry.isSuccessfulStatus(199))
+        assertFalse(WatchCreditTelemetry.isSuccessfulStatus(300))
+    }
+}


### PR DESCRIPTION
Xtra now sends the watch activity Twitch expects and reports failed requests. It also keeps the endpoint for the active viewing session and avoids duplicate bonus claims.