### PR TITLE
Refresh watch streaks while stream stays open

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatViewModel.kt
@@ -1334,35 +1334,7 @@ class ChatViewModel(
     }
 
     private fun mergeWatchStreak(incoming: WatchStreak, realtime: Boolean = false) {
-        val previous = watchStreak.value
-        if (previous == null) {
-            watchStreak.value = incoming
-            return
-        }
-
-        val staleCount = incoming.streakCount < previous.streakCount
-        val streakCount = maxOf(previous.streakCount, incoming.streakCount)
-        val nextMilestone = incoming.nextMilestone ?: previous.nextMilestone
-        val milestoneReached = previous.nextMilestone?.let {
-            previous.streakCount < it && streakCount >= it
-        } == true
-        val milestoneChanged = realtime && (incoming.pointsAwarded != null || milestoneReached)
-        watchStreak.value = incoming.copy(
-            streakCount = streakCount,
-            nextMilestone = nextMilestone,
-            rewardPoints = incoming.rewardPoints ?: previous.rewardPoints,
-            pointsAwarded = if (staleCount) previous.pointsAwarded else incoming.pointsAwarded ?: previous.pointsAwarded,
-            milestoneId = when {
-                staleCount -> previous.milestoneId
-                milestoneChanged -> incoming.milestoneId
-                else -> incoming.milestoneId ?: previous.milestoneId
-            },
-            shareStatus = when {
-                staleCount -> previous.shareStatus
-                milestoneChanged -> incoming.shareStatus
-                else -> incoming.shareStatus ?: previous.shareStatus
-            },
-        )
+        watchStreak.value = mergeWatchStreakState(watchStreak.value, incoming, realtime)
     }
 
     private fun JsonElement?.toIntOrNull(): Int? = this?.jsonPrimitive?.content?.toIntOrNull()
