### PR TITLE
Stop multiview chat from freezing and bursting

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatViewModel.kt
@@ -118,6 +118,18 @@ import javax.net.ssl.X509TrustManager
 import kotlin.concurrent.scheduleAtFixedRate
 import kotlin.time.Instant
 
+internal fun shouldResumeLiveChat(
+    liveChatInitialized: Boolean,
+    chatReadJobActive: Boolean?,
+    channelLogin: String?,
+    autoReconnect: Boolean,
+): Boolean {
+    return liveChatInitialized &&
+            chatReadJobActive != true &&
+            channelLogin != null &&
+            autoReconnect
+}
+
 class ChatViewModel(
     private val applicationContext: Context,
     private val graphQLRepository: GraphQLRepository,
@@ -176,6 +188,8 @@ class ChatViewModel(
     private var predictionSessionToken = 0L
     private var predictionSubscriptionSessionToken: Long? = null
     private var started = false
+    private var liveChatReadOnly = false
+    private var liveChatInitialized = false
     private var activeChannelId: String? = null
     private var activeChannelLogin: String? = null
     var autoReconnect = true
@@ -307,11 +321,19 @@ class ChatViewModel(
         thirdPartyEmotesUpdated.emit(Unit)
     }
 
-    fun startLive(networkLibrary: String?, recentMessagesUrl: String?, channelId: String?, channelLogin: String?, channelName: String?, streamId: String?) {
+    fun startLive(
+        networkLibrary: String?,
+        recentMessagesUrl: String?,
+        channelId: String?,
+        channelLogin: String?,
+        channelName: String?,
+        streamId: String?,
+        readOnly: Boolean = false,
+    ) {
         if (chatReadIRCSocket == null && chatReadWebSocket == null && eventSub == null && channelLogin != null) {
             messageLimit = 600
             this.streamId = streamId
-            startLiveChat(channelId, channelLogin)
+            startLiveChat(channelId, channelLogin, readOnly)
             addChatter(channelName)
             loadEmotes(channelId, channelLogin)
             if (applicationContext.prefs().getBoolean(C.CHAT_RECENT, true)) {
@@ -337,8 +359,9 @@ class ChatViewModel(
     }
 
     fun resumeLive(channelId: String?, channelLogin: String?) {
-        if ((chatReadJob?.isActive == false) && channelLogin != null && autoReconnect) {
-            startLiveChat(channelId, channelLogin)
+        val login = channelLogin ?: return
+        if (shouldResumeLiveChat(liveChatInitialized, chatReadJob?.isActive, login, autoReconnect)) {
+            startLiveChat(channelId, login, readOnly = liveChatReadOnly)
         }
     }
 
@@ -347,7 +370,7 @@ class ChatViewModel(
         val channelLogin = activeChannelLogin
         if (!channelLogin.isNullOrBlank()) {
             autoReconnect = true
-            startLiveChat(channelId, channelLogin)
+            startLiveChat(channelId, channelLogin, readOnly = liveChatReadOnly)
         }
     }
 
@@ -1103,6 +1126,16 @@ class ChatViewModel(
         }
     }
 
+    /** Trims history after a subscriber has consumed a message overflow. */
+    fun trimMessageOverflow() {
+        synchronized(chatMessages) {
+            val overflow = chatMessages.size - messageLimit
+            if (overflow > 0) {
+                chatMessages.subList(0, overflow).clear()
+            }
+        }
+    }
+
     private fun updateChannelPoints(response: ChannelPointContextResponse) {
         val channel = response.data?.community?.channel ?: return
         val balance = channel.self.communityPoints?.balance ?: return
@@ -1754,8 +1787,14 @@ class ChatViewModel(
         return true
     }
 
-    fun startLiveChat(channelId: String?, channelLogin: String) {
+    fun startLiveChat(
+        channelId: String?,
+        channelLogin: String,
+        readOnly: Boolean = liveChatReadOnly,
+    ) {
+        liveChatInitialized = true
         stopLiveChat()
+        liveChatReadOnly = readOnly
         val sessionToken = predictionSessionToken
         started = true
         _connectionState.value = ConnectionState.CONNECTING
@@ -1824,7 +1863,7 @@ class ChatViewModel(
             val helixToken = helixHeaders[C.HEADER_TOKEN]?.removePrefix("Bearer ")
             chatReadWebSocket = ChatReadWebSocket(channelLogin, trustManager, ChatReadListener(channelLogin, nameDisplay, showUserNotice, showClearMsg, showClearChat, usePubSub, networkLibrary, gqlHeaders, isLoggedIn, accountId, channelId))
             chatReadJob = chatReadWebSocket?.connect(viewModelScope)
-            if (isLoggedIn && (!gqlToken.isNullOrBlank() || !helixHeaders[C.HEADER_TOKEN].isNullOrBlank() && !useApiChatMessages)) {
+            if (!readOnly && isLoggedIn && (!gqlToken.isNullOrBlank() || !helixHeaders[C.HEADER_TOKEN].isNullOrBlank() && !useApiChatMessages)) {
                 chatWriteWebSocket = ChatWriteWebSocket(
                     userLogin = accountLogin,
                     userToken = gqlToken?.takeIf { it.isNotBlank() } ?: helixToken,
@@ -1939,44 +1978,50 @@ class ChatViewModel(
         _predictionBetState.value = PredictionBetState()
         if (started) {
             started = false
-            if (chatReadIRCSocket != null) {
-                MainScope().launch(Dispatchers.IO) {
-                    chatReadIRCSocket?.disconnect(chatReadJob)
-                }
-            } else {
-                if (chatReadWebSocket != null) {
-                    MainScope().launch(Dispatchers.IO) {
-                        chatReadWebSocket?.disconnect(chatReadJob)
-                    }
-                } else {
-                    if (eventSub != null) {
-                        MainScope().launch(Dispatchers.IO) {
-                            eventSub?.disconnect(chatReadJob)
-                        }
-                    }
-                }
+            val readIrcSocket = chatReadIRCSocket
+            val readWebSocket = chatReadWebSocket
+            val readEventSub = eventSub
+            val readJob = chatReadJob
+            val writeIrcSocket = chatWriteIRCSocket
+            val writeWebSocket = chatWriteWebSocket
+            val writeJob = chatWriteJob
+            val oldHermesWebSocket = hermesWebSocket
+            val oldPubSubJob = pubSubJob
+            val oldStvEventApi = stvEventApi
+            val oldStvEventApiJob = stvEventApiJob
+
+            chatReadIRCSocket = null
+            chatReadWebSocket = null
+            eventSub = null
+            chatReadJob = null
+            chatWriteIRCSocket = null
+            chatWriteWebSocket = null
+            chatWriteJob = null
+            hermesWebSocket = null
+            pubSubJob = null
+            stvEventApi = null
+            stvEventApiJob = null
+
+            readJob?.cancel()
+            writeJob?.cancel()
+            oldPubSubJob?.cancel()
+            oldStvEventApiJob?.cancel()
+
+            fun launchCleanup(block: suspend () -> Unit) {
+                MainScope().launch(Dispatchers.IO) { block() }
             }
-            if (chatWriteIRCSocket != null) {
-                MainScope().launch(Dispatchers.IO) {
-                    chatWriteIRCSocket?.disconnect(chatWriteJob)
-                }
-            } else {
-                if (chatWriteWebSocket != null) {
-                    MainScope().launch(Dispatchers.IO) {
-                        chatWriteWebSocket?.disconnect(chatWriteJob)
-                    }
-                }
+
+            when {
+                readIrcSocket != null -> launchCleanup { readIrcSocket.disconnect(readJob) }
+                readWebSocket != null -> launchCleanup { readWebSocket.disconnect(readJob) }
+                readEventSub != null -> launchCleanup { readEventSub.disconnect(readJob) }
             }
-            if (hermesWebSocket != null) {
-                MainScope().launch(Dispatchers.IO) {
-                    hermesWebSocket?.disconnect(pubSubJob)
-                }
+            when {
+                writeIrcSocket != null -> launchCleanup { writeIrcSocket.disconnect(writeJob) }
+                writeWebSocket != null -> launchCleanup { writeWebSocket.disconnect(writeJob) }
             }
-            if (stvEventApi != null) {
-                MainScope().launch(Dispatchers.IO) {
-                    stvEventApi?.disconnect(stvEventApiJob)
-                }
-            }
+            oldHermesWebSocket?.let { socket -> launchCleanup { socket.disconnect(oldPubSubJob) } }
+            oldStvEventApi?.let { api -> launchCleanup { api.disconnect(oldStvEventApiJob) } }
         }
     }
 

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/multiview/CombinedChatFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/multiview/CombinedChatFragment.kt
@@ -49,6 +49,7 @@ import com.google.mlkit.nl.translate.TranslateLanguage
 import com.google.mlkit.nl.translate.Translation
 import com.google.mlkit.nl.translate.Translator
 import com.google.mlkit.nl.translate.TranslatorOptions
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import java.util.Locale
@@ -66,6 +67,15 @@ class CombinedChatFragment : Fragment(R.layout.fragment_combined_chat),
     private var interactionIdentity: String? = null
     private var languageIdentifier: LanguageIdentifier? = null
     private val translators = mutableMapOf<String, Translator>()
+    private var renderPosted = false
+    private val renderRunnable = Runnable {
+        renderPosted = false
+        val layoutManager = _binding?.combinedChatRecyclerView?.layoutManager as? LinearLayoutManager
+        if (layoutManager != null && _binding != null) {
+            val wasAtBottom = isAtBottom(layoutManager)
+            submitMessages(forceScroll = CombinedChatPresentationPolicy.shouldAutoScroll(wasAtBottom))
+        }
+    }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -83,10 +93,8 @@ class CombinedChatFragment : Fragment(R.layout.fragment_combined_chat),
 
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
-                viewModel.updates.collectLatest {
-                    // Capture the position before DiffUtil applies the new list.
-                    val wasAtBottom = isAtBottom(layoutManager)
-                    submitMessages(forceScroll = CombinedChatPresentationPolicy.shouldAutoScroll(wasAtBottom))
+                viewModel.updates.collect {
+                    scheduleMessagesRender()
                 }
             }
         }
@@ -170,6 +178,8 @@ class CombinedChatFragment : Fragment(R.layout.fragment_combined_chat),
     }
 
     private fun submitMessages(forceScroll: Boolean) {
+        _binding?.combinedChatRecyclerView?.removeCallbacks(renderRunnable)
+        renderPosted = false
         if (!::adapter.isInitialized || _binding == null) return
         val items = viewModel.snapshot(filterIdentity)
         adapter.submitList(items) {
@@ -179,6 +189,13 @@ class CombinedChatFragment : Fragment(R.layout.fragment_combined_chat),
             }
         }
         binding.combinedChatEmpty.isVisible = items.isEmpty()
+    }
+
+    private fun scheduleMessagesRender() {
+        val recyclerView = _binding?.combinedChatRecyclerView ?: return
+        if (renderPosted) return
+        renderPosted = true
+        recyclerView.postOnAnimation(renderRunnable)
     }
 
     private fun isAtBottom(layoutManager: LinearLayoutManager): Boolean {
@@ -312,6 +329,8 @@ class CombinedChatFragment : Fragment(R.layout.fragment_combined_chat),
     }
 
     override fun onDestroyView() {
+        _binding?.combinedChatRecyclerView?.removeCallbacks(renderRunnable)
+        renderPosted = false
         interactionAdapter = null
         interactionIdentity = null
         languageIdentifier = null

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/multiview/chat/CombinedChatViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/multiview/chat/CombinedChatViewModel.kt
@@ -13,6 +13,8 @@ import com.github.andreyasadchy.xtra.ui.chat.ChatViewModel
 import com.github.andreyasadchy.xtra.ui.multiview.CombinedChatPresentationPolicy
 import com.github.andreyasadchy.xtra.util.C
 import com.github.andreyasadchy.xtra.util.prefs
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -31,7 +33,7 @@ class CombinedChatViewModel(
     private var sequence = 0L
     private var lifecycleStarted = false
     private val _updates = MutableSharedFlow<Unit>(
-        extraBufferCapacity = 64,
+        extraBufferCapacity = 1,
         onBufferOverflow = BufferOverflow.DROP_OLDEST,
     )
     val updates: SharedFlow<Unit> = _updates
@@ -90,12 +92,17 @@ class CombinedChatViewModel(
     }
 
     private fun observe(session: ChannelSession) {
-        session.jobs += viewModelScope.launch {
+        // ChatViewModel.onMessage waits for this collector. Keep the work off Main,
+        // but subscribe before startLive can deliver the first message.
+        session.jobs += viewModelScope.launch(Dispatchers.Default, start = CoroutineStart.UNDISPATCHED) {
             session.viewModel.newMessage.collect { result ->
+                if (result.third > 0) {
+                    session.viewModel.trimMessageOverflow()
+                }
                 append(session, result.first)
             }
         }
-        session.jobs += viewModelScope.launch {
+        session.jobs += viewModelScope.launch(Dispatchers.Default, start = CoroutineStart.UNDISPATCHED) {
             session.viewModel.addMessages.collect { result ->
                 prependHistory(session, result.first)
             }
@@ -112,7 +119,7 @@ class CombinedChatViewModel(
                         }
                     }
                 }
-                _updates.emit(Unit)
+                _updates.tryEmit(Unit)
             }
         }
         session.jobs += viewModelScope.launch {
@@ -120,20 +127,20 @@ class CombinedChatViewModel(
                 if (reload) {
                     session.renderGeneration = CombinedChatPresentationPolicy.nextRenderGeneration(session.renderGeneration)
                     session.viewModel.reloadMessages.value = false
-                    _updates.emit(Unit)
+                    _updates.tryEmit(Unit)
                 }
             }
         }
         session.jobs += viewModelScope.launch {
             session.viewModel.thirdPartyEmotesUpdated.collect {
                 session.renderGeneration = CombinedChatPresentationPolicy.nextRenderGeneration(session.renderGeneration)
-                _updates.emit(Unit)
+                _updates.tryEmit(Unit)
             }
         }
         session.jobs += viewModelScope.launch {
             session.viewModel.userEmotesUpdated.collect {
                 session.renderGeneration = CombinedChatPresentationPolicy.nextRenderGeneration(session.renderGeneration)
-                _updates.emit(Unit)
+                _updates.tryEmit(Unit)
             }
         }
         session.jobs += viewModelScope.launch {
@@ -164,12 +171,13 @@ class CombinedChatViewModel(
                 channelLogin = channelLogin,
                 channelName = stream.channelName,
                 streamId = stream.id,
+                readOnly = true,
             )
             session.hasStarted = true
         } else {
             // Match ChatFragment.reconnect(): restart the live transport and
             // rehydrate recent messages without recreating the ViewModel.
-            session.viewModel.startLiveChat(stream.channelId, channelLogin)
+            session.viewModel.startLiveChat(stream.channelId, channelLogin, readOnly = true)
             if (preferences.getBoolean(C.CHAT_RECENT, true)) {
                 session.viewModel.loadRecentMessages(
                     preferences.getString(C.NETWORK_LIBRARY, C.OKHTTP),
@@ -228,7 +236,7 @@ class CombinedChatViewModel(
 
     private class ChannelSession(
         val identity: String,
-        var stream: Stream,
+        @Volatile var stream: Stream,
         val viewModel: ChatViewModel,
     ) {
         val jobs = mutableListOf<Job>()

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/ChatViewModelTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/ChatViewModelTest.kt
@@ -1,0 +1,32 @@
+package com.github.andreyasadchy.xtra.ui.chat
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ChatViewModelTest {
+
+    @Test
+    fun neverInitializedSessionDoesNotResume() {
+        assertFalse(
+            shouldResumeLiveChat(
+                liveChatInitialized = false,
+                chatReadJobActive = null,
+                channelLogin = "channel",
+                autoReconnect = true,
+            ),
+        )
+    }
+
+    @Test
+    fun initializedInactiveSessionResumes() {
+        assertTrue(
+            shouldResumeLiveChat(
+                liveChatInitialized = true,
+                chatReadJobActive = false,
+                channelLogin = "channel",
+                autoReconnect = true,
+            ),
+        )
+    }
+}

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/multiview/chat/CombinedChatViewModelTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/multiview/chat/CombinedChatViewModelTest.kt
@@ -1,0 +1,54 @@
+package com.github.andreyasadchy.xtra.ui.multiview.chat
+
+import android.content.ContextWrapper
+import java.util.concurrent.atomic.AtomicInteger
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.yield
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.onSubscription
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class CombinedChatViewModelTest {
+    @Test
+    fun updateSignalKeepsOnlyOnePendingNotification() = runBlocking {
+        val viewModel = CombinedChatViewModel(ContextWrapper(null)) {
+            error("The test does not create chat sessions")
+        }
+        val received = AtomicInteger()
+        val collectorReady = CompletableDeferred<Unit>()
+        val firstNotification = CompletableDeferred<Unit>()
+        val releaseCollector = CompletableDeferred<Unit>()
+        val collector = launch(Dispatchers.Default) {
+            viewModel.updates
+                .onSubscription { collectorReady.complete(Unit) }
+                .collect {
+                    received.incrementAndGet()
+                    firstNotification.complete(Unit)
+                    releaseCollector.await()
+                }
+        }
+
+        collectorReady.await()
+        viewModel.ensureStreams(emptyList())
+        firstNotification.await()
+        repeat(64) {
+            viewModel.ensureStreams(emptyList())
+        }
+
+        releaseCollector.complete(Unit)
+        withTimeout(2_000) {
+            while (received.get() < 2) yield()
+        }
+        delay(100)
+        collector.cancelAndJoin()
+
+        assertEquals(2, received.get())
+    }
+}


### PR DESCRIPTION
Multiview chat now stays responsive during busy periods and catches up with one current render instead of replaying stale redraws. Per-channel history stays bounded, reconnects cannot close a new connection, and read-only multiview sessions skip write chat sockets.\n\nTests: :app:testDebugUnitTest and :app:assembleDebug. Smoke-tested the debug app on xtra-api35.