### PR TITLE
Add persistent slow mode countdown

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/model/helix/chat/SendChatMessageResponse.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/model/helix/chat/SendChatMessageResponse.kt
@@ -1,0 +1,33 @@
+package com.github.andreyasadchy.xtra.model.helix.chat
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+class SendChatMessageResponse(
+    val data: List<Message> = emptyList(),
+) {
+    @Serializable
+    class Message(
+        @SerialName("message_id")
+        val messageId: String? = null,
+        @SerialName("is_sent")
+        val isSent: Boolean = false,
+        @SerialName("drop_reason")
+        val dropReason: DropReason? = null,
+    )
+
+    @Serializable
+    class DropReason(
+        val code: String? = null,
+        val message: String? = null,
+    )
+}
+
+data class SendChatMessageResult(
+    val isSent: Boolean,
+    val messageId: String? = null,
+    val dropReasonCode: String? = null,
+    val dropReasonMessage: String? = null,
+    val errorMessage: String? = null,
+)

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/HelixRepository.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/HelixRepository.kt
@@ -12,6 +12,8 @@ import com.github.andreyasadchy.xtra.model.helix.chat.ChatSettings
 import com.github.andreyasadchy.xtra.model.helix.chat.ChatSettingsResponse
 import com.github.andreyasadchy.xtra.model.helix.chat.CheerEmotesResponse
 import com.github.andreyasadchy.xtra.model.helix.chat.EmoteSetsResponse
+import com.github.andreyasadchy.xtra.model.helix.chat.SendChatMessageResponse
+import com.github.andreyasadchy.xtra.model.helix.chat.SendChatMessageResult
 import com.github.andreyasadchy.xtra.model.helix.chat.UserEmotesResponse
 import com.github.andreyasadchy.xtra.model.helix.clip.ClipsResponse
 import com.github.andreyasadchy.xtra.model.helix.follows.FollowsResponse
@@ -176,6 +178,31 @@ internal fun parseEventSubSubscriptionInfo(
         cost = subscription?.get("cost")?.jsonPrimitive?.content?.toIntOrNull(),
         totalCost = number("total_cost"),
         maxTotalCost = number("max_total_cost"),
+    )
+}
+
+internal fun parseSendChatMessageResult(
+    json: Json,
+    statusCode: Int,
+    body: String,
+): SendChatMessageResult {
+    if (statusCode !in 200..299) {
+        return SendChatMessageResult(
+            isSent = false,
+            errorMessage = body,
+        )
+    }
+    val message = runCatching {
+        json.decodeFromString<SendChatMessageResponse>(body).data.firstOrNull()
+    }.getOrNull() ?: return SendChatMessageResult(
+        isSent = false,
+        errorMessage = body,
+    )
+    return SendChatMessageResult(
+        isSent = message.isSent,
+        messageId = message.messageId?.takeIf { it.isNotBlank() },
+        dropReasonCode = message.dropReason?.code,
+        dropReasonMessage = message.dropReason?.message,
     )
 }
 
@@ -1711,7 +1738,7 @@ class HelixRepository(
         return parseEventSubSubscriptionResult(json, statusCode, body, rateLimitResetEpochSeconds)
     }
 
