### PR TITLE
Add a Discover page for live Twitch streams

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/auth/AuthCoordinator.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/auth/AuthCoordinator.kt
@@ -88,11 +88,10 @@ class AuthCoordinator(
         return AuthCommitResult(
             session = official,
             accountChanged = accountChanged,
-            revocationFailures = revokeSupersededCredentials(
-                previous = previous,
-                replacementOfficial = official,
-                replacementCompatibility = compatibility,
-            ),
+            // A successful login only replaces the active session locally. It
+            // does not revoke existing grants; abandoned staged grants and
+            // explicit logout are handled by their separate cleanup flows.
+            revocationFailures = 0,
         )
     }
 
@@ -240,28 +239,6 @@ class AuthCoordinator(
             if (!sessionStore.clearAll()) failures += 1
         }
         return failures
-    }
-
-    private suspend fun revokeSupersededCredentials(
-        previous: StoredCredentials,
-        replacementOfficial: AuthSession,
-        replacementCompatibility: CompatibilitySession,
-    ): Int {
-        val credentials = linkedSetOf<Pair<String?, String>>()
-        previous.helixToken
-            ?.takeIf { it.isNotBlank() && it != replacementOfficial.accessToken }
-            ?.let { credentials += previous.helixClientId to it }
-        previous.gqlToken
-            ?.takeIf { it.isNotBlank() && it != replacementCompatibility.accessToken }
-            ?.let { credentials += previous.gqlClientId to it }
-        previous.gqlWebToken
-            ?.takeIf {
-                it.isNotBlank() &&
-                    it != previous.gqlToken &&
-                    it != replacementCompatibility.accessToken
-            }
-            ?.let { credentials += previous.gqlWebClientId to it }
-        return credentials.sumOf { (clientId, token) -> revoke(clientId, token) }
     }
 
     private suspend fun revoke(clientId: String?, token: String): Int {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/browse/BrowsePagerAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/browse/BrowsePagerAdapter.kt
@@ -2,9 +2,10 @@ package com.github.andreyasadchy.xtra.ui.browse
 
 import androidx.fragment.app.Fragment
 import androidx.viewpager2.adapter.FragmentStateAdapter
-import com.github.andreyasadchy.xtra.ui.following.channels.FollowedChannelsFragment
 import com.github.andreyasadchy.xtra.ui.games.GamesFragment
 import com.github.andreyasadchy.xtra.ui.games.GamesFragmentArgs
+import com.github.andreyasadchy.xtra.ui.top.TopStreamsFragment
+import com.github.andreyasadchy.xtra.ui.top.TopStreamsFragmentArgs
 
 class BrowsePagerAdapter(
     fragment: Fragment,
@@ -15,7 +16,9 @@ class BrowsePagerAdapter(
             0 -> GamesFragment().apply {
                 arguments = GamesFragmentArgs().toBundle()
             }
-            else -> FollowedChannelsFragment()
+            else -> TopStreamsFragment().apply {
+                arguments = TopStreamsFragmentArgs().toBundle()
+            }
         }
     }
 

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/browse/BrowsePagerFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/browse/BrowsePagerFragment.kt
@@ -26,6 +26,7 @@ import com.github.andreyasadchy.xtra.ui.login.LoginActivity
 import com.github.andreyasadchy.xtra.ui.main.MainActivity
 import com.github.andreyasadchy.xtra.ui.search.SearchPagerFragmentDirections
 import com.github.andreyasadchy.xtra.ui.settings.SettingsActivity
+import com.github.andreyasadchy.xtra.ui.top.TopStreamsFragment
 import com.github.andreyasadchy.xtra.util.C
 import com.github.andreyasadchy.xtra.util.TwitchApiHelper
 import com.github.andreyasadchy.xtra.util.getAlertDialogBuilder
@@ -181,7 +182,7 @@ class BrowsePagerFragment : Fragment(), Scrollable, FragmentHost {
     }
 
     private fun hideNestedToolbar(fragment: Fragment) {
-        if (fragment is GamesFragment) {
+        if (fragment is GamesFragment || fragment is TopStreamsFragment) {
             fragment.view?.findViewById<View>(R.id.toolbar)?.visibility = View.GONE
         }
     }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/discover/DiscoverFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/discover/DiscoverFragment.kt
@@ -1,0 +1,200 @@
+package com.github.andreyasadchy.xtra.ui.discover
+
+import android.content.Intent
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.isVisible
+import androidx.core.view.updateLayoutParams
+import androidx.core.view.updatePadding
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import androidx.navigation.fragment.findNavController
+import androidx.navigation.ui.AppBarConfiguration
+import androidx.navigation.ui.setupWithNavController
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import com.github.andreyasadchy.xtra.R
+import com.github.andreyasadchy.xtra.databinding.FragmentDiscoverBinding
+import com.github.andreyasadchy.xtra.ui.channel.ChannelPagerFragmentDirections
+import com.github.andreyasadchy.xtra.ui.common.BaseNetworkFragment
+import com.github.andreyasadchy.xtra.ui.common.Scrollable
+import com.github.andreyasadchy.xtra.ui.game.GamePagerFragmentDirections
+import com.github.andreyasadchy.xtra.ui.following.overview.FollowingOverviewAdapter
+import com.github.andreyasadchy.xtra.ui.main.MainActivity
+import com.github.andreyasadchy.xtra.ui.login.LoginActivity
+import com.github.andreyasadchy.xtra.ui.search.SearchPagerFragmentDirections
+import com.github.andreyasadchy.xtra.ui.settings.SettingsActivity
+import com.github.andreyasadchy.xtra.util.C
+import com.github.andreyasadchy.xtra.util.TwitchApiHelper
+import com.github.andreyasadchy.xtra.util.getAlertDialogBuilder
+import com.github.andreyasadchy.xtra.util.tokenPrefs
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+
+class DiscoverFragment : BaseNetworkFragment(), Scrollable {
+
+    override val initializeWithoutNetwork = true
+
+    private var _binding: FragmentDiscoverBinding? = null
+    private val binding get() = _binding!!
+    private val viewModel: DiscoverViewModel by viewModels { DiscoverViewModel.Factory }
+    private lateinit var adapter: FollowingOverviewAdapter
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+        _binding = FragmentDiscoverBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        val activity = requireActivity() as MainActivity
+        val navController = findNavController()
+        val isLoggedIn = !TwitchApiHelper.getGQLHeaders(requireContext(), true)[C.HEADER_TOKEN].isNullOrBlank() ||
+            !TwitchApiHelper.getHelixHeaders(requireContext())[C.HEADER_TOKEN].isNullOrBlank()
+        binding.toolbar.setupWithNavController(
+            navController,
+            AppBarConfiguration(
+                setOf(
+                    R.id.rootGamesFragment,
+                    R.id.rootDiscoverFragment,
+                    R.id.rootTopFragment,
+                    R.id.followPagerFragment,
+                    R.id.followMediaFragment,
+                    R.id.savedPagerFragment,
+                    R.id.savedMediaFragment,
+                ),
+            ),
+        )
+        binding.toolbar.menu.findItem(R.id.login).title = if (isLoggedIn) getString(R.string.log_out) else getString(R.string.log_in)
+        binding.toolbar.setOnMenuItemClickListener { menuItem ->
+            when (menuItem.itemId) {
+                R.id.search -> {
+                    navController.navigate(SearchPagerFragmentDirections.actionGlobalSearchPagerFragment())
+                    true
+                }
+                R.id.settings -> {
+                    activity.settingsResultLauncher?.launch(Intent(activity, SettingsActivity::class.java))
+                    true
+                }
+                R.id.statistics -> {
+                    activity.openStatistics()
+                    true
+                }
+                R.id.login -> {
+                    if (isLoggedIn) {
+                        activity.getAlertDialogBuilder().apply {
+                            setTitle(getString(R.string.logout_title))
+                            requireContext().tokenPrefs().getString(C.USERNAME, null)?.let { setMessage(getString(R.string.logout_msg, it)) }
+                            setNegativeButton(getString(R.string.no), null)
+                            setPositiveButton(getString(R.string.yes)) { _, _ ->
+                                activity.logoutResultLauncher?.launch(Intent(activity, LoginActivity::class.java).putExtra(LoginActivity.EXTRA_LOGOUT, true))
+                            }
+                        }.show()
+                    } else {
+                        activity.loginResultLauncher?.launch(Intent(activity, LoginActivity::class.java))
+                    }
+                    true
+                }
+                else -> false
+            }
+        }
+        adapter = FollowingOverviewAdapter(
+            onStreamClick = { stream -> activity.startStream(stream) },
+            onVideoClick = {},
+            onUpcomingClick = { upcoming ->
+                navController.navigate(
+                    ChannelPagerFragmentDirections.actionGlobalChannelPagerFragment(
+                        channelId = upcoming.channelId,
+                        channelLogin = upcoming.channelLogin,
+                        channelName = upcoming.channelName,
+                        channelImage = upcoming.channelImageURL?.let(TwitchApiHelper::getProfileImage),
+                    ),
+                )
+            },
+            onSeeAll = { key -> showAll(key) },
+            onGameClick = { game ->
+                navController.navigate(
+                    com.github.andreyasadchy.xtra.ui.game.GamePagerFragmentDirections.actionGlobalGamePagerFragment(
+                        gameId = game.id,
+                        gameSlug = game.slug,
+                        gameName = game.name,
+                        boxArt = game.boxArt,
+                    ),
+                )
+            },
+        )
+        binding.recyclerView.apply {
+            layoutManager = LinearLayoutManager(context)
+            this.adapter = this@DiscoverFragment.adapter
+            itemAnimator = null
+            clipToPadding = false
+            addOnScrollListener(object : RecyclerView.OnScrollListener() {
+                override fun onScrolled(recyclerView: RecyclerView, dx: Int, dy: Int) {
+                    binding.appBar.isLifted = recyclerView.canScrollVertically(-1)
+                }
+            })
+            addOnLayoutChangeListener { recyclerView, _, _, right, _, _, _, _, _ ->
+                val density = resources.displayMetrics.density
+                val maxContentWidth = (1200 * density).toInt()
+                val minimumGutter = (16 * density).toInt()
+                val sidePadding = maxOf(minimumGutter, (right - maxContentWidth) / 2)
+                updatePadding(left = sidePadding, right = sidePadding)
+            }
+        }
+        binding.appBar.setLiftOnScrollTargetView(binding.recyclerView)
+        ViewCompat.setOnApplyWindowInsetsListener(view) { _, windowInsets ->
+            val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout())
+            binding.toolbar.updateLayoutParams<ViewGroup.MarginLayoutParams> { topMargin = insets.top }
+            binding.recyclerView.updatePadding(bottom = insets.bottom)
+            windowInsets
+        }
+        viewLifecycleOwner.lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.state.collectLatest { state ->
+                    adapter.submitList(state.sections)
+                    binding.emptyState.isVisible = !state.isLoading && state.hasError
+                }
+            }
+        }
+    }
+
+    override fun initialize() {
+        viewModel.refresh()
+    }
+
+    override fun onNetworkRestored() {
+        viewModel.refresh()
+    }
+
+    private fun showAll(key: String) {
+        when (key) {
+            DiscoverViewModel.KEY_CATEGORIES -> findNavController().navigate(R.id.action_global_gamesFragment)
+            DiscoverViewModel.KEY_TRENDING -> viewModel.state.value.trendingGame?.let { game ->
+                findNavController().navigate(
+                    GamePagerFragmentDirections.actionGlobalGamePagerFragment(
+                        gameId = game.id,
+                        gameSlug = game.slug,
+                        gameName = game.name,
+                        boxArt = game.boxArt,
+                    ),
+                )
+            }
+        }
+    }
+
+    override fun scrollToTop() {
+        binding.appBar.setExpanded(true, true)
+        binding.recyclerView.scrollToPosition(0)
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/discover/DiscoverViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/discover/DiscoverViewModel.kt
@@ -1,0 +1,254 @@
+package com.github.andreyasadchy.xtra.ui.discover
+
+import android.content.Context
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider.AndroidViewModelFactory.Companion.APPLICATION_KEY
+import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
+import com.github.andreyasadchy.xtra.R
+import com.github.andreyasadchy.xtra.XtraApp
+import com.github.andreyasadchy.xtra.graphql.type.StreamSort
+import com.github.andreyasadchy.xtra.model.ui.Game
+import com.github.andreyasadchy.xtra.model.ui.Stream
+import com.github.andreyasadchy.xtra.repository.GraphQLRepository
+import com.github.andreyasadchy.xtra.repository.HelixRepository
+import com.github.andreyasadchy.xtra.repository.RecommendationsRepository
+import com.github.andreyasadchy.xtra.repository.datasource.GameStreamsPageLoader
+import com.github.andreyasadchy.xtra.repository.datasource.TopStreamsPageLoader
+import com.github.andreyasadchy.xtra.ui.following.overview.FollowingOverviewSection
+import com.github.andreyasadchy.xtra.ui.following.overview.FollowingOverviewLoadingType
+import com.github.andreyasadchy.xtra.util.C
+import com.github.andreyasadchy.xtra.util.TwitchApiHelper
+import com.github.andreyasadchy.xtra.util.prefs
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+data class DiscoverState(
+    val sections: List<FollowingOverviewSection> = emptyList(),
+    val trendingGame: Game? = null,
+    val isLoading: Boolean = false,
+    val hasError: Boolean = false,
+)
+
+class DiscoverViewModel(
+    private val applicationContext: Context,
+    private val graphQLRepository: GraphQLRepository,
+    private val helixRepository: HelixRepository,
+    private val recommendationsRepository: RecommendationsRepository,
+) : ViewModel() {
+
+    private val _state = MutableStateFlow(
+        DiscoverState(
+            sections = loadingSections(),
+            isLoading = true,
+        ),
+    )
+    val state: StateFlow<DiscoverState> = _state
+    private var refreshJob: Job? = null
+
+    fun refresh() {
+        refreshJob?.cancel()
+        refreshJob = viewModelScope.launch {
+            _state.value = DiscoverState(sections = loadingSections(), isLoading = true)
+            try {
+                val topStreams = loadOrEmpty { loadTopStreams() }
+                coroutineScope {
+                    val recommendations = async {
+                        loadOrEmpty {
+                            recommendationsRepository.getLiveRecommendations(
+                                limit = STREAM_LIMIT,
+                                excludedChannelIds = topStreams.mapNotNull { it.channelId }.toSet(),
+                            ).streams
+                        }
+                    }
+                    val games = async { loadOrEmpty { loadTopGames() } }
+                    val recommendedStreams = recommendations.await()
+                    val topGames = games.await()
+                    val trendingGame = topGames.firstOrNull()
+                    val trendingStreams = trendingGame?.let { loadOrEmpty { loadGameStreams(it) } }.orEmpty()
+                    _state.value = DiscoverState(
+                        sections = contentSections(topStreams, recommendedStreams, trendingGame, trendingStreams, topGames),
+                        trendingGame = trendingGame,
+                        hasError = topStreams.isEmpty() && recommendedStreams.isEmpty() && topGames.isEmpty(),
+                    )
+                }
+            } catch (error: CancellationException) {
+                throw error
+            } catch (_: Exception) {
+                _state.value = DiscoverState(sections = emptySections(), hasError = true)
+            }
+        }
+    }
+
+    private suspend fun loadTopStreams(): List<Stream> {
+        val networkLibrary = applicationContext.prefs().getString(C.NETWORK_LIBRARY, C.OKHTTP)
+        return TopStreamsPageLoader(
+            gqlQueryLanguages = null,
+            gqlQuerySort = StreamSort.VIEWER_COUNT,
+            gqlLanguages = null,
+            gqlSort = "VIEWER_COUNT",
+            tags = null,
+            gqlHeaders = { TwitchApiHelper.getGQLHeaders(applicationContext) },
+            graphQLRepository = graphQLRepository,
+            helixHeaders = { TwitchApiHelper.getHelixHeaders(applicationContext) },
+            helixRepository = helixRepository,
+            enableIntegrity = applicationContext.prefs().getBoolean(C.ENABLE_INTEGRITY, false),
+            networkLibrary = networkLibrary,
+            pageSize = STREAM_LIMIT,
+        ).load(null).items
+    }
+
+    private suspend fun loadTopGames(): List<Game> {
+        val networkLibrary = applicationContext.prefs().getString(C.NETWORK_LIBRARY, C.OKHTTP)
+        return try {
+            val response = graphQLRepository.loadQueryTopGames(
+                networkLibrary = networkLibrary,
+                headers = TwitchApiHelper.getGQLHeaders(applicationContext),
+                tags = null,
+                first = CATEGORY_LIMIT,
+                after = null,
+            )
+            if (applicationContext.prefs().getBoolean(C.ENABLE_INTEGRITY, false) &&
+                response.errors?.any { it.message == C.FAILED_INTEGRITY_CHECK } == true
+            ) {
+                throw IllegalStateException(C.FAILED_INTEGRITY_CHECK)
+            }
+            response.data?.games?.edges.orEmpty().mapNotNull { edge ->
+                edge?.node?.let { game ->
+                    Game(
+                        id = game.id,
+                        slug = game.slug,
+                        name = game.displayName,
+                        boxArtURL = game.boxArtURL,
+                        viewerCount = game.viewersCount,
+                        broadcasterCount = game.broadcastersCount,
+                    )
+                }
+            }
+        } catch (error: CancellationException) {
+            throw error
+        } catch (error: Exception) {
+            val headers = TwitchApiHelper.getHelixHeaders(applicationContext)
+            if (headers[C.HEADER_TOKEN].isNullOrBlank()) throw error
+            helixRepository.getTopGames(
+                networkLibrary = networkLibrary,
+                headers = headers,
+                limit = CATEGORY_LIMIT,
+                offset = null,
+            ).data.map { game ->
+                Game(id = game.id, name = game.name, boxArtURL = game.boxArtURL)
+            }
+        }
+    }
+
+    private suspend fun loadGameStreams(game: Game): List<Stream> {
+        val networkLibrary = applicationContext.prefs().getString(C.NETWORK_LIBRARY, C.OKHTTP)
+        return GameStreamsPageLoader(
+            gameId = game.id,
+            gameSlug = game.slug,
+            gameName = game.name,
+            gqlQueryLanguages = null,
+            gqlQuerySort = StreamSort.VIEWER_COUNT,
+            gqlLanguages = null,
+            gqlSort = "VIEWER_COUNT",
+            tags = null,
+            gqlHeaders = { TwitchApiHelper.getGQLHeaders(applicationContext) },
+            graphQLRepository = graphQLRepository,
+            helixHeaders = { TwitchApiHelper.getHelixHeaders(applicationContext) },
+            helixRepository = helixRepository,
+            enableIntegrity = applicationContext.prefs().getBoolean(C.ENABLE_INTEGRITY, false),
+            networkLibrary = networkLibrary,
+            pageSize = STREAM_LIMIT,
+        ).load(null).items
+    }
+
+    private suspend fun <T> loadOrEmpty(request: suspend () -> List<T>): List<T> {
+        return try {
+            request()
+        } catch (error: CancellationException) {
+            throw error
+        } catch (_: Exception) {
+            emptyList()
+        }
+    }
+
+    private fun loadingSections(): List<FollowingOverviewSection> = listOf(
+        section(KEY_BIG_EVENTS, R.string.discover_big_events, isLoading = true),
+        section(KEY_RECOMMENDED, R.string.discover_live_channels, isLoading = true),
+        section(KEY_TRENDING, R.string.discover_trending, isLoading = true),
+        section(KEY_CATEGORIES, R.string.discover_categories, loadingType = FollowingOverviewLoadingType.GAME, isLoading = true),
+    )
+
+    private fun emptySections(): List<FollowingOverviewSection> = listOf(
+        section(KEY_BIG_EVENTS, R.string.discover_big_events),
+        section(KEY_RECOMMENDED, R.string.discover_live_channels),
+        section(KEY_TRENDING, R.string.discover_trending),
+        section(KEY_CATEGORIES, R.string.discover_categories),
+    )
+
+    private fun contentSections(
+        topStreams: List<Stream>,
+        recommendations: List<Stream>,
+        trendingGame: Game?,
+        trendingStreams: List<Stream>,
+        topGames: List<Game>,
+    ): List<FollowingOverviewSection> = listOf(
+        section(KEY_BIG_EVENTS, R.string.discover_big_events, streams = topStreams),
+        section(KEY_RECOMMENDED, R.string.discover_live_channels, streams = recommendations),
+        section(
+            key = KEY_TRENDING,
+            titleRes = R.string.discover_trending,
+            title = trendingGame?.name?.let { applicationContext.getString(R.string.discover_trending_category, it) },
+            streams = trendingStreams,
+        ),
+        section(KEY_CATEGORIES, R.string.discover_categories, games = topGames),
+    )
+
+    private fun section(
+        key: String,
+        titleRes: Int,
+        title: CharSequence? = null,
+        streams: List<Stream> = emptyList(),
+        games: List<Game> = emptyList(),
+        isLoading: Boolean = false,
+        loadingType: FollowingOverviewLoadingType = FollowingOverviewLoadingType.STREAM,
+    ) = FollowingOverviewSection(
+        key = key,
+        titleRes = titleRes,
+        title = title,
+        emptyRes = if (key == KEY_CATEGORIES) R.string.discover_no_categories else R.string.discover_no_live_channels,
+        streams = streams,
+        games = games,
+        isLoading = isLoading,
+        loadingType = loadingType,
+        showSeeAll = key == KEY_TRENDING || key == KEY_CATEGORIES,
+    )
+
+    companion object {
+        const val KEY_BIG_EVENTS = "discover_big_events"
+        const val KEY_RECOMMENDED = "discover_recommended"
+        const val KEY_TRENDING = "discover_trending"
+        const val KEY_CATEGORIES = "discover_categories"
+        private const val STREAM_LIMIT = 12
+        private const val CATEGORY_LIMIT = 12
+
+        val Factory = viewModelFactory {
+            initializer {
+                val app = (this[APPLICATION_KEY] as XtraApp)
+                val module = app.xtraModule
+                DiscoverViewModel(
+                    applicationContext = app.applicationContext,
+                    graphQLRepository = module.graphQLRepository,
+                    helixRepository = module.helixRepository,
+                    recommendationsRepository = module.recommendationsRepository,
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/overview/FollowingOverviewAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/overview/FollowingOverviewAdapter.kt
@@ -9,6 +9,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.github.andreyasadchy.xtra.R
 import com.github.andreyasadchy.xtra.databinding.ItemFollowingSectionBinding
 import com.github.andreyasadchy.xtra.model.VideoHistory
+import com.github.andreyasadchy.xtra.model.ui.Game
 import com.github.andreyasadchy.xtra.model.ui.Stream
 import com.github.andreyasadchy.xtra.model.ui.UpcomingStream
 
@@ -16,10 +17,13 @@ data class FollowingOverviewSection(
     val key: String,
     val titleRes: Int,
     val emptyRes: Int,
+    val title: CharSequence? = null,
     val streams: List<Stream> = emptyList(),
+    val games: List<Game> = emptyList(),
     val videos: List<VideoHistory> = emptyList(),
     val scheduledStreams: List<UpcomingStream> = emptyList(),
     val isLoading: Boolean = false,
+    val loadingType: FollowingOverviewLoadingType = FollowingOverviewLoadingType.STREAM,
     val showSeeAll: Boolean = true,
 )
 
@@ -28,6 +32,7 @@ class FollowingOverviewAdapter(
     private val onVideoClick: (VideoHistory) -> Unit,
     private val onUpcomingClick: (UpcomingStream) -> Unit,
     private val onSeeAll: (String) -> Unit,
+    private val onGameClick: (Game) -> Unit = {},
     private val onStreamShelfAttached: ((String, RecyclerView, (Int) -> Stream?) -> Unit)? = null,
     private val onStreamShelfDetached: ((String) -> Unit)? = null,
     private val onVideoShelfAttached: ((String, RecyclerView, (Int) -> VideoHistory?) -> Unit)? = null,
@@ -37,6 +42,8 @@ class FollowingOverviewAdapter(
     private val recycledViewPool = RecyclerView.RecycledViewPool()
     private val videoRecycledViewPool = RecyclerView.RecycledViewPool()
     private val upcomingRecycledViewPool = RecyclerView.RecycledViewPool()
+    private val gameRecycledViewPool = RecyclerView.RecycledViewPool()
+    private val skeletonRecycledViewPool = RecyclerView.RecycledViewPool()
 
     init {
         setHasStableIds(true)
@@ -64,6 +71,8 @@ class FollowingOverviewAdapter(
         private val shelfAdapter = StreamShelfAdapter(onStreamClick)
         private val videoShelfAdapter = VideoShelfAdapter(onVideoClick)
         private val upcomingShelfAdapter = UpcomingStreamShelfAdapter(onUpcomingClick)
+        private val gameShelfAdapter = GameShelfAdapter(onGameClick)
+        private val skeletonShelfAdapter = ShelfSkeletonAdapter()
         private var shelfType: ShelfType? = null
         private var boundStreamShelfKey: String? = null
         private var boundVideoShelfKey: String? = null
@@ -80,14 +89,17 @@ class FollowingOverviewAdapter(
         }
 
         fun bind(section: FollowingOverviewSection) {
-            binding.sectionTitle.setText(section.titleRes)
-            binding.emptyMessage.setText(if (section.isLoading) R.string.loading else section.emptyRes)
-            val hasItems = section.streams.isNotEmpty() || section.videos.isNotEmpty() || section.scheduledStreams.isNotEmpty()
-            binding.emptyMessage.visibility = if (hasItems) android.view.View.GONE else android.view.View.VISIBLE
-            binding.shelfRecyclerView.visibility = if (hasItems) android.view.View.VISIBLE else android.view.View.GONE
+            section.title?.let { binding.sectionTitle.text = it } ?: binding.sectionTitle.setText(section.titleRes)
+            val hasItems = section.streams.isNotEmpty() || section.games.isNotEmpty() || section.videos.isNotEmpty() || section.scheduledStreams.isNotEmpty()
+            val showSkeleton = section.isLoading && !hasItems
+            binding.emptyMessage.setText(section.emptyRes)
+            binding.emptyMessage.visibility = if (hasItems || showSkeleton) android.view.View.GONE else android.view.View.VISIBLE
+            binding.shelfRecyclerView.visibility = if (hasItems || showSkeleton) android.view.View.VISIBLE else android.view.View.GONE
             binding.seeAll.visibility = if (hasItems && section.showSeeAll) android.view.View.VISIBLE else android.view.View.GONE
             binding.seeAll.setOnClickListener { onSeeAll(section.key) }
             val nextShelfType = when {
+                showSkeleton -> ShelfType.SKELETON
+                section.games.isNotEmpty() -> ShelfType.GAME
                 section.videos.isNotEmpty() -> ShelfType.VIDEO
                 section.scheduledStreams.isNotEmpty() -> ShelfType.UPCOMING
                 else -> ShelfType.STREAM
@@ -101,16 +113,24 @@ class FollowingOverviewAdapter(
             if (shelfType != nextShelfType) {
                 when (nextShelfType) {
                     ShelfType.VIDEO -> {
+                        binding.shelfRecyclerView.swapAdapter(videoShelfAdapter, true)
                         binding.shelfRecyclerView.setRecycledViewPool(videoRecycledViewPool)
-                        binding.shelfRecyclerView.adapter = videoShelfAdapter
                     }
                     ShelfType.UPCOMING -> {
+                        binding.shelfRecyclerView.swapAdapter(upcomingShelfAdapter, true)
                         binding.shelfRecyclerView.setRecycledViewPool(upcomingRecycledViewPool)
-                        binding.shelfRecyclerView.adapter = upcomingShelfAdapter
+                    }
+                    ShelfType.GAME -> {
+                        binding.shelfRecyclerView.swapAdapter(gameShelfAdapter, true)
+                        binding.shelfRecyclerView.setRecycledViewPool(gameRecycledViewPool)
+                    }
+                    ShelfType.SKELETON -> {
+                        binding.shelfRecyclerView.swapAdapter(skeletonShelfAdapter, true)
+                        binding.shelfRecyclerView.setRecycledViewPool(skeletonRecycledViewPool)
                     }
                     ShelfType.STREAM -> {
+                        binding.shelfRecyclerView.swapAdapter(shelfAdapter, true)
                         binding.shelfRecyclerView.setRecycledViewPool(recycledViewPool)
-                        binding.shelfRecyclerView.adapter = shelfAdapter
                     }
                 }
                 shelfType = nextShelfType
@@ -127,6 +147,8 @@ class FollowingOverviewAdapter(
                     }
                 }
                 ShelfType.UPCOMING -> upcomingShelfAdapter.submitList(section.scheduledStreams)
+                ShelfType.GAME -> gameShelfAdapter.submitList(section.games)
+                ShelfType.SKELETON -> skeletonShelfAdapter.setLoadingType(section.loadingType)
                 ShelfType.STREAM -> {
                     shelfAdapter.submitList(section.streams)
                     if (hasItems && boundStreamShelfKey != section.key) {
@@ -151,7 +173,7 @@ class FollowingOverviewAdapter(
         }
     }
 
-    private enum class ShelfType { STREAM, VIDEO, UPCOMING }
+    private enum class ShelfType { STREAM, VIDEO, UPCOMING, GAME, SKELETON }
 
     private companion object {
         val DIFF_CALLBACK = object : DiffUtil.ItemCallback<FollowingOverviewSection>() {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/overview/FollowingOverviewFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/overview/FollowingOverviewFragment.kt
@@ -201,12 +201,14 @@ class FollowingOverviewFragment : BaseNetworkFragment(), Scrollable {
                             titleRes = R.string.following_continue_watching,
                             emptyRes = R.string.following_no_continue_watching,
                             videos = continueWatching,
+                            loadingType = FollowingOverviewLoadingType.VIDEO,
                         ),
                         FollowingOverviewSections.UPCOMING to FollowingOverviewSection(
                             key = FollowingOverviewSections.UPCOMING,
                             titleRes = R.string.following_upcoming_streams,
                             emptyRes = R.string.following_no_upcoming_streams,
                             showSeeAll = false,
+                            loadingType = FollowingOverviewLoadingType.UPCOMING,
                         ),
                     )
                     sectionKeys.mapNotNull(availableSections::get)

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/overview/GameShelfAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/overview/GameShelfAdapter.kt
@@ -1,0 +1,112 @@
+package com.github.andreyasadchy.xtra.ui.following.overview
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import coil3.imageLoader
+import coil3.request.ImageRequest
+import coil3.request.crossfade
+import coil3.request.target
+import com.github.andreyasadchy.xtra.R
+import com.github.andreyasadchy.xtra.databinding.ItemGameShelfBinding
+import com.github.andreyasadchy.xtra.model.ui.Game
+import com.github.andreyasadchy.xtra.util.C
+import com.github.andreyasadchy.xtra.util.TwitchApiHelper
+import com.github.andreyasadchy.xtra.util.prefs
+
+class GameShelfAdapter(
+    private val onGameClick: (Game) -> Unit,
+) : ListAdapter<Game, GameShelfAdapter.ViewHolder>(DIFF_CALLBACK) {
+
+    init {
+        setHasStableIds(true)
+    }
+
+    override fun getItemId(position: Int): Long = getItem(position).id.hashCode().toLong()
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+        val binding = ItemGameShelfBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        (parent as? RecyclerView)?.let { ShelfCardSizing.apply(binding.root, it) }
+        return ViewHolder(binding)
+    }
+
+    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        (holder.itemView.parent as? RecyclerView)?.let { ShelfCardSizing.apply(holder.itemView, it) }
+        holder.itemView.post {
+            (holder.itemView.parent as? RecyclerView)?.let { ShelfCardSizing.apply(holder.itemView, it) }
+        }
+        holder.bind(getItem(position))
+    }
+
+    private val layoutChangeListener = View.OnLayoutChangeListener { view, left, _, right, _, oldLeft, _, oldRight, _ ->
+        if (right - left != oldRight - oldLeft) {
+            val shelf = view as RecyclerView
+            shelf.post { applyCardSizing(shelf) }
+        }
+    }
+
+    private fun applyCardSizing(shelf: RecyclerView) {
+        repeat(shelf.childCount) { index -> ShelfCardSizing.apply(shelf.getChildAt(index), shelf) }
+    }
+
+    override fun onAttachedToRecyclerView(recyclerView: RecyclerView) {
+        super.onAttachedToRecyclerView(recyclerView)
+        recyclerView.addOnLayoutChangeListener(layoutChangeListener)
+        recyclerView.post { applyCardSizing(recyclerView) }
+    }
+
+    override fun onDetachedFromRecyclerView(recyclerView: RecyclerView) {
+        recyclerView.removeOnLayoutChangeListener(layoutChangeListener)
+        super.onDetachedFromRecyclerView(recyclerView)
+    }
+
+    inner class ViewHolder(
+        private val binding: ItemGameShelfBinding,
+    ) : RecyclerView.ViewHolder(binding.root) {
+
+        fun bind(game: Game) {
+            val context = binding.root.context
+            binding.root.setOnClickListener { onGameClick(game) }
+            binding.gameName.text = game.name.orEmpty()
+            binding.gameName.visibility = if (game.name.isNullOrBlank()) View.GONE else View.VISIBLE
+            val viewerCount = game.viewerCount
+            binding.viewers.text = viewerCount?.let {
+                context.resources.getQuantityString(
+                    R.plurals.viewers,
+                    it,
+                    TwitchApiHelper.formatCount(
+                        it,
+                        context.prefs().getBoolean(C.UI_TRUNCATE_VIEW_COUNT, true),
+                    ),
+                )
+            }.orEmpty()
+            binding.viewers.visibility = if (binding.viewers.text.isNullOrBlank()) View.GONE else View.VISIBLE
+            val imageUrl = game.boxArt
+            binding.gameImage.contentDescription = game.name
+            if (imageUrl.isNullOrBlank()) {
+                binding.gameImage.visibility = View.INVISIBLE
+                binding.gameImage.setImageDrawable(null)
+            } else {
+                binding.gameImage.visibility = View.VISIBLE
+                context.imageLoader.enqueue(
+                    ImageRequest.Builder(context)
+                        .data(imageUrl)
+                        .crossfade(true)
+                        .target(binding.gameImage)
+                        .build(),
+                )
+            }
+        }
+    }
+
+    private companion object {
+        val DIFF_CALLBACK = object : DiffUtil.ItemCallback<Game>() {
+            override fun areItemsTheSame(oldItem: Game, newItem: Game): Boolean = oldItem.id == newItem.id
+            override fun areContentsTheSame(oldItem: Game, newItem: Game): Boolean =
+                oldItem.name == newItem.name && oldItem.boxArtURL == newItem.boxArtURL && oldItem.viewerCount == newItem.viewerCount
+        }
+    }
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/overview/ShelfSkeletonAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/overview/ShelfSkeletonAdapter.kt
@@ -1,0 +1,53 @@
+package com.github.andreyasadchy.xtra.ui.following.overview
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.constraintlayout.widget.ConstraintLayout
+import androidx.recyclerview.widget.RecyclerView
+import com.github.andreyasadchy.xtra.databinding.ItemShelfSkeletonBinding
+
+enum class FollowingOverviewLoadingType {
+    STREAM,
+    VIDEO,
+    UPCOMING,
+    GAME,
+}
+
+class ShelfSkeletonAdapter(
+    private val skeletonCount: Int = 6,
+) : RecyclerView.Adapter<ShelfSkeletonAdapter.ViewHolder>() {
+
+    private var loadingType = FollowingOverviewLoadingType.STREAM
+
+    override fun getItemCount(): Int = skeletonCount
+
+    fun setLoadingType(type: FollowingOverviewLoadingType) {
+        if (loadingType == type) return
+        loadingType = type
+        notifyItemRangeChanged(0, itemCount)
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+        val binding = ItemShelfSkeletonBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        (parent as? RecyclerView)?.let { ShelfCardSizing.apply(binding.root, it) }
+        return ViewHolder(binding)
+    }
+
+    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        (holder.itemView.parent as? RecyclerView)?.let { ShelfCardSizing.apply(holder.itemView, it) }
+        holder.bind(loadingType)
+    }
+
+    class ViewHolder(
+        private val binding: ItemShelfSkeletonBinding,
+    ) : RecyclerView.ViewHolder(binding.root) {
+
+        fun bind(type: FollowingOverviewLoadingType) {
+            val thumbnailParams = binding.thumbnail.layoutParams as ConstraintLayout.LayoutParams
+            thumbnailParams.dimensionRatio = if (type == FollowingOverviewLoadingType.GAME) "H,3:4" else "H,16:9"
+            binding.thumbnail.layoutParams = thumbnailParams
+            binding.tertiary.visibility = if (type == FollowingOverviewLoadingType.GAME) View.GONE else View.VISIBLE
+        }
+    }
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/main/MainActivity.kt
@@ -1322,6 +1322,7 @@ class MainActivity : AppCompatActivity() {
             when {
                 defaultItem == "2" -> it.setStartDestination(R.id.followPagerFragment)
                 defaultItem == "0" -> it.setStartDestination(R.id.rootGamesFragment)
+                defaultItem == "4" -> it.setStartDestination(R.id.rootDiscoverFragment)
                 defaultItem == "3" -> it.setStartDestination(R.id.savedPagerFragment)
             }
         }, null)
@@ -1334,6 +1335,7 @@ class MainActivity : AppCompatActivity() {
                     if (enabled) {
                         when (key) {
                             "0" -> menu.add(Menu.NONE, R.id.rootGamesFragment, Menu.NONE, R.string.browse).setIcon(R.drawable.ic_games_black_24dp)
+                            "4" -> menu.add(Menu.NONE, R.id.rootDiscoverFragment, Menu.NONE, R.string.discover).setIcon(R.drawable.ic_explore)
                             "1" -> menu.add(Menu.NONE, R.id.rootTopFragment, Menu.NONE, R.string.following_overview).setIcon(R.drawable.baseline_home_black_24)
                             "2" -> {
                                 menu.add(Menu.NONE, R.id.followPagerFragment, Menu.NONE, R.string.following).setIcon(R.drawable.ic_favorite_black_24dp)

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/settings/SettingsActivity.kt
@@ -321,7 +321,7 @@ class SettingsActivity : AppCompatActivity() {
             else -> C.DEFAULT_SEARCH_TABS
         }
         val labels = when (prefKey) {
-            C.UI_NAVIGATION_TAB_LIST -> mapOf("0" to getString(R.string.browse), "1" to getString(R.string.following_overview), "2" to getString(R.string.following), "3" to getString(R.string.saved))
+            C.UI_NAVIGATION_TAB_LIST -> mapOf("0" to getString(R.string.browse), "4" to getString(R.string.discover), "1" to getString(R.string.following_overview), "2" to getString(R.string.following), "3" to getString(R.string.saved))
             C.UI_FOLLOWING_TABS -> FollowingTabs.definitions.associate { it.key to getString(it.titleRes) }
             C.UI_SAVED_TABS -> mapOf("0" to getString(R.string.bookmarks), "1" to getString(R.string.downloads), "2" to getString(R.string.filters), "3" to getString(R.string.clips))
             C.UI_CHANNEL_TABS -> mapOf("0" to getString(R.string.suggestions), "1" to getString(R.string.videos), "2" to getString(R.string.clips), "3" to getString(R.string.chat), "4" to getString(R.string.about))
@@ -1872,6 +1872,7 @@ class SettingsActivity : AppCompatActivity() {
                         key = split[0],
                         text = when (split[0]) {
                             "0" -> getString(R.string.browse)
+                            "4" -> getString(R.string.discover)
                             "1" -> getString(R.string.following_overview)
                             "2" -> getString(R.string.following)
                             "3" -> getString(R.string.saved)

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/top/TopStreamsFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/top/TopStreamsFragment.kt
@@ -38,7 +38,6 @@ import com.github.andreyasadchy.xtra.ui.common.StreamsSortDialog.Companion.SORT_
 import com.github.andreyasadchy.xtra.ui.common.StreamsSortDialog.Companion.SORT_VIEWERS_ASC
 import com.github.andreyasadchy.xtra.ui.common.StreamFeedScreenController
 import com.github.andreyasadchy.xtra.ui.common.StreamPreloadViewportController
-import com.github.andreyasadchy.xtra.ui.game.GamePagerFragmentArgs
 import com.github.andreyasadchy.xtra.ui.login.LoginActivity
 import com.github.andreyasadchy.xtra.ui.main.MainActivity
 import com.github.andreyasadchy.xtra.ui.search.SearchPagerFragmentDirections
@@ -59,7 +58,7 @@ class TopStreamsFragment : PagedListFragment(), Scrollable, StreamsSortDialog.On
 
     private var _binding: FragmentGamesBinding? = null
     private val binding get() = _binding!!
-    private val args: GamePagerFragmentArgs by navArgs()
+    private val args: TopStreamsFragmentArgs by navArgs()
     private val viewModel: TopStreamsViewModel by viewModels { TopStreamsViewModelFactory }
     private lateinit var pagingAdapter: PagingDataAdapter<Stream, out RecyclerView.ViewHolder>
     private lateinit var streamFeedScreenController: StreamFeedScreenController

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/C.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/C.kt
@@ -286,7 +286,7 @@ object C {
     const val TOKEN_SUPPORTED_CODECS = "token_supported_codecs"
     const val TOKEN_SKIP_VIDEO_ACCESS_TOKEN = "token_skip_video_access_token"
     const val TOKEN_SKIP_CLIP_ACCESS_TOKEN = "token_skip_clip_access_token"
-    const val DEFAULT_NAVIGATION_TAB_LIST = "1:1:1,2:0:1,0:0:1,3:0:1"
+    const val DEFAULT_NAVIGATION_TAB_LIST = "0:0:1,4:0:1,1:1:1,2:0:1,3:0:1"
     const val DEFAULT_FOLLOWING_TABS = "1:1:1,2:0:1,0:0:1"
     const val DEFAULT_FOLLOWING_OVERVIEW_SECTIONS = "live:0:1,recommended:0:1,continue:0:1,upcoming:0:1"
     const val DEFAULT_SAVED_TABS = "0:1:1,1:0:1,2:0:1,3:0:1"

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/SettingsMigration.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/SettingsMigration.kt
@@ -595,6 +595,7 @@ object SettingsMigration {
 
     private fun navigationTabsWithDefault(defaultTab: String): String =
         "0:${if (defaultTab == "0") "1" else "0"}:1," +
+            "4:${if (defaultTab == "4") "1" else "0"}:1," +
             "1:${if (defaultTab == "1") "1" else "0"}:1," +
             "2:${if (defaultTab == "2") "1" else "0"}:1," +
             "3:${if (defaultTab == "3") "1" else "0"}:1"

--- a/app/src/main/res/drawable/bg_skeleton_bar.xml
+++ b/app/src/main/res/drawable/bg_skeleton_bar.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <corners android:radius="4dp" />
+    <solid android:color="?attr/colorSurfaceContainerHighest" />
+</shape>

--- a/app/src/main/res/drawable/bg_skeleton_placeholder.xml
+++ b/app/src/main/res/drawable/bg_skeleton_placeholder.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="?attr/colorSurfaceContainerHighest" />
+</shape>

--- a/app/src/main/res/drawable/ic_explore.xml
+++ b/app/src/main/res/drawable/ic_explore.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM12,20c-4.41,0 -8,-3.59 -8,-8s3.59,-8 8,-8 8,3.59 8,8 -3.59,8 -8,8zM15.5,8.5l-2.12,4.88L8.5,15.5l2.12,-4.88L15.5,8.5zM12,13.1c0.61,0 1.1,-0.49 1.1,-1.1s-0.49,-1.1 -1.1,-1.1 -1.1,0.49 -1.1,1.1 0.49,1.1 1.1,1.1z" />
+</vector>

--- a/app/src/main/res/layout/fragment_discover.xml
+++ b/app/src/main/res/layout/fragment_discover.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/coordinatorLayout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/appBar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:liftOnScrollTargetViewId="@id/recyclerView">
+
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:minHeight="?attr/actionBarSize"
+            app:layout_scrollFlags="scroll|enterAlways"
+            app:menu="@menu/top_menu" />
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <FrameLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior">
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/recyclerView"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:clipToPadding="false"
+            android:overScrollMode="never"
+            android:paddingTop="4dp" />
+
+        <TextView
+            android:id="@+id/emptyState"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:gravity="center"
+            android:padding="32dp"
+            android:text="@string/discover_no_content"
+            android:textAppearance="?attr/textAppearanceBodyLarge"
+            android:textColor="?android:attr/textColorSecondary"
+            android:visibility="gone" />
+    </FrameLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/item_game_shelf.xml
+++ b/app/src/main/res/layout/item_game_shelf.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginEnd="8dp"
+    android:background="?android:attr/colorBackground"
+    android:clickable="true"
+    android:focusable="true"
+    android:foreground="?attr/selectableItemBackground"
+    android:orientation="vertical"
+    android:paddingBottom="8dp">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <ImageView
+            android:id="@+id/gameImage"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:background="@drawable/bg_thumbnail_placeholder"
+            android:clipToOutline="true"
+            android:importantForAccessibility="no"
+            android:scaleType="centerCrop"
+            app:layout_constraintDimensionRatio="H,3:4"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:src="@tools:sample/backgrounds/scenic" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <TextView
+        android:id="@+id/gameName"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:ellipsize="end"
+        android:maxLines="2"
+        android:textAppearance="?attr/textAppearanceTitleMedium"
+        android:textStyle="bold"
+        tools:text="League of Legends" />
+
+    <TextView
+        android:id="@+id/viewers"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:ellipsize="end"
+        android:maxLines="1"
+        android:textAppearance="?attr/textAppearanceBodySmall"
+        android:textColor="?android:attr/textColorSecondary"
+        tools:text="1.2M viewers" />
+</LinearLayout>

--- a/app/src/main/res/layout/item_shelf_skeleton.xml
+++ b/app/src/main/res/layout/item_shelf_skeleton.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginEnd="8dp"
+    android:importantForAccessibility="no"
+    android:orientation="vertical"
+    android:paddingBottom="8dp">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <View
+            android:id="@+id/thumbnail"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:background="@drawable/bg_skeleton_placeholder"
+            app:layout_constraintDimensionRatio="H,16:9"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <View
+        android:id="@+id/primary"
+        android:layout_width="match_parent"
+        android:layout_height="16dp"
+        android:layout_marginTop="10dp"
+        android:layout_marginEnd="24dp"
+        android:background="@drawable/bg_skeleton_bar" />
+
+    <View
+        android:id="@+id/secondary"
+        android:layout_width="match_parent"
+        android:layout_height="12dp"
+        android:layout_marginTop="7dp"
+        android:layout_marginEnd="72dp"
+        android:background="@drawable/bg_skeleton_bar" />
+
+    <View
+        android:id="@+id/tertiary"
+        android:layout_width="match_parent"
+        android:layout_height="12dp"
+        android:layout_marginTop="7dp"
+        android:layout_marginEnd="112dp"
+        android:background="@drawable/bg_skeleton_bar" />
+</LinearLayout>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -10,6 +10,11 @@
         android:label="@string/browse">
     </fragment>
     <fragment
+        android:id="@+id/rootDiscoverFragment"
+        android:name="com.github.andreyasadchy.xtra.ui.discover.DiscoverFragment"
+        android:label="@string/discover">
+    </fragment>
+    <fragment
         android:id="@+id/rootTopFragment"
         android:name="com.github.andreyasadchy.xtra.ui.overview.OverviewFragment"
         android:label="@string/following_overview">

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -1,5 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="discover">استكشاف</string>
+    <string name="discover_big_events">الأحداث الكبيرة الآن</string>
+    <string name="discover_live_channels">قنوات مباشرة قد تعجبك</string>
+    <string name="discover_trending">الرائج على Twitch</string>
+    <string name="discover_trending_category">الرائج على Twitch: %1$s</string>
+    <string name="discover_categories">الفئات الشائعة</string>
+    <string name="discover_no_live_channels">لا يوجد بث مباشر هنا الآن.</string>
+    <string name="discover_no_categories">تعذر تحميل الفئات من Twitch الآن.</string>
+    <string name="discover_no_content">تعذر تحميل أي محتوى للاستكشاف الآن. حاول مرة أخرى لاحقًا.</string>
     <string name="games">الألعاب</string>
     <string name="popular">الأكثر شعبية</string>
     <string name="following">المُتابَعين</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -1,5 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="discover">Objevování</string>
+    <string name="discover_big_events">Velké události právě teď</string>
+    <string name="discover_live_channels">Živé kanály, které by se vám mohly líbit</string>
+    <string name="discover_trending">Trendy na Twitchi</string>
+    <string name="discover_trending_category">Trendy na Twitchi: %1$s</string>
+    <string name="discover_categories">Oblíbené kategorie</string>
+    <string name="discover_no_live_channels">Právě tu nic nevysílá.</string>
+    <string name="discover_no_categories">Twitch teď nemohl načíst kategorie.</string>
+    <string name="discover_no_content">Objevování teď nemohlo načíst žádný obsah. Zkuste to později.</string>
     <string name="app_name" translatable="false">Xtra</string>
     <string name="notification_downloads_channel_id" translatable="false">xtra_downloads_channel</string>
     <string name="notification_live_channel_id" translatable="false">xtra_live_channel</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1,5 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="discover">Entdecken</string>
+    <string name="discover_big_events">Große Events gerade jetzt</string>
+    <string name="discover_live_channels">Live-Kanäle, die dir gefallen könnten</string>
+    <string name="discover_trending">Auf Twitch im Trend</string>
+    <string name="discover_trending_category">Auf Twitch im Trend: %1$s</string>
+    <string name="discover_categories">Beliebte Kategorien</string>
+    <string name="discover_no_live_channels">Hier ist gerade nichts live.</string>
+    <string name="discover_no_categories">Twitch konnte die Kategorien gerade nicht laden.</string>
+    <string name="discover_no_content">Entdecken konnte gerade keine Inhalte laden. Versuche es später erneut.</string>
     <string name="games">Spiele</string>
     <string name="popular">Beliebt</string>
     <string name="following">Folgen</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -5,6 +5,15 @@
   - Traducir "buffer" como "búfer".
 -->
 <resources>
+    <string name="discover">Descubrir</string>
+    <string name="discover_big_events">Grandes eventos ahora mismo</string>
+    <string name="discover_live_channels">Canales en directo que podrían gustarte</string>
+    <string name="discover_trending">En tendencia en Twitch</string>
+    <string name="discover_trending_category">En tendencia en Twitch: %1$s</string>
+    <string name="discover_categories">Categorías populares</string>
+    <string name="discover_no_live_channels">No hay nada en directo ahora mismo.</string>
+    <string name="discover_no_categories">Twitch no ha podido cargar las categorías ahora mismo.</string>
+    <string name="discover_no_content">Descubrir no ha podido cargar contenido ahora mismo. Inténtalo de nuevo más tarde.</string>
     <string name="games">Juegos</string>
     <string name="popular">Popular</string>
     <string name="following">Siguiendo</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1,5 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="discover">Découvrir</string>
+    <string name="discover_big_events">Grands événements en ce moment</string>
+    <string name="discover_live_channels">Chaînes en direct susceptibles de vous plaire</string>
+    <string name="discover_trending">Tendances sur Twitch</string>
+    <string name="discover_trending_category">Tendances sur Twitch : %1$s</string>
+    <string name="discover_categories">Catégories populaires</string>
+    <string name="discover_no_live_channels">Rien n’est en direct pour le moment.</string>
+    <string name="discover_no_categories">Twitch n’a pas pu charger les catégories pour le moment.</string>
+    <string name="discover_no_content">Impossible de charger du contenu à découvrir pour le moment. Réessayez plus tard.</string>
     <string name="games">Jeux</string>
     <string name="popular">Populaire</string>
     <string name="following">Suivi</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -1,5 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="discover">Descubrir</string>
+    <string name="discover_big_events">Grandes eventos agora</string>
+    <string name="discover_live_channels">Canles en directo que che poden gustar</string>
+    <string name="discover_trending">Tendencias en Twitch</string>
+    <string name="discover_trending_category">Tendencias en Twitch: %1$s</string>
+    <string name="discover_categories">Categorías populares</string>
+    <string name="discover_no_live_channels">Agora mesmo non hai nada en directo.</string>
+    <string name="discover_no_categories">Twitch non puido cargar as categorías agora.</string>
+    <string name="discover_no_content">Descubrir non puido cargar contido agora. Téntao de novo máis tarde.</string>
     <string name="games">Xogos</string>
     <string name="popular">Popular</string>
     <string name="following">Seguindo</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -1,5 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="discover">Temukan</string>
+    <string name="discover_big_events">Acara besar saat ini</string>
+    <string name="discover_live_channels">Saluran live yang mungkin Anda sukai</string>
+    <string name="discover_trending">Sedang tren di Twitch</string>
+    <string name="discover_trending_category">Sedang tren di Twitch: %1$s</string>
+    <string name="discover_categories">Kategori populer</string>
+    <string name="discover_no_live_channels">Tidak ada siaran live saat ini.</string>
+    <string name="discover_no_categories">Twitch tidak dapat memuat kategori saat ini.</string>
+    <string name="discover_no_content">Temukan tidak dapat memuat konten saat ini. Coba lagi nanti.</string>
     <string name="games">Game</string>
     <string name="popular">Populer</string>
     <string name="following">Mengikuti</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1,5 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="discover">Scopri</string>
+    <string name="discover_big_events">Grandi eventi in corso</string>
+    <string name="discover_live_channels">Canali live che potrebbero piacerti</string>
+    <string name="discover_trending">Di tendenza su Twitch</string>
+    <string name="discover_trending_category">Di tendenza su Twitch: %1$s</string>
+    <string name="discover_categories">Categorie popolari</string>
+    <string name="discover_no_live_channels">Al momento non c’è nulla di live.</string>
+    <string name="discover_no_categories">Twitch non ha potuto caricare le categorie.</string>
+    <string name="discover_no_content">Non è stato possibile caricare contenuti da scoprire. Riprova più tardi.</string>
     <string name="games">Giochi</string>
     <string name="popular">Popolari</string>
     <string name="following">Seguiti</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1,5 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="discover">見つける</string>
+    <string name="discover_big_events">今注目の大きなイベント</string>
+    <string name="discover_live_channels">おすすめのライブチャンネル</string>
+    <string name="discover_trending">Twitchでトレンド</string>
+    <string name="discover_trending_category">Twitchでトレンド: %1$s</string>
+    <string name="discover_categories">人気のカテゴリー</string>
+    <string name="discover_no_live_channels">現在ライブ配信はありません。</string>
+    <string name="discover_no_categories">Twitchからカテゴリーを読み込めませんでした。</string>
+    <string name="discover_no_content">コンテンツを読み込めませんでした。後でもう一度お試しください。</string>
     <string name="games">ゲーム</string>
     <string name="popular">人気</string>
     <string name="following">フォロー中</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -1,5 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="discover">Odkrywaj</string>
+    <string name="discover_big_events">Najważniejsze wydarzenia teraz</string>
+    <string name="discover_live_channels">Polecane kanały na żywo</string>
+    <string name="discover_trending">Na topie na Twitchu</string>
+    <string name="discover_trending_category">Na topie na Twitchu: %1$s</string>
+    <string name="discover_categories">Popularne kategorie</string>
+    <string name="discover_no_live_channels">Nic nie jest teraz transmitowane na żywo.</string>
+    <string name="discover_no_categories">Nie udało się teraz wczytać kategorii z Twitcha.</string>
+    <string name="discover_no_content">Nie udało się teraz wczytać treści do odkrywania. Spróbuj ponownie później.</string>
     <string name="games">Gry</string>
     <string name="popular">Popularne</string>
     <string name="home">Strona główna</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -1,5 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="discover">Descobrir</string>
+    <string name="discover_big_events">Grandes eventos agora</string>
+    <string name="discover_live_channels">Canais ao vivo que você pode gostar</string>
+    <string name="discover_trending">Em alta na Twitch</string>
+    <string name="discover_trending_category">Em alta na Twitch: %1$s</string>
+    <string name="discover_categories">Categorias populares</string>
+    <string name="discover_no_live_channels">Nada está ao vivo no momento.</string>
+    <string name="discover_no_categories">Não foi possível carregar as categorias da Twitch agora.</string>
+    <string name="discover_no_content">Não foi possível carregar conteúdo para descobrir agora. Tente novamente mais tarde.</string>
     <string name="games">Jogos</string>
     <string name="popular">Populares</string>
     <string name="following">Seguindo</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1,5 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="discover">Открывай</string>
+    <string name="discover_big_events">Большие события прямо сейчас</string>
+    <string name="discover_live_channels">Прямые каналы, которые могут вам понравиться</string>
+    <string name="discover_trending">В тренде на Twitch</string>
+    <string name="discover_trending_category">В тренде на Twitch: %1$s</string>
+    <string name="discover_categories">Популярные категории</string>
+    <string name="discover_no_live_channels">Сейчас здесь нет прямых трансляций.</string>
+    <string name="discover_no_categories">Не удалось загрузить категории Twitch.</string>
+    <string name="discover_no_content">Не удалось загрузить контент для поиска. Повторите попытку позже.</string>
     <string name="games">Игры</string>
     <string name="popular">Популярное</string>
     <string name="following">Отслеживания</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -1,5 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="discover">Objavovať</string>
+    <string name="discover_big_events">Veľké udalosti práve teraz</string>
+    <string name="discover_live_channels">Živé kanály, ktoré by sa vám mohli páčiť</string>
+    <string name="discover_trending">Trendy na Twitchi</string>
+    <string name="discover_trending_category">Trendy na Twitchi: %1$s</string>
+    <string name="discover_categories">Populárne kategórie</string>
+    <string name="discover_no_live_channels">Momentálne tu nič nevysiela naživo.</string>
+    <string name="discover_no_categories">Kategórie sa teraz z Twitchu nepodarilo načítať.</string>
+    <string name="discover_no_content">Obsah na objavovanie sa teraz nepodarilo načítať. Skúste to znova neskôr.</string>
     <string name="app_name" translatable="false">Xtra</string>
     <string name="notification_downloads_channel_id" translatable="false">xtra_downloads_channel</string>
     <string name="notification_live_channel_id" translatable="false">xtra_live_channel</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -1,6 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Turkish -->
 <resources>
+    <string name="discover">Keşfet</string>
+    <string name="discover_big_events">Şu anda öne çıkan etkinlikler</string>
+    <string name="discover_live_channels">Beğenebileceğiniz canlı kanallar</string>
+    <string name="discover_trending">Twitch\'te gündemde</string>
+    <string name="discover_trending_category">Twitch\'te gündemde: %1$s</string>
+    <string name="discover_categories">Popüler kategoriler</string>
+    <string name="discover_no_live_channels">Şu anda burada canlı yayın yok.</string>
+    <string name="discover_no_categories">Twitch kategorileri şu anda yüklenemedi.</string>
+    <string name="discover_no_content">Keşfet içeriği şu anda yüklenemedi. Daha sonra tekrar deneyin.</string>
     <string name="games">Oyunlar</string>
     <string name="popular">Popüler</string>
     <string name="following">Takip Edilenler</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1,5 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="discover">发现</string>
+    <string name="discover_big_events">当前热门大事件</string>
+    <string name="discover_live_channels">你可能喜欢的直播频道</string>
+    <string name="discover_trending">Twitch 热门趋势</string>
+    <string name="discover_trending_category">Twitch 热门趋势：%1$s</string>
+    <string name="discover_categories">热门分类</string>
+    <string name="discover_no_live_channels">目前没有直播内容。</string>
+    <string name="discover_no_categories">目前无法加载 Twitch 分类。</string>
+    <string name="discover_no_content">目前无法加载发现内容，请稍后重试。</string>
     <string name="games">游戏</string>
     <string name="popular">热门</string>
     <string name="following">关注</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -1,5 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="discover">探索</string>
+    <string name="discover_big_events">目前的大型活動</string>
+    <string name="discover_live_channels">你可能會喜歡的直播頻道</string>
+    <string name="discover_trending">Twitch 熱門趨勢</string>
+    <string name="discover_trending_category">Twitch 熱門趨勢：%1$s</string>
+    <string name="discover_categories">熱門分類</string>
+    <string name="discover_no_live_channels">目前沒有直播內容。</string>
+    <string name="discover_no_categories">目前無法載入 Twitch 分類。</string>
+    <string name="discover_no_content">目前無法載入探索內容，請稍後再試。</string>
     <string name="games">遊戲</string>
     <string name="popular">熱門</string>
     <string name="following">追隨中</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -25,6 +25,15 @@
     <string name="popular">Popular</string>
     <string name="home">Home</string>
     <string name="browse">Browse</string>
+    <string name="discover">Discover</string>
+    <string name="discover_big_events">Big events right now</string>
+    <string name="discover_live_channels">Live channels we think you’ll like</string>
+    <string name="discover_trending">Trending on Twitch</string>
+    <string name="discover_trending_category">Trending on Twitch: %1$s</string>
+    <string name="discover_categories">Popular categories</string>
+    <string name="discover_no_live_channels">Nothing is live here right now.</string>
+    <string name="discover_no_categories">Twitch could not load categories right now.</string>
+    <string name="discover_no_content">Discover could not load anything right now. Try again later.</string>
     <string name="following">Following</string>
     <string name="following_overview">Overview</string>
     <string name="following_categories">Categories</string>

--- a/app/src/test/java/com/github/andreyasadchy/xtra/repository/auth/AuthCoordinatorTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/repository/auth/AuthCoordinatorTest.kt
@@ -99,16 +99,12 @@ class AuthCoordinatorTest {
     }
 
     @Test
-    fun `successful pair commit writes both grants before revoking the old pair`() {
+    fun `successful pair commit writes both grants without revoking the old pair`() {
         val (store, tokenPreferences) = seededStore()
         val repository = FakeAuthOperations(
             officialValidation = ValidationResponse("new-helix", userId = "new-user", scopes = HELIX_SCOPES),
             compatibilityValidation = ValidationResponse("new-gql-client", userId = "new-user", scopes = GQL_SCOPES),
         )
-        repository.onRevoke = { _, _ ->
-            assertEquals("new-access", store.read()?.accessToken)
-            assertEquals("new-gql", tokenPreferences.getString(C.GQL_TOKEN2, null))
-        }
         val coordinator = AuthCoordinator(repository, store, nowMillis = { 1_000L })
 
         val result = runBlocking {
@@ -125,10 +121,7 @@ class AuthCoordinatorTest {
         assertEquals("new-access", store.read()?.accessToken)
         assertEquals("new-user", store.read()?.userId)
         assertEquals("new-gql", tokenPreferences.getString(C.GQL_TOKEN2, null))
-        assertEquals(
-            listOf("old-access", "old-gql"),
-            repository.revoked.map { it.second },
-        )
+        assertTrue(repository.revoked.isEmpty())
     }
 
     @Test
@@ -157,7 +150,7 @@ class AuthCoordinatorTest {
         assertFalse(result.accountChanged)
         assertEquals("replacement-access", store.read()?.accessToken)
         assertEquals("replacement-gql", tokenPreferences.getString(C.GQL_TOKEN2, null))
-        assertEquals(listOf("old-access", "old-gql"), repository.revoked.map { it.second })
+        assertTrue(repository.revoked.isEmpty())
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Add a Discover page with big live events, recommended channels, a trending category, and popular categories.
- Keep previous Twitch authorizations when signing in again.

## Verification

- Built the debug app and checked the page on the Android emulator with live Twitch data.