### PR TITLE
Use the built-in client ID for debug builds

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -11,10 +11,12 @@ docker compose -f docker-compose.android.yml run --rm android-build
 
 The Compose service keeps Gradle distributions/dependencies in `xtra-gradle-cache` and the Android SDK in `xtra-android-sdk`. Later builds reuse both volumes. The Windows `gradlew` line endings are normalized only in a pipe inside the container; the checkout is not modified.
 
+Debug builds use Xtra's built-in public Twitch client ID automatically. Release builds require an explicit client ID.
+
 To build a release APK:
 
 ```powershell
-docker compose -f docker-compose.android.yml run --rm android-build :app:assembleRelease --no-daemon
+docker compose -f docker-compose.android.yml run --rm android-build :app:assembleRelease --no-daemon "-PtwitchPublicClientId=<public-client-id>"
 ```
 
 The APKs are written to `app/build/outputs/apk/` in the workspace. Rebuild the image with `docker compose -f docker-compose.android.yml build --pull` when the toolchain definition changes.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,14 +13,29 @@ val applicationVersionCode = providers.gradleProperty("ciVersionCode")
     .orNull
     ?.toInt()
     ?: defaultVersionCode
-val twitchPublicClientId = providers.gradleProperty("twitchPublicClientId").orElse("").get()
-val releaseTaskRequested = gradle.startParameter.taskNames.any { it.contains("release", ignoreCase = true) }
+/**
+ * This is Xtra's public Helix client ID, also used by the app's API defaults.
+ * Keep it in sync with C.DEFAULT_HELIX_CLIENT_ID. Debug builds use it automatically;
+ * release builds must provide their own value.
+ */
+val localDevelopmentTwitchPublicClientId = "ilfexgv3nnljz3isbm257gzwrzr7bi"
+val configuredTwitchPublicClientId = providers.gradleProperty("twitchPublicClientId")
+    .orNull
+    ?.trim()
+    ?.takeIf { it.isNotEmpty() }
+val releaseTaskRequested = gradle.startParameter.taskNames.any { taskName ->
+    val requestedTask = taskName.substringAfterLast(':')
+    requestedTask.contains("release", ignoreCase = true) ||
+        requestedTask in setOf("assemble", "build", "bundle")
+}
 
 if (releaseTaskRequested) {
-    require(twitchPublicClientId.isNotBlank()) {
+    require(configuredTwitchPublicClientId != null) {
         "twitchPublicClientId is required for release builds"
     }
 }
+
+val twitchPublicClientId = configuredTwitchPublicClientId ?: localDevelopmentTwitchPublicClientId
 
 require(applicationVersionCode in 1..2_100_000_000) {
     "versionCode must be between 1 and 2,100,000,000"

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/auth/TwitchClientConfig.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/auth/TwitchClientConfig.kt
@@ -4,8 +4,8 @@ import com.github.andreyasadchy.xtra.BuildConfig
 
 object TwitchClientConfig {
     /**
-     * The public Twitch application ID is supplied by the build, not stored in source.
-     * Configure a release with `-PtwitchPublicClientId=<public-client-id>`.
+     * Debug builds use Xtra's built-in public client ID. Configure a release with
+     * `-PtwitchPublicClientId=<public-client-id>`.
      */
     fun publicClientId(): String? = BuildConfig.TWITCH_PUBLIC_CLIENT_ID
         .trim()


### PR DESCRIPTION
Local debug builds now use Xtra's built-in public Twitch client ID automatically. Release builds still require an explicit client ID.