@@ -1385,11 +1357,31 @@ class ChatViewModel(
     private fun watchStreakCount(response: WatchStreakResponse): Int? =
         response.data?.channel?.self?.watchStreakMilestone?.watchStreakMilestone?.value?.toIntOrNull()
 
+    private fun reconcileWatchStreak(
+        networkLibrary: String?,
+        gqlHeaders: Map<String, String>,
+        channelId: String?,
+        reconciliation: WatchStreakReconciliation,
+    ) {
+        Log.d(
+            WatchCreditTelemetry.LOG_TAG,
+            "watch-streak reconciliation trigger source=${reconciliation.source} baseline=${reconciliation.countBeforeEvent}",
+        )
+        loadWatchStreak(
+            networkLibrary = networkLibrary,
+            gqlHeaders = gqlHeaders,
+            channelId = channelId,
+            delayMillis = WATCH_STREAK_RECONCILIATION_DELAY_MILLIS,
+            reconciliation = reconciliation,
+        )
+    }
+
     private fun loadWatchStreak(
         networkLibrary: String?,
         gqlHeaders: Map<String, String>,
         channelId: String?,
         delayMillis: Long = 0L,
+        reconciliation: WatchStreakReconciliation? = null,
     ) {
         if (channelId.isNullOrBlank() || gqlHeaders[C.HEADER_TOKEN].isNullOrBlank()) {
             return
@@ -1416,21 +1408,26 @@ class ChatViewModel(
                 ) {
                     return@launch
                 }
-                val locallyObservedCount = watchStreak.value?.streakCount
                 val responseCount = watchStreakCount(response)
                 updateWatchStreakStatus(response)
-                if (delayMillis > 0L &&
-                    locallyObservedCount != null &&
-                    (responseCount == null || responseCount < locallyObservedCount)
-                ) {
-                    scheduleWatchStreakRetry(
-                        networkLibrary = networkLibrary,
-                        gqlHeaders = gqlHeaders,
-                        channelId = channelId,
-                        expectedChannelId = expectedChannelId,
-                        expectedChannelLogin = expectedChannelLogin,
-                        expectedSession = expectedSession,
+                if (reconciliation != null) {
+                    val snapshotStatus = watchStreakSnapshotStatus(reconciliation, responseCount)
+                    Log.d(
+                        WatchCreditTelemetry.LOG_TAG,
+                        "watch-streak reconciliation first snapshot source=${reconciliation.source} status=$snapshotStatus",
                     )
+                    if (shouldRetryWatchStreakReconciliation(reconciliation, responseCount, retryAttempt = 0)) {
+                        scheduleWatchStreakRetry(
+                            networkLibrary = networkLibrary,
+                            gqlHeaders = gqlHeaders,
+                            channelId = channelId,
+                            expectedChannelId = expectedChannelId,
+                            expectedChannelLogin = expectedChannelLogin,
+                            expectedSession = expectedSession,
+                            reconciliation = reconciliation,
+                            retryAttempt = 1,
+                        )
+                    }
                 }
             } catch (e: CancellationException) {
                 throw e
@@ -1446,11 +1443,14 @@ class ChatViewModel(
         expectedChannelId: String?,
         expectedChannelLogin: String?,
         expectedSession: Long,
+        reconciliation: WatchStreakReconciliation,
+        retryAttempt: Int,
     ) {
+        val retryDelayMillis = watchStreakReconciliationRetryDelaysMillis.getOrNull(retryAttempt - 1) ?: return
         if (watchStreakRetryJob?.isActive == true) return
         watchStreakRetryJob = viewModelScope.launch {
             try {
-                delay(WATCH_STREAK_RECONCILIATION_RETRY_DELAY_MILLIS)
+                delay(retryDelayMillis)
                 if (watchStreakSession != expectedSession ||
                     activeChannelId != expectedChannelId ||
                     activeChannelLogin != expectedChannelLogin
@@ -1464,7 +1464,26 @@ class ChatViewModel(
                 ) {
                     return@launch
                 }
+                val responseCount = watchStreakCount(response)
                 updateWatchStreakStatus(response)
+                val snapshotStatus = watchStreakSnapshotStatus(reconciliation, responseCount)
+                Log.d(
+                    WatchCreditTelemetry.LOG_TAG,
+                    "watch-streak reconciliation retry attempt=$retryAttempt source=${reconciliation.source} status=$snapshotStatus",
+                )
+                if (shouldRetryWatchStreakReconciliation(reconciliation, responseCount, retryAttempt)) {
+                    watchStreakRetryJob = null
+                    scheduleWatchStreakRetry(
+                        networkLibrary = networkLibrary,
+                        gqlHeaders = gqlHeaders,
+                        channelId = channelId,
+                        expectedChannelId = expectedChannelId,
+                        expectedChannelLogin = expectedChannelLogin,
+                        expectedSession = expectedSession,
+                        reconciliation = reconciliation,
+                        retryAttempt = retryAttempt + 1,
+                    )
+                }
             } catch (e: CancellationException) {
                 throw e
             } catch (_: Exception) {
@@ -2075,15 +2094,20 @@ class ChatViewModel(
                 message.tags["msg-param-category"] == "watch-streak" &&
                 message.tags["user-id"] == accountId
             ) {
+                val countBeforeEvent = watchStreak.value?.streakCount
                 updateWatchStreak(
                     message.tags["msg-param-value"]?.toIntOrNull(),
                     message.tags["msg-param-copoReward"]?.toIntOrNull(),
                 )
-                loadWatchStreak(
-                    networkLibrary,
-                    gqlHeaders,
-                    channelId,
-                    delayMillis = WATCH_STREAK_RECONCILIATION_DELAY_MILLIS,
+                reconcileWatchStreak(
+                    networkLibrary = networkLibrary,
+                    gqlHeaders = gqlHeaders,
+                    channelId = channelId,
+                    reconciliation = WatchStreakReconciliation(
+                        source = WatchStreakReconciliationSource.LIVE_NOTIFICATION,
+                        countBeforeEvent = countBeforeEvent,
+                        observedLiveCount = watchStreak.value?.streakCount,
+                    ),
                 )
             }
             if (!userNotice || showUserNotice) {
@@ -2558,15 +2582,20 @@ class ChatViewModel(
         override suspend fun onUserNotice(event: JSONObject, timestamp: String?) {
             if (event.optString("notice_type") == "watch_streak" && event.optString("chatter_user_id") == accountId) {
                 val streak = event.optJSONObject("watch_streak")
+                val countBeforeEvent = watchStreak.value?.streakCount
                 updateWatchStreak(
                     streak?.optInt("streak_count")?.takeIf { it > 0 },
                     streak?.optInt("channel_points_awarded")?.takeIf { it > 0 },
                 )
-                loadWatchStreak(
-                    networkLibrary,
-                    gqlHeaders,
-                    channelId,
-                    delayMillis = WATCH_STREAK_RECONCILIATION_DELAY_MILLIS,
+                reconcileWatchStreak(
+                    networkLibrary = networkLibrary,
+                    gqlHeaders = gqlHeaders,
+                    channelId = channelId,
+                    reconciliation = WatchStreakReconciliation(
+                        source = WatchStreakReconciliationSource.LIVE_NOTIFICATION,
+                        countBeforeEvent = countBeforeEvent,
+                        observedLiveCount = watchStreak.value?.streakCount,
+                    ),
                 )
             }
             if (showUserNotice) {
@@ -2709,12 +2738,21 @@ class ChatViewModel(
             }
         }
 
-        override suspend fun onSubscriptionsSent() {
-            if (!showPredictions || sessionToken != predictionSessionToken || activeChannelLogin != channelLogin) return
-            if (predictionSubscriptionSessionToken == sessionToken) {
-                loadCurrentPredictionSnapshot(networkLibrary, channelLogin, channelId, sessionToken)
-            } else {
-                predictionSubscriptionSessionToken = sessionToken
+        override suspend fun onSubscriptionsSent(reconnected: Boolean) {
+            if (showPredictions && sessionToken == predictionSessionToken && activeChannelLogin == channelLogin) {
+                if (predictionSubscriptionSessionToken == sessionToken) {
+                    loadCurrentPredictionSnapshot(networkLibrary, channelLogin, channelId, sessionToken)
+                } else {
+                    predictionSubscriptionSessionToken = sessionToken
+                }
+            }
+            if (reconnected &&
+                isLoggedIn &&
+                isActiveWatchCreditSession() &&
+                !channelId.isNullOrBlank()
+            ) {
+                Log.d(WatchCreditTelemetry.LOG_TAG, "Hermes re-subscription healing watch-streak")
+                loadWatchStreak(networkLibrary, gqlHeaders, channelId)
             }
         }
 
@@ -2763,11 +2801,32 @@ class ChatViewModel(
         }
 
         override suspend fun onPointsEarned(message: JSONObject) {
+            if (!isActiveWatchCreditSession()) {
+                Log.d(WatchCreditTelemetry.LOG_TAG, "Hermes points-earned ignored for inactive watch session")
+                return
+            }
             val result = PubSubUtils.parsePointsEarned(message)
             val points = result.first
             val messageChannelId = result.second
+            Log.d(
+                WatchCreditTelemetry.LOG_TAG,
+                "Hermes points-earned channelMatched=${channelId == messageChannelId} channelIdPresent=${!messageChannelId.isNullOrBlank()} reason=${points.reasonCode ?: "unknown"}",
+            )
             if (channelId == messageChannelId) {
                 loadChannelPoints(networkLibrary, gqlHeaders, channelLogin, enableIntegrity)
+            }
+            watchStreakInvalidationForPointsEarned(
+                activeChannelId = channelId,
+                messageChannelId = messageChannelId,
+                reasonCode = points.reasonCode,
+                currentCount = watchStreak.value?.streakCount,
+            )?.let { reconciliation ->
+                reconcileWatchStreak(
+                    networkLibrary = networkLibrary,
+                    gqlHeaders = gqlHeaders,
+                    channelId = channelId,
+                    reconciliation = reconciliation,
+                )
             }
             if (notifyPoints) {
                 if (channelId == messageChannelId) {
@@ -4950,7 +5009,6 @@ class ChatViewModel(
 
     companion object {
         private const val WATCH_STREAK_RECONCILIATION_DELAY_MILLIS = 750L
-        private const val WATCH_STREAK_RECONCILIATION_RETRY_DELAY_MILLIS = 3_000L
         private const val METERED_CACHE_MAX_AGE_MS = 604_800_000L
         private const val MAX_BADGE_CACHE_FILES = 100
         private const val DEFAULT_REWARD_COLOR = "#9146FF"

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/WatchStreakReconciliation.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/WatchStreakReconciliation.kt
@@ -1,0 +1,102 @@
+package com.github.andreyasadchy.xtra.ui.chat
+
+import com.github.andreyasadchy.xtra.model.ui.WatchStreak
+
+internal enum class WatchStreakReconciliationSource {
+    POINTS_EARNED,
+    LIVE_NOTIFICATION,
+}
+
+internal data class WatchStreakReconciliation(
+    val source: WatchStreakReconciliationSource,
+    val countBeforeEvent: Int?,
+    val observedLiveCount: Int? = null,
+)
+
+internal val watchStreakReconciliationRetryDelaysMillis = listOf(
+    3_000L,
+    10_000L,
+)
+
+internal fun watchStreakInvalidationForPointsEarned(
+    activeChannelId: String?,
+    messageChannelId: String?,
+    reasonCode: String?,
+    currentCount: Int?,
+): WatchStreakReconciliation? {
+    if (activeChannelId.isNullOrBlank() ||
+        messageChannelId.isNullOrBlank() ||
+        activeChannelId != messageChannelId ||
+        !reasonCode.equals("WATCH_STREAK", ignoreCase = true)
+    ) {
+        return null
+    }
+    return WatchStreakReconciliation(
+        source = WatchStreakReconciliationSource.POINTS_EARNED,
+        countBeforeEvent = currentCount,
+    )
+}
+
+internal fun shouldRetryWatchStreakReconciliation(
+    reconciliation: WatchStreakReconciliation,
+    responseCount: Int?,
+    retryAttempt: Int,
+): Boolean {
+    if (retryAttempt !in 0 until watchStreakReconciliationRetryDelaysMillis.size) return false
+    return when (reconciliation.source) {
+        WatchStreakReconciliationSource.POINTS_EARNED -> when {
+            responseCount == null -> true
+            reconciliation.countBeforeEvent == null -> false
+            else -> responseCount <= reconciliation.countBeforeEvent
+        }
+        WatchStreakReconciliationSource.LIVE_NOTIFICATION ->
+            reconciliation.observedLiveCount?.let {
+                responseCount == null || responseCount < it
+            } == true
+    }
+}
+
+internal fun watchStreakSnapshotStatus(
+    reconciliation: WatchStreakReconciliation,
+    responseCount: Int?,
+): String {
+    if (responseCount == null) return "missing"
+    val baseline = reconciliation.countBeforeEvent ?: return "advanced"
+    return when {
+        responseCount > baseline -> "advanced"
+        responseCount == baseline -> "unchanged"
+        else -> "stale"
+    }
+}
+
+internal fun mergeWatchStreakState(
+    previous: WatchStreak?,
+    incoming: WatchStreak,
+    realtime: Boolean = false,
+): WatchStreak {
+    if (previous == null) return incoming
+
+    val staleCount = incoming.streakCount < previous.streakCount
+    val streakCount = maxOf(previous.streakCount, incoming.streakCount)
+    val nextMilestone = incoming.nextMilestone ?: previous.nextMilestone
+    val milestoneReached = previous.nextMilestone?.let {
+        previous.streakCount < it && streakCount >= it
+    } == true
+    val milestoneChanged = realtime && (incoming.pointsAwarded != null || milestoneReached)
+    return incoming.copy(
+        streakCount = streakCount,
+        nextMilestone = nextMilestone,
+        rewardPoints = incoming.rewardPoints ?: previous.rewardPoints,
+        pointsAwarded = if (staleCount) previous.pointsAwarded else incoming.pointsAwarded ?: previous.pointsAwarded,
+        milestoneId = when {
+            staleCount -> previous.milestoneId
+            milestoneChanged -> incoming.milestoneId
+            else -> incoming.milestoneId ?: previous.milestoneId
+        },
+        shareStatus = when {
+            staleCount -> previous.shareStatus
+            milestoneChanged -> incoming.shareStatus
+            else -> incoming.shareStatus ?: previous.shareStatus
+        },
+    )
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/chat/HermesWebSocket.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/chat/HermesWebSocket.kt
@@ -37,9 +37,11 @@ class HermesWebSocket(
     private var minuteWatchedTimer: Timer? = null
     private var topics = emptyMap<String, String>()
     private val handledMessageIds = mutableListOf<String>()
+    private var hasSubscribed = false
 
     fun connect(coroutineScope: CoroutineScope): Job {
         Log.d(WatchCreditTelemetry.LOG_TAG, "Hermes connect requested channelIdPresent=${channelId.isNotBlank()} userIdPresent=${!userId.isNullOrBlank()} collectPoints=$collectPoints listenForPoints=$listenForPoints")
+        hasSubscribed = false
         webSocket = WebSocket("wss://hermes.twitch.tv/v1?clientId=${gqlClientId}", trustManager, WebSocketListener())
         webSocket?.coroutineScope = coroutineScope
         return coroutineScope.launch(Dispatchers.IO) {
@@ -107,7 +109,9 @@ class HermesWebSocket(
             }
         }
         Log.d(WatchCreditTelemetry.LOG_TAG, "Hermes subscriptions sent count=${topics.size}")
-        listener.onSubscriptionsSent()
+        val reconnected = hasSubscribed
+        hasSubscribed = true
+        listener.onSubscriptionsSent(reconnected)
     }
 
     private suspend fun startPongTimer() = withContext(Dispatchers.IO) {
@@ -136,7 +140,7 @@ class HermesWebSocket(
     interface Listener {
         suspend fun onConnect() {}
         /** Called after every topic (re-)subscription message has been sent. */
-        suspend fun onSubscriptionsSent() {}
+        suspend fun onSubscriptionsSent(reconnected: Boolean) {}
         suspend fun onPlaybackMessage(message: JSONObject) {}
         suspend fun onStreamInfo(message: JSONObject) {}
         suspend fun onRewardMessage(message: JSONObject) {}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/chat/PubSubUtils.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/chat/PubSubUtils.kt
@@ -64,6 +64,7 @@ object PubSubUtils {
         return Pair(
             PointsEarned(
                 pointsGained = pointGain?.optInt("total_points"),
+                reasonCode = pointGain?.optString("reason_code")?.takeIf { it.isNotBlank() },
                 timestamp = if (messageData?.isNull("timestamp") == false) messageData.optString("timestamp").takeIf { it.isNotBlank() }?.let { Instant.parseOrNull(it)?.toEpochMilliseconds()?.takeIf { ms -> ms > 0 } } else null,
                 fullMsg = message.toString()
             ),
@@ -306,6 +307,7 @@ object PubSubUtils {
 
     class PointsEarned(
         val pointsGained: Int? = null,
+        val reasonCode: String? = null,
         val timestamp: Long? = null,
         val fullMsg: String? = null,
     )

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/WatchStreakReconciliationTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/WatchStreakReconciliationTest.kt
@@ -1,0 +1,129 @@
+package com.github.andreyasadchy.xtra.ui.chat
+
+import com.github.andreyasadchy.xtra.model.ui.WatchStreak
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class WatchStreakReconciliationTest {
+    @Test
+    fun retriesUseTheExtendedBoundedDelaySchedule() {
+        assertEquals(
+            listOf(3_000L, 10_000L),
+            watchStreakReconciliationRetryDelaysMillis,
+        )
+    }
+
+    @Test
+    fun ordinaryWatchDoesNotCreateStreakInvalidation() {
+        assertNull(
+            watchStreakInvalidationForPointsEarned(
+                activeChannelId = "channel-100",
+                messageChannelId = "channel-100",
+                reasonCode = "WATCH",
+                currentCount = 4,
+            ),
+        )
+    }
+
+    @Test
+    fun watchStreakForActiveChannelCapturesPreEventCount() {
+        assertEquals(
+            WatchStreakReconciliation(
+                source = WatchStreakReconciliationSource.POINTS_EARNED,
+                countBeforeEvent = 4,
+            ),
+            watchStreakInvalidationForPointsEarned(
+                activeChannelId = "channel-100",
+                messageChannelId = "channel-100",
+                reasonCode = "watch_streak",
+                currentCount = 4,
+            ),
+        )
+    }
+
+    @Test
+    fun watchStreakForAnotherChannelDoesNotCreateInvalidation() {
+        assertNull(
+            watchStreakInvalidationForPointsEarned(
+                activeChannelId = "channel-100",
+                messageChannelId = "channel-200",
+                reasonCode = "WATCH_STREAK",
+                currentCount = 4,
+            ),
+        )
+    }
+
+    @Test
+    fun staleFirstSnapshotAndFreshSecondSnapshotUpdateState() {
+        val reconciliation = WatchStreakReconciliation(
+            source = WatchStreakReconciliationSource.POINTS_EARNED,
+            countBeforeEvent = 4,
+        )
+        assertTrue(shouldRetryWatchStreakReconciliation(reconciliation, responseCount = 4, retryAttempt = 0))
+
+        val stale = mergeWatchStreakState(
+            previous = WatchStreak(streakCount = 4),
+            incoming = WatchStreak(streakCount = 4),
+        )
+        assertEquals(4, stale.streakCount)
+
+        val updated = mergeWatchStreakState(
+            previous = stale,
+            incoming = WatchStreak(streakCount = 5),
+        )
+
+        assertEquals(5, updated.streakCount)
+        assertFalse(shouldRetryWatchStreakReconciliation(reconciliation, responseCount = 5, retryAttempt = 1))
+    }
+
+    @Test
+    fun unchangedSnapshotGetsTwoBoundedRetries() {
+        val reconciliation = WatchStreakReconciliation(
+            source = WatchStreakReconciliationSource.POINTS_EARNED,
+            countBeforeEvent = 4,
+        )
+
+        assertTrue(shouldRetryWatchStreakReconciliation(reconciliation, responseCount = 4, retryAttempt = 0))
+        assertTrue(shouldRetryWatchStreakReconciliation(reconciliation, responseCount = 4, retryAttempt = 1))
+        assertFalse(shouldRetryWatchStreakReconciliation(reconciliation, responseCount = 4, retryAttempt = 2))
+        assertEquals("unchanged", watchStreakSnapshotStatus(reconciliation, responseCount = 4))
+    }
+
+    @Test
+    fun lowerStaleSnapshotStillGetsBoundedRetry() {
+        val reconciliation = WatchStreakReconciliation(
+            source = WatchStreakReconciliationSource.POINTS_EARNED,
+            countBeforeEvent = 4,
+        )
+
+        assertTrue(shouldRetryWatchStreakReconciliation(reconciliation, responseCount = 3, retryAttempt = 0))
+        assertTrue(shouldRetryWatchStreakReconciliation(reconciliation, responseCount = 3, retryAttempt = 1))
+        assertFalse(shouldRetryWatchStreakReconciliation(reconciliation, responseCount = 3, retryAttempt = 2))
+        assertEquals("stale", watchStreakSnapshotStatus(reconciliation, responseCount = 3))
+    }
+
+    @Test
+    fun snapshotStatusDistinguishesAdvancedAndMissingResponses() {
+        val reconciliation = WatchStreakReconciliation(
+            source = WatchStreakReconciliationSource.POINTS_EARNED,
+            countBeforeEvent = 4,
+        )
+
+        assertEquals("advanced", watchStreakSnapshotStatus(reconciliation, responseCount = 5))
+        assertEquals("missing", watchStreakSnapshotStatus(reconciliation, responseCount = null))
+    }
+
+    @Test
+    fun staleGraphQlCannotRollBackNewerLiveStreak() {
+        val updated = mergeWatchStreakState(
+            previous = WatchStreak(streakCount = 5, pointsAwarded = 300),
+            incoming = WatchStreak(streakCount = 4),
+        )
+
+        assertEquals(5, updated.streakCount)
+        assertEquals(300, updated.pointsAwarded)
+    }
+}

--- a/app/src/test/java/com/github/andreyasadchy/xtra/util/chat/PubSubUtilsTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/util/chat/PubSubUtilsTest.kt
@@ -1,0 +1,44 @@
+package com.github.andreyasadchy.xtra.util.chat
+
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class PubSubUtilsTest {
+    @Test
+    fun parsesWatchStreakReasonCode() {
+        val (points, channelId) = PubSubUtils.parsePointsEarned(
+            JSONObject(
+                """
+                {
+                  "data": {
+                    "channel_id": "channel-100",
+                    "timestamp": "2026-08-22T12:00:00Z",
+                    "point_gain": {
+                      "total_points": 300,
+                      "reason_code": "WATCH_STREAK"
+                    }
+                  }
+                }
+                """.trimIndent(),
+            ),
+        )
+
+        assertEquals("channel-100", channelId)
+        assertEquals(300, points.pointsGained)
+        assertEquals("WATCH_STREAK", points.reasonCode)
+    }
+
+    @Test
+    fun parsesOrdinaryWatchReasonCode() {
+        val (points, _) = PubSubUtils.parsePointsEarned(
+            JSONObject(
+                """
+                {"data":{"point_gain":{"total_points":10,"reason_code":"WATCH"}}}
+                """.trimIndent(),
+            ),
+        )
+
+        assertEquals("WATCH", points.reasonCode)
+    }
+}


### PR DESCRIPTION
Watch streaks now refresh when Twitch sends a WATCH_STREAK channel-point award, without reopening the stream. Normal WATCH awards do not trigger extra streak requests. The refresh retries once after Twitch's data catches up and heals after a Hermes reconnect.\n\nChecks: :app:testDebugUnitTest, :app:assembleDebug, and debug APK smoke-tested on xtra-api35.