### PR TITLE
Add explicit favorite emote reorder mode

### DIFF
--- a/.github/scripts/translation-baseline.json
+++ b/.github/scripts/translation-baseline.json
@@ -1,15 +1,15 @@
 {
-  "values-ar": 756,
-  "values-de": 756,
-  "values-es": 756,
-  "values-fr": 756,
-  "values-gl": 756,
-  "values-in": 756,
-  "values-it": 756,
-  "values-ja": 756,
-  "values-pt-rBR": 756,
-  "values-ru": 756,
-  "values-tr": 756,
-  "values-zh-rCN": 756,
-  "values-zh-rTW": 756
+  "values-ar": 759,
+  "values-de": 759,
+  "values-es": 759,
+  "values-fr": 759,
+  "values-gl": 759,
+  "values-in": 759,
+  "values-it": 759,
+  "values-ja": 759,
+  "values-pt-rBR": 759,
+  "values-ru": 759,
+  "values-tr": 759,
+  "values-zh-rCN": 759,
+  "values-zh-rTW": 759
 }

--- a/app/src/androidTest/java/com/github/andreyasadchy/xtra/ui/chat/EmotesAdapterReorderModeTest.kt
+++ b/app/src/androidTest/java/com/github/andreyasadchy/xtra/ui/chat/EmotesAdapterReorderModeTest.kt
@@ -1,0 +1,126 @@
+package com.github.andreyasadchy.xtra.ui.chat
+
+import android.os.SystemClock
+import androidx.fragment.app.Fragment
+import androidx.recyclerview.widget.RecyclerView
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.github.andreyasadchy.xtra.model.chat.Emote
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class EmotesAdapterReorderModeTest {
+
+    @Test
+    fun doneWithoutMoveRebindsTheVisibleItems() {
+        val adapter = adapterWithItems(listOf("A", "B"))
+        val observer = RecordingObserver()
+        adapter.registerAdapterDataObserver(observer)
+
+        onMain { adapter.setReorderMode(true) }
+        observer.reset()
+        onMain { adapter.setReorderMode(false) }
+
+        assertTrue("Done must rebind items after leaving reorder mode", observer.changed)
+        assertEquals(0, observer.moveEvents)
+    }
+
+    @Test
+    fun doneDoesNotReplayACompletedMove() {
+        val adapter = adapterWithItems(listOf("A", "B"))
+
+        onMain { adapter.setReorderMode(true) }
+        onMain { assertTrue(adapter.moveItem(0, 1)) }
+        assertEquals(listOf("B", "A"), currentNames(adapter))
+
+        val observer = RecordingObserver()
+        adapter.registerAdapterDataObserver(observer)
+        onMain { adapter.setReorderMode(false) }
+
+        assertEquals(listOf("B", "A"), currentNames(adapter))
+        assertTrue("Done must rebind items after a move", observer.changed)
+        assertEquals("Done must not replay the completed move", 0, observer.moveEvents)
+    }
+
+    @Test
+    fun externalUpdateStaysCoherentWhenLeavingReorderMode() {
+        val adapter = adapterWithItems(listOf("A", "B", "C"))
+
+        onMain { adapter.setReorderMode(true) }
+        onMain { adapter.submitList(listOf(Emote(name = "C"), Emote(name = "A"), Emote(name = "B"))) }
+        assertEquals(listOf("C", "A", "B"), currentNames(adapter))
+
+        val observer = RecordingObserver()
+        adapter.registerAdapterDataObserver(observer)
+        onMain { adapter.setReorderMode(false) }
+
+        assertEquals(listOf("C", "A", "B"), currentNames(adapter))
+        assertTrue("Done must rebind after an external update", observer.changed)
+        assertEquals("Done must not diff and replay an external reorder", 0, observer.moveEvents)
+    }
+
+    private fun adapterWithItems(names: List<String>): EmotesAdapter {
+        val adapter = EmotesAdapter(
+            fragment = Fragment(),
+            clickListener = {},
+            emoteQuality = "4",
+            imageLibrary = "0",
+            reorderable = true,
+        )
+        onMain { adapter.submitList(names.map(::Emote)) }
+        waitForItemCount(adapter, names.size)
+        return adapter
+    }
+
+    private fun waitForItemCount(adapter: EmotesAdapter, expected: Int) {
+        repeat(100) {
+            InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+            if (adapter.itemCount == expected) return
+            SystemClock.sleep(10)
+        }
+        assertEquals(expected, adapter.itemCount)
+    }
+
+    private fun onMain(action: () -> Unit) {
+        InstrumentationRegistry.getInstrumentation().runOnMainSync(action)
+    }
+
+    private fun currentNames(adapter: EmotesAdapter): List<String?> {
+        return onMainResult { adapter.currentItems().map { it.name } }
+    }
+
+    private fun <T : Any> onMainResult(action: () -> T): T {
+        lateinit var result: T
+        onMain { result = action() }
+        return result
+    }
+
+    private class RecordingObserver : RecyclerView.AdapterDataObserver() {
+        @Volatile var changed = false
+        @Volatile var moveEvents = 0
+
+        fun reset() {
+            changed = false
+            moveEvents = 0
+        }
+
+        override fun onChanged() {
+            changed = true
+        }
+
+        override fun onItemRangeChanged(positionStart: Int, itemCount: Int) {
+            changed = true
+        }
+
+        override fun onItemRangeChanged(positionStart: Int, itemCount: Int, payload: Any?) {
+            changed = true
+        }
+
+        override fun onItemRangeMoved(fromPosition: Int, toPosition: Int, itemCount: Int) {
+            moveEvents++
+        }
+    }
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/EmotesAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/EmotesAdapter.kt
@@ -50,6 +50,7 @@ class EmotesAdapter(
     private val differ = AsyncListDiffer(this, EMOTE_DIFF_CALLBACK)
     private val items = mutableListOf<Emote>()
     private var favoriteKeys: Set<FavoriteEmoteKey> = emptySet()
+    private var reorderMode = false
     var itemTouchHelper: ItemTouchHelper? = null
     var accessibilityMoveListener: ((Int, Int) -> Boolean)? = null
 
@@ -69,13 +70,22 @@ class EmotesAdapter(
         }
     }
 
+    fun setReorderMode(enabled: Boolean) {
+        if (!reorderable || reorderMode == enabled) return
+        reorderMode = enabled
+        if (itemCount > 0) {
+            notifyItemRangeChanged(0, itemCount)
+        }
+    }
+
     fun moveItem(from: Int, to: Int): Boolean {
+        if (!reorderMode) return false
         if (!moveListItem(items, from, to)) return false
         notifyItemMoved(from, to)
         return true
     }
 
-    fun currentItems(): List<Emote> = items.toList()
+    fun currentItems(): List<Emote> = if (reorderable) items.toList() else differ.currentList
 
     fun setFavoriteKeys(keys: Set<FavoriteEmoteKey>) {
         if (favoriteKeys != keys) {
@@ -115,8 +125,10 @@ class EmotesAdapter(
                 reorderAccessibilityActionIds.clear()
                 emote.setOnClickListener(null)
                 emote.setOnLongClickListener(null)
-                dragHandle.visibility = if (reorderable) View.VISIBLE else View.GONE
-                dragHandle.setOnTouchListener(if (reorderable) {
+                emote.isClickable = false
+                val canReorder = reorderable && reorderMode
+                dragHandle.visibility = if (canReorder) View.VISIBLE else View.GONE
+                dragHandle.setOnTouchListener(if (canReorder) {
                     { _, event ->
                         if (event.actionMasked == MotionEvent.ACTION_DOWN) {
                             itemTouchHelper?.startDrag(this@ViewHolder)
@@ -125,7 +137,10 @@ class EmotesAdapter(
                     }
                 } else null)
                 if (item != null) {
-                    emote.contentDescription = fragment.getString(R.string.use_emote, item.name)
+                    emote.contentDescription = fragment.getString(
+                        if (canReorder) R.string.reorder_favorite_emote else R.string.use_emote,
+                        item.name,
+                    )
                     emote.isFocusable = true
                     if (imageLibrary == "0" || (imageLibrary == "1" && !item.format.equals("webp", true))) {
                         fragment.requireContext().imageLoader.enqueue(
@@ -165,9 +180,11 @@ class EmotesAdapter(
                             .transition(DrawableTransitionOptions.withCrossFade())
                             .into(emote)
                     }
-                    emote.setOnClickListener { clickListener(item) }
+                    if (!canReorder) {
+                        emote.setOnClickListener { clickListener(item) }
+                    }
                     val key = item.favoriteKey()
-                    if (favoriteToggleListener != null && key != null) {
+                    if (!canReorder && favoriteToggleListener != null && key != null) {
                         val isFavorite = key in favoriteKeys
                         emote.setOnLongClickListener {
                             it.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS)
@@ -184,10 +201,10 @@ class EmotesAdapter(
                                 true
                             },
                         )
-                    } else if (consumeLongPress) {
+                    } else if (!canReorder && consumeLongPress) {
                         emote.setOnLongClickListener { true }
                     }
-                    if (reorderable) {
+                    if (canReorder) {
                         reorderAccessibilityActionIds += ViewCompat.addAccessibilityAction(
                             emote,
                             fragment.getString(R.string.move_favorite_emote_before),

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/EmotesFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/EmotesFragment.kt
@@ -55,6 +55,7 @@ class EmotesFragment : Fragment() {
     private val viewModel by viewModels<ChatViewModel>(ownerProducer = { requireParentFragment() }, factoryProducer = { ChatViewModelFactory })
     private var recentEmotes = emptyList<RecentEmote>()
     private var favoriteDragActive = false
+    private var favoriteEditMode = false
     private var pendingFavoriteItems: List<Emote>? = null
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
@@ -76,6 +77,9 @@ class EmotesFragment : Fragment() {
             consumeLongPress = section == EmotePickerSection.RECENTS,
             reorderable = section == EmotePickerSection.FAVORITES,
         )
+        binding.editFavorites.setOnClickListener {
+            setFavoriteEditMode(!favoriteEditMode, adapter)
+        }
         val itemTouchHelper = if (section == EmotePickerSection.FAVORITES) {
             ItemTouchHelper(
                 object : ItemTouchHelper.SimpleCallback(
@@ -188,11 +192,39 @@ class EmotesFragment : Fragment() {
         }
         if (section == EmotePickerSection.FAVORITES && favoriteDragActive) {
             pendingFavoriteItems = list.toList()
+            updateFavoriteEditControls(section, list, adapter)
             updateEmptyState(section, list)
             return
         }
         adapter.submitList(list)
+        updateFavoriteEditControls(section, list, adapter)
         updateEmptyState(section, list)
+    }
+
+    private fun setFavoriteEditMode(enabled: Boolean, adapter: EmotesAdapter) {
+        favoriteEditMode = enabled
+        adapter.setReorderMode(enabled)
+        binding.editFavorites.setText(
+            if (enabled) R.string.done_reordering_favorite_emotes else R.string.reorder_favorite_emotes,
+        )
+    }
+
+    private fun updateFavoriteEditControls(
+        section: EmotePickerSection,
+        list: List<Emote>,
+        adapter: EmotesAdapter,
+    ) {
+        val visible = section == EmotePickerSection.FAVORITES && list.isNotEmpty()
+        if (!visible && favoriteEditMode) {
+            setFavoriteEditMode(false, adapter)
+        }
+        binding.editFavorites.isVisible = visible
+        binding.emotesRecyclerView.setPadding(
+            binding.emotesRecyclerView.paddingLeft,
+            if (visible) resources.getDimensionPixelSize(R.dimen.emote_picker_edit_control_space) else 0,
+            binding.emotesRecyclerView.paddingRight,
+            binding.emotesRecyclerView.paddingBottom,
+        )
     }
 
     private fun updateEmptyState(section: EmotePickerSection, list: List<Emote>) {
@@ -252,6 +284,7 @@ class EmotesFragment : Fragment() {
 
     override fun onDestroyView() {
         super.onDestroyView()
+        favoriteEditMode = false
         _binding = null
     }
 

--- a/app/src/main/res/layout/fragment_emotes.xml
+++ b/app/src/main/res/layout/fragment_emotes.xml
@@ -13,6 +13,20 @@
         android:paddingRight="10dp"
         android:paddingEnd="10dp" />
 
+    <Button
+        android:id="@+id/editFavorites"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="top|end"
+        android:layout_marginTop="2dp"
+        android:layout_marginEnd="8dp"
+        android:minWidth="0dp"
+        android:minHeight="40dp"
+        android:paddingStart="12dp"
+        android:paddingEnd="12dp"
+        android:text="@string/reorder_favorite_emotes"
+        android:visibility="gone" />
+
     <TextView
         android:id="@+id/emptyState"
         android:layout_width="match_parent"

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -3,5 +3,6 @@
     <dimen name="divider_margin">5dp</dimen>
     <dimen name="settings_section_spacing">8dp</dimen>
     <dimen name="emote_picker_max_height">300dp</dimen>
+    <dimen name="emote_picker_edit_control_space">48dp</dimen>
     <dimen name="following_overview_bottom_padding">16dp</dimen>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1054,6 +1054,9 @@
     <string name="removed_emote_from_favorites">Removed %1$s from favorites</string>
     <string name="favorite_emotes_empty">No favorite emotes here yet\nLong-press an emote to add it to Favorites.</string>
     <string name="favorite_emotes_unavailable">None of your favorite emotes are available in this channel.</string>
+    <string name="reorder_favorite_emotes">Reorder</string>
+    <string name="done_reordering_favorite_emotes">Done</string>
+    <string name="reorder_favorite_emote">Reorder %1$s emote</string>
     <string name="move_favorite_emote_before">Move favorite emote before</string>
     <string name="move_favorite_emote_after">Move favorite emote after</string>
     <string name="watch_stream">Watch stream</string>


### PR DESCRIPTION
Adds a Reorder/Done mode for favorite emotes. Normal taps stay focused on sending, while drag handles and reorder actions appear only during editing.