### PR TITLE
Add visual control layout editor

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/settings/PlayerControlLayoutEditor.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/settings/PlayerControlLayoutEditor.kt
@@ -1,0 +1,559 @@
+package com.github.andreyasadchy.xtra.ui.settings
+
+import android.content.Context
+import android.content.res.ColorStateList
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
+import android.graphics.PointF
+import android.graphics.Typeface
+import android.graphics.drawable.GradientDrawable
+import android.view.Gravity
+import android.view.MotionEvent
+import android.view.View
+import android.view.ViewConfiguration
+import android.view.ViewGroup
+import android.widget.FrameLayout
+import android.widget.HorizontalScrollView
+import android.widget.ImageButton
+import android.widget.ImageView
+import android.widget.LinearLayout
+import android.widget.TextView
+import androidx.core.content.ContextCompat
+import androidx.core.widget.NestedScrollView
+import com.google.android.material.button.MaterialButton
+import com.github.andreyasadchy.xtra.R
+import com.github.andreyasadchy.xtra.util.PlayerControlLayout
+import kotlin.math.hypot
+import kotlin.math.roundToInt
+
+class PlayerControlLayoutEditor(
+    context: Context,
+    initialItems: List<PlayerControlLayout.ControlPlacement>,
+    private val labelFor: (String) -> String,
+) : NestedScrollView(context) {
+
+    private val items = initialItems.map { it.copy() }.toMutableList()
+    private val content = LinearLayout(context).apply {
+        orientation = LinearLayout.VERTICAL
+        setPadding(dp(12), dp(4), dp(12), dp(12))
+    }
+    private val preview = PreviewCanvas(context)
+    private val previewHolder = PreviewHolder(context).apply {
+        addView(
+            preview,
+            FrameLayout.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT).apply {
+                gravity = Gravity.CENTER
+            },
+        )
+    }
+    private val selectionText = TextView(context)
+    private val palette = LinearLayout(context).apply {
+        orientation = LinearLayout.VERTICAL
+    }
+    private var selectedAction: String? = null
+
+    init {
+        isFillViewport = true
+        addView(content, ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT))
+
+        val instruction = TextView(context).apply {
+            setText(R.string.settings_customize_controls_help)
+            setTextSize(android.util.TypedValue.COMPLEX_UNIT_SP, 14f)
+            setTextColor(themeColor(android.R.attr.textColorSecondary, Color.GRAY))
+            setPadding(0, dp(6), 0, dp(10))
+        }
+        content.addView(instruction)
+        content.addView(
+            previewHolder,
+            LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT).apply {
+                bottomMargin = dp(12)
+            },
+        )
+
+        val selectionRow = LinearLayout(context).apply {
+            gravity = Gravity.CENTER_VERTICAL
+        }
+        selectionText.apply {
+            text = context.getString(R.string.settings_customize_controls_selected_none)
+            setTextSize(android.util.TypedValue.COMPLEX_UNIT_SP, 13f)
+            setTextColor(themeColor(android.R.attr.textColorSecondary, Color.GRAY))
+        }
+        selectionRow.addView(
+            selectionText,
+            LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f),
+        )
+        val resetButton = MaterialButton(context).apply {
+            text = context.getString(R.string.settings_customize_controls_reset)
+            isAllCaps = false
+            minHeight = dp(36)
+            minimumHeight = dp(36)
+            setPadding(dp(8), 0, dp(8), 0)
+            setOnClickListener { resetLayout() }
+        }
+        selectionRow.addView(resetButton)
+        content.addView(
+            selectionRow,
+            LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT).apply {
+                bottomMargin = dp(8)
+            },
+        )
+        content.addView(palette)
+        refresh()
+    }
+
+    fun serializedLayout(): String = PlayerControlLayout.serializeControlLayout(items)
+
+    private fun resetLayout() {
+        items.forEach { item ->
+            val original = PlayerControlLayout.controlPlacements(
+                null,
+                PlayerControlLayout.defaultControlLayout(),
+            ).firstOrNull { it.action == item.action }
+            item.group = original?.group ?: PlayerControlLayout.GROUP_HIDDEN
+            item.anchor = PlayerControlLayout.defaultAnchor(item.action)
+        }
+        selectedAction = null
+        refresh()
+    }
+
+    private fun cycleGroup(action: String) {
+        val item = items.firstOrNull { it.action == action } ?: return
+        item.group = when (item.group) {
+            PlayerControlLayout.GROUP_QUICK -> if (PlayerControlLayout.canMenu(action)) {
+                PlayerControlLayout.GROUP_MENU
+            } else {
+                PlayerControlLayout.GROUP_HIDDEN
+            }
+            PlayerControlLayout.GROUP_MENU -> PlayerControlLayout.GROUP_HIDDEN
+            else -> when {
+                PlayerControlLayout.canQuick(action) -> PlayerControlLayout.GROUP_QUICK
+                PlayerControlLayout.canMenu(action) -> PlayerControlLayout.GROUP_MENU
+                else -> PlayerControlLayout.GROUP_HIDDEN
+            }
+        }
+        if (item.group == PlayerControlLayout.GROUP_QUICK && item.anchor !in PlayerControlLayout.anchors) {
+            item.anchor = PlayerControlLayout.defaultAnchor(action)
+        }
+        selectedAction = action
+        refresh()
+    }
+
+    private fun refresh() {
+        preview.refreshControls()
+        palette.removeAllViews()
+        addPaletteSection(
+            R.string.settings_control_group_menu,
+            items.filter { it.group == PlayerControlLayout.GROUP_MENU },
+        )
+        addPaletteSection(
+            R.string.settings_control_group_hidden,
+            items.filter { it.group == PlayerControlLayout.GROUP_HIDDEN },
+        )
+        selectionText.text = selectedAction?.let { action ->
+            context.getString(R.string.settings_customize_controls_selected, labelFor(action))
+        } ?: context.getString(R.string.settings_customize_controls_selected_none)
+    }
+
+    private fun addPaletteSection(titleRes: Int, sectionItems: List<PlayerControlLayout.ControlPlacement>) {
+        val header = TextView(context).apply {
+            text = context.getString(titleRes)
+            setTextSize(android.util.TypedValue.COMPLEX_UNIT_SP, 13f)
+            setTypeface(typeface, Typeface.BOLD)
+            setTextColor(themeColor(android.R.attr.textColorSecondary, Color.GRAY))
+            setPadding(0, dp(5), 0, dp(4))
+        }
+        palette.addView(header)
+
+        val row = LinearLayout(context).apply {
+            orientation = LinearLayout.HORIZONTAL
+            gravity = Gravity.CENTER_VERTICAL
+        }
+        if (sectionItems.isEmpty()) {
+            row.addView(TextView(context).apply {
+                text = context.getString(R.string.settings_customize_controls_empty)
+                setTextSize(android.util.TypedValue.COMPLEX_UNIT_SP, 13f)
+                setTextColor(themeColor(android.R.attr.textColorTertiary, Color.GRAY))
+                setPadding(0, dp(4), 0, dp(8))
+            })
+        } else {
+            sectionItems.forEach { item ->
+                row.addView(
+                    paletteButton(item),
+                    LinearLayout.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, dp(38)).apply {
+                        marginEnd = dp(6)
+                    },
+                )
+            }
+        }
+        val scroll = HorizontalScrollView(context).apply {
+            isHorizontalScrollBarEnabled = false
+            addView(row, ViewGroup.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT))
+        }
+        palette.addView(
+            scroll,
+            LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, dp(44)).apply {
+                bottomMargin = dp(3)
+            },
+        )
+    }
+
+    private fun paletteButton(item: PlayerControlLayout.ControlPlacement): MaterialButton = MaterialButton(context).apply {
+        text = labelFor(item.action)
+        isAllCaps = false
+        minHeight = dp(38)
+        minimumHeight = dp(38)
+        setPadding(dp(10), 0, dp(10), 0)
+        setTextSize(android.util.TypedValue.COMPLEX_UNIT_SP, 12f)
+        setTextColor(themeColor(android.R.attr.textColorPrimary, Color.WHITE))
+        backgroundTintList = ColorStateList.valueOf(themeColor(com.google.android.material.R.attr.colorSurfaceContainerHigh, Color.DKGRAY))
+        strokeWidth = dp(1)
+        strokeColor = ColorStateList.valueOf(themeColor(com.google.android.material.R.attr.colorOutline, Color.GRAY))
+        contentDescription = context.getString(
+            when {
+                item.group == PlayerControlLayout.GROUP_HIDDEN && PlayerControlLayout.canQuick(item.action) ->
+                    R.string.settings_customize_controls_enable
+                item.group == PlayerControlLayout.GROUP_HIDDEN ->
+                    R.string.settings_customize_controls_enable_menu
+                else -> R.string.settings_customize_controls_hide
+            },
+            labelFor(item.action),
+        )
+        setOnClickListener { cycleGroup(item.action) }
+    }
+
+    private inner class PreviewHolder(context: Context) : FrameLayout(context) {
+        override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
+            val availableWidth = MeasureSpec.getSize(widthMeasureSpec)
+            val previewWidth = availableWidth.coerceAtMost(dp(720))
+            val previewHeight = (previewWidth * 9f / 16f).roundToInt()
+            measureChild(
+                preview,
+                MeasureSpec.makeMeasureSpec(previewWidth, MeasureSpec.EXACTLY),
+                MeasureSpec.makeMeasureSpec(previewHeight, MeasureSpec.EXACTLY),
+            )
+            setMeasuredDimension(availableWidth, previewHeight)
+        }
+
+        override fun onLayout(changed: Boolean, left: Int, top: Int, right: Int, bottom: Int) {
+            val previewWidth = width.coerceAtMost(dp(720))
+            val previewHeight = (previewWidth * 9f / 16f).roundToInt()
+            val previewLeft = (width - previewWidth) / 2
+            preview.layout(previewLeft, 0, previewLeft + previewWidth, previewHeight)
+        }
+    }
+
+    private inner class PreviewCanvas(context: Context) : FrameLayout(context) {
+
+        private val chips = linkedMapOf<String, ImageButton>()
+        private val paint = Paint(Paint.ANTI_ALIAS_FLAG)
+        private val touchSlop = ViewConfiguration.get(context).scaledTouchSlop
+        private val play = ImageView(context).apply {
+            setImageResource(R.drawable.baseline_play_arrow_black_48)
+            imageTintList = ColorStateList.valueOf(Color.WHITE)
+            alpha = 0.9f
+            importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_NO
+        }
+        private val menu = ImageButton(context).apply {
+            setImageResource(R.drawable.baseline_more_vert_black_24)
+            imageTintList = ColorStateList.valueOf(Color.WHITE)
+            background = transparentBackground()
+            isClickable = false
+            importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_NO
+        }
+        private var draggingAction: String? = null
+        private var dragStartX = 0f
+        private var dragStartY = 0f
+        private var chipStartX = 0f
+        private var chipStartY = 0f
+        private var isDragging = false
+
+        init {
+            setWillNotDraw(false)
+            clipChildren = false
+            background = GradientDrawable().apply {
+                cornerRadius = dp(12).toFloat()
+                setColor(Color.rgb(12, 15, 21))
+            }
+            clipToOutline = true
+            addView(play, LayoutParams(dp(48), dp(48)))
+            addView(menu, LayoutParams(dp(42), dp(42)))
+            contentDescription = context.getString(R.string.settings_customize_controls_preview_description)
+        }
+
+        override fun onSizeChanged(width: Int, height: Int, oldWidth: Int, oldHeight: Int) {
+            super.onSizeChanged(width, height, oldWidth, oldHeight)
+            post { positionChildren() }
+        }
+
+        override fun onLayout(changed: Boolean, left: Int, top: Int, right: Int, bottom: Int) {
+            super.onLayout(changed, left, top, right, bottom)
+            positionChildren()
+        }
+
+        override fun onDraw(canvas: Canvas) {
+            super.onDraw(canvas)
+            paint.style = Paint.Style.FILL
+            paint.color = Color.argb(80, 105, 125, 155)
+            canvas.drawRect(0f, height * 0.31f, width.toFloat(), height * 0.32f, paint)
+            canvas.drawRect(0f, height * 0.67f, width.toFloat(), height * 0.68f, paint)
+
+            paint.color = Color.WHITE
+            paint.alpha = 220
+            paint.textSize = dp(12).toFloat()
+            paint.typeface = Typeface.DEFAULT_BOLD
+            val topStartCount = items.count {
+                it.group == PlayerControlLayout.GROUP_QUICK && it.anchor == PlayerControlLayout.ANCHOR_TOP_START
+            }
+            val infoStart = if (topStartCount > 0) {
+                dp(9 + topStartCount * 44 + (topStartCount - 1).coerceAtLeast(0) * 6 + 6)
+            } else {
+                dp(12)
+            }
+            canvas.drawText("LIVE PREVIEW", infoStart.toFloat(), dp(22).toFloat(), paint)
+            paint.alpha = 170
+            paint.typeface = Typeface.DEFAULT
+            paint.textSize = dp(13).toFloat()
+            canvas.drawText("channel name", infoStart.toFloat(), dp(42).toFloat(), paint)
+
+            paint.color = Color.argb(140, 255, 255, 255)
+            canvas.drawRoundRect(
+                dp(44).toFloat(),
+                (height - dp(13)).toFloat(),
+                (width - dp(44)).toFloat(),
+                (height - dp(10)).toFloat(),
+                dp(2).toFloat(),
+                dp(2).toFloat(),
+                paint,
+            )
+            paint.color = themeColor(androidx.appcompat.R.attr.colorPrimary, Color.WHITE)
+            canvas.drawRoundRect(
+                dp(44).toFloat(),
+                (height - dp(13)).toFloat(),
+                (width * 0.38f).coerceAtLeast(dp(45).toFloat()),
+                (height - dp(10)).toFloat(),
+                dp(2).toFloat(),
+                dp(2).toFloat(),
+                paint,
+            )
+            paint.color = Color.WHITE
+            paint.alpha = 170
+            paint.textSize = dp(10).toFloat()
+            canvas.drawText("12:16", dp(10).toFloat(), (height - dp(20)).toFloat(), paint)
+            canvas.drawText("1:12:16", (width - dp(47)).toFloat(), (height - dp(20)).toFloat(), paint)
+
+            if (draggingAction != null) {
+                paint.style = Paint.Style.STROKE
+                paint.strokeWidth = dp(1).toFloat()
+                paint.color = themeColor(androidx.appcompat.R.attr.colorPrimary, Color.WHITE)
+                paint.alpha = 180
+                PlayerControlLayout.anchors.forEach { anchor ->
+                    val point = anchorPoint(anchor)
+                    canvas.drawCircle(point.x, point.y, dp(8).toFloat(), paint)
+                }
+                paint.style = Paint.Style.FILL
+                paint.alpha = 110
+                canvas.drawText(
+                    context.getString(R.string.settings_customize_controls_snap_hint),
+                    dp(12).toFloat(),
+                    (height - dp(29)).toFloat(),
+                    paint,
+                )
+            }
+        }
+
+        fun refreshControls() {
+            chips.values.toList().forEach { removeView(it) }
+            chips.clear()
+            items.filter { it.group == PlayerControlLayout.GROUP_QUICK }.forEach { item ->
+                val chip = ImageButton(context).apply {
+                    setImageResource(iconFor(item.action))
+                    imageTintList = ColorStateList.valueOf(Color.WHITE)
+                    background = chipBackground(item.action == selectedAction)
+                    setPadding(dp(9), dp(9), dp(9), dp(9))
+                    contentDescription = context.getString(
+                        R.string.settings_customize_controls_drag_action,
+                        labelFor(item.action),
+                    )
+                    setOnTouchListener { _, event -> handleChipTouch(item.action, this, event) }
+                }
+                chips[item.action] = chip
+                addView(chip, LayoutParams(dp(44), dp(44)))
+            }
+            menu.visibility = if (items.any { it.group == PlayerControlLayout.GROUP_MENU }) View.VISIBLE else View.GONE
+            positionChildren()
+            invalidate()
+        }
+
+        private fun handleChipTouch(action: String, chip: ImageButton, event: MotionEvent): Boolean {
+            when (event.actionMasked) {
+                MotionEvent.ACTION_DOWN -> {
+                    parent?.requestDisallowInterceptTouchEvent(true)
+                    selectedAction = action
+                    draggingAction = action
+                    isDragging = false
+                    dragStartX = event.rawX
+                    dragStartY = event.rawY
+                    chipStartX = chip.x
+                    chipStartY = chip.y
+                    chip.bringToFront()
+                    chips.forEach { (chipAction, control) ->
+                        control.background = chipBackground(chipAction == selectedAction)
+                    }
+                    selectionText.text = context.getString(
+                        R.string.settings_customize_controls_selected,
+                        labelFor(action),
+                    )
+                    invalidate()
+                    return true
+                }
+                MotionEvent.ACTION_MOVE -> {
+                    val dx = event.rawX - dragStartX
+                    val dy = event.rawY - dragStartY
+                    if (!isDragging && hypot(dx.toDouble(), dy.toDouble()) > touchSlop) {
+                        isDragging = true
+                    }
+                    if (isDragging) {
+                        chip.x = (chipStartX + dx).coerceIn(0f, (width - chip.width).coerceAtLeast(0).toFloat())
+                        chip.y = (chipStartY + dy).coerceIn(0f, (height - chip.height).coerceAtLeast(0).toFloat())
+                        invalidate()
+                    }
+                    return true
+                }
+                MotionEvent.ACTION_UP -> {
+                    if (isDragging) {
+                        snapChip(action, chip.x + chip.width / 2f, chip.y + chip.height / 2f)
+                    } else {
+                        cycleGroup(action)
+                    }
+                    draggingAction = null
+                    isDragging = false
+                    parent?.requestDisallowInterceptTouchEvent(false)
+                    invalidate()
+                    return true
+                }
+                MotionEvent.ACTION_CANCEL -> {
+                    if (isDragging) snapChip(action, chip.x + chip.width / 2f, chip.y + chip.height / 2f)
+                    draggingAction = null
+                    isDragging = false
+                    parent?.requestDisallowInterceptTouchEvent(false)
+                    invalidate()
+                    return true
+                }
+            }
+            return true
+        }
+
+        private fun snapChip(action: String, centerX: Float, centerY: Float) {
+            val item = items.firstOrNull { it.action == action } ?: return
+            val anchor = PlayerControlLayout.anchors.minByOrNull { candidate ->
+                val point = anchorPoint(candidate)
+                hypot((point.x - centerX).toDouble(), (point.y - centerY).toDouble())
+            } ?: PlayerControlLayout.defaultAnchor(action)
+            items.remove(item)
+            item.anchor = anchor
+            val sameAnchor = items.filter {
+                it.group == PlayerControlLayout.GROUP_QUICK && it.anchor == anchor
+            }
+            val crossCoordinate = if (anchor.startsWith("middle")) centerY else centerX
+            val insertBefore = sameAnchor.firstOrNull { other ->
+                val index = sameAnchor.indexOf(other)
+                crossCoordinateFor(anchor, index, sameAnchor.size) > crossCoordinate
+            }
+            val targetIndex = insertBefore?.let { items.indexOf(it) } ?: items.size
+            items.add(targetIndex, item)
+            positionChildren()
+            invalidate()
+        }
+
+        private fun positionChildren() {
+            val grouped = items.filter { it.group == PlayerControlLayout.GROUP_QUICK }.groupBy { it.anchor }
+            grouped.forEach { (anchor, group) ->
+                group.forEachIndexed { index, item ->
+                    chips[item.action]?.let { chip ->
+                        val point = controlPoint(anchor, index, group.size)
+                        chip.x = point.x - chip.width / 2f
+                        chip.y = point.y - chip.height / 2f
+                    }
+                }
+            }
+            menu.x = (width - dp(10) - menu.width).coerceAtLeast(0).toFloat()
+            menu.y = dp(4).toFloat()
+            play.x = (width - play.width) / 2f
+            play.y = (height - play.height) / 2f
+        }
+
+        private fun controlPoint(anchor: String, index: Int, count: Int): PointF {
+            val size = dp(44)
+            val spacing = dp(6)
+            val padding = dp(9)
+            val menuReserve = if (menu.visibility == View.VISIBLE && anchor == PlayerControlLayout.ANCHOR_TOP_END) dp(48) else 0
+            val total = count * size + (count - 1).coerceAtLeast(0) * spacing
+            val x = when (anchor) {
+                PlayerControlLayout.ANCHOR_TOP_START, PlayerControlLayout.ANCHOR_BOTTOM_START -> padding + size / 2f + index * (size + spacing)
+                PlayerControlLayout.ANCHOR_TOP_CENTER, PlayerControlLayout.ANCHOR_BOTTOM_CENTER -> (width - total) / 2f + size / 2f + index * (size + spacing)
+                PlayerControlLayout.ANCHOR_TOP_END, PlayerControlLayout.ANCHOR_BOTTOM_END -> width - padding - menuReserve - total + size / 2f + index * (size + spacing)
+                PlayerControlLayout.ANCHOR_MIDDLE_START, PlayerControlLayout.ANCHOR_MIDDLE_END -> if (anchor.endsWith("start")) padding + size / 2f else width - padding - size / 2f
+                else -> width / 2f
+            }
+            val y = when (anchor) {
+                PlayerControlLayout.ANCHOR_TOP_START, PlayerControlLayout.ANCHOR_TOP_CENTER, PlayerControlLayout.ANCHOR_TOP_END -> padding + size / 2f
+                PlayerControlLayout.ANCHOR_BOTTOM_START, PlayerControlLayout.ANCHOR_BOTTOM_CENTER, PlayerControlLayout.ANCHOR_BOTTOM_END -> height - padding - size / 2f - dp(13)
+                PlayerControlLayout.ANCHOR_MIDDLE_START, PlayerControlLayout.ANCHOR_MIDDLE_END -> (height - total) / 2f + size / 2f + index * (size + spacing)
+                else -> height / 2f
+            }
+            return PointF(x.coerceIn(size / 2f, (width - size / 2f).coerceAtLeast(size / 2f)), y.coerceIn(size / 2f, (height - size / 2f).coerceAtLeast(size / 2f)))
+        }
+
+        private fun crossCoordinateFor(anchor: String, index: Int, count: Int): Float {
+            val point = controlPoint(anchor, index, count)
+            return if (anchor.startsWith("middle")) point.y else point.x
+        }
+
+        private fun anchorPoint(anchor: String): PointF = controlPoint(anchor, 0, 1)
+
+        private fun chipBackground(selected: Boolean): GradientDrawable = GradientDrawable().apply {
+            cornerRadius = dp(12).toFloat()
+            setColor(if (selected) {
+                themeColor(androidx.appcompat.R.attr.colorPrimary, Color.WHITE)
+            } else {
+                Color.argb(170, 35, 42, 52)
+            })
+            setStroke(dp(1), if (selected) Color.WHITE else Color.argb(100, 255, 255, 255))
+        }
+
+        private fun transparentBackground(): GradientDrawable = GradientDrawable().apply {
+            setColor(Color.TRANSPARENT)
+        }
+    }
+
+    private fun iconFor(action: String): Int = when (action) {
+        "minimize" -> R.drawable.baseline_expand_more_black_48
+        "download" -> R.drawable.ic_file_download_black_24dp
+        "follow" -> R.drawable.baseline_favorite_border_black_24
+        "quality" -> R.drawable.baseline_settings_black_24
+        "speed" -> androidx.media3.ui.R.drawable.exo_ic_speed
+        "sleep" -> R.drawable.baseline_alarm_black_24
+        "aspect" -> R.drawable.baseline_aspect_ratio_black_24
+        "chapters" -> R.drawable.baseline_format_list_bulleted_black_24
+        "restart" -> R.drawable.baseline_replay_black_24
+        "live" -> androidx.media3.ui.R.drawable.exo_icon_fastforward
+        "clip" -> R.drawable.ic_movie_clip_black_24
+        "volume" -> R.drawable.baseline_volume_up_black_24
+        "compressor" -> R.drawable.baseline_audio_compressor_off_24dp
+        "mode" -> R.drawable.baseline_audiotrack_black_24
+        "subtitles" -> androidx.media3.ui.R.drawable.exo_ic_subtitle_off
+        "chat_input" -> R.drawable.baseline_keyboard_black_24
+        "chat" -> R.drawable.baseline_speaker_notes_black_24
+        "fullscreen" -> R.drawable.baseline_fullscreen_black_24
+        else -> R.drawable.baseline_more_vert_black_24
+    }
+
+    private fun themeColor(attribute: Int, fallback: Int): Int {
+        val value = android.util.TypedValue()
+        if (!context.theme.resolveAttribute(attribute, value, true)) return fallback
+        return if (value.resourceId != 0) ContextCompat.getColor(context, value.resourceId) else value.data
+    }
+
+    private fun dp(value: Int): Int = (value * resources.displayMetrics.density).roundToInt()
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/settings/SettingsActivity.kt
@@ -28,6 +28,7 @@ import android.view.View
 import android.view.WindowManager
 import android.view.ViewGroup
 import android.widget.ImageButton
