### PR TITLE
Fix video surface restoration after background playback

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/ExoPlayerFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/ExoPlayerFragment.kt
@@ -290,12 +290,6 @@ class ExoPlayerFragment : PlayerFragment() {
                 }
             }
 
-            override fun changeSurfaceVisibility(visible: Boolean) {
-                if (view != null && !isClipEditorVisible()) {
-                    binding.playerSurface.visibility = if (visible) View.VISIBLE else View.GONE
-                }
-            }
-
             override fun toast(resId: Int, duration: Int) {
                 if (view != null) {
                     when (resId) {
@@ -354,13 +348,24 @@ class ExoPlayerFragment : PlayerFragment() {
                         ) return@launch
 
                         val editorRestored = restoreClipEditorIfNeeded()
+                        connectedService.serviceListener = serviceListener
                         if (!editorRestored) {
-                            connectedService.player?.setVideoSurfaceView(binding.playerSurface)
-                            connectedService.restoreBackgroundVideoIfNeeded()
+                            val restored = connectedService.restoreVideoOutputIfNeeded {
+                                val player = connectedService.player
+                                if (player == null) {
+                                    false
+                                } else {
+                                    binding.playerSurface.visibility = View.VISIBLE
+                                    player.setVideoSurfaceView(binding.playerSurface)
+                                    true
+                                }
+                            }
+                            if (!restored) {
+                                connectedService.player?.setVideoSurfaceView(binding.playerSurface)
+                            }
                         } else {
                             pauseLiveClipPlayback()
                         }
-                        connectedService.serviceListener = serviceListener
                         connectedService.player?.addListener(listener)
                         playerListener = listener
                         val endTime = connectedService.setSleepTimer(-1)
@@ -835,7 +840,13 @@ class ExoPlayerFragment : PlayerFragment() {
                 playbackService?.player?.playWhenReady = false
                 playbackService?.player?.pause()
             } else {
-                playbackService?.stop(isInPIPMode)
+                val videoDetachedForBackground = playbackService?.stop(isInPIPMode) == true
+                if (view != null && !isInPIPMode) {
+                    playbackService?.player?.clearVideoSurfaceView(binding.playerSurface)
+                    if (videoDetachedForBackground) {
+                        binding.playerSurface.visibility = View.GONE
+                    }
+                }
             }
             playbackService?.setSleepTimer((activity as? MainActivity)?.getSleepTimerTimeLeft() ?: 0)
             playbackService?.setStopServiceTimer(true)
@@ -874,6 +885,7 @@ class ExoPlayerFragment : PlayerFragment() {
     override fun onDestroy() {
         playbackService?.cancelLiveClipPreparation()
         super.onDestroy()
+        playbackService = null
     }
 
     override fun onNetworkRestored() {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/ExoPlayerService.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/ExoPlayerService.kt
@@ -25,7 +25,6 @@ import android.os.Bundle
 import android.os.Handler
 import android.os.IBinder
 import android.os.Looper
-import android.os.PowerManager
 import android.util.Base64
 import android.util.Log
 import android.view.KeyEvent
@@ -144,7 +143,7 @@ class ExoPlayerService : BasePlaybackService() {
     private var updateQualities = false
     private var created = false
     private var resumeWhenForeground = false
-    private var backgroundVideoDisabled = false
+    private val videoOutputState = VideoOutputState()
     private var streamRecoveryJob: Job? = null
     private var streamRecoveryAttempt = 0
     private val initialRestore = CompletableDeferred<Unit>()
@@ -167,7 +166,6 @@ class ExoPlayerService : BasePlaybackService() {
         fun updateLiveClipStatus() {}
         fun toast(resId: Int, duration: Int)
         fun updateVideoInfo()
-        fun changeSurfaceVisibility(visible: Boolean) {}
     }
 
     var serviceListener: Listener? = null
@@ -1843,33 +1841,27 @@ class ExoPlayerService : BasePlaybackService() {
         }
     }
 
-    fun stop(isInPIPMode: Boolean) {
-        player?.let { player ->
-            setProxyMediaPlaylist(false)
-            resumeWhenForeground = false
-            val isInteractive = (getSystemService(POWER_SERVICE) as PowerManager).isInteractive
-            if (prefs().getBoolean(C.SETTINGS_BACKGROUND_PLAYBACK, true)) {
-                if (player.playWhenReady && quality?.name != AUDIO_ONLY_QUALITY) {
-                    if (player.currentMediaItem != null) {
-                        backgroundVideoDisabled = true
-                        serviceListener?.changeSurfaceVisibility(false)
-                    }
-                }
-            } else {
-                resumeWhenForeground = player.playWhenReady && player.playbackState != Player.STATE_ENDED
-                player.pause()
-            }
+    fun stop(isInPIPMode: Boolean): Boolean {
+        val player = player ?: return false
+        setProxyMediaPlaylist(false)
+        resumeWhenForeground = false
+        if (isInPIPMode) {
+            return false
         }
+        if (prefs().getBoolean(C.SETTINGS_BACKGROUND_PLAYBACK, true)) {
+            if (player.playWhenReady && quality?.name != AUDIO_ONLY_QUALITY && player.currentMediaItem != null) {
+                videoOutputState.markDetachedForBackground()
+                return true
+            }
+        } else {
+            resumeWhenForeground = player.playWhenReady && player.playbackState != Player.STATE_ENDED
+            player.pause()
+        }
+        return false
     }
 
-    fun restoreBackgroundVideoIfNeeded() {
-        if (!backgroundVideoDisabled) {
-            return
-        }
-        backgroundVideoDisabled = false
-        player?.let { player ->
-            serviceListener?.changeSurfaceVisibility(true)
-        }
+    fun restoreVideoOutputIfNeeded(restore: () -> Boolean): Boolean {
+        return videoOutputState.restoreIfNeeded(restore)
     }
 
     fun resumePlaybackIfNeeded() {
@@ -2384,7 +2376,6 @@ class ExoPlayerService : BasePlaybackService() {
 
     override fun onTaskRemoved(rootIntent: Intent?) {
         savePosition()
-        val isInteractive = (getSystemService(POWER_SERVICE) as PowerManager).isInteractive
         val keepPlayback = player?.playWhenReady == true
                 && player?.playbackState != Player.STATE_ENDED
                 && prefs().getBoolean(C.PLAYER_KEEP_PLAYING_AFTER_TASK_REMOVED, true)
@@ -2408,7 +2399,7 @@ class ExoPlayerService : BasePlaybackService() {
         primaryStreamRestoreJob?.cancel()
         primaryStreamRestoreJob = null
         adController.reset()
-        backgroundVideoDisabled = false
+        videoOutputState.clear()
         player?.release()
         session?.release()
         bitmapLoadJob?.cancel()

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/Media3Fragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/Media3Fragment.kt
@@ -8,7 +8,6 @@ import android.net.ConnectivityManager
 import android.net.NetworkCapabilities
 import android.os.Build
 import android.os.Bundle
-import android.os.PowerManager
 import android.text.format.DateUtils
 import android.util.Log
 import android.view.View
@@ -120,7 +119,6 @@ class Media3Fragment : Media3PlayerFragment() {
                 MediaController.releaseFuture(future)
                 return@addListener
             }
-            controller.setVideoSurfaceView(binding.playerSurface)
             val listener = object : Player.Listener {
 
                 override fun onPlaybackStateChanged(playbackState: Int) {
@@ -464,9 +462,13 @@ class Media3Fragment : Media3PlayerFragment() {
                     }
                 }
             }
-            if (viewModel.backgroundVideoDisabled) {
-                viewModel.backgroundVideoDisabled = false
+            val restored = viewModel.videoOutputState.restoreIfNeeded {
                 binding.playerSurface.visibility = View.VISIBLE
+                controller.setVideoSurfaceView(binding.playerSurface)
+                true
+            }
+            if (!restored) {
+                controller.setVideoSurfaceView(binding.playerSurface)
             }
             controller.addListener(listener)
             playerListener = listener
@@ -1263,6 +1265,11 @@ class Media3Fragment : Media3PlayerFragment() {
 
     override fun onStop() {
         super.onStop()
+        val isInPIPMode = when {
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.R -> requireActivity().isInPictureInPictureMode
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.O -> !useController && isMaximized
+            else -> false
+        }
         player?.let { player ->
             if (player.isConnected) {
                 savePosition()
@@ -1276,16 +1283,10 @@ class Media3Fragment : Media3PlayerFragment() {
                     )
                     viewModel.usingProxy = false
                 }
-                val isInteractive = (requireContext().getSystemService(Context.POWER_SERVICE) as PowerManager).isInteractive
-                val isInPIPMode = when {
-                    Build.VERSION.SDK_INT >= Build.VERSION_CODES.R -> requireActivity().isInPictureInPictureMode
-                    Build.VERSION.SDK_INT >= Build.VERSION_CODES.O -> !useController && isMaximized
-                    else -> false
-                }
                 if (requireContext().prefs().getBoolean(C.SETTINGS_BACKGROUND_PLAYBACK, true)) {
-                    if (player.playWhenReady && viewModel.quality?.name != AUDIO_ONLY_QUALITY) {
+                    if (!isInPIPMode && player.playWhenReady && viewModel.quality?.name != AUDIO_ONLY_QUALITY) {
                         if (player.currentMediaItem != null) {
-                            viewModel.backgroundVideoDisabled = true
+                            viewModel.videoOutputState.markDetachedForBackground()
                             binding.playerSurface.visibility = View.GONE
                         }
                     }
@@ -1309,7 +1310,9 @@ class Media3Fragment : Media3PlayerFragment() {
             }
         }
         binding.playerControls.root.removeCallbacks(updateProgressAction)
-        releaseController()
+        if (!isInPIPMode) {
+            releaseController()
+        }
     }
 
     override fun onNetworkRestored() {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/Media3PlayerViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/Media3PlayerViewModel.kt
@@ -106,7 +106,7 @@ class Media3PlayerViewModel(
     var updateQualities = false
     var started = false
     var restoreQuality = false
-    var backgroundVideoDisabled = false
+    internal val videoOutputState = VideoOutputState()
     var resume = false
     var hidden = false
     val loaded = MutableStateFlow(false)

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/PlaybackService.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/PlaybackService.kt
@@ -10,7 +10,6 @@ import android.os.Build
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
-import android.os.PowerManager
 import android.util.Base64
 import androidx.annotation.OptIn
 import androidx.lifecycle.lifecycleScope
@@ -969,7 +968,6 @@ class PlaybackService : MediaSessionService() {
     override fun onTaskRemoved(rootIntent: Intent?) {
         savePosition()
         val player = mediaSession?.player
-        val isInteractive = (getSystemService(POWER_SERVICE) as PowerManager).isInteractive
         val keepPlayback = player?.playWhenReady == true
                 && player.playbackState != Player.STATE_ENDED
                 && prefs().getBoolean(C.PLAYER_KEEP_PLAYING_AFTER_TASK_REMOVED, true)

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/VideoOutputState.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/VideoOutputState.kt
@@ -1,0 +1,25 @@
+package com.github.andreyasadchy.xtra.ui.player
+
+/**
+ * Keeps a pending background-video surface restoration until the UI has
+ * successfully taken ownership of the restoration.
+ */
+internal class VideoOutputState {
+    private var detachedForBackground = false
+
+    fun markDetachedForBackground() {
+        detachedForBackground = true
+    }
+
+    fun restoreIfNeeded(restore: () -> Boolean): Boolean {
+        if (!detachedForBackground || !restore()) {
+            return false
+        }
+        detachedForBackground = false
+        return true
+    }
+
+    fun clear() {
+        detachedForBackground = false
+    }
+}

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/player/VideoOutputStateTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/player/VideoOutputStateTest.kt
@@ -1,0 +1,46 @@
+package com.github.andreyasadchy.xtra.ui.player
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class VideoOutputStateTest {
+    @Test
+    fun failedRestorationKeepsThePendingState() {
+        val state = VideoOutputState()
+        state.markDetachedForBackground()
+
+        assertFalse(state.restoreIfNeeded { false })
+        assertTrue(state.restoreIfNeeded { true })
+        assertFalse(state.restoreIfNeeded { true })
+    }
+
+    @Test
+    fun clearDropsPendingRestoration() {
+        val state = VideoOutputState()
+        state.markDetachedForBackground()
+        state.clear()
+
+        assertFalse(state.restoreIfNeeded { error("restore should not run") })
+    }
+
+    @Test
+    fun repeatedDetachMarksStayPendingUntilRestored() {
+        val state = VideoOutputState()
+        state.markDetachedForBackground()
+        state.markDetachedForBackground()
+
+        var restoreCount = 0
+        assertTrue(state.restoreIfNeeded { restoreCount++; true })
+        assertFalse(state.restoreIfNeeded { restoreCount++; true })
+        assertEquals(1, restoreCount)
+    }
+
+    @Test
+    fun noPendingRestorationDoesNotInvokeCallback() {
+        val state = VideoOutputState()
+
+        assertFalse(state.restoreIfNeeded { error("restore should not run") })
+    }
+}


### PR DESCRIPTION
Keep video surfaces attached only after the UI restores their visible state. Preserve pending restoration across reconnects, clear surfaces before unbinding, and honor PiP playback.