### PR TITLE
Fix player control reordering

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/Media3PlayerFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/Media3PlayerFragment.kt
@@ -86,6 +86,7 @@ import com.github.andreyasadchy.xtra.util.httpProxyHost
 import com.github.andreyasadchy.xtra.util.httpProxyPort
 import com.github.andreyasadchy.xtra.util.isKeyboardShown
 import com.github.andreyasadchy.xtra.util.isChatEnabled
+import com.github.andreyasadchy.xtra.util.PlayerControlLayout
 import com.github.andreyasadchy.xtra.util.prefs
 import com.github.andreyasadchy.xtra.util.shouldAvoidTwitchAds
 import com.github.andreyasadchy.xtra.util.tokenPrefs
@@ -253,6 +254,7 @@ abstract class Media3PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFr
             resizeMode = requireContext().prefs().getInt(C.ASPECT_RATIO_LANDSCAPE, AspectRatioFrameLayout.RESIZE_MODE_FIT)
             aspectRatioFrameLayout.setAspectRatio(16f / 9f)
             initLayout()
+            PlayerControlLayout.applyToPlayer(requireContext(), binding)
             changePlayerMode()
             val viewConfiguration = ViewConfiguration.get(requireContext())
             val touchSlop = viewConfiguration.scaledTouchSlop
@@ -2267,6 +2269,7 @@ abstract class Media3PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFr
                 (requireContext().getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager).hideSoftInputFromWindow(chatLayout.windowToken, 0)
                 chatLayout.clearFocus()
                 initLayout()
+                PlayerControlLayout.applyToPlayer(requireContext(), binding)
             }
             (childFragmentManager.findFragmentByTag("closeOnPip") as? PlayerSettingsDialog?)?.dismiss()
         }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/PlayerFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/PlayerFragment.kt
@@ -79,6 +79,7 @@ import com.github.andreyasadchy.xtra.util.TwitchApiHelper
 import com.github.andreyasadchy.xtra.util.getAlertDialogBuilder
 import com.github.andreyasadchy.xtra.util.isKeyboardShown
 import com.github.andreyasadchy.xtra.util.isChatEnabled
+import com.github.andreyasadchy.xtra.util.PlayerControlLayout
 import com.github.andreyasadchy.xtra.util.prefs
 import com.github.andreyasadchy.xtra.util.tokenPrefs
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
@@ -250,6 +251,7 @@ abstract class PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFragment
             resizeMode = requireContext().prefs().getInt(C.ASPECT_RATIO_LANDSCAPE, AspectRatioFrameLayout.RESIZE_MODE_FIT)
             aspectRatioFrameLayout.setAspectRatio(16f / 9f)
             initLayout()
+            applyControlLayout()
             changePlayerMode()
             val viewConfiguration = ViewConfiguration.get(requireContext())
             val touchSlop = viewConfiguration.scaledTouchSlop
@@ -1316,6 +1318,10 @@ abstract class PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFragment
         }
     }
 
+    private fun applyControlLayout() {
+        PlayerControlLayout.applyToPlayer(requireContext(), binding)
+    }
+
     fun setResizeMode() {
         resizeMode = (resizeMode + 1).let { if (it < 5) it else 0 }
         binding.aspectRatioFrameLayout.resizeMode = resizeMode
@@ -2060,6 +2066,7 @@ abstract class PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFragment
                 (requireContext().getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager).hideSoftInputFromWindow(chatLayout.windowToken, 0)
                 chatLayout.clearFocus()
                 initLayout()
+                applyControlLayout()
             }
             (childFragmentManager.findFragmentByTag("closeOnPip") as? PlayerSettingsDialog?)?.dismiss()
         }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/PlayerSettingsDialog.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/PlayerSettingsDialog.kt
@@ -14,6 +14,8 @@ import androidx.media3.common.Tracks
 import com.github.andreyasadchy.xtra.R
 import com.github.andreyasadchy.xtra.databinding.PlayerSettingsBinding
 import com.github.andreyasadchy.xtra.util.C
