### PR TITLE
Rename the category list

### DIFF
--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -22,7 +22,7 @@
     <fragment
         android:id="@+id/gamesFragment"
         android:name="com.github.andreyasadchy.xtra.ui.games.GamesFragment"
-        android:label="@string/games">
+        android:label="@string/following_categories">
         <argument
             android:name="tags"
             app:argType="com.github.andreyasadchy.xtra.model.ui.Tag[]"


### PR DESCRIPTION
The Popular categories destination is now titled Categories, matching entries such as Just Chatting and IRL.