+import android.widget.LinearLayout
 import android.widget.TextView
 import android.widget.Toast
 import androidx.annotation.DrawableRes
@@ -90,6 +91,7 @@ import com.github.andreyasadchy.xtra.ui.main.LiveNotificationScheduler
 import com.github.andreyasadchy.xtra.ui.main.LiveNotificationService
 import com.github.andreyasadchy.xtra.ui.settings.SettingsViewModel.Companion.SettingsViewModelFactory
 import com.github.andreyasadchy.xtra.util.C
+import com.github.andreyasadchy.xtra.util.PlayerControlLayout
 import com.github.andreyasadchy.xtra.util.SettingsMigration
 import com.github.andreyasadchy.xtra.util.TwitchApiHelper
 import com.github.andreyasadchy.xtra.XtraApp
@@ -255,11 +257,23 @@ class SettingsActivity : AppCompatActivity() {
         showDefaultSelector: Boolean = true,
     ) {
         val listAdapter = SettingsDragListAdapter()
+        val preview = when (prefKey) {
+            C.UI_NAVIGATION_TAB_LIST -> SettingsLayoutPreview(this, list, SettingsLayoutPreview.Mode.NAVIGATION)
+            C.UI_FOLLOWING_TABS,
+            C.UI_SAVED_TABS,
+            C.UI_CHANNEL_TABS,
+            C.UI_GAME_TABS,
+            C.UI_SEARCH_TABS,
+            -> SettingsLayoutPreview(this, list, SettingsLayoutPreview.Mode.TABS)
+            C.UI_FOLLOWING_OVERVIEW_SECTIONS -> SettingsLayoutPreview(this, list, SettingsLayoutPreview.Mode.SECTIONS)
+            else -> null
+        }
         val itemTouchHelper = ItemTouchHelper(
             object : ItemTouchHelper.SimpleCallback(ItemTouchHelper.UP or ItemTouchHelper.DOWN, 0) {
                 override fun onMove(recyclerView: RecyclerView, viewHolder: RecyclerView.ViewHolder, target: RecyclerView.ViewHolder): Boolean {
                     Collections.swap(list, viewHolder.bindingAdapterPosition, target.bindingAdapterPosition)
                     listAdapter.notifyItemMoved(viewHolder.bindingAdapterPosition, target.bindingAdapterPosition)
+                    preview?.refresh()
                     return true
                 }
 
@@ -289,13 +303,40 @@ class SettingsActivity : AppCompatActivity() {
                     }
                 }
                 item.default = true
+                preview?.refresh()
             }
         }
