### PR TITLE
Make slow mode countdown pill non-intrusive

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatFragment.kt
@@ -1036,20 +1036,21 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
     private fun updateSlowModeIndicator(state: SlowModeState) {
         if (_binding == null) return
         val indicator = binding.slowModeIndicator
-        val shouldShow = messagingEnabled && binding.messageView.isVisible && state.enabled
+        val becameReady = lastSlowModeUiState.coolingDown && state.enabled && !state.coolingDown
+        val shouldShow = messagingEnabled && binding.messageView.isVisible && state.enabled && state.blocked
         if (!shouldShow) {
             indicator.animate().cancel()
             indicator.alpha = 1f
+            if (becameReady && indicator.isVisible) {
+                @Suppress("DEPRECATION")
+                indicator.announceForAccessibility(getString(R.string.chat_slow_mode_ready))
+            }
             indicator.isVisible = false
             lastSlowModeUiState = state
             return
         }
 
-        val nextText = if (state.coolingDown) {
-            getString(R.string.chat_slow_mode_remaining, state.remainingSeconds)
-        } else {
-            getString(R.string.chat_slow_mode, state.intervalSeconds ?: 0)
-        }
+        val nextText = getString(R.string.chat_slow_mode_remaining, state.remainingSeconds)
         if (indicator.isVisible && indicator.text != nextText) {
             indicator.animate().cancel()
             indicator.animate()
@@ -1066,7 +1067,6 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
             indicator.text = nextText
         }
 
-        val becameReady = lastSlowModeUiState.coolingDown && !state.coolingDown
         val contentDescription = getString(
             R.string.chat_slow_mode_accessibility,
             state.intervalSeconds ?: 0,
@@ -1075,10 +1075,6 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
             indicator.contentDescription = contentDescription
         }
         indicator.isVisible = true
-        if (becameReady) {
-            @Suppress("DEPRECATION")
-            indicator.announceForAccessibility(getString(R.string.chat_slow_mode_ready))
-        }
         lastSlowModeUiState = state
     }
 

--- a/app/src/main/res/layout/fragment_chat.xml
+++ b/app/src/main/res/layout/fragment_chat.xml
@@ -38,6 +38,34 @@
                 android:text="@string/scroll_down"
                 android:visibility="gone"
                 tools:visibility="visible" />
+
+            <com.google.android.material.chip.Chip
+                android:id="@+id/slowModeIndicator"
+                style="@style/Widget.Material3.Chip.Assist"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="top|end"
+                android:layout_marginTop="8dp"
+                android:layout_marginEnd="8dp"
+                android:accessibilityLiveRegion="none"
+                android:clickable="false"
+                android:elevation="2dp"
+                android:focusable="false"
+                android:importantForAccessibility="yes"
+                android:maxLines="1"
+                android:textAppearance="?attr/textAppearanceLabelSmall"
+                android:visibility="gone"
+                app:chipBackgroundColor="?attr/colorSurfaceContainerHigh"
+                app:chipEndPadding="8dp"
+                app:chipIcon="@drawable/ic_stream_uptime"
+                app:chipIconSize="14dp"
+                app:chipIconTint="?attr/colorOnSurfaceVariant"
+                app:chipMinHeight="28dp"
+                app:chipStartPadding="8dp"
+                app:chipStrokeColor="?attr/colorOutlineVariant"
+                app:chipStrokeWidth="1dp"
+                tools:text="Send again · 4s"
+                tools:visibility="visible" />
         </FrameLayout>
 
         <LinearLayout
@@ -150,33 +178,6 @@
                 android:layout_height="1dp"
                 android:background="?attr/colorOutlineVariant" />
         </LinearLayout>
-
-        <com.google.android.material.chip.Chip
-            android:id="@+id/slowModeIndicator"
-            style="@style/Widget.Material3.Chip.Assist"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="end"
-            android:layout_marginEnd="6dp"
-            android:layout_marginBottom="2dp"
-            android:accessibilityLiveRegion="none"
-            android:clickable="false"
-            android:focusable="false"
-            android:importantForAccessibility="yes"
-            android:maxLines="1"
-            android:textAppearance="?attr/textAppearanceLabelSmall"
-            android:visibility="gone"
-            app:chipBackgroundColor="?attr/colorSurfaceContainerHigh"
-            app:chipEndPadding="10dp"
-            app:chipIcon="@drawable/ic_stream_uptime"
-            app:chipIconSize="16dp"
-            app:chipIconTint="?attr/colorOnSurfaceVariant"
-            app:chipMinHeight="30dp"
-            app:chipStartPadding="10dp"
-            app:chipStrokeColor="?attr/colorOutlineVariant"
-            app:chipStrokeWidth="1dp"
-            tools:text="Slow mode · 30s"
-            tools:visibility="visible" />
 
         <LinearLayout
             android:id="@+id/messageView"


### PR DESCRIPTION
Show the slow mode pill only during the user's cooldown. Place it as a small top-right overlay so it does not consume chat space.