### PR TITLE
Add a low-latency playback setting

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/PlayerRepository.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/PlayerRepository.kt
@@ -47,6 +47,7 @@ import com.github.andreyasadchy.xtra.model.ui.TranslatedChannel
 import com.github.andreyasadchy.xtra.util.C
 import com.github.andreyasadchy.xtra.util.NetworkUtils
 import com.github.andreyasadchy.xtra.util.NetworkUtils.executeAsync
+import com.github.andreyasadchy.xtra.util.prefs
 import com.github.andreyasadchy.xtra.util.m3u8.PlaylistUtils
 import com.github.andreyasadchy.xtra.util.m3u8.TwitchAdDetector
 import com.github.andreyasadchy.xtra.util.watch.WatchCreditSession
@@ -125,7 +126,7 @@ class PlayerRepository(
     private val watchCreditMutex = Mutex()
     private var cachedSpadeEndpoint: CachedSpadeEndpoint? = null
 
-    suspend fun loadStreamPlaylistUrl(context: Context, networkLibrary: String?, gqlHeaders: Map<String, String>, channelLogin: String, randomDeviceId: Boolean?, xDeviceId: String?, playerType: String?, supportedCodecs: String?, proxyPlaybackAccessToken: Boolean, proxyHost: String?, proxyPort: Int?, proxyUser: String?, proxyPassword: String?, enableIntegrity: Boolean): String = withContext(Dispatchers.IO) {
+    suspend fun loadStreamPlaylistUrl(context: Context, networkLibrary: String?, gqlHeaders: Map<String, String>, channelLogin: String, randomDeviceId: Boolean?, xDeviceId: String?, playerType: String?, supportedCodecs: String?, proxyPlaybackAccessToken: Boolean, proxyHost: String?, proxyPort: Int?, proxyUser: String?, proxyPassword: String?, enableIntegrity: Boolean, lowLatency: Boolean = context.prefs().getBoolean(C.PLAYER_LOW_LATENCY, C.DEFAULT_PLAYER_LOW_LATENCY)): String = withContext(Dispatchers.IO) {
         val accessToken = loadStreamPlaybackAccessToken(context, networkLibrary, gqlHeaders, channelLogin, randomDeviceId, xDeviceId, playerType, proxyPlaybackAccessToken, proxyHost, proxyPort, proxyUser, proxyPassword, enableIntegrity).let { token ->
             if (token.second?.contains("\"forbidden\":true") == true && !gqlHeaders[C.HEADER_TOKEN].isNullOrBlank()) {
                 loadStreamPlaybackAccessToken(context, networkLibrary, gqlHeaders.filterNot { it.key == C.HEADER_TOKEN }, channelLogin, randomDeviceId, xDeviceId, playerType, proxyPlaybackAccessToken, proxyHost, proxyPort, proxyUser, proxyPassword, enableIntegrity)
@@ -136,7 +137,9 @@ class PlayerRepository(
         "https://usher.ttvnw.net/api/v2/channel/hls/${channelLogin}.m3u8".toUri().buildUpon().apply {
             appendQueryParameter("allow_source", "true")
             appendQueryParameter("allow_audio_only", "true")
-            appendQueryParameter("fast_bread", "true") // low latency
+            if (lowLatency) {
+                appendQueryParameter("fast_bread", "true")
+            }
             appendQueryParameter("p", Random.nextInt(9999999).toString())
             if (supportedCodecs?.contains("av1", true) == true) {
                 appendQueryParameter("platform", "web")

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/preload/StreamPreloadCoordinator.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/preload/StreamPreloadCoordinator.kt
@@ -241,6 +241,7 @@ class StreamPreloadCoordinator(
                 proxyUser = config.proxyUser,
                 proxyPassword = config.proxyPassword,
                 enableIntegrity = config.enableIntegrity,
+                lowLatency = config.lowLatency,
             )
         }
     }
@@ -301,6 +302,7 @@ class StreamPreloadCoordinator(
             proxyUser = prefs.getString(C.PROXY_USER, null),
             proxyPassword = prefs.getString(C.PROXY_PASSWORD, null),
             enableIntegrity = prefs.getBoolean(C.ENABLE_INTEGRITY, false),
+            lowLatency = prefs.getBoolean(C.PLAYER_LOW_LATENCY, C.DEFAULT_PLAYER_LOW_LATENCY),
             customStreamProxyEnabled = prefs.getBoolean(C.PLAYER_STREAM_PROXY, false),
             customStreamProxyUrl = prefs.getString(C.PLAYER_PROXY_URL, null),
         )
@@ -363,6 +365,7 @@ class StreamPreloadCoordinator(
         val proxyUser: String?,
         val proxyPassword: String?,
         val enableIntegrity: Boolean,
+        val lowLatency: Boolean,
         val customStreamProxyEnabled: Boolean,
         val customStreamProxyUrl: String?,
     ) {
@@ -379,6 +382,7 @@ class StreamPreloadCoordinator(
                 append(proxyHost).append('\u0000').append(proxyPort).append('\u0000')
                 append(proxyUser).append('\u0000').append(proxyPassword).append('\u0000')
                 append(enableIntegrity).append('\u0000')
+                append(lowLatency).append('\u0000')
                 append(customStreamProxyEnabled).append('\u0000').append(customStreamProxyUrl)
             }
             digest.digest(input.toByteArray()).joinToString("") { "%02x".format(it) }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/download/DownloadViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/download/DownloadViewModel.kt
@@ -56,7 +56,7 @@ class DownloadViewModel(
                     val default = listOf("source", "1080p60", "1080p30", "720p60", "720p30", "480p30", "360p30", "160p30", "audio_only")
                     try {
                         val list = if (!channelLogin.isNullOrBlank()) {
-                            val url = playerRepository.loadStreamPlaylistUrl(applicationContext, networkLibrary, gqlHeaders, channelLogin, randomDeviceId, xDeviceId, playerType, supportedCodecs, false, null, null, null, null, enableIntegrity)
+                            val url = playerRepository.loadStreamPlaylistUrl(applicationContext, networkLibrary, gqlHeaders, channelLogin, randomDeviceId, xDeviceId, playerType, supportedCodecs, false, null, null, null, null, enableIntegrity, lowLatency = false)
                             val playlist = withContext(Dispatchers.IO) {
                                 when {
                                     networkLibrary == C.HTTP_ENGINE && httpEngine.value != null -> @SuppressLint("NewApi") {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/download/StreamDownloadService.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/download/StreamDownloadService.kt
@@ -245,7 +245,7 @@ class StreamDownloadService : LifecycleService() {
         val quality = offlineVideo.quality
         var startTime = System.currentTimeMillis()
         var endTime = startWait?.let { System.currentTimeMillis() + it }
-        var playlistUrl = xtraModule.playerRepository.loadStreamPlaylistUrl(this@StreamDownloadService, networkLibrary, gqlHeaders, channelLogin, randomDeviceId, xDeviceId, playerType, supportedCodecs, false, null, null, null, null, false)
+        var playlistUrl = xtraModule.playerRepository.loadStreamPlaylistUrl(this@StreamDownloadService, networkLibrary, gqlHeaders, channelLogin, randomDeviceId, xDeviceId, playerType, supportedCodecs, false, null, null, null, null, false, lowLatency = false)
         while (true) {
             val playlist = when {
                 networkLibrary == C.HTTP_ENGINE && xtraModule.httpEngine.value != null -> @SuppressLint("NewApi") {
@@ -422,7 +422,7 @@ class StreamDownloadService : LifecycleService() {
                     }
                     endTime = endWait?.let { System.currentTimeMillis() + it }
                     if (continueDownloading) {
-                        playlistUrl = xtraModule.playerRepository.loadStreamPlaylistUrl(this@StreamDownloadService, networkLibrary, gqlHeaders, channelLogin, randomDeviceId, xDeviceId, playerType, supportedCodecs, false, null, null, null, null, false)
+                        playlistUrl = xtraModule.playerRepository.loadStreamPlaylistUrl(this@StreamDownloadService, networkLibrary, gqlHeaders, channelLogin, randomDeviceId, xDeviceId, playerType, supportedCodecs, false, null, null, null, null, false, lowLatency = false)
                     }
                 }
             }
@@ -441,7 +441,7 @@ class StreamDownloadService : LifecycleService() {
 
     private suspend fun proxyPlaylist(playlistUrl: String, networkLibrary: String?, gqlHeaders: Map<String, String>, channelLogin: String, randomDeviceId: Boolean?, xDeviceId: String?, playerType: String?, supportedCodecs: String?, proxyPlaybackAccessToken: Boolean, proxyMultivariantPlaylist: Boolean, proxyHost: String, proxyPort: Int, proxyUser: String?, proxyPassword: String?): String? = withContext(Dispatchers.IO) {
         val playlistUrl = if (proxyPlaybackAccessToken) {
-            xtraModule.playerRepository.loadStreamPlaylistUrl(this@StreamDownloadService, networkLibrary, gqlHeaders, channelLogin, randomDeviceId, xDeviceId, playerType, supportedCodecs, true, proxyHost, proxyPort, proxyUser, proxyPassword, false)
+            xtraModule.playerRepository.loadStreamPlaylistUrl(this@StreamDownloadService, networkLibrary, gqlHeaders, channelLogin, randomDeviceId, xDeviceId, playerType, supportedCodecs, true, proxyHost, proxyPort, proxyUser, proxyPassword, false, lowLatency = false)
         } else {
             playlistUrl
         }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/multiview/playback/MultiviewPlaybackCoordinator.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/multiview/playback/MultiviewPlaybackCoordinator.kt
@@ -442,7 +442,13 @@ class MultiviewPlaybackCoordinator(
                     .setMimeType(MimeTypes.APPLICATION_M3U8)
                     .setLiveConfiguration(
                         MediaItem.LiveConfiguration.Builder().apply {
-                            setTargetOffsetMs(2000L)
+                            setTargetOffsetMs(
+                                if (applicationContext.prefs().getBoolean(C.PLAYER_LOW_LATENCY, C.DEFAULT_PLAYER_LOW_LATENCY)) {
+                                    C.LOW_LATENCY_TARGET_OFFSET_MS
+                                } else {
+                                    C.NORMAL_LATENCY_TARGET_OFFSET_MS
+                                }
+                            )
                         }.build()
                     )
                     .setMediaMetadata(metadata(slot.stream))

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/ExoPlayerService.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/ExoPlayerService.kt
@@ -1242,7 +1242,13 @@ class ExoPlayerService : BasePlaybackService() {
                                 setUri(url.toUri())
                                 setMimeType(MimeTypes.APPLICATION_M3U8)
                                 setLiveConfiguration(MediaItem.LiveConfiguration.Builder().apply {
-                                    setTargetOffsetMs(2000L)
+                                    setTargetOffsetMs(
+                                        if (prefs().getBoolean(C.PLAYER_LOW_LATENCY, C.DEFAULT_PLAYER_LOW_LATENCY)) {
+                                            C.LOW_LATENCY_TARGET_OFFSET_MS
+                                        } else {
+                                            C.NORMAL_LATENCY_TARGET_OFFSET_MS
+                                        }
+                                    )
                                 }.build())
                             }.build()
                         )

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/PlaybackService.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/PlaybackService.kt
@@ -520,7 +520,13 @@ class PlaybackService : MediaSessionService() {
                                             setUri(uri?.toUri())
                                             setMimeType(MimeTypes.APPLICATION_M3U8)
                                             setLiveConfiguration(MediaItem.LiveConfiguration.Builder().apply {
-                                                setTargetOffsetMs(2000L)
+                                                setTargetOffsetMs(
+                                                    if (prefs().getBoolean(C.PLAYER_LOW_LATENCY, C.DEFAULT_PLAYER_LOW_LATENCY)) {
+                                                        C.LOW_LATENCY_TARGET_OFFSET_MS
+                                                    } else {
+                                                        C.NORMAL_LATENCY_TARGET_OFFSET_MS
+                                                    }
+                                                )
                                             }.build())
                                             setMediaMetadata(
                                                 MediaMetadata.Builder().apply {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/C.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/C.kt
@@ -187,6 +187,10 @@ object C {
     const val PLAYER_USE_VIDEO_POSITIONS = "player_use_videopositions"
     const val PLAYER_DEFAULT_QUALITY = "player_defaultquality"
     const val PLAYER_DEFAULT_CELLULAR_QUALITY = "player_default_cellular_quality"
+    const val PLAYER_LOW_LATENCY = "player_low_latency"
+    const val DEFAULT_PLAYER_LOW_LATENCY = true
+    const val LOW_LATENCY_TARGET_OFFSET_MS = 2_000L
+    const val NORMAL_LATENCY_TARGET_OFFSET_MS = 10_000L
     const val PLAYER_QUALITY = "player_quality"
     const val PLAYER_VOLUME = "player_volume"
     const val PLAYER_SPEED = "player_speed"

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/SettingsMigration.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/SettingsMigration.kt
@@ -289,6 +289,7 @@ object SettingsMigration {
         "player_keep_screen_on_when_paused",
         "player_audio_focus",
         "player_handle_audio_becoming_noisy",
+        C.PLAYER_LOW_LATENCY,
         "player_buffer_min",
         "player_buffer_max",
         "player_buffer_playback",

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -692,6 +692,8 @@
     <string name="settings_player_menu_actions">إجراءات الدفق</string>
     <string name="settings_player_menu_chat">الدردشة والأدوات</string>
     <string name="settings_player_quality">الجودة وزمن الاستجابة</string>
+    <string name="settings_low_latency">تشغيل البث المباشر بزمن استجابة منخفض</string>
+    <string name="settings_low_latency_summary">يقلّل التأخير بينك وبين المذيع. قد يحدث التخزين المؤقت بشكل متكرر على الاتصالات غير المستقرة.</string>
     <string name="settings_player_behavior">سلوك اللاعب</string>
     <string name="settings_buffer_limits">حدود المخزن المؤقت</string>
     <string name="settings_buffer_live">زمن الوصول المباشر</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -180,6 +180,8 @@
     <string name="settings_player_menu_actions">Akce streamu</string>
     <string name="settings_player_menu_chat">Chat a nástroje</string>
     <string name="settings_player_quality">Kvalita a latence</string>
+    <string name="settings_low_latency">Přehrávání živého vysílání s nízkou latencí</string>
+    <string name="settings_low_latency_summary">Snižuje zpoždění vůči vysílateli. Při nestabilním připojení může docházet k častějšímu načítání do vyrovnávací paměti.</string>
     <string name="settings_player_behavior">Chování přehrávače</string>
     <string name="settings_buffer_limits">Limity vyrovnávací paměti</string>
     <string name="settings_buffer_live">Živá latence</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -692,6 +692,8 @@
     <string name="settings_player_menu_actions">Stream-Aktionen</string>
     <string name="settings_player_menu_chat">Chat und Tools</string>
     <string name="settings_player_quality">Qualität und Latenz</string>
+    <string name="settings_low_latency">Live-Wiedergabe mit niedriger Latenz</string>
+    <string name="settings_low_latency_summary">Verringert die Verzögerung zum Streamer. Bei instabilen Verbindungen kann es häufiger zu Pufferungen kommen.</string>
     <string name="settings_player_behavior">Player-Verhalten</string>
     <string name="settings_buffer_limits">Puffergrenzen</string>
     <string name="settings_buffer_live">Live-Latenz</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -697,6 +697,8 @@
     <string name="settings_player_menu_actions">Acciones de transmisión</string>
     <string name="settings_player_menu_chat">Chat y herramientas</string>
     <string name="settings_player_quality">Calidad y latencia</string>
+    <string name="settings_low_latency">Reproducción de directos con baja latencia</string>
+    <string name="settings_low_latency_summary">Reduce el retraso respecto al streamer. Puede haber más almacenamiento en búfer con conexiones inestables.</string>
     <string name="settings_player_behavior">Comportamiento del reproductor</string>
     <string name="settings_buffer_limits">Límites de búfer</string>
     <string name="settings_buffer_live">Latencia en vivo</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -692,6 +692,8 @@
     <string name="settings_player_menu_actions">Actions de flux</string>
     <string name="settings_player_menu_chat">Chat et outils</string>
     <string name="settings_player_quality">Qualité et latence</string>
+    <string name="settings_low_latency">Lecture en direct à faible latence</string>
+    <string name="settings_low_latency_summary">Réduit le délai avec le streamer. La mise en mémoire tampon peut être plus fréquente avec une connexion instable.</string>
     <string name="settings_player_behavior">Comportement du joueur</string>
     <string name="settings_buffer_limits">Limites de tampon</string>
     <string name="settings_buffer_live">Latence en direct</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -692,6 +692,8 @@
     <string name="settings_player_menu_actions">As accións de transmisión</string>
     <string name="settings_player_menu_chat">Chat e ferramentas</string>
     <string name="settings_player_quality">Calidade e latencia</string>
+    <string name="settings_low_latency">Reprodución en directo de baixa latencia</string>
+    <string name="settings_low_latency_summary">Reduce o atraso respecto ao emisor. Pode producirse máis almacenamento en búfer con conexións inestables.</string>
     <string name="settings_player_behavior">Comportamento do xogador</string>
     <string name="settings_buffer_limits">Límites do búfer</string>
     <string name="settings_buffer_live">Latencia en directo</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -693,6 +693,8 @@
     <string name="settings_player_menu_actions">Tindakan streaming</string>
     <string name="settings_player_menu_chat">Obrolan &amp; alat</string>
     <string name="settings_player_quality">Kualitas &amp; latensi</string>
+    <string name="settings_low_latency">Pemutaran live dengan latensi rendah</string>
+    <string name="settings_low_latency_summary">Kurangi jeda dengan penyiar. Buffering mungkin lebih sering terjadi pada koneksi yang tidak stabil.</string>
     <string name="settings_player_behavior">Perilaku pemain</string>
     <string name="settings_buffer_limits">Batas buffer</string>
     <string name="settings_buffer_live">Latensi langsung</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -692,6 +692,8 @@
     <string name="settings_player_menu_actions">Azioni streaming</string>
     <string name="settings_player_menu_chat">Chat e strumenti</string>
     <string name="settings_player_quality">Qualità e latenza</string>
+    <string name="settings_low_latency">Riproduzione live a bassa latenza</string>
+    <string name="settings_low_latency_summary">Riduce il ritardo rispetto allo streamer. Con connessioni instabili potrebbe verificarsi più buffering.</string>
     <string name="settings_player_behavior">Comportamento del giocatore</string>
     <string name="settings_buffer_limits">Limiti del buffer</string>
     <string name="settings_buffer_live">Latenza live</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -692,6 +692,8 @@
     <string name="settings_player_menu_actions">ストリームアクション</string>
     <string name="settings_player_menu_chat">チャットとツール</string>
     <string name="settings_player_quality">品質と遅延</string>
+    <string name="settings_low_latency">低遅延ライブ再生</string>
+    <string name="settings_low_latency_summary">配信者との遅延を短縮します。接続が不安定な場合、バッファリングが増えることがあります。</string>
     <string name="settings_player_behavior">プレーヤーの動作</string>
     <string name="settings_buffer_limits">バッファ制限</string>
     <string name="settings_buffer_live">ライブ遅延</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -159,6 +159,8 @@
     <string name="settings_player_menu_actions">Działania w transmisji strumieniowej</string>
     <string name="settings_player_menu_chat">Czat i narzędzia</string>
     <string name="settings_player_quality">Jakość i opóźnienie</string>
+    <string name="settings_low_latency">Odtwarzanie transmisji na żywo z niskim opóźnieniem</string>
+    <string name="settings_low_latency_summary">Zmniejsza opóźnienie względem nadawcy. Przy niestabilnym połączeniu buforowanie może występować częściej.</string>
     <string name="settings_player_behavior">Zachowanie gracza</string>
     <string name="settings_buffer_limits">Limity bufora</string>
     <string name="settings_buffer_live">Opóźnienie na żywo</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -692,6 +692,8 @@
     <string name="settings_player_menu_actions">Ações de streaming</string>
     <string name="settings_player_menu_chat">Bate-papo e ferramentas</string>
     <string name="settings_player_quality">Qualidade e latência</string>
+    <string name="settings_low_latency">Reprodução ao vivo com baixa latência</string>
+    <string name="settings_low_latency_summary">Reduz o atraso em relação ao streamer. Pode haver mais buffer em conexões instáveis.</string>
     <string name="settings_player_behavior">Comportamento do jogador</string>
     <string name="settings_buffer_limits">Limites de buffer</string>
     <string name="settings_buffer_live">Latência ao vivo</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -692,6 +692,8 @@
     <string name="settings_player_menu_actions">Действия с потоком</string>
     <string name="settings_player_menu_chat">Чат и инструменты</string>
     <string name="settings_player_quality">Качество и задержка</string>
+    <string name="settings_low_latency">Воспроизведение прямых трансляций с низкой задержкой</string>
+    <string name="settings_low_latency_summary">Уменьшает задержку относительно стримера. При нестабильном соединении буферизация может происходить чаще.</string>
     <string name="settings_player_behavior">Поведение игрока</string>
     <string name="settings_buffer_limits">Ограничения буфера</string>
     <string name="settings_buffer_live">Задержка в реальном времени</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -180,6 +180,8 @@
     <string name="settings_player_menu_actions">Streamovanie akcií</string>
     <string name="settings_player_menu_chat">Chat a nástroje</string>
     <string name="settings_player_quality">Kvalita a latencia</string>
+    <string name="settings_low_latency">Prehrávanie živého vysielania s nízkou latenciou</string>
+    <string name="settings_low_latency_summary">Znižuje oneskorenie voči vysielateľovi. Pri nestabilnom pripojení môže dochádzať k častejšiemu načítavaniu do vyrovnávacej pamäte.</string>
     <string name="settings_player_behavior">Správanie prehrávača</string>
     <string name="settings_buffer_limits">Limity vyrovnávacej pamäte</string>
     <string name="settings_buffer_live">Živá latencia</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -693,6 +693,8 @@
     <string name="settings_player_menu_actions">Akış eylemleri</string>
     <string name="settings_player_menu_chat">Sohbet ve araçlar</string>
     <string name="settings_player_quality">Kalite ve gecikme</string>
+    <string name="settings_low_latency">Düşük gecikmeli canlı yayın oynatma</string>
+    <string name="settings_low_latency_summary">Yayıncıya olan gecikmeyi azaltır. Kararsız bağlantılarda daha sık ara belleğe alma yaşanabilir.</string>
     <string name="settings_player_behavior">Oyuncu davranışı</string>
     <string name="settings_buffer_limits">Arabellek sınırları</string>
     <string name="settings_buffer_live">Canlı gecikme</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -692,6 +692,8 @@
     <string name="settings_player_menu_actions">流操作</string>
     <string name="settings_player_menu_chat">聊天和工具</string>
     <string name="settings_player_quality">质量和延迟</string>
+    <string name="settings_low_latency">低延迟直播播放</string>
+    <string name="settings_low_latency_summary">减少与主播之间的延迟。网络连接不稳定时可能会更频繁地缓冲。</string>
     <string name="settings_player_behavior">玩家行为</string>
     <string name="settings_buffer_limits">缓冲区限制</string>
     <string name="settings_buffer_live">实时延迟</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -692,6 +692,8 @@
     <string name="settings_player_menu_actions">流程操作</string>
     <string name="settings_player_menu_chat">聊天和工具</string>
     <string name="settings_player_quality">品質和延遲</string>
+    <string name="settings_low_latency">低延遲直播播放</string>
+    <string name="settings_low_latency_summary">減少與實況主之間的延遲。網路連線不穩定時可能會更頻繁地緩衝。</string>
     <string name="settings_player_behavior">玩家行為</string>
     <string name="settings_buffer_limits">緩衝區限制</string>
     <string name="settings_buffer_live">即時延遲</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -180,6 +180,8 @@
     <string name="settings_player_menu_actions">Stream actions</string>
     <string name="settings_player_menu_chat">Chat &amp; tools</string>
     <string name="settings_player_quality">Quality &amp; latency</string>
+    <string name="settings_low_latency">Low-latency live playback</string>
+    <string name="settings_low_latency_summary">Reduce the delay to the broadcaster. May buffer more often on unstable connections.</string>
     <string name="settings_player_behavior">Player behavior</string>
     <string name="settings_buffer_limits">Buffer limits</string>
     <string name="settings_buffer_live">Live latency</string>

--- a/app/src/main/res/xml/playback_preferences.xml
+++ b/app/src/main/res/xml/playback_preferences.xml
@@ -2,6 +2,7 @@
     <PreferenceCategory android:title="@string/settings_quality" app:iconSpaceReserved="false" />
     <ListPreference android:defaultValue="saved" android:entries="@array/playerQualityEntries" android:entryValues="@array/playerQualityValues" android:key="player_defaultquality" android:summary="%s" android:title="@string/player_defaultquality" app:iconSpaceReserved="false" />
     <ListPreference android:defaultValue="saved" android:entries="@array/playerQualityEntries" android:entryValues="@array/playerQualityValues" android:key="player_default_cellular_quality" android:summary="%s" android:title="@string/settings_mobile_data_quality" app:iconSpaceReserved="false" />
+    <SwitchPreferenceCompat android:defaultValue="true" android:key="player_low_latency" android:summary="@string/settings_low_latency_summary" android:title="@string/settings_low_latency" app:iconSpaceReserved="false" />
 
     <PreferenceCategory android:title="@string/settings_background_playback" app:iconSpaceReserved="false" />
     <SwitchPreferenceCompat android:defaultValue="true" android:key="player_picture_in_picture" android:summary="@string/picture_in_picture_summary" android:title="@string/picture_in_picture" app:iconSpaceReserved="false" />


### PR DESCRIPTION
Adds a playback setting for Twitch low latency. It controls Twitch's low-latency playlist request and the player's live target, while downloads keep normal playlist behavior.