### PR TITLE
Preserve errors for unsupported followed-stream fallbacks

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/datasource/StreamFeedPageLoader.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/datasource/StreamFeedPageLoader.kt
@@ -35,6 +35,10 @@ internal fun String?.toStreamFeedCursor(api: String): StreamFeedCursor? {
     return this?.takeIf { it.isNotBlank() }?.let { StreamFeedCursor(api, it) }
 }
 
+internal fun followedStreamsFallbackSupportsSort(sort: String): Boolean {
+    return sort == StreamsSortDialog.SORT_VIEWERS
+}
+
 class StreamFeedIntegrityException : IOException(C.FAILED_INTEGRITY_CHECK)
 
 private fun checkIntegrity(enabled: Boolean, errors: Iterable<Any?>?) {
@@ -43,8 +47,9 @@ private fun checkIntegrity(enabled: Boolean, errors: Iterable<Any?>?) {
     }
 }
 
-/** Select an API only for the first page; subsequent cursors stay on it. */
+/** Select a compatible API only for the first page; subsequent cursors stay on it. */
 internal suspend fun <T> loadFollowedFirstPageWithFallback(
+    sort: String,
     onApiSelected: (String) -> Unit,
     gql: suspend () -> T,
     persistedGql: suspend () -> T,
@@ -56,6 +61,7 @@ internal suspend fun <T> loadFollowedFirstPageWithFallback(
     } catch (error: Exception) {
         if (error is CancellationException) throw error
         if (error is StreamFeedIntegrityException) throw error
+        if (!followedStreamsFallbackSupportsSort(sort)) throw error
         try {
             onApiSelected(C.GQL_PERSISTED_QUERY)
             persistedGql()
@@ -257,8 +263,8 @@ class FollowedStreamsPageLoader(
 ) : StreamFeedPageLoader {
     private var api: String? = null
 
-    private fun requireUnsortedFallback() {
-        if (sort != StreamsSortDialog.SORT_VIEWERS) {
+    private fun requireSupportedFallbackSort() {
+        if (!followedStreamsFallbackSupportsSort(sort)) {
             throw IOException("Followed-stream fallback cannot represent sort: $sort")
         }
     }
@@ -299,6 +305,7 @@ class FollowedStreamsPageLoader(
 
     private suspend fun loadFirstPageWithFallback(): StreamFeedPage {
         return loadFollowedFirstPageWithFallback(
+            sort = sort,
             onApiSelected = { api = it },
             gql = { gqlQueryLoad(null) },
             persistedGql = { persistedGqlFallback(null) },
@@ -317,12 +324,12 @@ class FollowedStreamsPageLoader(
     }
 
     private suspend fun persistedGqlFallback(cursor: String?): StreamFeedPage {
-        requireUnsortedFallback()
+        requireSupportedFallbackSort()
         return gqlLoad(cursor)
     }
 
     private suspend fun helixFallback(cursor: String?): StreamFeedPage {
-        requireUnsortedFallback()
+        requireSupportedFallbackSort()
         return helixLoad(cursor)
     }
 

--- a/app/src/test/java/com/github/andreyasadchy/xtra/repository/datasource/FollowedStreamsPageLoaderTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/repository/datasource/FollowedStreamsPageLoaderTest.kt
@@ -1,11 +1,36 @@
 package com.github.andreyasadchy.xtra.repository.datasource
 
+import com.github.andreyasadchy.xtra.repository.TwitchApiException
+import com.github.andreyasadchy.xtra.ui.common.StreamsSortDialog
 import com.github.andreyasadchy.xtra.util.C
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
 import org.junit.Test
 
 class FollowedStreamsPageLoaderTest {
+
+    @Test
+    fun relevanceDoesNotUseUnsupportedFallbackApis() = runBlocking {
+        val calls = mutableListOf<String>()
+        val primaryError = TwitchApiException(
+            statusCode = 429,
+            rateLimitResetEpochSeconds = 123L,
+            message = "gql rate limited",
+        )
+        val failure = runCatching {
+            loadFollowedFirstPageWithFallback(
+                sort = StreamsSortDialog.RELEVANCE,
+                onApiSelected = { calls += it },
+                gql = { calls += "gql-first"; throw primaryError },
+                persistedGql = { calls += "persisted-first"; error("must not be called") },
+                helix = { calls += "helix-first"; error("must not be called") },
+            )
+        }.exceptionOrNull()
+
+        assertSame(primaryError, failure)
+        assertEquals(listOf(C.GQL, "gql-first"), calls)
+    }
 
     @Test
     fun persistedGraphQlFallbackKeepsItsCursorAffinity() = runBlocking {
@@ -13,6 +38,7 @@ class FollowedStreamsPageLoaderTest {
         val calls = mutableListOf<String>()
 
         val firstPage = loadFollowedFirstPageWithFallback(
+            sort = StreamsSortDialog.SORT_VIEWERS,
             onApiSelected = { selectedApi = it; calls += it },
             gql = { calls += "gql-first"; error("gql unavailable") },
             persistedGql = { calls += "persisted-first"; "first" },
@@ -39,6 +65,7 @@ class FollowedStreamsPageLoaderTest {
         val calls = mutableListOf<String>()
 
         loadFollowedFirstPageWithFallback(
+            sort = StreamsSortDialog.SORT_VIEWERS,
             onApiSelected = { selectedApi = it; calls += it },
             gql = { calls += "gql-first"; error("gql unavailable") },
             persistedGql = { calls += "persisted-first"; error("persisted unavailable") },


### PR DESCRIPTION
When followed-stream GraphQL fails, fallback APIs are used only for viewer-count sorting. Other sorts return the original GraphQL error, preserving rate-limit handling and avoiding incompatible API calls. The existing cache remains untouched when refresh fails.