+import com.github.andreyasadchy.xtra.util.PlayerControlLayout
+import com.github.andreyasadchy.xtra.util.SettingsMigration
 import com.github.andreyasadchy.xtra.util.TwitchApiHelper
 import com.github.andreyasadchy.xtra.util.prefs
 import com.github.andreyasadchy.xtra.util.isChatEnabled
@@ -248,7 +250,41 @@ class PlayerSettingsDialog : BottomSheetDialogFragment() {
                 }
             }
         }
+        reorderMenuItems()
         setMenuTextColor(view)
+    }
+
+    private fun reorderMenuItems() {
+        val preferences = requireContext().prefs()
+        val order = PlayerControlLayout.orderedActions(
+            preferences.getString(C.SETTINGS_PLAYER_CONTROL_LAYOUT, null),
+            SettingsMigration.defaultControlLayout(),
+        )
+        with(binding) {
+            PlayerControlLayout.reorderChildren(
+                menuContainer,
+                order,
+                mapOf(
+                    "quality" to menuQuality,
+                    "speed" to menuSpeed,
+                    "viewers" to menuViewerList,
+                    "chapters" to menuVodGames,
+                    "download" to menuDownload,
+                    "bookmark" to menuBookmark,
+                    "share" to menuShare,
+                    "find_vod" to menuFindVod,
+                    "sleep" to menuTimer,
+                    "aspect" to menuRatio,
+                    "volume" to menuVolume,
+                    "subtitles" to menuSubtitles,
+                    "restart" to menuRestart,
+                    "chat_input" to menuChatBar,
+                    "chat" to menuChatToggle,
+                    "reload_emotes" to menuReloadEmotes,
+                    "disconnect_chat" to menuChatDisconnect,
+                ),
+            )
+        }
     }
 
     private fun setMenuTextColor(view: View) {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/settings/SettingsActivity.kt
@@ -2285,12 +2285,19 @@ class SettingsActivity : AppCompatActivity() {
                     group = "quick",
                 )
             }