+        listAdapter.onItemChanged = { preview?.refresh() }
         itemTouchHelper.attachToRecyclerView(recyclerView)
         listAdapter.submitList(list)
+        val dialogView = preview?.let { layoutPreview ->
+            LinearLayout(this).apply {
+                orientation = LinearLayout.VERTICAL
+                addView(
+                    layoutPreview,
+                    LinearLayout.LayoutParams(
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                        ViewGroup.LayoutParams.WRAP_CONTENT,
+                    ).apply {
+                        bottomMargin = TypedValue.applyDimension(
+                            TypedValue.COMPLEX_UNIT_DIP,
+                            6F,
+                            resources.displayMetrics,
+                        ).toInt()
+                    },
+                )
+                addView(
+                    recyclerView,
+                    LinearLayout.LayoutParams(
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                        (resources.displayMetrics.heightPixels * 0.34f).toInt(),
+                    ),
+                )
+            }
+        } ?: recyclerView
         getAlertDialogBuilder()
             .setTitle(title)
-            .setView(recyclerView)
+            .setView(dialogView)
             .setPositiveButton(getString(android.R.string.ok)) { _, _ ->
                 prefs().edit {
                     putString(prefKey, listAdapter.currentList.joinToString(",") {
@@ -2373,214 +2414,53 @@ class SettingsActivity : AppCompatActivity() {
 
         private fun showControlLayoutDialog() {
             val preferences = requireContext().prefs()
-            val serialized = preferences.getString(C.SETTINGS_PLAYER_CONTROL_LAYOUT, null)
-                ?.takeIf { it.isNotBlank() }
-                ?: SettingsMigration.defaultControlLayout()
-            val items = serialized
-                .split(',')
-                .filter { it.contains(':') }
-                .map { item ->
-                    val parts = item.split(':')
-                    val action = parts[0]
-                    val requestedGroup = parts.getOrNull(1)?.takeIf { it in setOf("quick", "menu", "hidden") } ?: "hidden"
-                    val group = if (requestedGroup == "menu" && controlMenuKey(action) == null) {
-                        "hidden"
-                    } else {
-                        requestedGroup
-                    }
-                    SettingsDragListItem(
-                        key = action,
-                        text = formatControlText(action, group),
-                        default = false,
-                        enabled = group != "hidden",
-                        group = group,
-                    )
-                }
-                .toMutableList()
-            if (items.none { it.key == "clip" }) {
-                items += SettingsDragListItem(
-                    key = "clip",
-                    text = formatControlText("clip", "quick"),
-                    default = false,
-                    enabled = true,
-                    group = "quick",
-                )
-            }
-            items.sortBy { controlRegion(it.key, it.group) }
-            val listAdapter = SettingsDragListAdapter()
-            val itemTouchHelper = ItemTouchHelper(
-                object : ItemTouchHelper.SimpleCallback(ItemTouchHelper.UP or ItemTouchHelper.DOWN, 0) {
-                    override fun onMove(recyclerView: RecyclerView, viewHolder: RecyclerView.ViewHolder, target: RecyclerView.ViewHolder): Boolean {
-                        val from = viewHolder.bindingAdapterPosition
-                        val to = target.bindingAdapterPosition
-                        if (from == RecyclerView.NO_POSITION || to == RecyclerView.NO_POSITION) return false
-                        if (controlRegion(items[from].key, items[from].group) != controlRegion(items[to].key, items[to].group)) {
-                            return false
-                        }
-                        Collections.swap(items, from, to)
-                        listAdapter.notifyItemMoved(from, to)
-                        return true
-                    }
-
-                    override fun onSwiped(viewHolder: RecyclerView.ViewHolder, direction: Int) = Unit
-
-                    override fun isLongPressDragEnabled(): Boolean = false
-                }
+            val items = PlayerControlLayout.controlPlacements(
+                preferences.getString(C.SETTINGS_PLAYER_CONTROL_LAYOUT, null),
+                SettingsMigration.defaultControlLayout(),
             )
-            listAdapter.itemTouchHelper = itemTouchHelper
-            listAdapter.cycleGroup = { item ->
-                item.group = when (item.group) {
-                    "quick" -> if (controlMenuKey(item.key) == null) "hidden" else "menu"
-                    "menu" -> "hidden"
-                    else -> "quick"
-                }
-                item.enabled = item.group != "hidden"
-                item.text = formatControlText(item.key, item.group)
-                items.sortBy { controlRegion(it.key, it.group) }
-                listAdapter.notifyDataSetChanged()
-            }
-            val recyclerView = RecyclerView(requireContext()).apply {
-                layoutManager = LinearLayoutManager(requireContext())
-                adapter = listAdapter
-                val padding = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 10F, resources.displayMetrics).toInt()
-                setPadding(0, padding, 0, 0)
-            }
-            val listContainer = android.widget.FrameLayout(requireContext()).apply {
-                addView(
-                    recyclerView,
-                    android.widget.FrameLayout.LayoutParams(
-                        ViewGroup.LayoutParams.MATCH_PARENT,
-                        (resources.displayMetrics.heightPixels * 0.42f).toInt(),
-                    ),
-                )
-            }
-            itemTouchHelper.attachToRecyclerView(recyclerView)
-            listAdapter.submitList(items)
+            val editor = PlayerControlLayoutEditor(
+                context = requireContext(),
+                initialItems = items,
+                labelFor = ::controlTitle,
+            )
             requireActivity().getAlertDialogBuilder()
                 .setTitle(R.string.settings_customize_controls)
-                .setMessage("Drag to reorder within each player area. Each row shows its area. Tap the group button to cycle Quick controls, More menu and Hidden.")
-                .setView(listContainer)
+                .setView(editor)
                 .setPositiveButton(android.R.string.ok) { _, _ ->
-                    val serialized = items.joinToString(",") { "${it.key}:${it.group}" }
+                    val serialized = editor.serializedLayout()
                     preferences.edit { putString(C.SETTINGS_PLAYER_CONTROL_LAYOUT, serialized) }
-                    syncLegacyControlVisibility(preferences, items.map { "${it.key}:${it.group}" })
+                    SettingsMigration.syncLegacyControlVisibility(preferences, serialized)
                 }
+                .setNegativeButton(android.R.string.cancel, null)
                 .show()
         }
 
-        private fun controlMenuKey(action: String): String? = when (action) {
-            "download" -> C.PLAYER_MENU_DOWNLOAD
-            "quality" -> C.PLAYER_MENU_QUALITY
-            "speed" -> C.PLAYER_MENU_SPEED
-            "chapters" -> C.PLAYER_MENU_GAMES
-            "restart" -> C.PLAYER_MENU_RESTART
-            "volume" -> C.PLAYER_MENU_VOLUME
-            "subtitles" -> C.PLAYER_MENU_SUBTITLES
-            "chat_input" -> C.PLAYER_MENU_CHAT_BAR
-            "chat" -> C.PLAYER_MENU_CHAT_TOGGLE
-            "viewers" -> C.PLAYER_MENU_VIEWER_LIST
-            "bookmark" -> C.PLAYER_MENU_BOOKMARK
-            "share" -> C.PLAYER_MENU_SHARE
-            "find_vod" -> C.PLAYER_MENU_FIND_VOD
-            "sleep" -> C.PLAYER_MENU_SLEEP
-            "aspect" -> C.PLAYER_MENU_ASPECT
-            "reload_emotes" -> C.PLAYER_MENU_RELOAD_EMOTES
-            "disconnect_chat" -> C.PLAYER_MENU_CHAT_DISCONNECT
-            else -> null
-        }
-
-        private fun controlRegion(action: String, group: String): Int = when {
-            group == "menu" -> 4
-            action == "minimize" -> 0
-            action in setOf("download", "follow", "quality", "speed", "sleep", "aspect") -> 1
-            action in setOf("chapters", "restart", "live", "clip", "volume", "compressor", "mode") -> 2
-            action in setOf("subtitles", "chat_input", "chat", "fullscreen") -> 3
-            else -> 4
-        }
-
-        private fun controlRegionTitle(region: Int): String = getString(when (region) {
-            0 -> R.string.settings_control_region_top_left
-            1 -> R.string.settings_control_region_top_right
-            2 -> R.string.settings_control_region_bottom_left
-            3 -> R.string.settings_control_region_bottom_right
-            else -> R.string.settings_control_region_more_menu
-        })
-
-        private fun formatControlText(action: String, group: String): String {
-            val title = when (action) {
-                "minimize" -> getString(R.string.player_minimize)
-                "download" -> getString(R.string.player_download)
-                "follow" -> getString(R.string.player_follow)
-                "quality" -> getString(R.string.player_quality)
-                "speed" -> getString(R.string.player_playback_speed)
-                "chapters" -> getString(R.string.player_vod_games)
-                "restart" -> getString(R.string.player_restart)
-                "live" -> getString(R.string.player_seek_live)
-                "clip" -> getString(R.string.player_clip)
-                "volume" -> getString(R.string.player_volume)
-                "compressor" -> getString(R.string.player_audio_compressor)
-                "mode" -> getString(R.string.settings_player_mode)
-                "subtitles" -> getString(R.string.player_subtitles)
-                "chat_input" -> getString(R.string.player_chat_input)
-                "chat" -> getString(R.string.player_show_chat)
-                "fullscreen" -> getString(R.string.fullscreen)
-                "viewers" -> getString(R.string.viewer_list)
-                "bookmark" -> getString(R.string.bookmark)
-                "share" -> getString(R.string.share)
-                "find_vod" -> getString(R.string.find_unlisted_video)
-                "sleep" -> getString(R.string.sleep_timer)
-                "aspect" -> getString(R.string.aspect_ratio)
-                "reload_emotes" -> getString(R.string.reload_emotes)
-                "disconnect_chat" -> getString(R.string.disconnect_chat)
-                else -> action
-            }
-            val groupTitle = getString(when (group) {
-                "quick" -> R.string.settings_control_group_quick
-                "menu" -> R.string.settings_control_group_menu
-                else -> R.string.settings_control_group_hidden
-            })
-            return "$title — $groupTitle · ${controlRegionTitle(controlRegion(action, group))}"
-        }
-
-        private fun syncLegacyControlVisibility(preferences: android.content.SharedPreferences, items: List<String>) {
-            val actionKeys = mapOf(
-                "minimize" to (C.PLAYER_MINIMIZE to null),
-                "download" to (C.PLAYER_DOWNLOAD to C.PLAYER_MENU_DOWNLOAD),
-                "follow" to (C.PLAYER_FOLLOW to null),
-                "quality" to (C.PLAYER_SETTINGS to C.PLAYER_MENU_QUALITY),
-                "speed" to (C.PLAYER_SPEED_BUTTON to C.PLAYER_MENU_SPEED),
-                "chapters" to (C.PLAYER_GAMES_BUTTON to C.PLAYER_MENU_GAMES),
-                "restart" to (C.PLAYER_RESTART to C.PLAYER_MENU_RESTART),
-                "live" to (C.PLAYER_SEEK_LIVE to null),
-                "clip" to (C.PLAYER_CLIP_BUTTON to null),
-                "volume" to (C.PLAYER_VOLUME_BUTTON to C.PLAYER_MENU_VOLUME),
-                "compressor" to (C.PLAYER_AUDIO_COMPRESSOR_BUTTON to null),
-                "mode" to (C.PLAYER_MODE to null),
-                "subtitles" to (C.PLAYER_SUBTITLES to C.PLAYER_MENU_SUBTITLES),
-                "chat_input" to (C.PLAYER_CHAT_BAR_TOGGLE to C.PLAYER_MENU_CHAT_BAR),
-                "chat" to (C.PLAYER_CHAT_TOGGLE to C.PLAYER_MENU_CHAT_TOGGLE),
-                "fullscreen" to (C.PLAYER_FULLSCREEN to null),
-                "viewers" to (C.PLAYER_VIEWER_LIST to C.PLAYER_MENU_VIEWER_LIST),
-                "bookmark" to (null to C.PLAYER_MENU_BOOKMARK),
-                "share" to (null to C.PLAYER_MENU_SHARE),
-                "find_vod" to (null to C.PLAYER_MENU_FIND_VOD),
-                "sleep" to (C.PLAYER_SLEEP to C.PLAYER_MENU_SLEEP),
-                "aspect" to (C.PLAYER_ASPECT to C.PLAYER_MENU_ASPECT),
-                "reload_emotes" to (null to C.PLAYER_MENU_RELOAD_EMOTES),
-                "disconnect_chat" to (null to C.PLAYER_MENU_CHAT_DISCONNECT),
-            )
-            val groups = items.associate { item ->
-                val parts = item.split(':')
-                parts[0] to (parts.getOrNull(1) ?: "hidden")
-            }
-            preferences.edit {
-                actionKeys.forEach { (action, keys) ->
-                    val group = groups[action]
-                    keys.first?.let { putBoolean(it, group == "quick") }
-                    keys.second?.let { putBoolean(it, group == "menu") }
-                }
-                putBoolean(C.PLAYER_MENU, groups.values.any { it == "menu" })
-            }
+        private fun controlTitle(action: String): String = when (action) {
+            "minimize" -> getString(R.string.player_minimize)
+            "download" -> getString(R.string.player_download)
+            "follow" -> getString(R.string.player_follow)
+            "quality" -> getString(R.string.player_quality)
+            "speed" -> getString(R.string.player_playback_speed)
+            "chapters" -> getString(R.string.player_vod_games)
+            "restart" -> getString(R.string.player_restart)
+            "live" -> getString(R.string.player_seek_live)
+            "clip" -> getString(R.string.player_clip)
+            "volume" -> getString(R.string.player_volume)
+            "compressor" -> getString(R.string.player_audio_compressor)
+            "mode" -> getString(R.string.settings_player_mode)
+            "subtitles" -> getString(R.string.player_subtitles)
+            "chat_input" -> getString(R.string.player_chat_input)
+            "chat" -> getString(R.string.player_show_chat)
+            "fullscreen" -> getString(R.string.fullscreen)
+            "viewers" -> getString(R.string.viewer_list)
+            "bookmark" -> getString(R.string.bookmark)
+            "share" -> getString(R.string.share)
+            "find_vod" -> getString(R.string.find_unlisted_video)
+            "sleep" -> getString(R.string.sleep_timer)
+            "aspect" -> getString(R.string.aspect_ratio)
+            "reload_emotes" -> getString(R.string.reload_emotes)
+            "disconnect_chat" -> getString(R.string.disconnect_chat)
+            else -> action
         }
 
     }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/settings/SettingsDragListAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/settings/SettingsDragListAdapter.kt
@@ -27,6 +27,7 @@ class SettingsDragListAdapter : ListAdapter<SettingsDragListItem, SettingsDragLi
     var itemTouchHelper: ItemTouchHelper? = null
     var setDefault: ((SettingsDragListItem) -> Unit)? = null
     var cycleGroup: ((SettingsDragListItem) -> Unit)? = null
+    var onItemChanged: (() -> Unit)? = null
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
         val binding = SettingsDragListItemBinding.inflate(LayoutInflater.from(parent.context), parent, false)
@@ -78,9 +79,11 @@ class SettingsDragListAdapter : ListAdapter<SettingsDragListItem, SettingsDragLi
                 } else {
                     setAsDefault.visibility = View.GONE
                     checkBox.visibility = View.VISIBLE
+                    checkBox.setOnCheckedChangeListener(null)
                     checkBox.isChecked = item.enabled
                     checkBox.setOnCheckedChangeListener { _, isChecked ->
                         item.enabled = isChecked
+                        onItemChanged?.invoke()
                     }
                 }
             }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/settings/SettingsLayoutPreview.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/settings/SettingsLayoutPreview.kt
@@ -1,0 +1,240 @@
+package com.github.andreyasadchy.xtra.ui.settings
+
+import android.content.Context
+import android.graphics.Color
+import android.graphics.Typeface
+import android.graphics.drawable.GradientDrawable
+import android.view.Gravity
+import android.view.View
+import android.view.ViewGroup
+import android.widget.FrameLayout
+import android.widget.HorizontalScrollView
+import android.widget.LinearLayout
+import android.widget.TextView
+import androidx.core.content.ContextCompat
+import com.google.android.material.card.MaterialCardView
+import com.github.andreyasadchy.xtra.R
+import com.github.andreyasadchy.xtra.model.ui.SettingsDragListItem
+import kotlin.math.roundToInt
+
+class SettingsLayoutPreview(
+    context: Context,
+    private val items: List<SettingsDragListItem>,
+    private val mode: Mode,
+) : MaterialCardView(context) {
+
+    enum class Mode {
+        NAVIGATION,
+        TABS,
+        SECTIONS,
+    }
+
+    private val content = LinearLayout(context).apply {
+        orientation = LinearLayout.VERTICAL
+        setPadding(dp(12), dp(8), dp(12), dp(10))
+    }
+    private val previewFrame = FrameLayout(context)
+
+    init {
+        cardElevation = 0f
+        strokeWidth = dp(1)
+        strokeColor = themeColor(com.google.android.material.R.attr.colorOutline, Color.GRAY)
+        setCardBackgroundColor(themeColor(com.google.android.material.R.attr.colorSurfaceContainerLow, Color.DKGRAY))
+        addView(content, LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT))
+
+        val title = TextView(context).apply {
+            text = context.getString(R.string.settings_layout_preview)
+            setTextSize(android.util.TypedValue.COMPLEX_UNIT_SP, 13f)
+            setTypeface(typeface, Typeface.BOLD)
+            setTextColor(themeColor(android.R.attr.textColorPrimary, Color.WHITE))
+        }
+        content.addView(title)
+        val hint = TextView(context).apply {
+            text = context.getString(
+                when (mode) {
+                    Mode.NAVIGATION, Mode.TABS -> R.string.settings_tabs_preview_help
+                    Mode.SECTIONS -> R.string.settings_sections_preview_help
+                },
+            )
+            setTextSize(android.util.TypedValue.COMPLEX_UNIT_SP, 12f)
+            setTextColor(themeColor(android.R.attr.textColorSecondary, Color.GRAY))
+            setPadding(0, dp(2), 0, dp(7))
+        }
+        content.addView(hint)
+        content.addView(
+            previewFrame,
+            LinearLayout.LayoutParams(LayoutParams.MATCH_PARENT, dp(142)),
+        )
+        refresh()
+    }
+
+    fun refresh() {
+        previewFrame.removeAllViews()
+        previewFrame.background = roundedBackground(Color.rgb(18, 21, 28), dp(10))
+        when (mode) {
+            Mode.NAVIGATION -> buildNavigationPreview()
+            Mode.TABS -> buildTabsPreview()
+            Mode.SECTIONS -> buildSectionsPreview()
+        }
+    }
+
+    private fun buildNavigationPreview() {
+        addToolbar()
+        addContentLines(top = dp(38))
+        addNavigationBar()
+    }
+
+    private fun buildTabsPreview() {
+        addToolbar()
+        addTabStrip(top = dp(34))
+        addContentLines(top = dp(72))
+    }
+
+    private fun buildSectionsPreview() {
+        addToolbar()
+        val enabled = items.filter { it.enabled }
+        if (enabled.isEmpty()) {
+            previewFrame.addView(TextView(context).apply {
+                text = context.getString(R.string.settings_customize_controls_empty)
+                gravity = Gravity.CENTER
+                setTextColor(themeColor(android.R.attr.textColorSecondary, Color.GRAY))
+            }, FrameLayout.LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT))
+            return
+        }
+        enabled.take(3).forEachIndexed { index, item ->
+            val row = LinearLayout(context).apply {
+                orientation = LinearLayout.VERTICAL
+                setPadding(dp(9), dp(5), dp(9), dp(5))
+                background = roundedBackground(Color.rgb(34, 39, 49), dp(7))
+            }
+            row.addView(TextView(context).apply {
+                text = item.text
+                maxLines = 1
+                ellipsize = android.text.TextUtils.TruncateAt.END
+                setTextSize(android.util.TypedValue.COMPLEX_UNIT_SP, 10f)
+                setTypeface(typeface, Typeface.BOLD)
+                setTextColor(themeColor(android.R.attr.textColorPrimary, Color.WHITE))
+            })
+            row.addView(View(context).apply {
+                setBackgroundColor(Color.argb(65, 255, 255, 255))
+            }, LinearLayout.LayoutParams((width * 0.52f).roundToInt().coerceAtLeast(dp(70)), dp(4)).apply {
+                topMargin = dp(4)
+            })
+            previewFrame.addView(
+                row,
+                FrameLayout.LayoutParams(LayoutParams.MATCH_PARENT, dp(34)).apply {
+                    leftMargin = dp(8)
+                    rightMargin = dp(8)
+                    topMargin = dp(36) + index * dp(35)
+                },
+            )
+        }
+    }
+
+    private fun addToolbar() {
+        val toolbar = LinearLayout(context).apply {
+            gravity = Gravity.CENTER_VERTICAL
+            setPadding(dp(10), 0, dp(10), 0)
+        }
+        toolbar.addView(TextView(context).apply {
+            text = "Xtra"
+            setTextSize(android.util.TypedValue.COMPLEX_UNIT_SP, 13f)
+            setTypeface(typeface, Typeface.BOLD)
+            setTextColor(Color.WHITE)
+        }, LinearLayout.LayoutParams(0, LayoutParams.WRAP_CONTENT, 1f))
+        toolbar.addView(TextView(context).apply {
+            text = "•••"
+            setTextSize(android.util.TypedValue.COMPLEX_UNIT_SP, 13f)
+            setTextColor(Color.argb(190, 255, 255, 255))
+        })
+        previewFrame.addView(toolbar, FrameLayout.LayoutParams(LayoutParams.MATCH_PARENT, dp(32)))
+    }
+
+    private fun addContentLines(top: Int) {
+        val lines = LinearLayout(context).apply {
+            orientation = LinearLayout.VERTICAL
+            setPadding(dp(10), dp(8), dp(10), 0)
+        }
+        repeat(2) { index ->
+            lines.addView(View(context).apply {
+                setBackgroundColor(Color.argb(if (index == 0) 105 else 62, 255, 255, 255))
+            }, LinearLayout.LayoutParams(if (index == 0) dp(108) else dp(76), dp(5)).apply {
+                bottomMargin = dp(5)
+            })
+        }
+        previewFrame.addView(lines, FrameLayout.LayoutParams(LayoutParams.MATCH_PARENT, dp(35)).apply {
+            topMargin = top
+        })
+    }
+
+    private fun addNavigationBar() {
+        val bar = chipRow(items.filter { it.enabled }, selectedUsesDefault = true)
+        previewFrame.addView(bar, FrameLayout.LayoutParams(LayoutParams.MATCH_PARENT, dp(49)).apply {
+            gravity = Gravity.BOTTOM
+        })
+    }
+
+    private fun addTabStrip(top: Int) {
+        val bar = chipRow(items.filter { it.enabled }, selectedUsesDefault = true)
+        previewFrame.addView(bar, FrameLayout.LayoutParams(LayoutParams.MATCH_PARENT, dp(39)).apply {
+            topMargin = top
+        })
+    }
+
+    private fun chipRow(visibleItems: List<SettingsDragListItem>, selectedUsesDefault: Boolean): HorizontalScrollView {
+        val row = LinearLayout(context).apply {
+            orientation = LinearLayout.HORIZONTAL
+            gravity = Gravity.CENTER_VERTICAL
+            setPadding(dp(6), dp(4), dp(6), dp(4))
+        }
+        if (visibleItems.isEmpty()) {
+            row.addView(TextView(context).apply {
+                text = context.getString(R.string.settings_customize_controls_empty)
+                setTextSize(android.util.TypedValue.COMPLEX_UNIT_SP, 11f)
+                setTextColor(Color.argb(150, 255, 255, 255))
+                gravity = Gravity.CENTER_VERTICAL
+            })
+        } else {
+            visibleItems.forEach { item ->
+                val selected = selectedUsesDefault && item.default
+                row.addView(TextView(context).apply {
+                    text = item.text
+                    gravity = Gravity.CENTER
+                    maxLines = 1
+                    ellipsize = android.text.TextUtils.TruncateAt.END
+                    setTextSize(android.util.TypedValue.COMPLEX_UNIT_SP, 10f)
+                    setTextColor(if (selected) {
+                        themeColor(com.google.android.material.R.attr.colorOnPrimaryContainer, Color.WHITE)
+                    } else {
+                        Color.argb(215, 255, 255, 255)
+                    })
+                    background = roundedBackground(
+                        if (selected) themeColor(com.google.android.material.R.attr.colorPrimaryContainer, Color.DKGRAY)
+                        else Color.rgb(42, 48, 60),
+                        dp(8),
+                    )
+                    setPadding(dp(9), 0, dp(9), 0)
+                }, LinearLayout.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, dp(29)).apply {
+                    marginEnd = dp(5)
+                })
+            }
+        }
+        return HorizontalScrollView(context).apply {
+            isHorizontalScrollBarEnabled = false
+            addView(row, ViewGroup.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.MATCH_PARENT))
+        }
+    }
+
+    private fun roundedBackground(color: Int, radius: Int): GradientDrawable = GradientDrawable().apply {
+        cornerRadius = radius.toFloat()
+        setColor(color)
+    }
+
+    private fun themeColor(attribute: Int, fallback: Int): Int {
+        val value = android.util.TypedValue()
+        if (!context.theme.resolveAttribute(attribute, value, true)) return fallback
+        return if (value.resourceId != 0) ContextCompat.getColor(context, value.resourceId) else value.data
+    }
+
+    private fun dp(value: Int): Int = (value * resources.displayMetrics.density).roundToInt()
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/PlayerControlLayout.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/PlayerControlLayout.kt
@@ -7,53 +7,175 @@ import com.github.andreyasadchy.xtra.databinding.FragmentPlayerBinding
 
 object PlayerControlLayout {
 
+    const val GROUP_QUICK = "quick"
+    const val GROUP_MENU = "menu"
+    const val GROUP_HIDDEN = "hidden"
+
+    const val ANCHOR_TOP_START = "top_start"
+    const val ANCHOR_TOP_CENTER = "top_center"
+    const val ANCHOR_TOP_END = "top_end"
+    const val ANCHOR_MIDDLE_START = "middle_start"
+    const val ANCHOR_MIDDLE_END = "middle_end"
+    const val ANCHOR_BOTTOM_START = "bottom_start"
+    const val ANCHOR_BOTTOM_CENTER = "bottom_center"
+    const val ANCHOR_BOTTOM_END = "bottom_end"
+
+    val anchors = setOf(
+        ANCHOR_TOP_START,
+        ANCHOR_TOP_CENTER,
+        ANCHOR_TOP_END,
+        ANCHOR_MIDDLE_START,
+        ANCHOR_MIDDLE_END,
+        ANCHOR_BOTTOM_START,
+        ANCHOR_BOTTOM_CENTER,
+        ANCHOR_BOTTOM_END,
+    )
+
+    data class ControlPlacement(
+        val action: String,
+        var group: String,
+        var anchor: String,
+    )
+
+    data class ControlDefinition(
+        val action: String,
+        val quickKey: String?,
+        val quickDefault: Boolean,
+        val menuKey: String?,
+        val menuDefault: Boolean,
+        val canQuick: Boolean,
+        val canMenu: Boolean,
+    )
+
+    internal val controlDefinitions = listOf(
+        ControlDefinition("minimize", C.PLAYER_MINIMIZE, true, null, false, canQuick = true, canMenu = false),
+        ControlDefinition("download", C.PLAYER_DOWNLOAD, false, C.PLAYER_MENU_DOWNLOAD, true, canQuick = true, canMenu = true),
+        ControlDefinition("follow", C.PLAYER_FOLLOW, false, null, false, canQuick = true, canMenu = false),
+        ControlDefinition("quality", C.PLAYER_SETTINGS, true, C.PLAYER_MENU_QUALITY, false, canQuick = true, canMenu = true),
+        ControlDefinition("speed", C.PLAYER_SPEED_BUTTON, true, C.PLAYER_MENU_SPEED, false, canQuick = true, canMenu = true),
+        ControlDefinition("chapters", C.PLAYER_GAMES_BUTTON, true, C.PLAYER_MENU_GAMES, false, canQuick = true, canMenu = true),
+        ControlDefinition("restart", C.PLAYER_RESTART, true, C.PLAYER_MENU_RESTART, false, canQuick = true, canMenu = true),
+        ControlDefinition("live", C.PLAYER_SEEK_LIVE, false, null, false, canQuick = true, canMenu = false),
+        ControlDefinition("clip", C.PLAYER_CLIP_BUTTON, true, null, false, canQuick = true, canMenu = false),
+        ControlDefinition("volume", C.PLAYER_VOLUME_BUTTON, true, C.PLAYER_MENU_VOLUME, false, canQuick = true, canMenu = true),
+        ControlDefinition("compressor", C.PLAYER_AUDIO_COMPRESSOR_BUTTON, true, null, false, canQuick = true, canMenu = false),
+        ControlDefinition("mode", C.PLAYER_MODE, false, null, false, canQuick = true, canMenu = false),
+        ControlDefinition("subtitles", C.PLAYER_SUBTITLES, false, C.PLAYER_MENU_SUBTITLES, true, canQuick = true, canMenu = true),
+        ControlDefinition("chat_input", C.PLAYER_CHAT_BAR_TOGGLE, false, C.PLAYER_MENU_CHAT_BAR, true, canQuick = true, canMenu = true),
+        ControlDefinition("chat", C.PLAYER_CHAT_TOGGLE, true, C.PLAYER_MENU_CHAT_TOGGLE, false, canQuick = true, canMenu = true),
+        ControlDefinition("fullscreen", C.PLAYER_FULLSCREEN, true, null, false, canQuick = true, canMenu = false),
+        ControlDefinition("viewers", C.PLAYER_VIEWER_LIST, false, C.PLAYER_MENU_VIEWER_LIST, true, canQuick = false, canMenu = true),
+        ControlDefinition("bookmark", null, false, C.PLAYER_MENU_BOOKMARK, true, canQuick = false, canMenu = true),
+        ControlDefinition("share", null, false, C.PLAYER_MENU_SHARE, true, canQuick = false, canMenu = true),
+        ControlDefinition("find_vod", null, false, C.PLAYER_MENU_FIND_VOD, true, canQuick = false, canMenu = true),
+        ControlDefinition("sleep", C.PLAYER_SLEEP, false, C.PLAYER_MENU_SLEEP, true, canQuick = true, canMenu = true),
+        ControlDefinition("aspect", C.PLAYER_ASPECT, true, C.PLAYER_MENU_ASPECT, false, canQuick = true, canMenu = true),
+        ControlDefinition("reload_emotes", null, false, C.PLAYER_MENU_RELOAD_EMOTES, true, canQuick = false, canMenu = true),
+        ControlDefinition("disconnect_chat", null, false, C.PLAYER_MENU_CHAT_DISCONNECT, true, canQuick = false, canMenu = true),
+    )
+
     fun applyToPlayer(context: Context, binding: FragmentPlayerBinding) {
-        val order = orderedActions(
+        val placements = controlPlacements(
             context.prefs().getString(C.SETTINGS_PLAYER_CONTROL_LAYOUT, null),
-            SettingsMigration.defaultControlLayout(),
+            defaultControlLayout(),
         )
         with(binding.playerControls) {
-            reorderChildren(
-                topLeftLayout,
-                order,
-                mapOf("minimize" to minimize),
+            val containers = mapOf(
+                ANCHOR_TOP_START to topLeftLayout,
+                ANCHOR_TOP_CENTER to topCenterLayout,
+                ANCHOR_TOP_END to topRightLayout,
+                ANCHOR_MIDDLE_START to middleLeftLayout,
+                ANCHOR_MIDDLE_END to middleRightLayout,
+                ANCHOR_BOTTOM_START to bottomLeftLayout,
+                ANCHOR_BOTTOM_CENTER to bottomCenterLayout,
+                ANCHOR_BOTTOM_END to bottomRightLayout,
             )
-            reorderChildren(
-                topRightLayout,
-                order,
-                mapOf(
-                    "download" to download,
-                    "follow" to follow,
-                    "sleep" to sleepTimer,
-                    "aspect" to aspectRatio,
-                    "speed" to speed,
-                    "quality" to quality,
-                ),
+            val controls = mapOf(
+                "minimize" to minimize,
+                "download" to download,
+                "follow" to follow,
+                "sleep" to sleepTimer,
+                "aspect" to aspectRatio,
+                "speed" to speed,
+                "quality" to quality,
+                "restart" to restart,
+                "live" to seekLive,
+                "clip" to clip,
+                "chapters" to vodGames,
+                "volume" to volume,
+                "compressor" to audioCompressor,
+                "mode" to audioOnly,
+                "subtitles" to subtitles,
+                "chat_input" to toggleChatInput,
+                "chat" to toggleChat,
+                "fullscreen" to fullscreen,
             )
-            reorderChildren(
-                bottomLeftLayout,
-                order,
-                mapOf(
-                    "restart" to restart,
-                    "live" to seekLive,
-                    "clip" to clip,
-                    "chapters" to vodGames,
-                    "volume" to volume,
-                    "compressor" to audioCompressor,
-                    "mode" to audioOnly,
-                ),
-            )
-            reorderChildren(
-                bottomRightLayout,
-                order,
-                mapOf(
-                    "subtitles" to subtitles,
-                    "chat_input" to toggleChatInput,
-                    "chat" to toggleChat,
-                    "fullscreen" to fullscreen,
-                ),
-            )
+            val placementByAction = placements.associateBy { it.action }
+            val quickOrderByAnchor = placements
+                .filter { it.group == GROUP_QUICK }
+                .groupBy { it.anchor }
+                .mapValues { (_, items) -> items.map { it.action } }
+
+            controls.forEach { (action, view) ->
+                val placement = placementByAction[action]
+                val container = containers[placement?.anchor] ?: containers.getValue(defaultAnchor(action))
+                if (view.parent !== container) {
+                    (view.parent as? ViewGroup)?.removeView(view)
+                    container.addView(view)
+                }
+                if (placement?.group != GROUP_QUICK) {
+                    view.visibility = View.GONE
+                }
+            }
+            containers.forEach { (anchor, container) ->
+                reorderChildren(
+                    container,
+                    quickOrderByAnchor[anchor].orEmpty(),
+                    controls,
+                )
+            }
         }
+    }
+
+    fun controlPlacements(serialized: String?, fallback: String): List<ControlPlacement> {
+        val fallbackItems = fallback.split(',').mapNotNull(::parseControlPlacement)
+        val knownActions = fallbackItems.map { it.action }.toSet()
+        val savedItems = serialized.orEmpty().split(',').mapNotNull(::parseControlPlacement)
+            .filter { it.action in knownActions }
+        return (savedItems + fallbackItems).distinctBy { it.action }
+    }
+
+    fun serializeControlLayout(items: List<ControlPlacement>): String = items
+        .distinctBy { it.action }
+        .joinToString(",") { item ->
+            val group = normalizedGroup(item.action, item.group)
+            val anchor = item.anchor.takeIf { it in anchors } ?: defaultAnchor(item.action)
+            "${item.action}:$group:$anchor"
+        }
+
+    internal fun defaultControlLayout(): String = controlDefinitions.joinToString(",") { definition ->
+        val group = when {
+            definition.canQuick && definition.quickDefault -> GROUP_QUICK
+            definition.menuDefault -> GROUP_MENU
+            else -> GROUP_HIDDEN
+        }
+        "${definition.action}:$group"
+    }
+
+    internal fun canQuick(action: String): Boolean = controlDefinitions
+        .firstOrNull { it.action == action }
+        ?.canQuick == true
+
+    internal fun canMenu(action: String): Boolean = controlDefinitions
+        .firstOrNull { it.action == action }
+        ?.canMenu == true
+
+    fun defaultAnchor(action: String): String = when (action) {
+        "minimize" -> ANCHOR_TOP_START
+        "download", "follow", "quality", "speed", "sleep", "aspect" -> ANCHOR_TOP_END
+        "chapters", "restart", "live", "clip", "volume", "compressor", "mode" -> ANCHOR_BOTTOM_START
+        "subtitles", "chat_input", "chat", "fullscreen" -> ANCHOR_BOTTOM_END
+        else -> ANCHOR_TOP_END
     }
 
     fun orderedActions(serialized: String?, fallback: String): List<String> {
@@ -80,6 +202,23 @@ object PlayerControlLayout {
 
         orderedChildren.forEach(container::removeView)
         orderedChildren.forEach(container::addView)
+    }
+
+    internal fun parseControlPlacement(serialized: String): ControlPlacement? {
+        val parts = serialized.split(':')
+        val action = parts.getOrNull(0)?.trim()?.takeIf(String::isNotEmpty) ?: return null
+        val group = parts.getOrNull(1)?.trim()?.takeIf {
+            it in setOf(GROUP_QUICK, GROUP_MENU, GROUP_HIDDEN)
+        } ?: GROUP_HIDDEN
+        val anchor = parts.getOrNull(2)?.trim()?.takeIf { it in anchors } ?: defaultAnchor(action)
+        return ControlPlacement(action, normalizedGroup(action, group), anchor)
+    }
+
+    private fun normalizedGroup(action: String, group: String): String = when {
+        group == GROUP_QUICK && !canQuick(action) -> if (canMenu(action)) GROUP_MENU else GROUP_HIDDEN
+        group == GROUP_MENU && !canMenu(action) -> if (canQuick(action)) GROUP_QUICK else GROUP_HIDDEN
+        group in setOf(GROUP_QUICK, GROUP_MENU, GROUP_HIDDEN) -> group
+        else -> GROUP_HIDDEN
     }
 
     private fun parseActions(serialized: String): List<String> = serialized

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/SettingsMigration.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/SettingsMigration.kt
@@ -685,40 +685,7 @@ object SettingsMigration {
         }
     }
 
-    private data class ControlSource(
-        val action: String,
-        val quickKey: String?,
-        val quickDefault: Boolean,
-        val menuKey: String?,
-        val menuDefault: Boolean,
-    )
-
-    private val controlSources = listOf(
-        ControlSource("minimize", C.PLAYER_MINIMIZE, true, null, false),
-        ControlSource("download", C.PLAYER_DOWNLOAD, false, C.PLAYER_MENU_DOWNLOAD, true),
-        ControlSource("follow", C.PLAYER_FOLLOW, false, null, false),
-        ControlSource("quality", C.PLAYER_SETTINGS, true, C.PLAYER_MENU_QUALITY, false),
-        ControlSource("speed", C.PLAYER_SPEED_BUTTON, true, C.PLAYER_MENU_SPEED, false),
-        ControlSource("chapters", C.PLAYER_GAMES_BUTTON, true, C.PLAYER_MENU_GAMES, false),
-        ControlSource("restart", C.PLAYER_RESTART, true, C.PLAYER_MENU_RESTART, false),
-        ControlSource("live", C.PLAYER_SEEK_LIVE, false, null, false),
-        ControlSource("clip", C.PLAYER_CLIP_BUTTON, true, null, false),
-        ControlSource("volume", C.PLAYER_VOLUME_BUTTON, true, C.PLAYER_MENU_VOLUME, false),
-        ControlSource("compressor", C.PLAYER_AUDIO_COMPRESSOR_BUTTON, true, null, false),
-        ControlSource("mode", C.PLAYER_MODE, false, null, false),
-        ControlSource("subtitles", C.PLAYER_SUBTITLES, false, C.PLAYER_MENU_SUBTITLES, true),
-        ControlSource("chat_input", C.PLAYER_CHAT_BAR_TOGGLE, false, C.PLAYER_MENU_CHAT_BAR, true),
-        ControlSource("chat", C.PLAYER_CHAT_TOGGLE, true, C.PLAYER_MENU_CHAT_TOGGLE, false),
-        ControlSource("fullscreen", C.PLAYER_FULLSCREEN, true, null, false),
-        ControlSource("viewers", C.PLAYER_VIEWER_LIST, false, C.PLAYER_MENU_VIEWER_LIST, true),
-        ControlSource("bookmark", null, false, C.PLAYER_MENU_BOOKMARK, true),
-        ControlSource("share", null, false, C.PLAYER_MENU_SHARE, true),
-        ControlSource("find_vod", null, false, C.PLAYER_MENU_FIND_VOD, true),
-        ControlSource("sleep", C.PLAYER_SLEEP, false, C.PLAYER_MENU_SLEEP, true),
-        ControlSource("aspect", C.PLAYER_ASPECT, true, C.PLAYER_MENU_ASPECT, false),
-        ControlSource("reload_emotes", null, false, C.PLAYER_MENU_RELOAD_EMOTES, true),
-        ControlSource("disconnect_chat", null, false, C.PLAYER_MENU_CHAT_DISCONNECT, true),
-    )
+    private val controlSources = PlayerControlLayout.controlDefinitions
 
     internal fun controlGroup(quickEnabled: Boolean, menuEnabled: Boolean): String = when {
         quickEnabled -> "quick"
@@ -742,11 +709,11 @@ object SettingsMigration {
         if (split(',').any { it.substringBefore(':') == "clip" }) this else "$this,clip:quick"
 
     internal fun defaultControlLayout(): String = controlSources.joinToString(",") {
-        "${it.action}:${controlGroup(it.quickDefault, it.menuDefault)}"
+        "${it.action}:${controlGroup(it.canQuick && it.quickDefault, it.menuDefault)}"
     }
 
     private fun controlLayout(preferences: SharedPreferences): String = controlSources.joinToString(",") { source ->
-        val quick = source.quickKey?.let { preferences.getBoolean(it, source.quickDefault) } ?: false
+        val quick = source.canQuick && source.quickKey?.let { preferences.getBoolean(it, source.quickDefault) } == true
         val menu = source.menuKey?.let { preferences.getBoolean(it, source.menuDefault) } ?: false
         "${source.action}:${controlGroup(quick, menu)}"
     }
@@ -764,9 +731,8 @@ object SettingsMigration {
 
     private fun SharedPreferences.Editor.syncLegacyControlVisibility(serializedLayout: String) {
         val groups = serializedLayout.split(',').mapNotNull { item ->
-            val parts = item.split(':', limit = 2)
-            parts.getOrNull(0)?.takeIf { it.isNotBlank() }?.let { action ->
-                action to (parts.getOrNull(1) ?: "hidden")
+            PlayerControlLayout.parseControlPlacement(item)?.let { placement ->
+                placement.action to placement.group
             }
         }.toMap()
         controlSources.forEach { source ->
@@ -775,5 +741,11 @@ object SettingsMigration {
             source.menuKey?.let { putBoolean(it, group == "menu") }
         }
         putBoolean(C.PLAYER_MENU, controlSources.any { groups[it.action] == "menu" })
+    }
+
+    internal fun syncLegacyControlVisibility(preferences: SharedPreferences, serializedLayout: String) {
+        preferences.edit {
+            syncLegacyControlVisibility(serializedLayout)
+        }
     }
 }

--- a/app/src/main/res/layout/player_layout.xml
+++ b/app/src/main/res/layout/player_layout.xml
@@ -275,6 +275,32 @@
     </LinearLayout>
 
     <LinearLayout
+        android:id="@+id/topCenterLayout"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentTop="true"
+        android:layout_centerHorizontal="true"
+        android:layout_marginTop="5dp" />
+
+    <LinearLayout
+        android:id="@+id/middleLeftLayout"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentStart="true"
+        android:layout_centerVertical="true"
+        android:layout_marginStart="10dp"
+        android:orientation="vertical" />
+
+    <LinearLayout
+        android:id="@+id/middleRightLayout"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentEnd="true"
+        android:layout_centerVertical="true"
+        android:layout_marginEnd="10dp"
+        android:orientation="vertical" />
+
+    <LinearLayout
         android:id="@+id/bottomLeftLayout"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
@@ -439,6 +465,14 @@
             tools:visibility="visible" />
 
     </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/bottomCenterLayout"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_above="@id/streamInfoLayout"
+        android:layout_centerHorizontal="true"
+        android:layout_marginBottom="5dp" />
 
     <LinearLayout
         android:id="@+id/streamInfoLayout"

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -1410,4 +1410,18 @@
     <string name="update_frequency_daily">مرة واحدة يوميًا</string>
     <string name="update_frequency_3_days">كل 3 أيام</string>
     <string name="update_frequency_weekly">مرة واحدة أسبوعيًا</string>
+    <string name="settings_customize_controls_help">اسحب عنصر تحكم إلى زاوية أو حافة. اضغط عليه للتبديل بين المشغل وقائمة المزيد والمخفي.</string>
+    <string name="settings_customize_controls_selected">المحدد: %1$s</string>
+    <string name="settings_customize_controls_selected_none">حدد عنصر تحكم لرؤية موضعه الحالي.</string>
+    <string name="settings_customize_controls_reset">إعادة ضبط التخطيط</string>
+    <string name="settings_customize_controls_empty">لا شيء هنا</string>
+    <string name="settings_customize_controls_enable">إظهار %1$s في المشغل</string>
+    <string name="settings_customize_controls_enable_menu">إظهار %1$s في قائمة المزيد</string>
+    <string name="settings_customize_controls_hide">إخفاء %1$s</string>
+    <string name="settings_customize_controls_preview_description">معاينة مشغل وهمي. اسحب أزرار التحكم الظاهرة لإعادة ترتيبها.</string>
+    <string name="settings_customize_controls_snap_hint">حرر للإرساء</string>
+    <string name="settings_customize_controls_drag_action">اسحب أو اضغط %1$s</string>
+    <string name="settings_layout_preview">معاينة</string>
+    <string name="settings_tabs_preview_help">تتبع المعاينة الترتيب والعناصر الظاهرة أدناه.</string>
+    <string name="settings_sections_preview_help">تعرض المعاينة الرفوف الظاهرة بالترتيب الحالي.</string>
 </resources>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -1434,4 +1434,18 @@
     <string name="update_frequency_daily">Jednou denně</string>
     <string name="update_frequency_3_days">Každé 3 dny</string>
     <string name="update_frequency_weekly">Jednou týdně</string>
+    <string name="settings_customize_controls_help">Přetáhněte ovládací prvek do rohu nebo na okraj. Klepnutím přepnete mezi přehrávačem, nabídkou Více a skrytím.</string>
+    <string name="settings_customize_controls_selected">Vybráno: %1$s</string>
+    <string name="settings_customize_controls_selected_none">Vyberte ovládací prvek a zobrazte jeho aktuální pozici.</string>
+    <string name="settings_customize_controls_reset">Obnovit rozložení</string>
+    <string name="settings_customize_controls_empty">Nic zde není</string>
+    <string name="settings_customize_controls_enable">Zobrazit %1$s v přehrávači</string>
+    <string name="settings_customize_controls_enable_menu">Zobrazit %1$s v nabídce Více</string>
+    <string name="settings_customize_controls_hide">Skrýt %1$s</string>
+    <string name="settings_customize_controls_preview_description">Náhled fiktivního přehrávače. Přetažením viditelných ovládacích tlačítek je přemístíte.</string>
+    <string name="settings_customize_controls_snap_hint">Uvolněním přichytíte</string>
+    <string name="settings_customize_controls_drag_action">Přetažení nebo klepnutí na %1$s</string>
+    <string name="settings_layout_preview">Náhled</string>
+    <string name="settings_tabs_preview_help">Náhled sleduje pořadí a viditelnost níže.</string>
+    <string name="settings_sections_preview_help">Náhled zobrazuje viditelné police v aktuálním pořadí.</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1410,4 +1410,18 @@
     <string name="update_frequency_daily">Einmal täglich</string>
     <string name="update_frequency_3_days">Alle 3 Tage</string>
     <string name="update_frequency_weekly">Einmal wöchentlich</string>
+    <string name="settings_customize_controls_help">Ziehen Sie ein Steuerelement in eine Ecke oder an einen Rand. Tippen Sie darauf, um zwischen Player, Mehr-Menü und Ausblenden zu wechseln.</string>
+    <string name="settings_customize_controls_selected">Ausgewählt: %1$s</string>
+    <string name="settings_customize_controls_selected_none">Wählen Sie ein Steuerelement, um seine aktuelle Position zu sehen.</string>
+    <string name="settings_customize_controls_reset">Anordnung zurücksetzen</string>
+    <string name="settings_customize_controls_empty">Hier ist nichts</string>
+    <string name="settings_customize_controls_enable">%1$s im Player anzeigen</string>
+    <string name="settings_customize_controls_enable_menu">%1$s im Mehr-Menü anzeigen</string>
+    <string name="settings_customize_controls_hide">%1$s ausblenden</string>
+    <string name="settings_customize_controls_preview_description">Vorschau eines simulierten Players. Ziehen Sie die sichtbaren Bedienelemente an die gewünschte Stelle.</string>
+    <string name="settings_customize_controls_snap_hint">Zum Einrasten loslassen</string>
+    <string name="settings_customize_controls_drag_action">%1$s ziehen oder antippen</string>
+    <string name="settings_layout_preview">Vorschau</string>
+    <string name="settings_tabs_preview_help">Die Vorschau folgt der unten angezeigten Reihenfolge und Sichtbarkeit.</string>
+    <string name="settings_sections_preview_help">Die Vorschau zeigt die sichtbaren Bereiche in ihrer aktuellen Reihenfolge.</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1415,4 +1415,18 @@
     <string name="update_frequency_daily">Una vez al día</string>
     <string name="update_frequency_3_days">Cada 3 días</string>
     <string name="update_frequency_weekly">Una vez a la semana</string>
+    <string name="settings_customize_controls_help">Arrastra un control a una esquina o un borde. Tócalo para alternar entre el reproductor, el menú Más y ocultarlo.</string>
+    <string name="settings_customize_controls_selected">Seleccionado: %1$s</string>
+    <string name="settings_customize_controls_selected_none">Selecciona un control para ver su posición actual.</string>
+    <string name="settings_customize_controls_reset">Restablecer diseño</string>
+    <string name="settings_customize_controls_empty">No hay nada aquí</string>
+    <string name="settings_customize_controls_enable">Mostrar %1$s en el reproductor</string>
+    <string name="settings_customize_controls_enable_menu">Mostrar %1$s en el menú Más</string>
+    <string name="settings_customize_controls_hide">Ocultar %1$s</string>
+    <string name="settings_customize_controls_preview_description">Vista previa de un reproductor simulado. Arrastra los botones de control visibles para recolocarlos.</string>
+    <string name="settings_customize_controls_snap_hint">Suelta para ajustar</string>
+    <string name="settings_customize_controls_drag_action">Arrastra o toca %1$s</string>
+    <string name="settings_layout_preview">Vista previa</string>
+    <string name="settings_tabs_preview_help">La vista previa sigue el orden y la visibilidad indicados abajo.</string>
+    <string name="settings_sections_preview_help">La vista previa muestra las secciones visibles en su orden actual.</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1410,4 +1410,18 @@
     <string name="update_frequency_daily">Une fois par jour</string>
     <string name="update_frequency_3_days">Tous les 3 jours</string>
     <string name="update_frequency_weekly">Une fois par semaine</string>
+    <string name="settings_customize_controls_help">Faites glisser une commande vers un coin ou un bord. Touchez-la pour alterner entre le lecteur, le menu Plus et l’état masqué.</string>
+    <string name="settings_customize_controls_selected">Sélectionné : %1$s</string>
+    <string name="settings_customize_controls_selected_none">Sélectionnez une commande pour voir sa position actuelle.</string>
+    <string name="settings_customize_controls_reset">Réinitialiser la disposition</string>
+    <string name="settings_customize_controls_empty">Rien ici</string>
+    <string name="settings_customize_controls_enable">Afficher %1$s dans le lecteur</string>
+    <string name="settings_customize_controls_enable_menu">Afficher %1$s dans le menu Plus</string>
+    <string name="settings_customize_controls_hide">Masquer %1$s</string>
+    <string name="settings_customize_controls_preview_description">Aperçu d’un lecteur fictif. Faites glisser les boutons de commande visibles pour les repositionner.</string>
+    <string name="settings_customize_controls_snap_hint">Relâchez pour aligner</string>
+    <string name="settings_customize_controls_drag_action">Faites glisser ou touchez %1$s</string>
+    <string name="settings_layout_preview">Aperçu</string>
+    <string name="settings_tabs_preview_help">L’aperçu suit l’ordre et la visibilité indiqués ci-dessous.</string>
+    <string name="settings_sections_preview_help">L’aperçu affiche les sections visibles dans leur ordre actuel.</string>
 </resources>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -1410,4 +1410,18 @@
     <string name="update_frequency_daily">Unha vez ao día</string>
     <string name="update_frequency_3_days">Cada 3 días</string>
     <string name="update_frequency_weekly">Unha vez á semana</string>
+    <string name="settings_customize_controls_help">Arrastra un control a unha esquina ou bordo. Tócao para alternar entre o reprodutor, o menú Máis e ocultalo.</string>
+    <string name="settings_customize_controls_selected">Seleccionado: %1$s</string>
+    <string name="settings_customize_controls_selected_none">Selecciona un control para ver a súa posición actual.</string>
+    <string name="settings_customize_controls_reset">Restablecer disposición</string>
+    <string name="settings_customize_controls_empty">Non hai nada aquí</string>
+    <string name="settings_customize_controls_enable">Amosar %1$s no reprodutor</string>
+    <string name="settings_customize_controls_enable_menu">Amosar %1$s no menú Máis</string>
+    <string name="settings_customize_controls_hide">Ocultar %1$s</string>
+    <string name="settings_customize_controls_preview_description">Vista previa dun reprodutor simulado. Arrastra os botóns de control visibles para recolocalos.</string>
+    <string name="settings_customize_controls_snap_hint">Solta para axustar</string>
+    <string name="settings_customize_controls_drag_action">Arrastra ou toca %1$s</string>
+    <string name="settings_layout_preview">Vista previa</string>
+    <string name="settings_tabs_preview_help">A vista previa segue a orde e visibilidade que aparecen abaixo.</string>
+    <string name="settings_sections_preview_help">A vista previa mostra as seccións visibles na súa orde actual.</string>
 </resources>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -1411,4 +1411,18 @@
     <string name="update_frequency_daily">Sekali sehari</string>
     <string name="update_frequency_3_days">Setiap 3 hari</string>
     <string name="update_frequency_weekly">Sekali seminggu</string>
+    <string name="settings_customize_controls_help">Seret kontrol ke sudut atau tepi. Ketuk untuk beralih antara pemutar, menu Lainnya, dan tersembunyi.</string>
+    <string name="settings_customize_controls_selected">Dipilih: %1$s</string>
+    <string name="settings_customize_controls_selected_none">Pilih kontrol untuk melihat posisinya saat ini.</string>
+    <string name="settings_customize_controls_reset">Atur ulang tata letak</string>
+    <string name="settings_customize_controls_empty">Tidak ada apa-apa di sini</string>
+    <string name="settings_customize_controls_enable">Tampilkan %1$s di pemutar</string>
+    <string name="settings_customize_controls_enable_menu">Tampilkan %1$s di menu Lainnya</string>
+    <string name="settings_customize_controls_hide">Sembunyikan %1$s</string>
+    <string name="settings_customize_controls_preview_description">Pratinjau pemutar tiruan. Seret tombol kontrol yang terlihat untuk memindahkannya.</string>
+    <string name="settings_customize_controls_snap_hint">Lepaskan untuk menempel</string>
+    <string name="settings_customize_controls_drag_action">Seret atau ketuk %1$s</string>
+    <string name="settings_layout_preview">Pratinjau</string>
+    <string name="settings_tabs_preview_help">Pratinjau mengikuti urutan dan visibilitas di bawah.</string>
+    <string name="settings_sections_preview_help">Pratinjau menampilkan bagian yang terlihat dalam urutan saat ini.</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1410,4 +1410,18 @@
     <string name="update_frequency_daily">Una volta al giorno</string>
     <string name="update_frequency_3_days">Ogni 3 giorni</string>
     <string name="update_frequency_weekly">Una volta alla settimana</string>
+    <string name="settings_customize_controls_help">Trascina un controllo in un angolo o su un bordo. Toccalo per alternare tra lettore, menu Altro e nascosto.</string>
+    <string name="settings_customize_controls_selected">Selezionato: %1$s</string>
+    <string name="settings_customize_controls_selected_none">Seleziona un controllo per vederne la posizione attuale.</string>
+    <string name="settings_customize_controls_reset">Reimposta disposizione</string>
+    <string name="settings_customize_controls_empty">Non c’è nulla qui</string>
+    <string name="settings_customize_controls_enable">Mostra %1$s nel lettore</string>
+    <string name="settings_customize_controls_enable_menu">Mostra %1$s nel menu Altro</string>
+    <string name="settings_customize_controls_hide">Nascondi %1$s</string>
+    <string name="settings_customize_controls_preview_description">Anteprima di un lettore fittizio. Trascina i pulsanti di controllo visibili per riposizionarli.</string>
+    <string name="settings_customize_controls_snap_hint">Rilascia per agganciare</string>
+    <string name="settings_customize_controls_drag_action">Trascina o tocca %1$s</string>
+    <string name="settings_layout_preview">Anteprima</string>
+    <string name="settings_tabs_preview_help">L’anteprima segue l’ordine e la visibilità indicati sotto.</string>
+    <string name="settings_sections_preview_help">L’anteprima mostra le sezioni visibili nell’ordine attuale.</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1410,4 +1410,18 @@
     <string name="update_frequency_daily">1日1回</string>
     <string name="update_frequency_3_days">3日ごと</string>
     <string name="update_frequency_weekly">週1回</string>
+    <string name="settings_customize_controls_help">コントロールを隅または端へドラッグします。タップするとプレーヤー、その他メニュー、非表示を切り替えます。</string>
+    <string name="settings_customize_controls_selected">選択中: %1$s</string>
+    <string name="settings_customize_controls_selected_none">現在の位置を確認するコントロールを選択してください。</string>
+    <string name="settings_customize_controls_reset">レイアウトをリセット</string>
+    <string name="settings_customize_controls_empty">ここにはありません</string>
+    <string name="settings_customize_controls_enable">プレーヤーに%1$sを表示</string>
+    <string name="settings_customize_controls_enable_menu">その他メニューに%1$sを表示</string>
+    <string name="settings_customize_controls_hide">%1$sを非表示</string>
+    <string name="settings_customize_controls_preview_description">プレーヤーのプレビューです。表示中のコントロールボタンをドラッグして移動できます。</string>
+    <string name="settings_customize_controls_snap_hint">離してスナップ</string>
+    <string name="settings_customize_controls_drag_action">%1$sをドラッグまたはタップ</string>
+    <string name="settings_layout_preview">プレビュー</string>
+    <string name="settings_tabs_preview_help">プレビューには下の順序と表示状態が反映されます。</string>
+    <string name="settings_sections_preview_help">プレビューには現在の順序で表示されるセクションが表示されます。</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -1412,4 +1412,18 @@
     <string name="update_frequency_daily">Raz dziennie</string>
     <string name="update_frequency_3_days">Co 3 dni</string>
     <string name="update_frequency_weekly">Raz w tygodniu</string>
+    <string name="settings_customize_controls_help">Przeciągnij element sterujący do rogu lub krawędzi. Dotknij go, aby przełączać między odtwarzaczem, menu Więcej i ukryciem.</string>
+    <string name="settings_customize_controls_selected">Wybrano: %1$s</string>
+    <string name="settings_customize_controls_selected_none">Wybierz element sterujący, aby zobaczyć jego bieżące położenie.</string>
+    <string name="settings_customize_controls_reset">Resetuj układ</string>
+    <string name="settings_customize_controls_empty">Nic tutaj nie ma</string>
+    <string name="settings_customize_controls_enable">Pokaż %1$s w odtwarzaczu</string>
+    <string name="settings_customize_controls_enable_menu">Pokaż %1$s w menu Więcej</string>
+    <string name="settings_customize_controls_hide">Ukryj %1$s</string>
+    <string name="settings_customize_controls_preview_description">Podgląd fikcyjnego odtwarzacza. Przeciągnij widoczne przyciski sterowania, aby je przenieść.</string>
+    <string name="settings_customize_controls_snap_hint">Puść, aby przyciągnąć</string>
+    <string name="settings_customize_controls_drag_action">Przeciągnij lub dotknij %1$s</string>
+    <string name="settings_layout_preview">Podgląd</string>
+    <string name="settings_tabs_preview_help">Podgląd odzwierciedla kolejność i widoczność poniżej.</string>
+    <string name="settings_sections_preview_help">Podgląd pokazuje widoczne sekcje w bieżącej kolejności.</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -1410,4 +1410,18 @@
     <string name="update_frequency_daily">Uma vez por dia</string>
     <string name="update_frequency_3_days">A cada 3 dias</string>
     <string name="update_frequency_weekly">Uma vez por semana</string>
+    <string name="settings_customize_controls_help">Arraste um controle para um canto ou uma borda. Toque nele para alternar entre o player, o menu Mais e oculto.</string>
+    <string name="settings_customize_controls_selected">Selecionado: %1$s</string>
+    <string name="settings_customize_controls_selected_none">Selecione um controle para ver sua posição atual.</string>
+    <string name="settings_customize_controls_reset">Redefinir layout</string>
+    <string name="settings_customize_controls_empty">Não há nada aqui</string>
+    <string name="settings_customize_controls_enable">Mostrar %1$s no player</string>
+    <string name="settings_customize_controls_enable_menu">Mostrar %1$s no menu Mais</string>
+    <string name="settings_customize_controls_hide">Ocultar %1$s</string>
+    <string name="settings_customize_controls_preview_description">Prévia de um player fictício. Arraste os botões de controle visíveis para reposicioná-los.</string>
+    <string name="settings_customize_controls_snap_hint">Solte para encaixar</string>
+    <string name="settings_customize_controls_drag_action">Arraste ou toque em %1$s</string>
+    <string name="settings_layout_preview">Prévia</string>
+    <string name="settings_tabs_preview_help">A prévia segue a ordem e a visibilidade abaixo.</string>
+    <string name="settings_sections_preview_help">A prévia mostra as seções visíveis na ordem atual.</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1410,4 +1410,18 @@
     <string name="update_frequency_daily">Раз в день</string>
     <string name="update_frequency_3_days">Каждые 3 дня</string>
     <string name="update_frequency_weekly">Раз в неделю</string>
+    <string name="settings_customize_controls_help">Перетащите элемент управления в угол или к краю. Нажмите его, чтобы переключаться между плеером, меню «Ещё» и скрытым состоянием.</string>
+    <string name="settings_customize_controls_selected">Выбрано: %1$s</string>
+    <string name="settings_customize_controls_selected_none">Выберите элемент управления, чтобы увидеть его текущее положение.</string>
+    <string name="settings_customize_controls_reset">Сбросить расположение</string>
+    <string name="settings_customize_controls_empty">Здесь ничего нет</string>
+    <string name="settings_customize_controls_enable">Показывать %1$s в плеере</string>
+    <string name="settings_customize_controls_enable_menu">Показывать %1$s в меню «Ещё»</string>
+    <string name="settings_customize_controls_hide">Скрыть %1$s</string>
+    <string name="settings_customize_controls_preview_description">Предпросмотр фиктивного плеера. Перетащите видимые кнопки управления, чтобы изменить их положение.</string>
+    <string name="settings_customize_controls_snap_hint">Отпустите, чтобы закрепить</string>
+    <string name="settings_customize_controls_drag_action">Перетащите или нажмите %1$s</string>
+    <string name="settings_layout_preview">Предпросмотр</string>
+    <string name="settings_tabs_preview_help">Предпросмотр учитывает порядок и видимость ниже.</string>
+    <string name="settings_sections_preview_help">Предпросмотр показывает видимые разделы в текущем порядке.</string>
 </resources>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -1434,4 +1434,18 @@
     <string name="update_frequency_daily">Raz denne</string>
     <string name="update_frequency_3_days">Každé 3 dni</string>
     <string name="update_frequency_weekly">Raz týždenne</string>
+    <string name="settings_customize_controls_help">Presuňte ovládací prvok do rohu alebo na okraj. Klepnutím prepínate medzi prehrávačom, ponukou Viac a skrytím.</string>
+    <string name="settings_customize_controls_selected">Vybrané: %1$s</string>
+    <string name="settings_customize_controls_selected_none">Vyberte ovládací prvok a zobrazte jeho aktuálnu pozíciu.</string>
+    <string name="settings_customize_controls_reset">Obnoviť rozloženie</string>
+    <string name="settings_customize_controls_empty">Nič tu nie je</string>
+    <string name="settings_customize_controls_enable">Zobraziť %1$s v prehrávači</string>
+    <string name="settings_customize_controls_enable_menu">Zobraziť %1$s v ponuke Viac</string>
+    <string name="settings_customize_controls_hide">Skryť %1$s</string>
+    <string name="settings_customize_controls_preview_description">Náhľad fiktívneho prehrávača. Presunutím viditeľných ovládacích tlačidiel zmeníte ich polohu.</string>
+    <string name="settings_customize_controls_snap_hint">Uvoľnením prichytíte</string>
+    <string name="settings_customize_controls_drag_action">Presuňte alebo klepnite na %1$s</string>
+    <string name="settings_layout_preview">Náhľad</string>
+    <string name="settings_tabs_preview_help">Náhľad sleduje poradie a viditeľnosť uvedené nižšie.</string>
+    <string name="settings_sections_preview_help">Náhľad zobrazuje viditeľné sekcie v aktuálnom poradí.</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -1411,4 +1411,18 @@
     <string name="update_frequency_daily">Günde bir kez</string>
     <string name="update_frequency_3_days">3 günde bir</string>
     <string name="update_frequency_weekly">Haftada bir</string>
+    <string name="settings_customize_controls_help">Bir kontrolü köşeye veya kenara sürükleyin. Oynatıcı, Diğer menüsü ve gizli arasında geçiş yapmak için dokunun.</string>
+    <string name="settings_customize_controls_selected">Seçili: %1$s</string>
+    <string name="settings_customize_controls_selected_none">Geçerli konumunu görmek için bir kontrol seçin.</string>
+    <string name="settings_customize_controls_reset">Düzeni sıfırla</string>
+    <string name="settings_customize_controls_empty">Burada hiçbir şey yok</string>
+    <string name="settings_customize_controls_enable">%1$s oynatıcıda göster</string>
+    <string name="settings_customize_controls_enable_menu">%1$s Diğer menüsünde göster</string>
+    <string name="settings_customize_controls_hide">%1$s gizle</string>
+    <string name="settings_customize_controls_preview_description">Sahte oynatıcı önizlemesi. Görünen kontrol düğmelerini sürükleyerek yeniden konumlandırın.</string>
+    <string name="settings_customize_controls_snap_hint">Mıknatıslamak için bırakın</string>
+    <string name="settings_customize_controls_drag_action">%1$s sürükleyin veya dokunun</string>
+    <string name="settings_layout_preview">Önizleme</string>
+    <string name="settings_tabs_preview_help">Önizleme, aşağıdaki sırayı ve görünürlüğü izler.</string>
+    <string name="settings_sections_preview_help">Önizleme, görünür bölümleri geçerli sıralarında gösterir.</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1410,4 +1410,18 @@
     <string name="update_frequency_daily">每天一次</string>
     <string name="update_frequency_3_days">每3天</string>
     <string name="update_frequency_weekly">每周一次</string>
+    <string name="settings_customize_controls_help">将控件拖到角落或边缘。点按控件可在播放器、更多菜单和隐藏之间切换。</string>
+    <string name="settings_customize_controls_selected">已选择：%1$s</string>
+    <string name="settings_customize_controls_selected_none">选择一个控件以查看其当前位置。</string>
+    <string name="settings_customize_controls_reset">重置布局</string>
+    <string name="settings_customize_controls_empty">这里没有内容</string>
+    <string name="settings_customize_controls_enable">在播放器中显示%1$s</string>
+    <string name="settings_customize_controls_enable_menu">在更多菜单中显示%1$s</string>
+    <string name="settings_customize_controls_hide">隐藏%1$s</string>
+    <string name="settings_customize_controls_preview_description">模拟播放器预览。拖动可见的控制按钮来调整位置。</string>
+    <string name="settings_customize_controls_snap_hint">松开以吸附</string>
+    <string name="settings_customize_controls_drag_action">拖动或点按%1$s</string>
+    <string name="settings_layout_preview">预览</string>
+    <string name="settings_tabs_preview_help">预览会按照下方的顺序和可见性显示。</string>
+    <string name="settings_sections_preview_help">预览会按当前顺序显示可见分区。</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -1410,4 +1410,18 @@
     <string name="update_frequency_daily">每天一次</string>
     <string name="update_frequency_3_days">每3天</string>
     <string name="update_frequency_weekly">每週一次</string>
+    <string name="settings_customize_controls_help">將控制項拖曳到角落或邊緣。點按控制項可在播放器、更多選單和隱藏之間切換。</string>
+    <string name="settings_customize_controls_selected">已選取：%1$s</string>
+    <string name="settings_customize_controls_selected_none">選取控制項以查看目前位置。</string>
+    <string name="settings_customize_controls_reset">重設版面配置</string>
+    <string name="settings_customize_controls_empty">這裡沒有內容</string>
+    <string name="settings_customize_controls_enable">在播放器中顯示%1$s</string>
+    <string name="settings_customize_controls_enable_menu">在更多選單中顯示%1$s</string>
+    <string name="settings_customize_controls_hide">隱藏%1$s</string>
+    <string name="settings_customize_controls_preview_description">模擬播放器預覽。拖曳可見的控制按鈕來調整位置。</string>
+    <string name="settings_customize_controls_snap_hint">放開以吸附</string>
+    <string name="settings_customize_controls_drag_action">拖曳或點按%1$s</string>
+    <string name="settings_layout_preview">預覽</string>
+    <string name="settings_tabs_preview_help">預覽會依照下方的順序和可見性顯示。</string>
+    <string name="settings_sections_preview_help">預覽會依目前順序顯示可見區段。</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -395,6 +395,17 @@
     <string name="settings_watch_history">Watch history</string>
     <string name="settings_clear_positions">Clear watch positions</string>
     <string name="settings_customize_controls">Customize controls</string>
+    <string name="settings_customize_controls_help">Drag a control to a corner or edge. Tap it to cycle between the player, More menu and hidden.</string>
+    <string name="settings_customize_controls_selected">Selected: %1$s</string>
+    <string name="settings_customize_controls_selected_none">Select a control to see its current position.</string>
+    <string name="settings_customize_controls_reset">Reset layout</string>
+    <string name="settings_customize_controls_empty">Nothing here</string>
+    <string name="settings_customize_controls_enable">Show %1$s on the player</string>
+    <string name="settings_customize_controls_enable_menu">Show %1$s in More menu</string>
+    <string name="settings_customize_controls_hide">Hide %1$s</string>
+    <string name="settings_customize_controls_preview_description">Fake player preview. Drag the visible control buttons to reposition them.</string>
+    <string name="settings_customize_controls_snap_hint">Release to snap</string>
+    <string name="settings_customize_controls_drag_action">Drag or tap %1$s</string>
     <string name="settings_seek_controls">Seek controls</string>
     <string name="settings_gestures">Gestures</string>
     <string name="settings_clip_capture">Local clips</string>
@@ -1426,6 +1437,9 @@
     <string name="settings_download_restart_wait_summary">Keep waiting briefly after a stream ends so a quick restart can continue the capture.</string>
     <string name="live_notifications_following_summary">Automatically enable live alerts for channels you follow through Xtra. Twitch notification preferences are used when compatibility authorization is available.</string>
     <string name="settings_customize_controls_summary">Quick controls, More menu and Hidden</string>
+    <string name="settings_layout_preview">Preview</string>
+    <string name="settings_tabs_preview_help">The preview follows the order and visibility below.</string>
+    <string name="settings_sections_preview_help">The preview shows the visible shelves in their current order.</string>
     <string name="settings_playback_speed_options_summary">Choose and reorder speed values</string>
     <string name="settings_double_tap_chat_summary">Toggle chat with a double tap while watching.</string>
     <string name="avoid_rounded_corners_summary">Inset player content so physical curved corners and cutouts do not obscure video or controls.</string>

--- a/app/src/test/java/com/github/andreyasadchy/xtra/util/PlayerControlLayoutTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/util/PlayerControlLayoutTest.kt
@@ -1,0 +1,47 @@
+package com.github.andreyasadchy.xtra.util
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class PlayerControlLayoutTest {
+
+    @Test
+    fun `anchored entries preserve their group and anchor`() {
+        val placements = PlayerControlLayout.controlPlacements(
+            "minimize:quick:top_start,quality:menu:top_end",
+            "minimize:hidden,quality:hidden",
+        )
+
+        assertEquals(
+            PlayerControlLayout.ControlPlacement(
+                "minimize",
+                PlayerControlLayout.GROUP_QUICK,
+                PlayerControlLayout.ANCHOR_TOP_START,
+            ),
+            placements.first { it.action == "minimize" },
+        )
+        assertEquals(
+            PlayerControlLayout.ControlPlacement(
+                "quality",
+                PlayerControlLayout.GROUP_MENU,
+                PlayerControlLayout.ANCHOR_TOP_END,
+            ),
+            placements.first { it.action == "quality" },
+        )
+    }
+
+    @Test
+    fun `unsupported quick actions stay in the More menu`() {
+        val placements = PlayerControlLayout.controlPlacements(
+            "bookmark:quick:top_center,viewers:quick:top_center",
+            "bookmark:menu,viewers:menu",
+        )
+
+        assertEquals(PlayerControlLayout.GROUP_MENU, placements.first { it.action == "bookmark" }.group)
+        assertEquals(PlayerControlLayout.GROUP_MENU, placements.first { it.action == "viewers" }.group)
+        assertEquals(
+            "bookmark:menu:top_center,viewers:menu:top_center",
+            PlayerControlLayout.serializeControlLayout(placements),
+        )
+    }
+}

--- a/app/src/test/java/com/github/andreyasadchy/xtra/util/SettingsMigrationTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/util/SettingsMigrationTest.kt
@@ -274,6 +274,27 @@ class SettingsMigrationTest {
     }
 
     @Test
+    fun `new anchored control layout keeps legacy visibility groups in sync`() {
+        val preferences = MemoryPreferences(
+            mutableMapOf(
+                C.SETTINGS_VERSION to C.SETTINGS_SCHEMA_VERSION - 1,
+                C.SETTINGS_PLAYER_CONTROL_LAYOUT to "minimize:quick:top_start,quality:menu:top_end,bookmark:menu:top_end",
+                C.PLAYER_MINIMIZE to false,
+                C.PLAYER_SETTINGS to true,
+                C.PLAYER_MENU_QUALITY to false,
+                C.PLAYER_MENU_BOOKMARK to false,
+            ),
+        )
+
+        SettingsMigration.migratePreferences(preferences, freshInstall = false)
+
+        assertTrue(preferences.getBoolean(C.PLAYER_MINIMIZE, false))
+        assertFalse(preferences.getBoolean(C.PLAYER_SETTINGS, true))
+        assertTrue(preferences.getBoolean(C.PLAYER_MENU_QUALITY, false))
+        assertTrue(preferences.getBoolean(C.PLAYER_MENU_BOOKMARK, false))
+    }
+
+    @Test
     fun `empty migrated control layout is repaired to production defaults`() {
         assertEquals(
             SettingsMigration.defaultControlLayout(),


### PR DESCRIPTION
Replaces the player-control list with a fake player preview. Controls can be dragged, snapped, shown in the More menu, or hidden. Adds previews to tab and section customization dialogs.