### PR TITLE
Show previews on visible VODs

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/preload/StreamMedia3Runtime.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/preload/StreamMedia3Runtime.kt
@@ -234,6 +234,24 @@ class StreamMedia3Runtime(
     }
 
     @Synchronized
+    fun createVodMediaItem(
+        videoId: String,
+        url: String,
+        title: String? = null,
+        channelName: String? = null,
+        channelLogo: String? = null,
+    ): MediaItem {
+        val generation = ensureGeneration()
+        return generation.hlsFactory.createVodMediaItem(
+            mediaId(generation.configuration, "vod:$videoId", url),
+            url,
+            title,
+            channelName,
+            channelLogo,
+        )
+    }
+
+    @Synchronized
     fun getPreloadedMediaSource(channelLogin: String, url: String): PreloadedLiveMediaSource? {
         check(Looper.myLooper() == Looper.getMainLooper()) { "Media3 playback handoff must run on the main looper" }
         val generation = currentGeneration ?: return null

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/preload/StreamPreloadCoordinator.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/preload/StreamPreloadCoordinator.kt
@@ -47,6 +47,10 @@ class StreamPreloadCoordinator(
 ) {
     private val context = context.applicationContext
     private val cache = StreamPreloadUrlCache(elapsedRealtimeMs = elapsedRealtimeMs)
+    private val vodPreviewUrls = StreamPreloadUrlCache(
+        maxEntries = StreamPreloadPolicy.MAX_VOD_PREVIEW_URLS,
+        elapsedRealtimeMs = elapsedRealtimeMs,
+    )
     private val urlOwnership = StreamPreloadUrlOwnership(cache)
     private val scheduledJobs = ConcurrentHashMap<String, Job>()
     private val dwellStarts = ConcurrentHashMap<String, Long>()
@@ -200,6 +204,27 @@ class StreamPreloadCoordinator(
             ?.streamKey
             ?: login
         return preloadUrl(login, key, forPreview = true)
+    }
+
+    /** Resolves a VOD playlist for a visible preview without consuming live URL ownership. */
+    suspend fun resolveVodForPreview(videoId: String?): String? {
+        val id = videoId?.trim()?.takeIf { it.isNotEmpty() } ?: return null
+        val config = refreshConfiguration()
+        if (!canResolvePreview()) return null
+        vodPreviewUrls.get(id, config.fingerprint)?.let { return it }
+        val url = runCatching {
+            playerRepository.loadVideoPlaylistUrl(
+                networkLibrary = config.networkLibrary,
+                gqlHeaders = config.gqlHeaders,
+                videoId = id,
+                playerType = config.playerType,
+                supportedCodecs = config.supportedCodecs,
+                enableIntegrity = config.enableIntegrity,
+            ).first
+        }.getOrNull() ?: return null
+        if (refreshConfiguration().fingerprint != config.fingerprint) return null
+        vodPreviewUrls.put(id, url, config.fingerprint)
+        return url
     }
 
     private fun reconcilePreloads(config: StreamPlaybackConfiguration) {
@@ -406,6 +431,7 @@ class StreamPreloadCoordinator(
         val next = StreamPlaybackConfiguration.from(context)
         if (configuration?.fingerprint != next.fingerprint) {
             cache.setConfiguration(next.fingerprint)
+            vodPreviewUrls.clear()
             resolver.cancelAll()
             invalidateMediaOperations()
             mediaPreloadRuntime?.let { runtime ->

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/preload/StreamPreloadPolicy.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/preload/StreamPreloadPolicy.kt
@@ -26,6 +26,7 @@ data class StreamPreloadCandidate(
 
 object StreamPreloadPolicy {
     const val MAX_URL_CANDIDATES = 3
+    const val MAX_VOD_PREVIEW_URLS = 8
     const val MAX_RESOLVER_CONCURRENCY = 2
     const val URL_DWELL_MS = 350L
     const val URL_TTL_MS = 30_000L

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/preload/StreamPreviewLifecycle.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/preload/StreamPreviewLifecycle.kt
@@ -9,6 +9,7 @@ class StreamPreviewLifecycle(
     private val offscreenGraceMs: Long = StreamPreviewLifecyclePolicy.OFFSCREEN_GRACE_MS,
 ) {
     private val entries = linkedMapOf<String, Entry>()
+    private var scrolling = false
 
     fun track(identity: String, nowMs: Long) {
         val normalized = StreamPreviewSelectionPolicy.normalizeIdentity(identity)
@@ -18,13 +19,16 @@ class StreamPreviewLifecycle(
         }
     }
 
-    fun observeVisible(visibleIdentities: Collection<String>, nowMs: Long) {
+    fun observeVisible(visibleIdentities: Collection<String>, nowMs: Long, scrolling: Boolean = false) {
+        this.scrolling = scrolling
         val visible = visibleIdentities
             .mapTo(mutableSetOf(), StreamPreviewSelectionPolicy::normalizeIdentity)
         entries.keys.toList().forEach { identity ->
             val entry = entries[identity] ?: return@forEach
             entries[identity] = if (identity in visible) {
                 entry.copy(lastVisibleAtMs = nowMs, offscreenSinceMs = null)
+            } else if (scrolling) {
+                entry.copy(offscreenSinceMs = null)
             } else {
                 entry.copy(offscreenSinceMs = entry.offscreenSinceMs ?: nowMs)
             }
@@ -32,6 +36,7 @@ class StreamPreviewLifecycle(
     }
 
     fun expire(nowMs: Long) {
+        if (scrolling) return
         entries.entries.toList().forEach { (identity, entry) ->
             if (entry.offscreenSinceMs?.let { nowMs - it >= offscreenGraceMs } == true) {
                 entries.remove(identity)
@@ -52,7 +57,17 @@ class StreamPreviewLifecycle(
     }
 
     fun onScrolling() {
-        // Scrolling changes visibility; it is not a release event.
+        scrolling = true
+    }
+
+    fun markOffscreen(identity: String, nowMs: Long) {
+        val normalized = StreamPreviewSelectionPolicy.normalizeIdentity(identity)
+        val entry = entries[normalized] ?: return
+        entries[normalized] = if (scrolling) {
+            entry.copy(offscreenSinceMs = null)
+        } else {
+            entry.copy(offscreenSinceMs = entry.offscreenSinceMs ?: nowMs)
+        }
     }
 
     fun failed(identity: String) {
@@ -64,7 +79,10 @@ class StreamPreviewLifecycle(
         entries.keys.retainAll { it == normalized }
     }
 
-    fun clear() = entries.clear()
+    fun clear() {
+        scrolling = false
+        entries.clear()
+    }
 
     fun activeIdentities(): Set<String> = entries.keys.toSet()
 

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/channel/videos/ChannelVideosFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/channel/videos/ChannelVideosFragment.kt
@@ -29,6 +29,8 @@ import com.github.andreyasadchy.xtra.ui.common.IntegrityDialog
 import com.github.andreyasadchy.xtra.ui.common.PagedListFragment
 import com.github.andreyasadchy.xtra.ui.common.Scrollable
 import com.github.andreyasadchy.xtra.ui.common.Sortable
+import com.github.andreyasadchy.xtra.ui.common.StreamPreloadViewportController
+import com.github.andreyasadchy.xtra.ui.common.StreamPreviewCandidate
 import com.github.andreyasadchy.xtra.ui.common.VideosAdapter
 import com.github.andreyasadchy.xtra.ui.common.VideosSortDialog
 import com.github.andreyasadchy.xtra.ui.download.DownloadDialog
@@ -45,6 +47,7 @@ class ChannelVideosFragment : PagedListFragment(), Scrollable, Sortable, VideosS
     private val args: ChannelPagerFragmentArgs by navArgs()
     private val viewModel: ChannelVideosViewModel by viewModels { ChannelVideosViewModelFactory }
     private lateinit var pagingAdapter: PagingDataAdapter<Video, out RecyclerView.ViewHolder>
+    private lateinit var videoPreviewViewportController: StreamPreloadViewportController
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         _binding = CommonRecyclerViewLayoutBinding.inflate(inflater, container, false)
@@ -80,6 +83,29 @@ class ChannelVideosFragment : PagedListFragment(), Scrollable, Sortable, VideosS
             )
         }, showChannel = false)
         setAdapter(binding.recyclerView, pagingAdapter)
+        videoPreviewViewportController = StreamPreloadViewportController(
+            fragment = this,
+            coordinator = null,
+            viewportKey = "channel-videos",
+            recyclerView = binding.recyclerView,
+            previewAtPosition = { position, surface ->
+                pagingAdapter.peek(position)?.let { video ->
+                    video.id?.trim()?.takeIf { it.isNotEmpty() }?.let { videoId ->
+                        StreamPreviewCandidate(
+                            streamKey = "vod:$videoId",
+                            channelLogin = video.channelLogin.orEmpty(),
+                            visibleFraction = 0f,
+                            centerProximity = 0f,
+                            title = video.title,
+                            channelName = video.channelName,
+                            channelLogo = video.channelImage,
+                            videoId = videoId,
+                            surface = surface,
+                        )
+                    }
+                }
+            },
+        ).also { it.start() }
         ViewCompat.setOnApplyWindowInsetsListener(view) { _, windowInsets ->
             if (activity?.findViewById<LinearLayout>(R.id.navBarContainer)?.isVisible == false) {
                 val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars())
@@ -224,7 +250,24 @@ class ChannelVideosFragment : PagedListFragment(), Scrollable, Sortable, VideosS
         }
     }
 
+    override fun onResume() {
+        super.onResume()
+        if (::videoPreviewViewportController.isInitialized) {
+            videoPreviewViewportController.onResume()
+        }
+    }
+
+    override fun onPause() {
+        if (::videoPreviewViewportController.isInitialized) {
+            videoPreviewViewportController.onPause()
+        }
+        super.onPause()
+    }
+
     override fun onDestroyView() {
+        if (::videoPreviewViewportController.isInitialized) {
+            videoPreviewViewportController.stop()
+        }
         super.onDestroyView()
         _binding = null
     }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/StreamPreloadViewportController.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/StreamPreloadViewportController.kt
@@ -18,11 +18,12 @@ import kotlin.math.max
 /** Reports actual visible stream cards without doing any network work itself. */
 class StreamPreloadViewportController(
     private val fragment: Fragment,
-    private val coordinator: StreamPreloadCoordinator,
+    private val coordinator: StreamPreloadCoordinator?,
     private val viewportKey: String,
     private val recyclerView: RecyclerView,
-    private val streamAtPosition: (Int) -> Stream?,
+    private val streamAtPosition: ((Int) -> Stream?)? = null,
     private val isParentScrolling: () -> Boolean = { false },
+    private val previewAtPosition: ((Int, PlayerView) -> StreamPreviewCandidate?)? = null,
 ) {
     private var scrollState = RecyclerView.SCROLL_STATE_IDLE
     private var started = false
@@ -63,7 +64,7 @@ class StreamPreloadViewportController(
         }
         recyclerView.removeCallbacks(publishRunnable)
         publishPosted = false
-        coordinator.detachViewport(viewportKey)
+        coordinator?.detachViewport(viewportKey)
         previewCoordinator.detachViewport(viewportKey)
     }
 
@@ -72,7 +73,7 @@ class StreamPreloadViewportController(
     }
 
     fun onPause() {
-        coordinator.detachViewport(viewportKey)
+        coordinator?.detachViewport(viewportKey)
         previewCoordinator.detachViewport(viewportKey)
     }
 
@@ -93,13 +94,13 @@ class StreamPreloadViewportController(
             !fragment.lifecycle.currentState.isAtLeast(Lifecycle.State.RESUMED) ||
             !recyclerView.isAttachedToWindow
         ) {
-            coordinator.detachViewport(viewportKey)
+            coordinator?.detachViewport(viewportKey)
             previewCoordinator.detachViewport(viewportKey)
             return
         }
         val viewportRect = Rect()
         if (!recyclerView.getGlobalVisibleRect(viewportRect) || viewportRect.width() <= 0 || viewportRect.height() <= 0) {
-            coordinator.updateViewport(viewportKey, emptyList(), scrolling = isScrolling())
+            coordinator?.updateViewport(viewportKey, emptyList(), scrolling = isScrolling())
             previewCoordinator.updateViewport(viewportKey, emptyList(), scrolling = isScrolling())
             return
         }
@@ -111,7 +112,7 @@ class StreamPreloadViewportController(
                 val child = recyclerView.getChildAt(childIndex)
                 val position = recyclerView.getChildAdapterPosition(child)
                 if (position == RecyclerView.NO_POSITION) return@repeat
-                val stream = streamAtPosition(position) ?: return@repeat
+                val stream = streamAtPosition?.invoke(position) ?: return@repeat
                 val childRect = Rect()
                 if (!child.getGlobalVisibleRect(childRect)) return@repeat
                 val fullArea = (child.width.toLong() * child.height.toLong()).coerceAtLeast(1L)
@@ -137,23 +138,39 @@ class StreamPreloadViewportController(
                 }
             }
         }
-        coordinator.updateViewport(viewportKey, candidates, isScrolling())
-        val previewCandidates = candidates.mapNotNull { candidate ->
-            val child = (0 until recyclerView.childCount)
-                .map(recyclerView::getChildAt)
-                .firstOrNull { recyclerView.getChildAdapterPosition(it) != RecyclerView.NO_POSITION &&
-                    streamAtPosition(recyclerView.getChildAdapterPosition(it))?.channelLogin?.trim()?.equals(candidate.channelLogin, true) == true }
-            child?.findViewById<PlayerView>(R.id.previewPlayerView)?.let { surface ->
-                StreamPreviewCandidate(
-                    streamKey = candidate.streamKey,
-                    channelLogin = candidate.channelLogin,
-                    visibleFraction = candidate.visibleFraction,
-                    centerProximity = candidate.centerProximity,
-                    title = candidate.title,
-                    channelName = candidate.channelName,
-                    channelLogo = candidate.channelLogo,
-                    surface = surface,
-                )
+        coordinator?.updateViewport(viewportKey, candidates, isScrolling())
+        val previewCandidates = buildList {
+            repeat(recyclerView.childCount) { childIndex ->
+                val child = recyclerView.getChildAt(childIndex)
+                val position = recyclerView.getChildAdapterPosition(child)
+                if (position == RecyclerView.NO_POSITION) return@repeat
+                val childRect = Rect()
+                if (!child.getGlobalVisibleRect(childRect)) return@repeat
+                val fullArea = (child.width.toLong() * child.height.toLong()).coerceAtLeast(1L)
+                val visibleArea = childRect.width().toLong() * childRect.height().toLong()
+                val visibleFraction = (visibleArea.toDouble() / fullArea).toFloat().coerceIn(0f, 1f)
+                if (visibleFraction <= 0f) return@repeat
+                val childCenter = if (horizontal) childRect.centerX() else childRect.centerY()
+                val halfSpan = max(1, viewportSize / 2 + if (horizontal) child.width else child.height)
+                val centerProximity = 1f - (abs(childCenter - viewportCenter).toFloat() / halfSpan).coerceIn(0f, 1f)
+                val surface = child.findViewById<PlayerView>(R.id.previewPlayerView) ?: return@repeat
+                val candidate = previewAtPosition?.invoke(position, surface)
+                    ?: streamAtPosition?.invoke(position)?.let { stream ->
+                        val channelLogin = stream.channelLogin?.trim().orEmpty()
+                        channelLogin.takeIf { it.isNotEmpty() }?.let {
+                            StreamPreviewCandidate(
+                                streamKey = streamKey(stream),
+                                channelLogin = it,
+                                visibleFraction = visibleFraction,
+                                centerProximity = centerProximity,
+                                title = stream.title,
+                                channelName = stream.channelName,
+                                channelLogo = stream.channelImage,
+                                surface = surface,
+                            )
+                        }
+                    }
+                candidate?.let { add(it.copy(visibleFraction = visibleFraction, centerProximity = centerProximity, surface = surface)) }
             }
         }
         previewCoordinator.updateViewport(viewportKey, previewCandidates, isScrolling())

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/StreamPreviewCoordinator.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/StreamPreviewCoordinator.kt
@@ -53,8 +53,14 @@ data class StreamPreviewCandidate(
     val title: String? = null,
     val channelName: String? = null,
     val channelLogo: String? = null,
+    val videoId: String? = null,
     val surface: PlayerView,
-)
+) {
+    /** Live previews share a channel slot; VOD previews get their own slot. */
+    val previewIdentity: String?
+        get() = videoId?.trim()?.takeIf { it.isNotEmpty() }?.let { "vod:$it" }
+            ?: channelLogin.trim().lowercase().takeIf { it.isNotEmpty() }?.let { "live:$it" }
+}
 
 /** App-scoped owner of a small pool of muted browsing preview players. */
 @UnstableApi
@@ -155,28 +161,29 @@ class StreamPreviewCoordinator(
 
     fun onFullscreenPlaybackStarted(channelLogin: String?) {
         val login = normalize(channelLogin)
-        if (login == null && handoffLogin != null) {
+        val identity = login?.let(::livePreviewIdentity)
+        if (identity == null && handoffLogin != null) {
             cancelPendingStarts()
             activePreviews.keys.toList()
                 .filter { it != handoffLogin }
                 .forEach(::releasePreview)
             return
         }
-        if (login == null || activePreviews[login] == null) {
+        if (identity == null || activePreviews[identity] == null) {
             stopPreview()
             return
         }
-        handoffLogin = login
+        handoffLogin = identity
         cancelPendingStarts()
         activePreviews.keys.toList()
-            .filter { it != login }
+            .filter { it != identity }
             .forEach(::releasePreview)
-        previewLifecycle.retainOnly(login)
+        previewLifecycle.retainOnly(identity)
     }
 
     fun onFullscreenPlaybackFirstFrame(channelLogin: String?) {
         val login = normalize(channelLogin)
-        if (handoffLogin != null && (login == null || handoffLogin == login)) {
+        if (handoffLogin != null && (login == null || handoffLogin == livePreviewIdentity(login))) {
             val handoff = handoffLogin
             handoffLogin = null
             if (handoff != null) releasePreview(handoff)
@@ -192,13 +199,17 @@ class StreamPreviewCoordinator(
     }
 
     fun isPreviewing(channelLogin: String): Boolean =
-        activePreviews.containsKey(normalize(channelLogin))
+        normalize(channelLogin)?.let(::livePreviewIdentity)?.let(activePreviews::containsKey) == true
 
     /** Unbinds only the view. The player remains reusable during the offscreen grace period. */
     fun detachSurface(surface: PlayerView) {
-        activePreviews.values
-            .firstOrNull { it.surface === surface }
-            ?.surface = null
+        val active = activePreviews.values.firstOrNull { it.surface === surface }
+        active?.surface = null
+        active?.let {
+            val now = SystemClock.elapsedRealtime()
+            previewLifecycle.markOffscreen(it.identity, now)
+            lifecycleReconciler.reconcile(now, additionalDeadlines = failedUntil.values)
+        }
         surface.player = null
         surface.alpha = 0f
         surface.visibility = View.GONE
@@ -233,7 +244,7 @@ class StreamPreviewCoordinator(
 
         val now = SystemClock.elapsedRealtime()
         val candidates = currentCandidates()
-        val candidateIdentities = candidates.mapTo(mutableSetOf()) { normalize(it.channelLogin)!! }
+        val candidateIdentities = candidates.mapNotNullTo(mutableSetOf(), StreamPreviewCandidate::previewIdentity)
         dwellStarts.keys.retainAll(candidateIdentities)
         failedUntil.entries.toList().forEach { (identity, retryAt) ->
             if (retryAt <= now) failedUntil.remove(identity)
@@ -241,8 +252,9 @@ class StreamPreviewCoordinator(
 
         val reasonablyVisible = candidates
             .filter { it.visibleFraction >= StreamPreviewSelectionPolicy.STOP_VISIBLE_FRACTION }
-            .map { normalize(it.channelLogin)!! }
-        previewLifecycle.observeVisible(reasonablyVisible, now)
+            .mapNotNull { it.previewIdentity }
+        val scrolling = viewports.values.any { it.scrolling }
+        previewLifecycle.observeVisible(reasonablyVisible, now, scrolling = scrolling)
         previewLifecycle.expire(now)
         lifecycleReconciler.reconcile(now, additionalDeadlines = failedUntil.values)
         activePreviews.keys.toList()
@@ -253,7 +265,7 @@ class StreamPreviewCoordinator(
         val selected = StreamPreviewSelectionPolicy.select(
             candidates = candidates.mapIndexed { index, candidate ->
                 StreamPreviewSelectionCandidate(
-                    identity = candidate.channelLogin,
+                    identity = candidate.previewIdentity!!,
                     visibleFraction = candidate.visibleFraction,
                     centerProximity = candidate.centerProximity,
                     order = index,
@@ -305,19 +317,19 @@ class StreamPreviewCoordinator(
     }
 
     private fun scheduleStart(candidate: StreamPreviewCandidate, now: Long) {
-        val login = normalize(candidate.channelLogin) ?: return
-        if (activePreviews.containsKey(login) || pendingStarts[login]?.isActive == true) return
-        pendingStarts.remove(login)
-        if (failedUntil[login]?.let { it > now } == true) return
+        val identity = candidate.previewIdentity ?: return
+        if (activePreviews.containsKey(identity) || pendingStarts[identity]?.isActive == true) return
+        pendingStarts.remove(identity)
+        if (failedUntil[identity]?.let { it > now } == true) return
         val startedAt = StreamPreviewDwellPolicy.startAt(
-            existingStartMs = dwellStarts[login],
+            existingStartMs = dwellStarts[identity],
             nowMs = now,
             isScrolling = isScrolling(candidate),
         ) ?: run {
-            dwellStarts.remove(login)
+            dwellStarts.remove(identity)
             return
         }
-        dwellStarts[login] = startedAt
+        dwellStarts[identity] = startedAt
         val remainingDelay = StreamPreviewDwellPolicy.remainingDelay(
             startedAtMs = startedAt,
             nowMs = now,
@@ -327,18 +339,18 @@ class StreamPreviewCoordinator(
         startJob = scope.launch(start = CoroutineStart.LAZY) {
             try {
                 if (remainingDelay > 0L) delay(remainingDelay)
-                startPreview(login)
+                startPreview(identity)
             } finally {
-                if (pendingStarts[login] === startJob) pendingStarts.remove(login)
+                if (pendingStarts[identity] === startJob) pendingStarts.remove(identity)
             }
         }
-        pendingStarts[login] = startJob
+        pendingStarts[identity] = startJob
         startJob.start()
     }
 
-    private suspend fun startPreview(login: String) {
-        if (activePreviews.containsKey(login) || activePreviews.size >= maxActivePreviews()) return
-        if (failedUntil[login]?.let { it > SystemClock.elapsedRealtime() } == true) return
+    private suspend fun startPreview(identity: String) {
+        if (activePreviews.containsKey(identity) || activePreviews.size >= maxActivePreviews()) return
+        if (failedUntil[identity]?.let { it > SystemClock.elapsedRealtime() } == true) return
         if (!StreamPreviewPolicy.canStartPreview(
                 isPlayerFullscreen = streamFeedRefreshCoordinator.isPlayerFullscreen,
                 networkAllowed = StreamPreviewPolicy.allowsNetwork(context),
@@ -346,17 +358,21 @@ class StreamPreviewCoordinator(
             )
         ) return
 
-        val candidate = bestCandidatesByIdentity(currentCandidates())[login] ?: return
+        val candidate = bestCandidatesByIdentity(currentCandidates())[identity] ?: return
         if (candidate.visibleFraction < StreamPreviewSelectionPolicy.START_VISIBLE_FRACTION) return
         if (isScrolling(candidate)) {
-            dwellStarts.remove(login)
+            dwellStarts.remove(identity)
             return
         }
-        val url = urlCoordinator.resolveForPreview(login) ?: return
-        val latestCandidate = bestCandidatesByIdentity(currentCandidates())[login] ?: return
+        val url = if (candidate.videoId.isNullOrBlank()) {
+            urlCoordinator.resolveForPreview(candidate.channelLogin)
+        } else {
+            urlCoordinator.resolveVodForPreview(candidate.videoId)
+        } ?: return
+        val latestCandidate = bestCandidatesByIdentity(currentCandidates())[identity] ?: return
         if (latestCandidate.visibleFraction < StreamPreviewSelectionPolicy.START_VISIBLE_FRACTION) return
         if (isScrolling(latestCandidate)) {
-            dwellStarts.remove(login)
+            dwellStarts.remove(identity)
             return
         }
         if (activePreviews.size >= maxActivePreviews()) return
@@ -371,58 +387,73 @@ class StreamPreviewCoordinator(
         try {
             val builtPlayer = mediaRuntime.buildPreviewPlayer(context, previewTrackSelectionParameters())
             player = builtPlayer
-            val mediaItem = mediaRuntime.createLiveMediaItem(
-                channelLogin = login,
-                url = url,
-                title = latestCandidate.title,
-                channelName = latestCandidate.channelName,
-                channelLogo = latestCandidate.channelLogo,
-            )
-            val active = ActivePreview(identity = login, player = player)
-            activePreviews[login] = active
-            previewLifecycle.track(login, SystemClock.elapsedRealtime())
+            val mediaItem = if (latestCandidate.videoId.isNullOrBlank()) {
+                mediaRuntime.createLiveMediaItem(
+                    channelLogin = latestCandidate.channelLogin,
+                    url = url,
+                    title = latestCandidate.title,
+                    channelName = latestCandidate.channelName,
+                    channelLogo = latestCandidate.channelLogo,
+                )
+            } else {
+                mediaRuntime.createVodMediaItem(
+                    videoId = latestCandidate.videoId,
+                    url = url,
+                    title = latestCandidate.title,
+                    channelName = latestCandidate.channelName,
+                    channelLogo = latestCandidate.channelLogo,
+                )
+            }
+            val active = ActivePreview(identity = identity, player = player)
+            activePreviews[identity] = active
+            previewLifecycle.track(identity, SystemClock.elapsedRealtime())
+            builtPlayer.repeatMode = if (latestCandidate.videoId.isNullOrBlank()) {
+                Player.REPEAT_MODE_OFF
+            } else {
+                Player.REPEAT_MODE_ONE
+            }
             attachSurfaceIfNeeded(active, latestCandidate)
             builtPlayer.addListener(object : Player.Listener {
                 override fun onRenderedFirstFrame() {
-                    val current = activePreviews[login]
+                    val current = activePreviews[identity]
                     if (current?.player === builtPlayer) {
                         current.firstFrameRendered = true
                         current.surface?.let { surface ->
                             surface.alpha = 1f
                             surface.visibility = View.VISIBLE
                         }
-                        if (BuildConfig.DEBUG) Log.d("StreamPreview", "first_frame channel=$login")
+                        if (BuildConfig.DEBUG) Log.d("StreamPreview", "first_frame identity=$identity")
                     }
                 }
 
                 override fun onPlayerError(error: androidx.media3.common.PlaybackException) {
-                    if (BuildConfig.DEBUG) Log.d("StreamPreview", "failed channel=$login type=${error.errorCodeName}")
-                    handlePreviewFailure(login, builtPlayer)
+                    if (BuildConfig.DEBUG) Log.d("StreamPreview", "failed identity=$identity type=${error.errorCodeName}")
+                    handlePreviewFailure(identity, builtPlayer)
                 }
             })
             builtPlayer.setMediaItem(mediaItem)
             builtPlayer.volume = 0f
             builtPlayer.prepare()
             builtPlayer.playWhenReady = true
-            if (BuildConfig.DEBUG) Log.d("StreamPreview", "started channel=$login quality=${StreamPreviewPolicy.quality(context)}")
+            if (BuildConfig.DEBUG) Log.d("StreamPreview", "started identity=$identity quality=${StreamPreviewPolicy.quality(context)}")
         } catch (cancellation: CancellationException) {
             player?.let { runCatching { it.release() } }
             throw cancellation
         } catch (error: Throwable) {
             player?.let { runCatching { it.release() } }
-            markPreviewFailure(login)
+            markPreviewFailure(identity)
         }
     }
 
-    private fun handlePreviewFailure(login: String, player: ExoPlayer) {
-        if (activePreviews[login]?.player !== player) return
-        markPreviewFailure(login)
+    private fun handlePreviewFailure(identity: String, player: ExoPlayer) {
+        if (activePreviews[identity]?.player !== player) return
+        markPreviewFailure(identity)
         scheduleSelection()
     }
 
-    private fun markPreviewFailure(login: String) {
-        failedUntil[login] = SystemClock.elapsedRealtime() + PLAYER_FAILURE_RETRY_MS
-        releasePreview(login)
+    private fun markPreviewFailure(identity: String) {
+        failedUntil[identity] = SystemClock.elapsedRealtime() + PLAYER_FAILURE_RETRY_MS
+        releasePreview(identity)
         lifecycleReconciler.reconcile(SystemClock.elapsedRealtime(), additionalDeadlines = failedUntil.values)
     }
 
@@ -459,7 +490,7 @@ class StreamPreviewCoordinator(
 
     private fun currentCandidates(): List<StreamPreviewCandidate> =
         viewports.values.flatMap { it.candidates }
-            .mapNotNull { candidate -> candidate.takeIf { normalize(it.channelLogin) != null } }
+            .mapNotNull { candidate -> candidate.takeIf { it.previewIdentity != null } }
 
     private fun maxActivePreviews(): Int =
         if (StreamPreviewPolicy.allowsMultiplePreviews(context)) {
@@ -471,7 +502,8 @@ class StreamPreviewCoordinator(
     private fun bestCandidatesByIdentity(candidates: Collection<StreamPreviewCandidate>): Map<String, StreamPreviewCandidate> =
         candidates
             .mapIndexed { index, candidate -> RankedCandidate(candidate, index) }
-            .groupBy { normalize(it.candidate.channelLogin)!! }
+            .mapNotNull { it.takeIf { ranked -> ranked.candidate.previewIdentity != null } }
+            .groupBy { it.candidate.previewIdentity!! }
             .mapValues { (_, sameIdentity) ->
                 sameIdentity.minWithOrNull(
                     compareByDescending<RankedCandidate> { it.candidate.visibleFraction.coerceIn(0f, 1f) }
@@ -526,6 +558,8 @@ class StreamPreviewCoordinator(
 
     private fun normalize(login: String?): String? =
         login?.trim()?.lowercase()?.takeIf { it.isNotEmpty() }
+
+    private fun livePreviewIdentity(login: String): String = "live:$login"
 
     private data class Viewport(
         val candidates: List<StreamPreviewCandidate>,

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/VideosAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/VideosAdapter.kt
@@ -19,6 +19,7 @@ import coil3.request.target
 import coil3.request.transformations
 import coil3.transform.CircleCropTransformation
 import com.github.andreyasadchy.xtra.R
+import com.github.andreyasadchy.xtra.XtraApp
 import com.github.andreyasadchy.xtra.databinding.FragmentVideosListItemBinding
 import com.github.andreyasadchy.xtra.model.VideoPosition
 import com.github.andreyasadchy.xtra.model.ui.Bookmark
@@ -58,6 +59,11 @@ class VideosAdapter(
         holder.bind(getItem(position))
     }
 
+    override fun onViewRecycled(holder: PagingViewHolder) {
+        holder.detachPreview()
+        super.onViewRecycled(holder)
+    }
+
     private var positions: List<VideoPosition>? = null
 
     fun setVideoPositions(positions: List<VideoPosition>) {
@@ -79,8 +85,19 @@ class VideosAdapter(
         private val showGame: Boolean,
         private val showChannel: Boolean,
     ) : RecyclerView.ViewHolder(binding.root) {
+        val previewSurface get() = binding.previewPlayerView
+        private var boundPreviewIdentity: String? = null
+
+        private val streamPreviewCoordinator
+            get() = (binding.root.context.applicationContext as XtraApp).xtraModule.streamPreviewCoordinator
+
         fun bind(item: Video?) {
+            val nextPreviewIdentity = item?.id?.trim()?.takeIf { it.isNotEmpty() }?.let { "vod:$it" }
             with(binding) {
+                if (boundPreviewIdentity != nextPreviewIdentity) {
+                    streamPreviewCoordinator.detachSurface(previewPlayerView)
+                    boundPreviewIdentity = nextPreviewIdentity
+                }
                 if (item != null) {
                     val context = fragment.requireContext()
                     val position = item.id?.toLongOrNull()?.let { id -> positions?.find { it.id == id }?.position }
@@ -260,6 +277,11 @@ class VideosAdapter(
                     }
                 }
             }
+        }
+
+        fun detachPreview() {
+            streamPreviewCoordinator.detachSurface(previewSurface)
+            boundPreviewIdentity = null
         }
     }
 }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/overview/FollowingOverviewAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/overview/FollowingOverviewAdapter.kt
@@ -30,6 +30,8 @@ class FollowingOverviewAdapter(
     private val onSeeAll: (String) -> Unit,
     private val onStreamShelfAttached: ((String, RecyclerView, (Int) -> Stream?) -> Unit)? = null,
     private val onStreamShelfDetached: ((String) -> Unit)? = null,
+    private val onVideoShelfAttached: ((String, RecyclerView, (Int) -> VideoHistory?) -> Unit)? = null,
+    private val onVideoShelfDetached: ((String) -> Unit)? = null,
 ) : ListAdapter<FollowingOverviewSection, FollowingOverviewAdapter.ViewHolder>(DIFF_CALLBACK) {
 
     private val recycledViewPool = RecyclerView.RecycledViewPool()
@@ -52,6 +54,7 @@ class FollowingOverviewAdapter(
 
     override fun onViewRecycled(holder: ViewHolder) {
         holder.detachStreamShelf()
+        holder.detachVideoShelf()
         super.onViewRecycled(holder)
     }
 
@@ -63,6 +66,7 @@ class FollowingOverviewAdapter(
         private val upcomingShelfAdapter = UpcomingStreamShelfAdapter(onUpcomingClick)
         private var shelfType: ShelfType? = null
         private var boundStreamShelfKey: String? = null
+        private var boundVideoShelfKey: String? = null
 
         init {
             binding.shelfRecyclerView.apply {
@@ -91,6 +95,9 @@ class FollowingOverviewAdapter(
             if (nextShelfType != ShelfType.STREAM || section.streams.isEmpty()) {
                 detachStreamShelf()
             }
+            if (nextShelfType != ShelfType.VIDEO || section.videos.isEmpty()) {
+                detachVideoShelf()
+            }
             if (shelfType != nextShelfType) {
                 when (nextShelfType) {
                     ShelfType.VIDEO -> {
@@ -109,7 +116,16 @@ class FollowingOverviewAdapter(
                 shelfType = nextShelfType
             }
             when (nextShelfType) {
-                ShelfType.VIDEO -> videoShelfAdapter.submitList(section.videos)
+                ShelfType.VIDEO -> {
+                    videoShelfAdapter.submitList(section.videos)
+                    if (hasItems && boundVideoShelfKey != section.key) {
+                        detachVideoShelf()
+                        boundVideoShelfKey = section.key
+                        onVideoShelfAttached?.invoke(section.key, binding.shelfRecyclerView) { position ->
+                            videoShelfAdapter.currentList.getOrNull(position)
+                        }
+                    }
+                }
                 ShelfType.UPCOMING -> upcomingShelfAdapter.submitList(section.scheduledStreams)
                 ShelfType.STREAM -> {
                     shelfAdapter.submitList(section.streams)
@@ -127,6 +143,11 @@ class FollowingOverviewAdapter(
         fun detachStreamShelf() {
             boundStreamShelfKey?.let(onStreamShelfDetached ?: {})
             boundStreamShelfKey = null
+        }
+
+        fun detachVideoShelf() {
+            boundVideoShelfKey?.let(onVideoShelfDetached ?: {})
+            boundVideoShelfKey = null
         }
     }
 

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/overview/FollowingOverviewFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/overview/FollowingOverviewFragment.kt
@@ -27,6 +27,7 @@ import com.github.andreyasadchy.xtra.ui.common.BaseNetworkFragment
 import com.github.andreyasadchy.xtra.ui.common.Scrollable
 import com.github.andreyasadchy.xtra.ui.common.StreamFeedScreenController
 import com.github.andreyasadchy.xtra.ui.common.StreamPreloadViewportController
+import com.github.andreyasadchy.xtra.ui.common.StreamPreviewCandidate
 import com.github.andreyasadchy.xtra.ui.following.FollowMediaFragment
 import com.github.andreyasadchy.xtra.ui.following.FollowPagerFragment
 import com.github.andreyasadchy.xtra.ui.main.MainActivity
@@ -47,6 +48,7 @@ class FollowingOverviewFragment : BaseNetworkFragment(), Scrollable {
     private lateinit var overviewAdapter: FollowingOverviewAdapter
     private lateinit var streamFeedScreenController: StreamFeedScreenController
     private val streamShelfPreloadControllers = mutableMapOf<String, StreamPreloadViewportController>()
+    private val videoShelfPreviewControllers = mutableMapOf<String, StreamPreloadViewportController>()
     private var overviewScrolling = false
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
@@ -89,6 +91,37 @@ class FollowingOverviewFragment : BaseNetworkFragment(), Scrollable {
             onStreamShelfDetached = { key ->
                 streamShelfPreloadControllers.remove(key)?.stop()
             },
+            onVideoShelfAttached = { key, recyclerView, videoAtPosition ->
+                videoShelfPreviewControllers.remove(key)?.stop()
+                StreamPreloadViewportController(
+                    fragment = this,
+                    coordinator = null,
+                    viewportKey = "following-overview-videos:$key",
+                    recyclerView = recyclerView,
+                    previewAtPosition = { position, surface ->
+                        videoAtPosition(position)?.let { video ->
+                            StreamPreviewCandidate(
+                                streamKey = "vod:${video.id}",
+                                channelLogin = video.channelLogin.orEmpty(),
+                                visibleFraction = 0f,
+                                centerProximity = 0f,
+                                title = video.title,
+                                channelName = video.channelName,
+                                channelLogo = video.channelImageURL?.let(TwitchApiHelper::getProfileImage),
+                                videoId = video.id.toString(),
+                                surface = surface,
+                            )
+                        }
+                    },
+                    isParentScrolling = { overviewScrolling },
+                ).also {
+                    videoShelfPreviewControllers[key] = it
+                    it.start()
+                }
+            },
+            onVideoShelfDetached = { key ->
+                videoShelfPreviewControllers.remove(key)?.stop()
+            },
         )
         binding.recyclerView.apply {
             layoutManager = LinearLayoutManager(context)
@@ -99,6 +132,7 @@ class FollowingOverviewFragment : BaseNetworkFragment(), Scrollable {
                 override fun onScrollStateChanged(recyclerView: RecyclerView, newState: Int) {
                     overviewScrolling = newState != RecyclerView.SCROLL_STATE_IDLE
                     streamShelfPreloadControllers.values.forEach(StreamPreloadViewportController::onParentScrollStateChanged)
+                    videoShelfPreviewControllers.values.forEach(StreamPreloadViewportController::onParentScrollStateChanged)
                 }
             })
             addOnLayoutChangeListener { recyclerView, _, _, right, _, _, _, _, _ ->
@@ -223,6 +257,7 @@ class FollowingOverviewFragment : BaseNetworkFragment(), Scrollable {
             streamFeedScreenController.onResume()
         }
         streamShelfPreloadControllers.values.forEach(StreamPreloadViewportController::onResume)
+        videoShelfPreviewControllers.values.forEach(StreamPreloadViewportController::onResume)
     }
 
     override fun onPause() {
@@ -230,6 +265,7 @@ class FollowingOverviewFragment : BaseNetworkFragment(), Scrollable {
             streamFeedScreenController.onPause()
         }
         streamShelfPreloadControllers.values.forEach(StreamPreloadViewportController::onPause)
+        videoShelfPreviewControllers.values.forEach(StreamPreloadViewportController::onPause)
         super.onPause()
     }
 
@@ -239,6 +275,8 @@ class FollowingOverviewFragment : BaseNetworkFragment(), Scrollable {
         }
         streamShelfPreloadControllers.values.forEach(StreamPreloadViewportController::stop)
         streamShelfPreloadControllers.clear()
+        videoShelfPreviewControllers.values.forEach(StreamPreloadViewportController::stop)
+        videoShelfPreviewControllers.clear()
         overviewScrolling = false
         super.onDestroyView()
         _binding = null

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/overview/VideoShelfAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/overview/VideoShelfAdapter.kt
@@ -15,6 +15,7 @@ import coil3.request.target
 import coil3.request.transformations
 import coil3.transform.CircleCropTransformation
 import com.github.andreyasadchy.xtra.R
+import com.github.andreyasadchy.xtra.XtraApp
 import com.github.andreyasadchy.xtra.databinding.ItemVideoShelfBinding
 import com.github.andreyasadchy.xtra.model.VideoHistory
 import com.github.andreyasadchy.xtra.util.TwitchApiHelper
@@ -40,6 +41,11 @@ class VideoShelfAdapter(
         holder.bind(getItem(position))
     }
 
+    override fun onViewRecycled(holder: ViewHolder) {
+        holder.detachPreview()
+        super.onViewRecycled(holder)
+    }
+
     private val layoutChangeListener = View.OnLayoutChangeListener { view, left, _, right, _, oldLeft, _, oldRight, _ ->
         if (right - left != oldRight - oldLeft) {
             val shelf = view as RecyclerView
@@ -60,8 +66,19 @@ class VideoShelfAdapter(
     inner class ViewHolder(
         private val binding: ItemVideoShelfBinding,
     ) : RecyclerView.ViewHolder(binding.root) {
+        val previewSurface get() = binding.previewPlayerView
+        private var boundPreviewIdentity: String? = null
+
+        private val streamPreviewCoordinator
+            get() = (binding.root.context.applicationContext as XtraApp).xtraModule.streamPreviewCoordinator
+
         fun bind(item: VideoHistory) {
             val context = binding.root.context
+            val nextPreviewIdentity = "vod:${item.id}"
+            if (boundPreviewIdentity != nextPreviewIdentity) {
+                streamPreviewCoordinator.detachSurface(previewSurface)
+                boundPreviewIdentity = nextPreviewIdentity
+            }
             binding.root.setOnClickListener { onVideoClick(item) }
             context.imageLoader.enqueue(ImageRequest.Builder(context).apply {
                 data(item.thumbnailURL?.let(TwitchApiHelper::getVideoThumbnail))
@@ -87,6 +104,11 @@ class VideoShelfAdapter(
                 target(binding.avatar)
             }.build())
             binding.avatar.visibility = if (avatarUrl.isNullOrBlank()) View.INVISIBLE else View.VISIBLE
+        }
+
+        fun detachPreview() {
+            streamPreviewCoordinator.detachSurface(previewSurface)
+            boundPreviewIdentity = null
         }
     }
 

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/videos/FollowedVideosFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/videos/FollowedVideosFragment.kt
@@ -24,6 +24,8 @@ import com.github.andreyasadchy.xtra.model.ui.Video
 import com.github.andreyasadchy.xtra.ui.common.FragmentHost
 import com.github.andreyasadchy.xtra.ui.common.PagedListFragment
 import com.github.andreyasadchy.xtra.ui.common.Scrollable
+import com.github.andreyasadchy.xtra.ui.common.StreamPreloadViewportController
+import com.github.andreyasadchy.xtra.ui.common.StreamPreviewCandidate
 import com.github.andreyasadchy.xtra.ui.common.Sortable
 import com.github.andreyasadchy.xtra.ui.common.VideosAdapter
 import com.github.andreyasadchy.xtra.ui.common.VideosSortDialog
@@ -41,6 +43,7 @@ class FollowedVideosFragment : PagedListFragment(), Scrollable, Sortable, Videos
     private val binding get() = _binding!!
     private val viewModel: FollowedVideosViewModel by viewModels { FollowedVideosViewModelFactory }
     private lateinit var pagingAdapter: PagingDataAdapter<Video, out RecyclerView.ViewHolder>
+    private lateinit var videoPreviewViewportController: StreamPreloadViewportController
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         _binding = CommonRecyclerViewLayoutBinding.inflate(inflater, container, false)
@@ -76,6 +79,29 @@ class FollowedVideosFragment : PagedListFragment(), Scrollable, Sortable, Videos
             )
         })
         setAdapter(binding.recyclerView, pagingAdapter)
+        videoPreviewViewportController = StreamPreloadViewportController(
+            fragment = this,
+            coordinator = null,
+            viewportKey = "followed-videos",
+            recyclerView = binding.recyclerView,
+            previewAtPosition = { position, surface ->
+                pagingAdapter.peek(position)?.let { video ->
+                    video.id?.trim()?.takeIf { it.isNotEmpty() }?.let { videoId ->
+                        StreamPreviewCandidate(
+                            streamKey = "vod:$videoId",
+                            channelLogin = video.channelLogin.orEmpty(),
+                            visibleFraction = 0f,
+                            centerProximity = 0f,
+                            title = video.title,
+                            channelName = video.channelName,
+                            channelLogo = video.channelImage,
+                            videoId = videoId,
+                            surface = surface,
+                        )
+                    }
+                }
+            },
+        ).also { it.start() }
         ViewCompat.setOnApplyWindowInsetsListener(view) { _, windowInsets ->
             if (activity?.findViewById<LinearLayout>(R.id.navBarContainer)?.isVisible == false) {
                 val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars())
@@ -182,6 +208,20 @@ class FollowedVideosFragment : PagedListFragment(), Scrollable, Sortable, Videos
         pagingAdapter.retry()
     }
 
+    override fun onResume() {
+        super.onResume()
+        if (::videoPreviewViewportController.isInitialized) {
+            videoPreviewViewportController.onResume()
+        }
+    }
+
+    override fun onPause() {
+        if (::videoPreviewViewportController.isInitialized) {
+            videoPreviewViewportController.onPause()
+        }
+        super.onPause()
+    }
+
     override fun onIntegrityTokenLoaded(callback: String?) {
         when (callback) {
             "refresh" -> {
@@ -191,6 +231,9 @@ class FollowedVideosFragment : PagedListFragment(), Scrollable, Sortable, Videos
     }
 
     override fun onDestroyView() {
+        if (::videoPreviewViewportController.isInitialized) {
+            videoPreviewViewportController.stop()
+        }
         super.onDestroyView()
         _binding = null
     }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/game/videos/GameVideosFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/game/videos/GameVideosFragment.kt
@@ -27,6 +27,8 @@ import com.github.andreyasadchy.xtra.ui.common.IntegrityDialog
 import com.github.andreyasadchy.xtra.ui.common.PagedListFragment
 import com.github.andreyasadchy.xtra.ui.common.Scrollable
 import com.github.andreyasadchy.xtra.ui.common.Sortable
+import com.github.andreyasadchy.xtra.ui.common.StreamPreloadViewportController
+import com.github.andreyasadchy.xtra.ui.common.StreamPreviewCandidate
 import com.github.andreyasadchy.xtra.ui.common.VideosAdapter
 import com.github.andreyasadchy.xtra.ui.common.VideosSortDialog
 import com.github.andreyasadchy.xtra.ui.download.DownloadDialog
@@ -45,6 +47,7 @@ class GameVideosFragment : PagedListFragment(), Scrollable, Sortable, VideosSort
     private val args: GamePagerFragmentArgs by navArgs()
     private val viewModel: GameVideosViewModel by viewModels { GameVideosViewModelFactory }
     private lateinit var pagingAdapter: PagingDataAdapter<Video, out RecyclerView.ViewHolder>
+    private lateinit var videoPreviewViewportController: StreamPreloadViewportController
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         _binding = CommonRecyclerViewLayoutBinding.inflate(inflater, container, false)
@@ -80,6 +83,29 @@ class GameVideosFragment : PagedListFragment(), Scrollable, Sortable, VideosSort
             )
         }, showGame = false)
         setAdapter(binding.recyclerView, pagingAdapter)
+        videoPreviewViewportController = StreamPreloadViewportController(
+            fragment = this,
+            coordinator = null,
+            viewportKey = "game-videos",
+            recyclerView = binding.recyclerView,
+            previewAtPosition = { position, surface ->
+                pagingAdapter.peek(position)?.let { video ->
+                    video.id?.trim()?.takeIf { it.isNotEmpty() }?.let { videoId ->
+                        StreamPreviewCandidate(
+                            streamKey = "vod:$videoId",
+                            channelLogin = video.channelLogin.orEmpty(),
+                            visibleFraction = 0f,
+                            centerProximity = 0f,
+                            title = video.title,
+                            channelName = video.channelName,
+                            channelLogo = video.channelImage,
+                            videoId = videoId,
+                            surface = surface,
+                        )
+                    }
+                }
+            },
+        ).also { it.start() }
         ViewCompat.setOnApplyWindowInsetsListener(view) { _, windowInsets ->
             if (activity?.findViewById<LinearLayout>(R.id.navBarContainer)?.isVisible == false) {
                 val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars())
@@ -259,7 +285,24 @@ class GameVideosFragment : PagedListFragment(), Scrollable, Sortable, VideosSort
         }
     }
 
+    override fun onResume() {
+        super.onResume()
+        if (::videoPreviewViewportController.isInitialized) {
+            videoPreviewViewportController.onResume()
+        }
+    }
+
+    override fun onPause() {
+        if (::videoPreviewViewportController.isInitialized) {
+            videoPreviewViewportController.onPause()
+        }
+        super.onPause()
+    }
+
     override fun onDestroyView() {
+        if (::videoPreviewViewportController.isInitialized) {
+            videoPreviewViewportController.stop()
+        }
         super.onDestroyView()
         _binding = null
     }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/StreamHlsMediaSourceFactory.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/StreamHlsMediaSourceFactory.kt
@@ -121,6 +121,25 @@ class StreamHlsMediaSourceFactory(
         )
         .build()
 
+    fun createVodMediaItem(
+        mediaId: String,
+        uri: String,
+        title: String?,
+        channelName: String?,
+        channelLogo: String?,
+    ): MediaItem = MediaItem.Builder()
+        .setMediaId(mediaId)
+        .setUri(uri.toUri())
+        .setMimeType(MimeTypes.APPLICATION_M3U8)
+        .setMediaMetadata(
+            MediaMetadata.Builder()
+                .setTitle(title ?: channelName)
+                .setArtist(channelName)
+                .setArtworkUri(channelLogo?.toUri())
+                .build()
+        )
+        .build()
+
     fun stateFor(mediaId: String): StreamProxyState = proxyStates.getOrPut(mediaId) { StreamProxyState() }
 
     fun findState(mediaId: String): StreamProxyState? = proxyStates[mediaId]

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/search/videos/VideoSearchFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/search/videos/VideoSearchFragment.kt
@@ -19,6 +19,8 @@ import com.github.andreyasadchy.xtra.R
 import com.github.andreyasadchy.xtra.databinding.CommonRecyclerViewLayoutBinding
 import com.github.andreyasadchy.xtra.model.ui.Video
 import com.github.andreyasadchy.xtra.ui.common.PagedListFragment
+import com.github.andreyasadchy.xtra.ui.common.StreamPreloadViewportController
+import com.github.andreyasadchy.xtra.ui.common.StreamPreviewCandidate
 import com.github.andreyasadchy.xtra.ui.common.VideosAdapter
 import com.github.andreyasadchy.xtra.ui.download.DownloadDialog
 import com.github.andreyasadchy.xtra.ui.search.RecentSearchAdapter
@@ -37,6 +39,7 @@ class VideoSearchFragment : PagedListFragment(), Searchable {
     private val binding get() = _binding!!
     private val viewModel: VideoSearchViewModel by viewModels { VideoSearchViewModelFactory }
     private lateinit var pagingAdapter: PagingDataAdapter<Video, out RecyclerView.ViewHolder>
+    private lateinit var videoPreviewViewportController: StreamPreloadViewportController
     private var recentSearchAdapter = RecentSearchAdapter({ (parentFragment as? SearchPagerFragment)?.setQuery(it.query) }, { viewModel.deleteRecentSearch(it) })
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
@@ -73,6 +76,29 @@ class VideoSearchFragment : PagedListFragment(), Searchable {
             )
         })
         setAdapter(binding.recyclerView, pagingAdapter)
+        videoPreviewViewportController = StreamPreloadViewportController(
+            fragment = this,
+            coordinator = null,
+            viewportKey = "search-videos",
+            recyclerView = binding.recyclerView,
+            previewAtPosition = { position, surface ->
+                pagingAdapter.peek(position)?.let { video ->
+                    video.id?.trim()?.takeIf { it.isNotEmpty() }?.let { videoId ->
+                        StreamPreviewCandidate(
+                            streamKey = "vod:$videoId",
+                            channelLogin = video.channelLogin.orEmpty(),
+                            visibleFraction = 0f,
+                            centerProximity = 0f,
+                            title = video.title,
+                            channelName = video.channelName,
+                            channelLogo = video.channelImage,
+                            videoId = videoId,
+                            surface = surface,
+                        )
+                    }
+                }
+            },
+        ).also { it.start() }
         ViewCompat.setOnApplyWindowInsetsListener(view) { _, windowInsets ->
             if (activity?.findViewById<LinearLayout>(R.id.navBarContainer)?.isVisible == false) {
                 val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars())
@@ -153,7 +179,24 @@ class VideoSearchFragment : PagedListFragment(), Searchable {
         }
     }
 
+    override fun onResume() {
+        super.onResume()
+        if (::videoPreviewViewportController.isInitialized) {
+            videoPreviewViewportController.onResume()
+        }
+    }
+
+    override fun onPause() {
+        if (::videoPreviewViewportController.isInitialized) {
+            videoPreviewViewportController.onPause()
+        }
+        super.onPause()
+    }
+
     override fun onDestroyView() {
+        if (::videoPreviewViewportController.isInitialized) {
+            videoPreviewViewportController.stop()
+        }
         super.onDestroyView()
         _binding = null
     }

--- a/app/src/main/res/layout/fragment_videos_list_item.xml
+++ b/app/src/main/res/layout/fragment_videos_list_item.xml
@@ -19,6 +19,20 @@
             app:layout_constraintTop_toTopOf="parent"
             tools:src="@tools:sample/backgrounds/scenic" />
 
+        <androidx.media3.ui.PlayerView
+            android:id="@+id/previewPlayerView"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:importantForAccessibility="no"
+            android:visibility="gone"
+            app:layout_constraintBottom_toBottomOf="@id/thumbnail"
+            app:layout_constraintEnd_toEndOf="@id/thumbnail"
+            app:layout_constraintStart_toStartOf="@id/thumbnail"
+            app:layout_constraintTop_toTopOf="@id/thumbnail"
+            app:resize_mode="zoom"
+            app:show_buffering="never"
+            app:use_controller="false" />
+
         <com.github.andreyasadchy.xtra.ui.view.TextWithShadow
             android:id="@+id/date"
             style="@style/ThumbnailItem"

--- a/app/src/main/res/layout/item_video_shelf.xml
+++ b/app/src/main/res/layout/item_video_shelf.xml
@@ -29,6 +29,20 @@
             app:layout_constraintTop_toTopOf="parent"
             tools:src="@tools:sample/backgrounds/scenic" />
 
+        <androidx.media3.ui.PlayerView
+            android:id="@+id/previewPlayerView"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:importantForAccessibility="no"
+            android:visibility="gone"
+            app:layout_constraintBottom_toBottomOf="@id/thumbnail"
+            app:layout_constraintEnd_toEndOf="@id/thumbnail"
+            app:layout_constraintStart_toStartOf="@id/thumbnail"
+            app:layout_constraintTop_toTopOf="@id/thumbnail"
+            app:resize_mode="zoom"
+            app:show_buffering="never"
+            app:use_controller="false" />
+
         <com.github.andreyasadchy.xtra.ui.view.TextWithShadow
             android:id="@+id/duration"
             style="@style/ThumbnailItem"

--- a/app/src/test/java/com/github/andreyasadchy/xtra/repository/preload/StreamPreloadUrlCacheTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/repository/preload/StreamPreloadUrlCacheTest.kt
@@ -15,9 +15,23 @@ class StreamPreloadUrlCacheTest {
         cache.put("three", "url-three", "config")
         assertNull(cache.get("one", "config"))
         assertEquals("url-two", cache.get("two", "config"))
+        assertEquals(2, cache.size())
 
         now = 101L
         assertNull(cache.take("two", "config"))
+        assertEquals(1, cache.size())
+    }
+
+    @Test
+    fun boundedCacheSupportsVODPreviewUrlsAndConfigurationInvalidation() {
+        var now = 0L
+        val cache = StreamPreloadUrlCache(maxEntries = 8, ttlMs = 100, elapsedRealtimeMs = { now })
+
+        repeat(9) { id -> cache.put("vod-$id", "signed-url-$id", "old-config") }
+
+        assertNull(cache.get("vod-0", "old-config"))
+        assertEquals("signed-url-8", cache.get("vod-8", "old-config"))
+        assertNull(cache.get("vod-8", "new-config"))
     }
 
     @Test

--- a/app/src/test/java/com/github/andreyasadchy/xtra/repository/preload/StreamPreviewDwellPolicyTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/repository/preload/StreamPreviewDwellPolicyTest.kt
@@ -17,4 +17,13 @@ class StreamPreviewDwellPolicyTest {
             StreamPreviewDwellPolicy.remainingDelay(startedAt!!, nowMs = 1_500L, delayMs = 1_250L),
         )
     }
+
+    @Test
+    fun immediatePreferenceAllowsAZeroMillisecondStart() {
+        assertEquals(StreamPreviewDelay.IMMEDIATE, StreamPreviewDelay.fromPreference("instant"))
+        assertEquals(
+            0L,
+            StreamPreviewDwellPolicy.remainingDelay(startedAtMs = 1_500L, nowMs = 1_500L, delayMs = 0L),
+        )
+    }
 }

--- a/app/src/test/java/com/github/andreyasadchy/xtra/repository/preload/StreamPreviewLifecycleTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/repository/preload/StreamPreviewLifecycleTest.kt
@@ -39,6 +39,22 @@ class StreamPreviewLifecycleTest {
     }
 
     @Test
+    fun scrollingDoesNotExpireAnOffscreenPreviewUntilScrollingStops() {
+        val lifecycle = StreamPreviewLifecycle()
+        lifecycle.track("channel-a", nowMs = 0L)
+
+        lifecycle.observeVisible(emptySet(), nowMs = 100L, scrolling = true)
+        lifecycle.expire(nowMs = 100L + StreamPreviewLifecyclePolicy.OFFSCREEN_GRACE_MS + 1L)
+
+        assertTrue(lifecycle.activeIdentities().contains("channel-a"))
+
+        lifecycle.observeVisible(emptySet(), nowMs = 2_000L, scrolling = false)
+        lifecycle.expire(nowMs = 2_000L + StreamPreviewLifecyclePolicy.OFFSCREEN_GRACE_MS)
+
+        assertFalse(lifecycle.activeIdentities().contains("channel-a"))
+    }
+
+    @Test
     fun offscreenCardPublishesFutureExpiryForCoordinatorReconciliation() {
         val lifecycle = StreamPreviewLifecycle()
         lifecycle.track("channel-a", nowMs = 0L)


### PR DESCRIPTION
Visible VOD cards now show previews while browsing. Scrolling keeps active previews alive, unloaded cards stop after a short grace period, and Immediate (0 seconds) preview start is supported and remains the default.