+            items.sortBy { controlRegion(it.key, it.group) }
             val listAdapter = SettingsDragListAdapter()
             val itemTouchHelper = ItemTouchHelper(
                 object : ItemTouchHelper.SimpleCallback(ItemTouchHelper.UP or ItemTouchHelper.DOWN, 0) {
                     override fun onMove(recyclerView: RecyclerView, viewHolder: RecyclerView.ViewHolder, target: RecyclerView.ViewHolder): Boolean {
-                        Collections.swap(items, viewHolder.bindingAdapterPosition, target.bindingAdapterPosition)
-                        listAdapter.notifyItemMoved(viewHolder.bindingAdapterPosition, target.bindingAdapterPosition)
+                        val from = viewHolder.bindingAdapterPosition
+                        val to = target.bindingAdapterPosition
+                        if (from == RecyclerView.NO_POSITION || to == RecyclerView.NO_POSITION) return false
+                        if (controlRegion(items[from].key, items[from].group) != controlRegion(items[to].key, items[to].group)) {
+                            return false
+                        }
+                        Collections.swap(items, from, to)
+                        listAdapter.notifyItemMoved(from, to)
                         return true
                     }
 
@@ -2308,7 +2315,8 @@ class SettingsActivity : AppCompatActivity() {
                 }
                 item.enabled = item.group != "hidden"
                 item.text = formatControlText(item.key, item.group)
-                listAdapter.notifyItemChanged(items.indexOf(item))
+                items.sortBy { controlRegion(it.key, it.group) }
+                listAdapter.notifyDataSetChanged()
             }
             val recyclerView = RecyclerView(requireContext()).apply {
                 layoutManager = LinearLayoutManager(requireContext())
@@ -2316,12 +2324,21 @@ class SettingsActivity : AppCompatActivity() {
                 val padding = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 10F, resources.displayMetrics).toInt()
                 setPadding(0, padding, 0, 0)
             }
+            val listContainer = android.widget.FrameLayout(requireContext()).apply {
+                addView(
+                    recyclerView,
+                    android.widget.FrameLayout.LayoutParams(
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                        (resources.displayMetrics.heightPixels * 0.42f).toInt(),
+                    ),
+                )
+            }
             itemTouchHelper.attachToRecyclerView(recyclerView)
             listAdapter.submitList(items)
             requireActivity().getAlertDialogBuilder()
                 .setTitle(R.string.settings_customize_controls)
-                .setMessage("Drag to reorder. Tap the group button to cycle Quick controls, More menu and Hidden.")
-                .setView(recyclerView)
+                .setMessage("Drag to reorder within each player area. Each row shows its area. Tap the group button to cycle Quick controls, More menu and Hidden.")
+                .setView(listContainer)
                 .setPositiveButton(android.R.string.ok) { _, _ ->
                     val serialized = items.joinToString(",") { "${it.key}:${it.group}" }
                     preferences.edit { putString(C.SETTINGS_PLAYER_CONTROL_LAYOUT, serialized) }
@@ -2350,6 +2367,23 @@ class SettingsActivity : AppCompatActivity() {
             "disconnect_chat" -> C.PLAYER_MENU_CHAT_DISCONNECT
             else -> null
         }
+
+        private fun controlRegion(action: String, group: String): Int = when {
+            group == "menu" -> 4
+            action == "minimize" -> 0
+            action in setOf("download", "follow", "quality", "speed", "sleep", "aspect") -> 1
+            action in setOf("chapters", "restart", "live", "clip", "volume", "compressor", "mode") -> 2
+            action in setOf("subtitles", "chat_input", "chat", "fullscreen") -> 3
+            else -> 4
+        }
+
+        private fun controlRegionTitle(region: Int): String = getString(when (region) {
+            0 -> R.string.settings_control_region_top_left
+            1 -> R.string.settings_control_region_top_right
+            2 -> R.string.settings_control_region_bottom_left
+            3 -> R.string.settings_control_region_bottom_right
+            else -> R.string.settings_control_region_more_menu
+        })
 
         private fun formatControlText(action: String, group: String): String {
             val title = when (action) {
@@ -2384,7 +2418,7 @@ class SettingsActivity : AppCompatActivity() {
                 "menu" -> R.string.settings_control_group_menu
                 else -> R.string.settings_control_group_hidden
             })
-            return "$title — $groupTitle"
+            return "$title — $groupTitle · ${controlRegionTitle(controlRegion(action, group))}"
         }
 
         private fun syncLegacyControlVisibility(preferences: android.content.SharedPreferences, items: List<String>) {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/PlayerControlLayout.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/PlayerControlLayout.kt
@@ -1,0 +1,88 @@
+package com.github.andreyasadchy.xtra.util
+
+import android.content.Context
+import android.view.View
+import android.view.ViewGroup
+import com.github.andreyasadchy.xtra.databinding.FragmentPlayerBinding
+
+object PlayerControlLayout {
+
+    fun applyToPlayer(context: Context, binding: FragmentPlayerBinding) {
+        val order = orderedActions(
+            context.prefs().getString(C.SETTINGS_PLAYER_CONTROL_LAYOUT, null),
+            SettingsMigration.defaultControlLayout(),
+        )
+        with(binding.playerControls) {
+            reorderChildren(
+                topLeftLayout,
+                order,
+                mapOf("minimize" to minimize),
+            )
+            reorderChildren(
+                topRightLayout,
+                order,
+                mapOf(
+                    "download" to download,
+                    "follow" to follow,
+                    "sleep" to sleepTimer,
+                    "aspect" to aspectRatio,
+                    "speed" to speed,
+                    "quality" to quality,
+                ),
+            )
+            reorderChildren(
+                bottomLeftLayout,
+                order,
+                mapOf(
+                    "restart" to restart,
+                    "live" to seekLive,
+                    "clip" to clip,
+                    "chapters" to vodGames,
+                    "volume" to volume,
+                    "compressor" to audioCompressor,
+                    "mode" to audioOnly,
+                ),
+            )
+            reorderChildren(
+                bottomRightLayout,
+                order,
+                mapOf(
+                    "subtitles" to subtitles,
+                    "chat_input" to toggleChatInput,
+                    "chat" to toggleChat,
+                    "fullscreen" to fullscreen,
+                ),
+            )
+        }
+    }
+
+    fun orderedActions(serialized: String?, fallback: String): List<String> {
+        val fallbackActions = parseActions(fallback)
+        val knownActions = fallbackActions.toSet()
+        val savedActions = parseActions(serialized.orEmpty())
+            .filter { it in knownActions }
+
+        return (savedActions + fallbackActions).distinct()
+    }
+
+    fun reorderChildren(
+        container: ViewGroup,
+        order: List<String>,
+        controls: Map<String, View>,
+    ) {
+        val orderIndex = order.withIndex().associate { (index, action) -> action to index }
+        val childIndex = controls.entries.associate { (action, view) ->
+            view to (orderIndex[action] ?: Int.MAX_VALUE)
+        }
+        val orderedChildren = (0 until container.childCount)
+            .map(container::getChildAt)
+            .sortedBy { childIndex[it] ?: Int.MAX_VALUE }
+
+        orderedChildren.forEach(container::removeView)
+        orderedChildren.forEach(container::addView)
+    }
+
+    private fun parseActions(serialized: String): List<String> = serialized
+        .split(',')
+        .mapNotNull { it.substringBefore(':').trim().takeIf(String::isNotEmpty) }
+}

--- a/app/src/main/res/drawable/ic_movie_clip_black_24.xml
+++ b/app/src/main/res/drawable/ic_movie_clip_black_24.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M5,3h14c1.1,0 2,0.9 2,2v14c0,1.1 -0.9,2 -2,2H5c-1.1,0 -2,-0.9 -2,-2V5c0,-1.1 0.9,-2 2,-2zM5,5v3h2V5H5zM9,5v3h2V5H9zM13,5v3h2V5H13zM17,5v3h2V5H17zM5,10v9h14v-9H5zM9,11.5l6,3.5 -6,3.5v-7zM5,16v3h2v-3H5zM17,16v3h2v-3H17z" />
+</vector>

--- a/app/src/main/res/layout/player_layout.xml
+++ b/app/src/main/res/layout/player_layout.xml
@@ -318,7 +318,7 @@
             android:enabled="false"
             android:minWidth="48dp"
             android:minHeight="48dp"
-            android:src="@drawable/baseline_content_cut_black_24"
+            android:src="@drawable/ic_movie_clip_black_24"
             android:visibility="gone"
             app:tint="@android:color/white"
             tools:visibility="visible" />

--- a/app/src/main/res/layout/player_settings.xml
+++ b/app/src/main/res/layout/player_settings.xml
@@ -5,6 +5,7 @@
     android:layout_height="wrap_content">
 
     <LinearLayout
+        android:id="@+id/menuContainer"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical"

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -942,6 +942,11 @@
     <string name="settings_control_group_quick">عناصر التحكم السريعة</string>
     <string name="settings_control_group_menu">المزيد من القائمة</string>
     <string name="settings_control_group_hidden">مخفي</string>
+    <string name="settings_control_region_top_left">Top left</string>
+    <string name="settings_control_region_top_right">Top right</string>
+    <string name="settings_control_region_bottom_left">Bottom left</string>
+    <string name="settings_control_region_bottom_right">Bottom right</string>
+    <string name="settings_control_region_more_menu">More menu area</string>
     <string name="settings_player_mode">وضع المشغل</string>
     <string name="settings_developer_enabled">تمكين خيارات المطور</string>
     <string name="settings_developer_unlocking">%dالمزيد من النقرات لتمكين خيارات المطور</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -426,6 +426,11 @@
     <string name="settings_control_group_quick">Rychlé ovládání</string>
     <string name="settings_control_group_menu">Více menu</string>
     <string name="settings_control_group_hidden">Skryté</string>
+    <string name="settings_control_region_top_left">Top left</string>
+    <string name="settings_control_region_top_right">Top right</string>
+    <string name="settings_control_region_bottom_left">Bottom left</string>
+    <string name="settings_control_region_bottom_right">Bottom right</string>
+    <string name="settings_control_region_more_menu">More menu area</string>
     <string name="settings_player_mode">Režim přehrávače</string>
     <string name="settings_developer_enabled">Povolit možnosti vývojáře</string>
     <string name="settings_developer_unlocking">%d dalších klepnutí pro povolení možností vývojáře</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -942,6 +942,11 @@
     <string name="settings_control_group_quick">Schnellsteuerung</string>
     <string name="settings_control_group_menu">Menü „Mehr“</string>
     <string name="settings_control_group_hidden">Ausgeblendet</string>
+    <string name="settings_control_region_top_left">Top left</string>
+    <string name="settings_control_region_top_right">Top right</string>
+    <string name="settings_control_region_bottom_left">Bottom left</string>
+    <string name="settings_control_region_bottom_right">Bottom right</string>
+    <string name="settings_control_region_more_menu">More menu area</string>
     <string name="settings_player_mode">Player-Modus</string>
     <string name="settings_developer_enabled">Entwickleroptionen aktivieren</string>
     <string name="settings_developer_unlocking">%d weitere Fingertipps, um Entwickleroptionen zu aktivieren</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -947,6 +947,11 @@
     <string name="settings_control_group_quick">Controles rápidos</string>
     <string name="settings_control_group_menu">Más menú</string>
     <string name="settings_control_group_hidden">Oculto</string>
+    <string name="settings_control_region_top_left">Top left</string>
+    <string name="settings_control_region_top_right">Top right</string>
+    <string name="settings_control_region_bottom_left">Bottom left</string>
+    <string name="settings_control_region_bottom_right">Bottom right</string>
+    <string name="settings_control_region_more_menu">More menu area</string>
     <string name="settings_player_mode">Modo reproductor</string>
     <string name="settings_developer_enabled">Habilitar opciones de desarrollador</string>
     <string name="settings_developer_unlocking">%d más toques para habilitar Opciones de desarrollador</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -942,6 +942,11 @@
     <string name="settings_control_group_quick">Contrôles rapides</string>
     <string name="settings_control_group_menu">Plus de menu</string>
     <string name="settings_control_group_hidden">Masqué</string>
+    <string name="settings_control_region_top_left">Top left</string>
+    <string name="settings_control_region_top_right">Top right</string>
+    <string name="settings_control_region_bottom_left">Bottom left</string>
+    <string name="settings_control_region_bottom_right">Bottom right</string>
+    <string name="settings_control_region_more_menu">More menu area</string>
     <string name="settings_player_mode">Mode lecteur</string>
     <string name="settings_developer_enabled">Activer les options de développement</string>
     <string name="settings_developer_unlocking">%d autres pressions pour activer les options de développeur</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -942,6 +942,11 @@
     <string name="settings_control_group_quick">Controis rápidos</string>
     <string name="settings_control_group_menu">Menú Máis</string>
     <string name="settings_control_group_hidden">Oculto</string>
+    <string name="settings_control_region_top_left">Top left</string>
+    <string name="settings_control_region_top_right">Top right</string>
+    <string name="settings_control_region_bottom_left">Bottom left</string>
+    <string name="settings_control_region_bottom_right">Bottom right</string>
+    <string name="settings_control_region_more_menu">More menu area</string>
     <string name="settings_player_mode">Modo reprodutor</string>
     <string name="settings_developer_enabled">Activar opcións para programador</string>
     <string name="settings_developer_unlocking">%d toques máis para activar as opcións para programador</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -943,6 +943,11 @@
     <string name="settings_control_group_quick">Kontrol cepat</string>
     <string name="settings_control_group_menu">Menu lainnya</string>
     <string name="settings_control_group_hidden">Tersembunyi</string>
+    <string name="settings_control_region_top_left">Top left</string>
+    <string name="settings_control_region_top_right">Top right</string>
+    <string name="settings_control_region_bottom_left">Bottom left</string>
+    <string name="settings_control_region_bottom_right">Bottom right</string>
+    <string name="settings_control_region_more_menu">More menu area</string>
     <string name="settings_player_mode">Mode pemutar</string>
     <string name="settings_developer_enabled">Aktifkan opsi pengembang</string>
     <string name="settings_developer_unlocking">%d ketuk lagi untuk mengaktifkan Opsi pengembang</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -942,6 +942,11 @@
     <string name="settings_control_group_quick">Controlli rapidi</string>
     <string name="settings_control_group_menu">Menu Altro</string>
     <string name="settings_control_group_hidden">Nascosto</string>
+    <string name="settings_control_region_top_left">Top left</string>
+    <string name="settings_control_region_top_right">Top right</string>
+    <string name="settings_control_region_bottom_left">Bottom left</string>
+    <string name="settings_control_region_bottom_right">Bottom right</string>
+    <string name="settings_control_region_more_menu">More menu area</string>
     <string name="settings_player_mode">Modalità giocatore</string>
     <string name="settings_developer_enabled">Abilita opzioni sviluppatore</string>
     <string name="settings_developer_unlocking">%d più tocchi per abilitare Opzioni sviluppatore</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -942,6 +942,11 @@
     <string name="settings_control_group_quick">クイック コントロール</string>
     <string name="settings_control_group_menu">その他のメニュー</string>
     <string name="settings_control_group_hidden">非表示</string>
+    <string name="settings_control_region_top_left">Top left</string>
+    <string name="settings_control_region_top_right">Top right</string>
+    <string name="settings_control_region_bottom_left">Bottom left</string>
+    <string name="settings_control_region_bottom_right">Bottom right</string>
+    <string name="settings_control_region_more_menu">More menu area</string>
     <string name="settings_player_mode">プレーヤー モード</string>
     <string name="settings_developer_enabled">開発者向けオプションを有効にする</string>
     <string name="settings_developer_unlocking">%d をさらにタップして開発者向けオプションを有効にする</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -403,6 +403,11 @@
     <string name="settings_control_group_quick">Szybkie sterowanie</string>
     <string name="settings_control_group_menu">Więcej menu</string>
     <string name="settings_control_group_hidden">Ukryty</string>
+    <string name="settings_control_region_top_left">Top left</string>
+    <string name="settings_control_region_top_right">Top right</string>
+    <string name="settings_control_region_bottom_left">Bottom left</string>
+    <string name="settings_control_region_bottom_right">Bottom right</string>
+    <string name="settings_control_region_more_menu">More menu area</string>
     <string name="settings_player_mode">Tryb odtwarzacza</string>
     <string name="settings_developer_enabled">Włącz opcje programistyczne</string>
     <string name="settings_developer_unlocking">%d więcej kliknięć, aby włączyć opcje programisty</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -942,6 +942,11 @@
     <string name="settings_control_group_quick">Controles rápidos</string>
     <string name="settings_control_group_menu">Menu Mais</string>
     <string name="settings_control_group_hidden">Oculto</string>
+    <string name="settings_control_region_top_left">Top left</string>
+    <string name="settings_control_region_top_right">Top right</string>
+    <string name="settings_control_region_bottom_left">Bottom left</string>
+    <string name="settings_control_region_bottom_right">Bottom right</string>
+    <string name="settings_control_region_more_menu">More menu area</string>
     <string name="settings_player_mode">Modo Player</string>
     <string name="settings_developer_enabled">Ativar opções do desenvolvedor</string>
     <string name="settings_developer_unlocking">%d mais toques para ativar as opções do desenvolvedor</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -942,6 +942,11 @@
     <string name="settings_control_group_quick">Быстрое управление</string>
     <string name="settings_control_group_menu">Дополнительное меню</string>
     <string name="settings_control_group_hidden">Скрыто</string>
+    <string name="settings_control_region_top_left">Top left</string>
+    <string name="settings_control_region_top_right">Top right</string>
+    <string name="settings_control_region_bottom_left">Bottom left</string>
+    <string name="settings_control_region_bottom_right">Bottom right</string>
+    <string name="settings_control_region_more_menu">More menu area</string>
     <string name="settings_player_mode">Режим проигрывателя</string>
     <string name="settings_developer_enabled">Включить параметры разработчика</string>
     <string name="settings_developer_unlocking">%d больше нажатий, чтобы включить параметры разработчика</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -426,6 +426,11 @@
     <string name="settings_control_group_quick">Rýchle ovládacie prvky</string>
     <string name="settings_control_group_menu">Viac menu</string>
     <string name="settings_control_group_hidden">Skryté</string>
+    <string name="settings_control_region_top_left">Top left</string>
+    <string name="settings_control_region_top_right">Top right</string>
+    <string name="settings_control_region_bottom_left">Bottom left</string>
+    <string name="settings_control_region_bottom_right">Bottom right</string>
+    <string name="settings_control_region_more_menu">More menu area</string>
     <string name="settings_player_mode">Režim prehrávača</string>
     <string name="settings_developer_enabled">Povoliť možnosti vývojára</string>
     <string name="settings_developer_unlocking">%d ďalších klepnutí na aktiváciu možností vývojára</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -943,6 +943,11 @@
     <string name="settings_control_group_quick">Hızlı kontroller</string>
     <string name="settings_control_group_menu">Diğer menü</string>
     <string name="settings_control_group_hidden">Gizli</string>
+    <string name="settings_control_region_top_left">Top left</string>
+    <string name="settings_control_region_top_right">Top right</string>
+    <string name="settings_control_region_bottom_left">Bottom left</string>
+    <string name="settings_control_region_bottom_right">Bottom right</string>
+    <string name="settings_control_region_more_menu">More menu area</string>
     <string name="settings_player_mode">Oynatıcı modu</string>
     <string name="settings_developer_enabled">Geliştirici seçeneklerini etkinleştir</string>
     <string name="settings_developer_unlocking">Geliştirici seçeneklerini etkinleştirmek için %d daha fazla dokunuş</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -942,6 +942,11 @@
     <string name="settings_control_group_quick">快速控件</string>
     <string name="settings_control_group_menu">更多菜单</string>
     <string name="settings_control_group_hidden">隐藏</string>
+    <string name="settings_control_region_top_left">Top left</string>
+    <string name="settings_control_region_top_right">Top right</string>
+    <string name="settings_control_region_bottom_left">Bottom left</string>
+    <string name="settings_control_region_bottom_right">Bottom right</string>
+    <string name="settings_control_region_more_menu">More menu area</string>
     <string name="settings_player_mode">播放器模式</string>
     <string name="settings_developer_enabled">启用开发者选项</string>
     <string name="settings_developer_unlocking">%d 更多点击以启用开发者选项</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -942,6 +942,11 @@
     <string name="settings_control_group_quick">快速控制</string>
     <string name="settings_control_group_menu">更多選單</string>
     <string name="settings_control_group_hidden">隱藏</string>
+    <string name="settings_control_region_top_left">Top left</string>
+    <string name="settings_control_region_top_right">Top right</string>
+    <string name="settings_control_region_bottom_left">Bottom left</string>
+    <string name="settings_control_region_bottom_right">Bottom right</string>
+    <string name="settings_control_region_more_menu">More menu area</string>
     <string name="settings_player_mode">播放器模式</string>
     <string name="settings_developer_enabled">啟用開發者選項</string>
     <string name="settings_developer_unlocking">%d 多次點擊即可啟用開發者選項</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -455,6 +455,11 @@
     <string name="settings_control_group_quick">Quick controls</string>
     <string name="settings_control_group_menu">More menu</string>
     <string name="settings_control_group_hidden">Hidden</string>
+    <string name="settings_control_region_top_left">Top left</string>
+    <string name="settings_control_region_top_right">Top right</string>
+    <string name="settings_control_region_bottom_left">Bottom left</string>
+    <string name="settings_control_region_bottom_right">Bottom right</string>
+    <string name="settings_control_region_more_menu">More menu area</string>
     <string name="settings_player_mode">Player mode</string>
     <string name="settings_developer_enabled">Enable developer options</string>
     <string name="settings_developer_unlocking">%d more taps to enable Developer options</string>


### PR DESCRIPTION
The customize-controls list now stays within the dialog, so its save action remains reachable. Saved control order is applied to player buttons and the More menu. The local clip button uses a new film-frame vector icon.