-    suspend fun sendMessage(networkLibrary: String?, headers: Map<String, String>, userId: String?, channelId: String?, message: String?, replyId: String?): String? = withContext(Dispatchers.IO) {
+    suspend fun sendMessage(networkLibrary: String?, headers: Map<String, String>, userId: String?, channelId: String?, message: String?, replyId: String?): SendChatMessageResult = withContext(Dispatchers.IO) {
         val url = "https://api.twitch.tv/helix/chat/messages"
         val body = buildJsonObject {
             put("broadcaster_id", channelId)
@@ -1739,11 +1766,11 @@ class HelixRepository(
                         timeout.stop()
                     }
                 }
-                if (response.info.httpStatusCode in 200..299) {
-                    null
-                } else {
-                    response.body.decodeToString()
-                }
+                parseSendChatMessageResult(
+                    json,
+                    response.info.httpStatusCode,
+                    response.body.decodeToString(),
+                )
             }
             networkLibrary == C.CRONET && cronetEngine.value != null -> {
                 val response = suspendCancellableCoroutine { continuation ->
@@ -1764,11 +1791,11 @@ class HelixRepository(
                         timeout.stop()
                     }
                 }
-                if (response.info.httpStatusCode in 200..299) {
-                    null
-                } else {
-                    response.body.decodeToString()
-                }
+                parseSendChatMessageResult(
+                    json,
+                    response.info.httpStatusCode,
+                    response.body.decodeToString(),
+                )
             }
             else -> {
                 okHttpClient.value.newCall(Request.Builder().apply {
@@ -1777,11 +1804,11 @@ class HelixRepository(
                     header("Content-Type", "application/json")
                     post(body.toRequestBody())
                 }.build()).executeAsync().use { response ->
-                    if (response.isSuccessful) {
-                        null
-                    } else {
-                        response.body.string()
-                    }
+                    parseSendChatMessageResult(
+                        json,
+                        response.code,
+                        response.body.string(),
+                    )
                 }
             }
         }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatFragment.kt
@@ -10,6 +10,7 @@ import android.view.KeyEvent
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.InputMethodManager
 import android.widget.LinearLayout
 import android.widget.MultiAutoCompleteTextView
@@ -121,6 +122,7 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
     private var composerTextBeforeOverlay: String? = null
     private var composerSelectionBeforeOverlay: Int? = null
     private var messageViewWasVisibleBeforeOverlay: Boolean? = null
+    private var lastSlowModeUiState = SlowModeState()
 
     private var autoCompleteAdapter: AutoCompleteAdapter<Any>? = null
 
@@ -258,6 +260,14 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
             }
         }
         with(binding) {
+            viewLifecycleOwner.lifecycleScope.launch {
+                repeatOnLifecycle(Lifecycle.State.STARTED) {
+                    viewModel.slowModeState.collectLatest { state ->
+                        updateSlowModeIndicator(state)
+                        updateComposerButtons()
+                    }
+                }
+            }
             viewLifecycleOwner.lifecycleScope.launch {
                 repeatOnLifecycle(Lifecycle.State.STARTED) {
                     combine(
@@ -446,7 +456,18 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
                         editText.setTokenizer(SpaceTokenizer())
                         editText.setOnKeyListener { _, keyCode, event ->
                             if (event.action == KeyEvent.ACTION_DOWN && keyCode == KeyEvent.KEYCODE_ENTER) {
-                                sendMessage()
+                                val sent = sendMessage()
+                                sent || viewModel.isSlowModeBlocked()
+                            } else {
+                                false
+                            }
+                        }
+                        editText.setOnEditorActionListener { _, actionId, event ->
+                            if (actionId == EditorInfo.IME_ACTION_SEND ||
+                                event?.keyCode == KeyEvent.KEYCODE_ENTER && event.action == KeyEvent.ACTION_DOWN
+                            ) {
+                                val sent = sendMessage()
+                                sent || viewModel.isSlowModeBlocked()
                             } else {
                                 false
                             }
@@ -467,6 +488,7 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
                         } else {
                             messageView.visibility = View.VISIBLE
                         }
+                        updateSlowModeIndicator(viewModel.slowModeState.value)
                         messageView.addOnLayoutChangeListener { _, _, _, _, _, _, _, _, _ ->
                             updateComposerDensity()
                         }
@@ -508,6 +530,7 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
                             }
                         }
                         messagingEnabled = true
+                        updateSlowModeIndicator(viewModel.slowModeState.value)
                     }
                     viewLifecycleOwner.lifecycleScope.launch {
                         repeatOnLifecycle(Lifecycle.State.STARTED) {
@@ -981,7 +1004,18 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
             send.setOnClickListener { sendMessage() }
             editText.setOnKeyListener { _, keyCode, event ->
                 if (event.action == KeyEvent.ACTION_DOWN && keyCode == KeyEvent.KEYCODE_ENTER) {
-                    sendMessage()
+                    val sent = sendMessage()
+                    sent || viewModel.isSlowModeBlocked()
+                } else {
+                    false
+                }
+            }
+            editText.setOnEditorActionListener { _, actionId, event ->
+                if (actionId == EditorInfo.IME_ACTION_SEND ||
+                    event?.keyCode == KeyEvent.KEYCODE_ENTER && event.action == KeyEvent.ACTION_DOWN
+                ) {
+                    val sent = sendMessage()
+                    sent || viewModel.isSlowModeBlocked()
                 } else {
                     false
                 }
@@ -993,8 +1027,59 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
         if (_binding == null) return
         val hasText = binding.editText.text.isNotBlank()
         val canShareWithoutMessage = composerOverlayState is ComposerOverlayState.StreakShare
+        val blockedBySlowMode = composerOverlayState == null && viewModel.isSlowModeBlocked()
         binding.send.isVisible = !composerSubmissionInProgress && (hasText || canShareWithoutMessage)
+        binding.send.isEnabled = !blockedBySlowMode
         binding.clear.isVisible = !composerSubmissionInProgress && hasText
+    }
+
+    private fun updateSlowModeIndicator(state: SlowModeState) {
+        if (_binding == null) return
+        val indicator = binding.slowModeIndicator
+        val shouldShow = messagingEnabled && binding.messageView.isVisible && state.enabled
+        if (!shouldShow) {
+            indicator.animate().cancel()
+            indicator.alpha = 1f
+            indicator.isVisible = false
+            lastSlowModeUiState = state
+            return
+        }
+
+        val nextText = if (state.coolingDown) {
+            getString(R.string.chat_slow_mode_remaining, state.remainingSeconds)
+        } else {
+            getString(R.string.chat_slow_mode, state.intervalSeconds ?: 0)
+        }
+        if (indicator.isVisible && indicator.text != nextText) {
+            indicator.animate().cancel()
+            indicator.animate()
+                .alpha(0.72f)
+                .setDuration(80L)
+                .withEndAction {
+                    indicator.text = nextText
+                    indicator.animate().alpha(1f).setDuration(120L).start()
+                }
+                .start()
+        } else {
+            indicator.animate().cancel()
+            indicator.alpha = 1f
+            indicator.text = nextText
+        }
+
+        val becameReady = lastSlowModeUiState.coolingDown && !state.coolingDown
+        val contentDescription = getString(
+            R.string.chat_slow_mode_accessibility,
+            state.intervalSeconds ?: 0,
+        )
+        if (indicator.contentDescription != contentDescription) {
+            indicator.contentDescription = contentDescription
+        }
+        indicator.isVisible = true
+        if (becameReady) {
+            @Suppress("DEPRECATION")
+            indicator.announceForAccessibility(getString(R.string.chat_slow_mode_ready))
+        }
+        lastSlowModeUiState = state
     }
 
     private fun updateChannelPointsActivity(state: ChannelPointsActivityState) {
@@ -1307,6 +1392,9 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
                 }
                 return true
             }
+            if (viewModel.isSlowModeBlocked()) {
+                return false
+            }
             (requireContext().getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager).hideSoftInputFromWindow(editText.windowToken, 0)
             editText.clearFocus()
             toggleEmoteMenu(false)
@@ -1370,7 +1458,18 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
                 send.setOnClickListener { sendMessage(replyId) }
                 editText.setOnKeyListener { _, keyCode, event ->
                     if (event.action == KeyEvent.ACTION_DOWN && keyCode == KeyEvent.KEYCODE_ENTER) {
-                        sendMessage(replyId)
+                        val sent = sendMessage(replyId)
+                        sent || viewModel.isSlowModeBlocked()
+                    } else {
+                        false
+                    }
+                }
+                editText.setOnEditorActionListener { _, actionId, event ->
+                    if (actionId == EditorInfo.IME_ACTION_SEND ||
+                        event?.keyCode == KeyEvent.KEYCODE_ENTER && event.action == KeyEvent.ACTION_DOWN
+                    ) {
+                        val sent = sendMessage(replyId)
+                        sent || viewModel.isSlowModeBlocked()
                     } else {
                         false
                     }
@@ -1601,6 +1700,7 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
         composerTextBeforeOverlay = null
         composerSelectionBeforeOverlay = null
         messageViewWasVisibleBeforeOverlay = null
+        lastSlowModeUiState = SlowModeState()
         super.onDestroyView()
         _binding = null
     }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatViewModel.kt
@@ -3,6 +3,7 @@ package com.github.andreyasadchy.xtra.ui.chat
 import android.content.ContentResolver
 import android.content.Context
 import android.net.ConnectivityManager
+import android.os.SystemClock
 import android.util.Base64
 import android.util.JsonReader
 import android.util.JsonToken
@@ -192,6 +193,11 @@ class ChatViewModel(
     private var liveChatInitialized = false
     private var activeChannelId: String? = null
     private var activeChannelLogin: String? = null
+    private var loggedInUserId: String? = null
+    private var loggedInUserLogin: String? = null
+    private var slowModeLastMessageElapsedRealtime: Long? = null
+    private var slowModeCountdownJob: Job? = null
+    private val slowModeMessageDedupe = SlowModeMessageDedupe()
     var autoReconnect = true
 
     private val _connectionState = MutableStateFlow(ConnectionState.IDLE)
@@ -211,6 +217,8 @@ class ChatViewModel(
     val cheerEmotes = mutableListOf<CheerEmote>()
 
     val roomState = MutableStateFlow<RoomState?>(null)
+    private val _slowModeState = MutableStateFlow(SlowModeState())
+    val slowModeState: StateFlow<SlowModeState> = _slowModeState
     val raid = MutableStateFlow<Raid?>(null)
     val raidClicked = MutableStateFlow<Raid?>(null)
     var raidClosed = false
@@ -1106,6 +1114,16 @@ class ChatViewModel(
     }
 
     suspend fun onMessage(message: ChatMessage) {
+        if (message.type == ChatMessage.USER_MESSAGE && message.message != null && message.msgId == null && isOwnChatMessage(message)) {
+            updateSlowModeApplicabilityFromBadges(message.badges)
+            onAcceptedOwnChatMessage(
+                SlowModeMessageIdentity(
+                    messageId = message.id,
+                    message = message.message,
+                    replyId = message.reply?.threadParentId,
+                ),
+            )
+        }
         synchronized(chatMessages) {
             chatMessages.add(message)
             val removeCount = if (chatMessages.size > messageLimit) {
@@ -1124,6 +1142,158 @@ class ChatViewModel(
         }?.let {
             newMessage.emit(it)
         }
+    }
+
+    fun isSlowModeBlocked(): Boolean = slowModeState.value.blocked
+
+    private fun isOwnChatMessage(message: ChatMessage): Boolean {
+        val userId = loggedInUserId
+        if (!userId.isNullOrBlank() && message.userId == userId) return true
+        val login = loggedInUserLogin
+        return !login.isNullOrBlank() && message.userLogin?.equals(login, ignoreCase = true) == true
+    }
+
+    private fun onAcceptedOwnChatMessage(identity: SlowModeMessageIdentity) {
+        val intervalSeconds = _slowModeState.value.intervalSeconds ?: return
+        val nowElapsedRealtime = SystemClock.elapsedRealtime()
+        if (!slowModeMessageDedupe.accept(identity, nowElapsedRealtime)) return
+        slowModeLastMessageElapsedRealtime = nowElapsedRealtime
+        val current = _slowModeState.value
+        val remaining = if (current.applicability == SlowModeApplicability.EXEMPT) {
+            0
+        } else {
+            slowModeRemainingSeconds(
+                intervalSeconds,
+                slowModeLastMessageElapsedRealtime,
+                nowElapsedRealtime,
+            )
+        }
+        _slowModeState.value = current.copy(remainingSeconds = remaining)
+        updateSlowModeCountdown()
+    }
+
+    private fun updateSlowModeFromValue(slow: String?) {
+        val intervalSeconds = slow?.toIntOrNull()?.takeIf { it > 0 }
+        if (intervalSeconds == null) {
+            slowModeCountdownJob?.cancel()
+            slowModeCountdownJob = null
+            slowModeLastMessageElapsedRealtime = null
+            slowModeMessageDedupe.clear()
+            _slowModeState.value = SlowModeState(
+                applicability = _slowModeState.value.applicability,
+            )
+            return
+        }
+        val current = _slowModeState.value
+        val remaining = if (current.applicability == SlowModeApplicability.EXEMPT) {
+            0
+        } else {
+            slowModeRemainingSeconds(
+                intervalSeconds,
+                slowModeLastMessageElapsedRealtime,
+                SystemClock.elapsedRealtime(),
+            )
+        }
+        _slowModeState.value = current.copy(
+            intervalSeconds = intervalSeconds,
+            remainingSeconds = remaining,
+        )
+        updateSlowModeCountdown()
+    }
+
+    private fun updateSlowModeApplicability(tags: Map<String, String>) {
+        if (!tags.containsKey("mod") && !tags.containsKey("badges") && !tags.containsKey("subscriber")) return
+        val badges = tags["badges"].orEmpty()
+            .split(',')
+            .mapNotNull { it.substringBefore('/').takeIf(String::isNotBlank) }
+        val applicability = when {
+            tags["mod"] == "1" || "moderator" in badges || "broadcaster" in badges || "vip" in badges -> SlowModeApplicability.EXEMPT
+            tags["subscriber"] == "0" -> SlowModeApplicability.APPLIES
+            else -> SlowModeApplicability.UNKNOWN
+        }
+        val current = _slowModeState.value
+        val intervalSeconds = current.intervalSeconds
+        val remaining = if (intervalSeconds == null || applicability == SlowModeApplicability.EXEMPT) {
+            0
+        } else {
+            slowModeRemainingSeconds(
+                intervalSeconds,
+                slowModeLastMessageElapsedRealtime,
+                SystemClock.elapsedRealtime(),
+            )
+        }
+        _slowModeState.value = current.copy(
+            applicability = applicability,
+            remainingSeconds = remaining,
+        )
+        updateSlowModeCountdown()
+    }
+
+    private fun updateSlowModeApplicabilityFromBadges(badges: List<Badge>?) {
+        if (badges == null) return
+        val badgeSets = badges.map { it.setId }
+        val applicability = when {
+            "moderator" in badgeSets || "broadcaster" in badgeSets || "vip" in badgeSets -> SlowModeApplicability.EXEMPT
+            "subscriber" in badgeSets -> SlowModeApplicability.UNKNOWN
+            else -> SlowModeApplicability.APPLIES
+        }
+        val current = _slowModeState.value
+        val intervalSeconds = current.intervalSeconds
+        val remaining = if (intervalSeconds == null || applicability == SlowModeApplicability.EXEMPT) {
+            0
+        } else {
+            slowModeRemainingSeconds(
+                intervalSeconds,
+                slowModeLastMessageElapsedRealtime,
+                SystemClock.elapsedRealtime(),
+            )
+        }
+        _slowModeState.value = current.copy(
+            applicability = applicability,
+            remainingSeconds = remaining,
+        )
+        updateSlowModeCountdown()
+    }
+
+    private fun updateSlowModeCountdown() {
+        val current = _slowModeState.value
+        if (!current.enabled || current.applicability == SlowModeApplicability.EXEMPT || !current.coolingDown) {
+            slowModeCountdownJob?.cancel()
+            slowModeCountdownJob = null
+            return
+        }
+        if (slowModeCountdownJob?.isActive == true) return
+        slowModeCountdownJob = viewModelScope.launch {
+            while (isActive) {
+                val state = _slowModeState.value
+                val intervalSeconds = state.intervalSeconds ?: break
+                if (state.applicability == SlowModeApplicability.EXEMPT) break
+                val remaining = slowModeRemainingSeconds(
+                    intervalSeconds,
+                    slowModeLastMessageElapsedRealtime,
+                    SystemClock.elapsedRealtime(),
+                )
+                if (_slowModeState.value != state) continue
+                if (remaining <= 0) {
+                    _slowModeState.value = state.copy(remainingSeconds = 0)
+                    break
+                }
+                if (state.remainingSeconds != remaining) {
+                    _slowModeState.value = state.copy(remainingSeconds = remaining)
+                }
+                delay(1000L)
+            }
+        }
+    }
+
+    private fun resetSlowModeState() {
+        slowModeCountdownJob?.cancel()
+        slowModeCountdownJob = null
+        slowModeLastMessageElapsedRealtime = null
+        slowModeMessageDedupe.clear()
+        loggedInUserId = null
+        loggedInUserLogin = null
+        _slowModeState.value = SlowModeState()
     }
 
     /** Trims history after a subscriber has consumed a message overflow. */
@@ -1806,6 +1976,8 @@ class ChatViewModel(
         val enableIntegrity = applicationContext.prefs().getBoolean(C.ENABLE_INTEGRITY, false)
         val accountId = applicationContext.tokenPrefs().getString(C.USER_ID, null)
         val accountLogin = applicationContext.tokenPrefs().getString(C.USERNAME, null)
+        loggedInUserId = accountId
+        loggedInUserLogin = accountLogin
         val isLoggedIn = !accountLogin.isNullOrBlank() && (!gqlHeaders[C.HEADER_TOKEN].isNullOrBlank() || !helixHeaders[C.HEADER_TOKEN].isNullOrBlank())
         val usePubSub = true
         val showUserNotice = applicationContext.prefs().getBoolean(C.CHAT_SHOW_USER_NOTICE, true)
@@ -1944,6 +2116,7 @@ class ChatViewModel(
         predictionSessionToken += 1
         predictionSnapshotJob?.cancel()
         predictionSnapshotJob = null
+        resetSlowModeState()
         _connectionState.value = ConnectionState.IDLE
         watchStreakSession++
         activeChannelId = null
@@ -2134,6 +2307,9 @@ class ChatViewModel(
         }
 
         override suspend fun onRoomState(message: ChatUtils.IRCMessage) {
+            if (message.tags.containsKey("slow")) {
+                updateSlowModeFromValue(message.tags["slow"])
+            }
             roomState.value = RoomState(
                 emote = message.tags["emote-only"],
                 followers = message.tags["followers-only"],
@@ -2171,6 +2347,10 @@ class ChatViewModel(
         }
 
         override suspend fun onUserState(message: ChatUtils.IRCMessage) {
+            updateSlowModeApplicability(message.tags)
+            message.tags["id"]?.takeIf { it.isNotBlank() }?.let {
+                onAcceptedOwnChatMessage(SlowModeMessageIdentity(messageId = it))
+            }
             val emoteSets = message.tags["emote-sets"]?.split(",")
             if (emoteSets != null && savedEmoteSets != emoteSets) {
                 savedEmoteSets = emoteSets
@@ -2581,7 +2761,11 @@ class ChatViewModel(
         }
 
         override suspend fun onRoomState(event: JSONObject, timestamp: String?) {
-            roomState.value = EventSubUtils.parseRoomState(event)
+            val state = EventSubUtils.parseRoomState(event)
+            if (!event.isNull("slow_mode")) {
+                updateSlowModeFromValue(state.slow)
+            }
+            roomState.value = state
         }
 
         override suspend fun onDisconnect(message: String, fullMsg: String?) {
@@ -3556,17 +3740,35 @@ class ChatViewModel(
             viewModelScope.launch {
                 if (useApiChatMessages) {
                     if (!gqlHeaders[C.HEADER_TOKEN].isNullOrBlank()) {
-                        graphQLRepository.sendMessage(networkLibrary, gqlHeaders, channelId, message.toString(), replyId).also { response ->
+                        val response = graphQLRepository.sendMessage(networkLibrary, gqlHeaders, channelId, message.toString(), replyId).also { response ->
                             if (enableIntegrity) {
                                 response.errors?.find { it.message == C.FAILED_INTEGRITY_CHECK }?.let {
                                     integrity.emit("refresh")
                                     return@launch
                                 }
                             }
-                        }.takeIf { !it.errors.isNullOrEmpty() }?.toString()
+                        }
+                        if (response.errors.isNullOrEmpty()) {
+                            onAcceptedOwnChatMessage(
+                                SlowModeMessageIdentity(message = message.toString(), replyId = replyId),
+                            )
+                            null
+                        } else {
+                            response.toString()
+                        }
                     } else {
                         if (!helixHeaders[C.HEADER_TOKEN].isNullOrBlank()) {
-                            helixRepository.sendMessage(networkLibrary, helixHeaders, accountId, channelId, message.toString(), replyId)
+                            helixRepository.sendMessage(networkLibrary, helixHeaders, accountId, channelId, message.toString(), replyId).also { response ->
+                                if (response.isSent) {
+                                    onAcceptedOwnChatMessage(
+                                        SlowModeMessageIdentity(
+                                            messageId = response.messageId,
+                                            message = message.toString(),
+                                            replyId = replyId,
+                                        ),
+                                    )
+                                }
+                            }.errorMessage
                         } else null
                     }?.let {
                         onMessage(ChatMessage(systemMsg = it))

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/SlowModeState.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/SlowModeState.kt
@@ -1,0 +1,94 @@
+package com.github.andreyasadchy.xtra.ui.chat
+
+enum class SlowModeApplicability {
+    APPLIES,
+    EXEMPT,
+    UNKNOWN,
+}
+
+data class SlowModeState(
+    val intervalSeconds: Int? = null,
+    val remainingSeconds: Int = 0,
+    val applicability: SlowModeApplicability = SlowModeApplicability.UNKNOWN,
+) {
+    val enabled: Boolean
+        get() = intervalSeconds != null
+
+    val coolingDown: Boolean
+        get() = remainingSeconds > 0
+
+    val blocked: Boolean
+        get() = applicability == SlowModeApplicability.APPLIES && coolingDown
+}
+
+internal fun slowModeRemainingSeconds(
+    intervalSeconds: Int,
+    lastMessageElapsedRealtime: Long?,
+    nowElapsedRealtime: Long,
+): Int {
+    if (intervalSeconds <= 0 || lastMessageElapsedRealtime == null) return 0
+    val remainingMillis = intervalSeconds * 1000L - (nowElapsedRealtime - lastMessageElapsedRealtime)
+    return if (remainingMillis <= 0L) 0 else ((remainingMillis + 999L) / 1000L).toInt()
+}
+
+internal data class SlowModeMessageIdentity(
+    val messageId: String? = null,
+    val message: String? = null,
+    val replyId: String? = null,
+)
+
+internal class SlowModeMessageDedupe(
+    private val windowMillis: Long = 500L,
+) {
+    private companion object {
+        const val MAX_ACCEPTED_MESSAGE_IDS = 64
+    }
+
+    private data class Fingerprint(
+        val message: String,
+        val replyId: String?,
+    )
+
+    private val acceptedMessageIds = linkedMapOf<String, Long>()
+    private val pendingFingerprints = linkedMapOf<Fingerprint, Long>()
+
+    fun accept(identity: SlowModeMessageIdentity, nowElapsedRealtime: Long): Boolean {
+        pruneFingerprints(nowElapsedRealtime)
+
+        val messageId = identity.messageId
+        if (messageId != null && acceptedMessageIds.containsKey(messageId)) return false
+
+        val fingerprint = identity.message?.let { Fingerprint(it, identity.replyId) }
+        if (fingerprint != null) {
+            val acceptedAt = pendingFingerprints.remove(fingerprint)
+            if (acceptedAt != null && nowElapsedRealtime - acceptedAt <= windowMillis) {
+                messageId?.let { rememberMessageId(it, nowElapsedRealtime) }
+                return false
+            }
+        }
+
+        messageId?.let { rememberMessageId(it, nowElapsedRealtime) }
+        if (messageId == null && fingerprint != null) {
+            pendingFingerprints[fingerprint] = nowElapsedRealtime
+        }
+        return true
+    }
+
+    fun clear() {
+        acceptedMessageIds.clear()
+        pendingFingerprints.clear()
+    }
+
+    private fun pruneFingerprints(nowElapsedRealtime: Long) {
+        pendingFingerprints.entries.removeAll {
+            nowElapsedRealtime - it.value > windowMillis
+        }
+    }
+
+    private fun rememberMessageId(messageId: String, nowElapsedRealtime: Long) {
+        acceptedMessageIds[messageId] = nowElapsedRealtime
+        while (acceptedMessageIds.size > MAX_ACCEPTED_MESSAGE_IDS) {
+            acceptedMessageIds.remove(acceptedMessageIds.keys.first())
+        }
+    }
+}

--- a/app/src/main/res/layout/fragment_chat.xml
+++ b/app/src/main/res/layout/fragment_chat.xml
@@ -151,6 +151,33 @@
                 android:background="?attr/colorOutlineVariant" />
         </LinearLayout>
 
+        <com.google.android.material.chip.Chip
+            android:id="@+id/slowModeIndicator"
+            style="@style/Widget.Material3.Chip.Assist"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="end"
+            android:layout_marginEnd="6dp"
+            android:layout_marginBottom="2dp"
+            android:accessibilityLiveRegion="none"
+            android:clickable="false"
+            android:focusable="false"
+            android:importantForAccessibility="yes"
+            android:maxLines="1"
+            android:textAppearance="?attr/textAppearanceLabelSmall"
+            android:visibility="gone"
+            app:chipBackgroundColor="?attr/colorSurfaceContainerHigh"
+            app:chipEndPadding="10dp"
+            app:chipIcon="@drawable/ic_stream_uptime"
+            app:chipIconSize="16dp"
+            app:chipIconTint="?attr/colorOnSurfaceVariant"
+            app:chipMinHeight="30dp"
+            app:chipStartPadding="10dp"
+            app:chipStrokeColor="?attr/colorOutlineVariant"
+            app:chipStrokeWidth="1dp"
+            tools:text="Slow mode · 30s"
+            tools:visibility="visible" />
+
         <LinearLayout
             android:id="@+id/messageView"
             android:layout_width="match_parent"

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -158,6 +158,10 @@
     <string name="room_followers_min">المتابعون%s</string>
     <string name="room_unique">الفريد</string>
     <string name="room_slow">%sالبطيء</string>
+    <string name="chat_slow_mode">الوضع البطيء · %1$ds</string>
+    <string name="chat_slow_mode_remaining">إرسال مرة أخرى · %1$ds</string>
+    <string name="chat_slow_mode_accessibility">الوضع البطيء مفعّل. يمكن إرسال الرسائل كل %1$d ثانية.</string>
+    <string name="chat_slow_mode_ready">يمكنك إرسال رسالة أخرى.</string>
     <string name="room_subs">الغواصات</string>
     <string name="chat_join">متصل بـ%s</string>
     <string name="copy_clip">نسخ إلى الحافظة</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -585,6 +585,10 @@
     <string name="room_followers_min">Sledující %s</string>
     <string name="room_unique">Unikátní</string>
     <string name="room_slow">Pomalý režim %s</string>
+    <string name="chat_slow_mode">Pomalý režim · %1$ds</string>
+    <string name="chat_slow_mode_remaining">Odeslat znovu · %1$ds</string>
+    <string name="chat_slow_mode_accessibility">Pomalý režim je zapnutý. Zprávy lze odesílat každých %1$d sekund.</string>
+    <string name="chat_slow_mode_ready">Můžete odeslat další zprávu.</string>
     <string name="room_subs">Předplatitelé</string>
     <string name="chat_join">Připojeno k %s</string>
     <string name="copy_clip">Kopírovat do schránky</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -158,6 +158,10 @@
     <string name="room_followers_min">%s Follower</string>
     <string name="room_unique">Einzigartig</string>
     <string name="room_slow">Langsam %s</string>
+    <string name="chat_slow_mode">Slow-Modus · %1$ds</string>
+    <string name="chat_slow_mode_remaining">Erneut senden · %1$ds</string>
+    <string name="chat_slow_mode_accessibility">Slow-Modus aktiviert. Nachrichten können alle %1$d Sekunden gesendet werden.</string>
+    <string name="chat_slow_mode_ready">Du kannst eine weitere Nachricht senden.</string>
     <string name="room_subs">Abonnenten</string>
     <string name="chat_join">Verbunden mit %s</string>
     <string name="copy_clip">In Zwischenablage kopieren</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -163,6 +163,10 @@
     <string name="room_followers_min">%s Seguidores</string>
     <string name="room_unique">Único</string>
     <string name="room_slow">Modo Lento %s</string>
+    <string name="chat_slow_mode">Modo lento · %1$ds</string>
+    <string name="chat_slow_mode_remaining">Enviar de nuevo · %1$ds</string>
+    <string name="chat_slow_mode_accessibility">Modo lento activado. Los mensajes se pueden enviar cada %1$d segundos.</string>
+    <string name="chat_slow_mode_ready">Puedes enviar otro mensaje.</string>
     <string name="room_subs">Modo Solo Suscriptores</string>
     <string name="chat_join">Conectado a %s</string>
     <string name="copy_clip">Copiar al portapapeles</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -158,6 +158,10 @@
     <string name="room_followers_min">Abonnés %s</string>
     <string name="room_unique">Unique</string>
     <string name="room_slow">Lent %s</string>
+    <string name="chat_slow_mode">Mode lent · %1$ds</string>
+    <string name="chat_slow_mode_remaining">Envoyer à nouveau · %1$ds</string>
+    <string name="chat_slow_mode_accessibility">Mode lent activé. Les messages peuvent être envoyés toutes les %1$d secondes.</string>
+    <string name="chat_slow_mode_ready">Vous pouvez envoyer un autre message.</string>
     <string name="room_subs">Abonnés</string>
     <string name="chat_join">Connecté.e à %s</string>
     <string name="copy_clip">Copier dans le presse-papier</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -158,6 +158,10 @@
     <string name="room_followers_min">Seguidores %s</string>
     <string name="room_unique">Único</string>
     <string name="room_slow">Lento %s</string>
+    <string name="chat_slow_mode">Modo lento · %1$ds</string>
+    <string name="chat_slow_mode_remaining">Enviar de novo · %1$ds</string>
+    <string name="chat_slow_mode_accessibility">Modo lento activado. As mensaxes pódense enviar cada %1$d segundos.</string>
+    <string name="chat_slow_mode_ready">Podes enviar outra mensaxe.</string>
     <string name="room_subs">Subs</string>
     <string name="chat_join">Conectado a %s</string>
     <string name="copy_clip">Copiar ao portapapeis</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -157,6 +157,10 @@
     <string name="room_followers_min">%s Pengikut</string>
     <string name="room_unique">Unik</string>
     <string name="room_slow">Lambat %s</string>
+    <string name="chat_slow_mode">Mode lambat · %1$ds</string>
+    <string name="chat_slow_mode_remaining">Kirim lagi · %1$ds</string>
+    <string name="chat_slow_mode_accessibility">Mode lambat aktif. Pesan dapat dikirim setiap %1$d detik.</string>
+    <string name="chat_slow_mode_ready">Anda dapat mengirim pesan lagi.</string>
     <string name="room_subs">Subs</string>
     <string name="chat_join">Menyambungkan ke %s</string>
     <string name="copy_clip">Salin ke clipboard</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -158,6 +158,10 @@
     <string name="room_followers_min">Seguaci %s</string>
     <string name="room_unique">Unico</string>
     <string name="room_slow">Lento %s</string>
+    <string name="chat_slow_mode">Modalità lenta · %1$ds</string>
+    <string name="chat_slow_mode_remaining">Invia di nuovo · %1$ds</string>
+    <string name="chat_slow_mode_accessibility">Modalità lenta attiva. I messaggi possono essere inviati ogni %1$d secondi.</string>
+    <string name="chat_slow_mode_ready">Puoi inviare un altro messaggio.</string>
     <string name="room_subs">Sottoscrittori</string>
     <string name="chat_join">Connesso a %s</string>
     <string name="copy_clip">Copia negli appunti</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -158,6 +158,10 @@
     <string name="room_followers_min">フォロワー限定 %s</string>
     <string name="room_unique">重複チャット禁止</string>
     <string name="room_slow">スローモード %s</string>
+    <string name="chat_slow_mode">スローモード · %1$ds</string>
+    <string name="chat_slow_mode_remaining">再送信 · %1$ds</string>
+    <string name="chat_slow_mode_accessibility">スローモードが有効です。メッセージは%1$d秒ごとに送信できます。</string>
+    <string name="chat_slow_mode_ready">別のメッセージを送信できます。</string>
     <string name="room_subs">サブスクライバー限定</string>
     <string name="chat_join">%s に接続しています</string>
     <string name="copy_clip">クリップボードにコピー</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -562,6 +562,10 @@
     <string name="room_followers_min">Obserwujący %s</string>
     <string name="room_unique">Unikalne</string>
     <string name="room_slow">Wolno %s</string>
+    <string name="chat_slow_mode">Tryb powolny · %1$ds</string>
+    <string name="chat_slow_mode_remaining">Wyślij ponownie · %1$ds</string>
+    <string name="chat_slow_mode_accessibility">Tryb powolny jest włączony. Wiadomości można wysyłać co %1$d sekund.</string>
+    <string name="chat_slow_mode_ready">Możesz wysłać kolejną wiadomość.</string>
     <string name="room_subs">Subs</string>
     <string name="chat_join">Połączono z %s</string>
     <string name="copy_clip">Skopiuj do schowka</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -158,6 +158,10 @@
     <string name="room_followers_min">%s seguidores</string>
     <string name="room_unique">Único</string>
     <string name="room_slow">%s de lentidão no chat</string>
+    <string name="chat_slow_mode">Modo lento · %1$ds</string>
+    <string name="chat_slow_mode_remaining">Enviar novamente · %1$ds</string>
+    <string name="chat_slow_mode_accessibility">O modo lento está ativado. As mensagens podem ser enviadas a cada %1$d segundos.</string>
+    <string name="chat_slow_mode_ready">Você pode enviar outra mensagem.</string>
     <string name="room_subs">Subs</string>
     <string name="chat_join">Conectado a %s</string>
     <string name="copy_clip">Copiar para área de transferência</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -158,6 +158,10 @@
     <string name="room_followers_min">Следящие %s</string>
     <string name="room_unique">Уник. сообщ.</string>
     <string name="room_slow">Медл. режим %s</string>
+    <string name="chat_slow_mode">Медленный режим · %1$ds</string>
+    <string name="chat_slow_mode_remaining">Отправить снова · %1$ds</string>
+    <string name="chat_slow_mode_accessibility">Медленный режим включён. Сообщения можно отправлять каждые %1$d секунд.</string>
+    <string name="chat_slow_mode_ready">Можно отправить ещё одно сообщение.</string>
     <string name="room_subs">Подписчики</string>
     <string name="chat_join">Выполнено подключение к %s</string>
     <string name="copy_clip">Копировать в буфер обмена</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -585,6 +585,10 @@
     <string name="room_followers_min">Nasledovatelia %s</string>
     <string name="room_unique">Jedinečný</string>
     <string name="room_slow">Pomaly %s</string>
+    <string name="chat_slow_mode">Pomalý režim · %1$ds</string>
+    <string name="chat_slow_mode_remaining">Odoslať znova · %1$ds</string>
+    <string name="chat_slow_mode_accessibility">Pomalý režim je zapnutý. Správy možno odosielať každých %1$d sekúnd.</string>
+    <string name="chat_slow_mode_ready">Môžete odoslať ďalšiu správu.</string>
     <string name="room_subs">Subs</string>
     <string name="chat_join">Pripojené k %s</string>
     <string name="copy_clip">Kopírovať do schránky</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -159,6 +159,10 @@
     <string name="room_followers_min">Takipçiler %s</string>
     <string name="room_unique">Benzersiz</string>
     <string name="room_slow">Yavaş %s</string>
+    <string name="chat_slow_mode">Yavaş mod · %1$ds</string>
+    <string name="chat_slow_mode_remaining">Tekrar gönder · %1$ds</string>
+    <string name="chat_slow_mode_accessibility">Yavaş mod etkin. Mesajlar her %1$d saniyede bir gönderilebilir.</string>
+    <string name="chat_slow_mode_ready">Başka bir mesaj gönderebilirsiniz.</string>
     <string name="room_subs">Aboneler</string>
     <string name="chat_join">%s kanalına bağlanıldı</string>
     <string name="copy_clip">Panoya kopyala</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -158,6 +158,10 @@
     <string name="room_followers_min">粉丝 %s</string>
     <string name="room_unique">不重复的</string>
     <string name="room_slow">显示 %s</string>
+    <string name="chat_slow_mode">慢速模式 · %1$ds</string>
+    <string name="chat_slow_mode_remaining">再次发送 · %1$ds</string>
+    <string name="chat_slow_mode_accessibility">慢速模式已启用。每 %1$d 秒可以发送一条消息。</string>
+    <string name="chat_slow_mode_ready">可以发送下一条消息。</string>
     <string name="room_subs">订阅</string>
     <string name="chat_join">已连接至 %s</string>
     <string name="copy_clip">复制到剪贴板</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -158,6 +158,10 @@
     <string name="room_followers_min">追隨者 %s</string>
     <string name="room_unique">不重複的</string>
     <string name="room_slow">顯示 %s</string>
+    <string name="chat_slow_mode">慢速模式 · %1$ds</string>
+    <string name="chat_slow_mode_remaining">再次傳送 · %1$ds</string>
+    <string name="chat_slow_mode_accessibility">慢速模式已啟用。每 %1$d 秒可以傳送一則訊息。</string>
+    <string name="chat_slow_mode_ready">您可以傳送另一則訊息。</string>
     <string name="room_subs">訂閱</string>
     <string name="chat_join">已連接至 %s</string>
     <string name="copy_clip">複製到剪貼簿</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -586,6 +586,10 @@
     <string name="room_unique">Unique</string>
     <string name="room_slow">Slow %s</string>
     <string name="room_subs">Subs</string>
+    <string name="chat_slow_mode">Slow mode · %1$ds</string>
+    <string name="chat_slow_mode_remaining">Send again · %1$ds</string>
+    <string name="chat_slow_mode_accessibility">Slow mode enabled. Messages can be sent every %1$d seconds.</string>
+    <string name="chat_slow_mode_ready">You can send another message.</string>
     <string name="chat_join">Connected to %s</string>
     <string name="copy_clip">Copy to clipboard</string>
     <string name="chat_clear">Chat has been cleared by a moderator.</string>

--- a/app/src/test/java/com/github/andreyasadchy/xtra/repository/HelixChatMessageTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/repository/HelixChatMessageTest.kt
@@ -1,0 +1,62 @@
+package com.github.andreyasadchy.xtra.repository
+
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class HelixChatMessageTest {
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @Test
+    fun acceptedHttp200ResponseExposesMessageId() {
+        val result = parseSendChatMessageResult(
+            json,
+            statusCode = 200,
+            body = """
+                {
+                  "data": [{
+                    "message_id": "message-id",
+                    "is_sent": true,
+                    "drop_reason": null
+                  }]
+                }
+            """.trimIndent(),
+        )
+
+        assertTrue(result.isSent)
+        assertEquals("message-id", result.messageId)
+        assertNull(result.dropReasonCode)
+        assertNull(result.dropReasonMessage)
+        assertNull(result.errorMessage)
+    }
+
+    @Test
+    fun droppedHttp200ResponseDoesNotExposeAcceptance() {
+        val result = parseSendChatMessageResult(
+            json,
+            statusCode = 200,
+            body = """
+                {
+                  "data": [{
+                    "message_id": "",
+                    "is_sent": false,
+                    "drop_reason": {
+                      "code": "slow_mode",
+                      "message": "You are sending messages too quickly."
+                    }
+                  }]
+                }
+            """.trimIndent(),
+        )
+
+        assertFalse(result.isSent)
+        assertNull(result.messageId)
+        assertEquals("slow_mode", result.dropReasonCode)
+        assertEquals("You are sending messages too quickly.", result.dropReasonMessage)
+        assertNull(result.errorMessage)
+    }
+}

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/SlowModeStateTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/SlowModeStateTest.kt
@@ -1,0 +1,100 @@
+package com.github.andreyasadchy.xtra.ui.chat
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SlowModeStateTest {
+
+    @Test
+    fun remainingTimeRoundsUpUntilTheDeadline() {
+        assertEquals(30, slowModeRemainingSeconds(30, 1_000L, 1_000L))
+        assertEquals(29, slowModeRemainingSeconds(30, 1_000L, 2_001L))
+        assertEquals(1, slowModeRemainingSeconds(30, 1_000L, 30_001L))
+        assertEquals(0, slowModeRemainingSeconds(30, 1_000L, 31_000L))
+    }
+
+    @Test
+    fun onlyDefinitelyApplicableUsersAreBlocked() {
+        assertTrue(
+            SlowModeState(
+                intervalSeconds = 30,
+                remainingSeconds = 1,
+                applicability = SlowModeApplicability.APPLIES,
+            ).blocked,
+        )
+        assertFalse(
+            SlowModeState(
+                intervalSeconds = 30,
+                remainingSeconds = 1,
+                applicability = SlowModeApplicability.UNKNOWN,
+            ).blocked,
+        )
+        assertFalse(
+            SlowModeState(
+                intervalSeconds = 30,
+                remainingSeconds = 1,
+                applicability = SlowModeApplicability.EXEMPT,
+            ).blocked,
+        )
+    }
+
+    @Test
+    fun writeAcknowledgementAndReadEchoAreOneAcceptance() {
+        val dedupe = SlowModeMessageDedupe()
+
+        assertTrue(
+            dedupe.accept(
+                SlowModeMessageIdentity(messageId = "message-id"),
+                nowElapsedRealtime = 1_000L,
+            ),
+        )
+        assertFalse(
+            dedupe.accept(
+                SlowModeMessageIdentity(messageId = "message-id"),
+                nowElapsedRealtime = 1_200L,
+            ),
+        )
+    }
+
+    @Test
+    fun apiAcceptanceAndReadEchoWithDifferentIdAreOneAcceptance() {
+        val dedupe = SlowModeMessageDedupe()
+
+        assertTrue(
+            dedupe.accept(
+                SlowModeMessageIdentity(message = "hello", replyId = "parent-id"),
+                nowElapsedRealtime = 1_000L,
+            ),
+        )
+        assertFalse(
+            dedupe.accept(
+                SlowModeMessageIdentity(
+                    messageId = "message-id",
+                    message = "hello",
+                    replyId = "parent-id",
+                ),
+                nowElapsedRealtime = 1_250L,
+            ),
+        )
+    }
+
+    @Test
+    fun sameMessageWithoutIdAfterDedupeWindowIsAcceptedAgain() {
+        val dedupe = SlowModeMessageDedupe()
+        val identity = SlowModeMessageIdentity(message = "hello")
+
+        assertTrue(dedupe.accept(identity, nowElapsedRealtime = 1_000L))
+        assertTrue(dedupe.accept(identity, nowElapsedRealtime = 1_501L))
+    }
+
+    @Test
+    fun messageIdRemainsDeduplicatedWhenReadEchoIsDelayed() {
+        val dedupe = SlowModeMessageDedupe()
+        val identity = SlowModeMessageIdentity(messageId = "message-id")
+
+        assertTrue(dedupe.accept(identity, nowElapsedRealtime = 1_000L))
+        assertFalse(dedupe.accept(identity, nowElapsedRealtime = 30_000L))
+    }
+}


### PR DESCRIPTION
Adds a persistent slow-mode pill above the chat composer with a countdown after accepted messages. It keeps composing usable, locally blocks only confirmed regular viewers, and handles moderator, VIP, broadcaster, and unknown subscriber exemptions.