### PR TITLE
Fix auth session recovery

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/AccountScopedStateCleanup.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/AccountScopedStateCleanup.kt
@@ -1,0 +1,13 @@
+package com.github.andreyasadchy.xtra
+
+internal suspend fun clearAccountScopedState(
+    disableScheduler: () -> Unit,
+    disableNotifications: () -> Unit,
+    clearNotificationState: suspend () -> Unit,
+    clearAccountMetadata: suspend () -> Unit,
+) {
+    disableScheduler()
+    disableNotifications()
+    clearNotificationState()
+    clearAccountMetadata()
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/XtraApp.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/XtraApp.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import android.app.Application
 import android.os.Build
 import android.os.SystemClock
+import androidx.core.content.edit
 import coil3.ImageLoader
 import coil3.PlatformContext
 import coil3.SingletonImageLoader
@@ -20,11 +21,17 @@ import com.github.andreyasadchy.xtra.util.C
 import com.github.andreyasadchy.xtra.util.NetworkUtils
 import com.github.andreyasadchy.xtra.util.coil.CacheControlCacheStrategy
 import com.github.andreyasadchy.xtra.util.prefs
+import com.github.andreyasadchy.xtra.util.tokenPrefs
+import com.github.andreyasadchy.xtra.repository.auth.AuthSessionStore
 import com.github.andreyasadchy.xtra.repository.streamfeed.StreamFeedPrewarmScheduler
+import com.github.andreyasadchy.xtra.ui.main.LiveNotificationScheduler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import okio.Buffer
 import okio.buffer
 import okio.source
@@ -40,6 +47,7 @@ class XtraApp : Application(), SingletonImageLoader.Factory {
 
     lateinit var xtraModule: XtraModule
     val applicationScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    private val accountCleanupMutex = Mutex()
 
     @Volatile
     var isInForeground: Boolean = false
@@ -51,6 +59,7 @@ class XtraApp : Application(), SingletonImageLoader.Factory {
         super.onCreate()
         INSTANCE = this
         xtraModule = XtraModule(this)
+        reconcilePendingAccountScopedState()
         xtraModule.authSessionMaintainer.start(applicationScope)
         registerActivityLifecycleCallbacks(object : ActivityLifecycleCallbacks {
             override fun onActivityStarted(activity: android.app.Activity) {
@@ -88,6 +97,48 @@ class XtraApp : Application(), SingletonImageLoader.Factory {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
             val conscrypt = Conscrypt.newProvider()
             Security.insertProviderAt(conscrypt, 1)
+        }
+    }
+
+    internal fun scheduleAccountScopedStateCleanup(userId: String?, login: String?) {
+        val sessionStore = AuthSessionStore(prefs(), tokenPrefs())
+        if (!sessionStore.markAccountCleanupPending(userId, login)) return
+        reconcilePendingAccountScopedState()
+    }
+
+    private fun reconcilePendingAccountScopedState() {
+        val sessionStore = AuthSessionStore(prefs(), tokenPrefs())
+        if (sessionStore.pendingAccountCleanups().isEmpty()) return
+        applicationScope.launch(Dispatchers.IO) {
+            accountCleanupMutex.withLock {
+                val pending = sessionStore.pendingAccountCleanups()
+                if (pending.isEmpty()) return@withLock
+                val globalCleanupSucceeded = runCatching {
+                    clearAccountScopedState(
+                        disableScheduler = { LiveNotificationScheduler.disable(this@XtraApp) },
+                        disableNotifications = {
+                            prefs().edit { putBoolean(C.LIVE_NOTIFICATIONS_ENABLED, false) }
+                        },
+                        clearNotificationState = { xtraModule.notificationsRepository.clearNotificationState() },
+                        clearAccountMetadata = {},
+                    )
+                }.isSuccess
+                if (!globalCleanupSucceeded) return@withLock
+                pending.forEach { target ->
+                    runCatching {
+                        val activeSession = sessionStore.read()
+                        val belongsToActiveAccount = when {
+                            !target.userId.isNullOrBlank() -> target.userId == activeSession?.userId
+                            !target.login.isNullOrBlank() -> target.login.equals(activeSession?.login, ignoreCase = true)
+                            else -> false
+                        }
+                        if (!belongsToActiveAccount) {
+                            xtraModule.metadataCache.clearAccount(target.userId, target.login)
+                        }
+                        check(sessionStore.clearAccountCleanup(target))
+                    }
+                }
+            }
         }
     }
 

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/auth/AuthCapabilities.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/auth/AuthCapabilities.kt
@@ -1,13 +1,44 @@
 package com.github.andreyasadchy.xtra.repository.auth
 
-val REAUTHORIZATION_ACCOUNT_SCOPES = setOf(
+/** The scopes Xtra requests for its official Helix account capabilities. */
+val REQUIRED_OFFICIAL_SCOPES = setOf(
+    "channel:edit:commercial",
+    "channel:manage:broadcast",
+    "channel:manage:moderators",
+    "channel:manage:raids",
+    "channel:manage:vips",
+    "channel:moderate",
+    "channel:read:polls",
+    "channel:read:predictions",
+    "chat:edit",
+    "chat:read",
+    "moderator:manage:announcements",
+    "moderator:manage:banned_users",
+    "moderator:manage:chat_messages",
+    "moderator:manage:chat_settings",
+    "moderator:read:chatters",
+    "moderator:read:followers",
+    "user:manage:chat_color",
+    "user:manage:whispers",
     "user:edit",
     "user:read:blocked_users",
     "user:manage:blocked_users",
+    "user:read:chat",
+    "user:read:emotes",
+    "user:read:follows",
+    "user:write:chat",
 )
 
+val REAUTHORIZATION_ACCOUNT_SCOPES = REQUIRED_OFFICIAL_SCOPES
+
+fun missingOfficialScopes(scopes: Collection<String>): Set<String> =
+    REQUIRED_OFFICIAL_SCOPES - scopes.toSet()
+
+fun hasRequiredOfficialScopes(scopes: Collection<String>): Boolean =
+    missingOfficialScopes(scopes).isEmpty()
+
 fun hasRequiredReauthorizationScopes(scopes: Collection<String>): Boolean =
-    REAUTHORIZATION_ACCOUNT_SCOPES.all(scopes::contains)
+    hasRequiredOfficialScopes(scopes)
 
 fun isReauthorizationUserAllowed(
     reauthorize: Boolean,

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/auth/AuthCoordinator.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/auth/AuthCoordinator.kt
@@ -39,7 +39,7 @@ class AuthCoordinator(
         if (!isReauthorizationUserAllowed(reauthorize, previousUserId, userId)) {
             throw TwitchAuthAccountMismatchException()
         }
-        if (reauthorize && !hasRequiredReauthorizationScopes(validation.scopes)) {
+        if (!hasRequiredOfficialScopes(validation.scopes)) {
             throw TwitchAuthMissingScopesException()
         }
 
@@ -95,6 +95,51 @@ class AuthCoordinator(
         )
     }
 
+    /** Commits the official account independently from the optional compatibility capability. */
+    suspend fun commitOfficialSession(
+        official: AuthSession,
+        reauthorize: Boolean,
+    ): AuthCommitResult = SESSION_MUTEX.withLock {
+        val previousSession = sessionStore.read()
+        val previousUserId = previousSession?.userId ?: sessionStore.storedUserId()
+        val previousLogin = previousSession?.login ?: sessionStore.storedLogin()
+        if (!isReauthorizationUserAllowed(reauthorize, previousUserId, official.userId)) {
+            throw TwitchAuthAccountMismatchException()
+        }
+        val sameStoredAccount = when {
+            previousUserId != null -> previousUserId == official.userId
+            previousLogin != null -> official.login?.equals(previousLogin, ignoreCase = true) == true
+            else -> false
+        }
+        val accountChanged = (previousUserId != null || previousLogin != null) && !sameStoredAccount
+        if (!sessionStore.commitOfficialSession(official)) {
+            throw TwitchAuthException("Unable to save the official Twitch session")
+        }
+        AuthCommitResult(
+            session = official,
+            accountChanged = accountChanged,
+            revocationFailures = 0,
+        )
+    }
+
+    /** Commits compatibility without changing the already authenticated official account. */
+    suspend fun commitCompatibilitySession(
+        compatibility: CompatibilitySession,
+    ): AuthCommitResult = SESSION_MUTEX.withLock {
+        val official = sessionStore.read() ?: throw TwitchAuthException("No official Twitch session is available")
+        if (official.userId != compatibility.userId) {
+            throw TwitchAuthAccountMismatchException()
+        }
+        if (!sessionStore.updateCompatibilitySession(compatibility)) {
+            throw TwitchAuthException("Unable to save the Twitch compatibility session")
+        }
+        AuthCommitResult(
+            session = official,
+            accountChanged = false,
+            revocationFailures = 0,
+        )
+    }
+
     suspend fun refreshIfNeeded(force: Boolean = false): AuthSession? = SESSION_MUTEX.withLock {
         val current = sessionStore.read() ?: return null
         if (!force && !current.isAccessTokenExpired(nowMillis())) return current
@@ -104,16 +149,33 @@ class AuthCoordinator(
             ?: throw TwitchAuthProtocolException("Twitch did not return a refreshed access token")
         val expiresIn = response.expiresIn?.takeIf { it > 0 }
             ?: throw TwitchAuthProtocolException("Twitch did not return a refreshed token lifetime")
+        val rotatedRefreshToken = response.refreshToken?.takeIf { it.isNotBlank() }
+            ?: throw TwitchAuthProtocolException("Twitch refresh response did not contain a refresh token")
+        val expiresAtMillis = nowMillis() + expiresIn * 1_000L
+        if (!sessionStore.updateTokens(
+                accessToken = accessToken,
+                refreshToken = rotatedRefreshToken,
+                expiresAtMillis = expiresAtMillis,
+                clientId = current.clientId,
+                userId = current.userId,
+                login = current.login,
+                scopes = current.scopes,
+                validatedAtMillis = null,
+            )
+        ) {
+            throw TwitchAuthException("Unable to save the refreshed Twitch session")
+        }
         val validation = repository.validate(accessToken)
         if (validation.clientId != current.clientId || validation.userId != current.userId) {
             throw TwitchAuthAccountMismatchException()
         }
-        val rotatedRefreshToken = response.refreshToken?.takeIf { it.isNotBlank() }
-            ?: throw TwitchAuthProtocolException("Twitch refresh response did not contain a refresh token")
+        if (!hasRequiredOfficialScopes(validation.scopes)) {
+            throw TwitchAuthMissingScopesException()
+        }
         val refreshed = current.copy(
             accessToken = accessToken,
             refreshToken = rotatedRefreshToken,
-            expiresAtMillis = nowMillis() + expiresIn * 1_000L,
+            expiresAtMillis = expiresAtMillis,
             login = validation.login ?: current.login,
             scopes = validation.scopes.toSet().ifEmpty { current.scopes },
         )
@@ -196,6 +258,18 @@ class AuthCoordinator(
             ?: throw TwitchAuthProtocolException("Twitch did not return a refreshed compatibility access token")
         val replacementRefreshToken = response.refreshToken?.takeIf { it.isNotBlank() }
             ?: throw TwitchAuthProtocolException("Twitch compatibility refresh response did not contain a refresh token")
+        val expiresAtMillis = response.expiresIn
+            ?.takeIf { it > 0 }
+            ?.let { nowMillis() + it * 1_000L }
+            ?: current.expiresAtMillis
+        val replacement = current.copy(
+            accessToken = accessToken,
+            refreshToken = replacementRefreshToken,
+            expiresAtMillis = expiresAtMillis,
+        )
+        if (!sessionStore.updateCompatibilitySession(replacement)) {
+            throw TwitchAuthException("Unable to save the refreshed Twitch compatibility session")
+        }
         val validation = repository.validateCompatibility(accessToken)
         if (validation.clientId != current.clientId || validation.userId != current.userId) {
             throw TwitchAuthAccountMismatchException()
@@ -203,10 +277,7 @@ class AuthCoordinator(
         val refreshed = current.copy(
             accessToken = accessToken,
             refreshToken = replacementRefreshToken,
-            expiresAtMillis = response.expiresIn
-                ?.takeIf { it > 0 }
-                ?.let { nowMillis() + it * 1_000L }
-                ?: current.expiresAtMillis,
+            expiresAtMillis = expiresAtMillis,
             scopes = validation.scopes.toSet().ifEmpty { response.scopes.toSet().ifEmpty { current.scopes } },
             tokenType = response.tokenType ?: current.tokenType,
         )

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/auth/AuthHealth.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/auth/AuthHealth.kt
@@ -1,14 +1,15 @@
 package com.github.andreyasadchy.xtra.repository.auth
 
-/** Describes whether the signed-in account has all credentials Xtra can maintain. */
+/** Describes the official account session and its optional enhanced capability. */
 enum class AuthHealth {
     SIGNED_OUT,
     HEALTHY,
+    ENHANCED_FEATURES_UNAVAILABLE,
     REAUTH_REQUIRED,
     UNKNOWN;
 
     val requiresUserAction: Boolean
-        get() = this == REAUTH_REQUIRED
+        get() = this == REAUTH_REQUIRED || this == ENHANCED_FEATURES_UNAVAILABLE
 }
 
 internal fun classifyAuthHealth(
@@ -21,7 +22,6 @@ internal fun classifyAuthHealth(
     storedAccountIdentityPresent: Boolean = false,
 ): AuthHealth = when {
     officialState == OfficialAuthState.REAUTHORIZATION_REQUIRED -> AuthHealth.REAUTH_REQUIRED
-    compatibilityState == CompatibilityAuthState.REAUTHORIZATION_REQUIRED -> AuthHealth.REAUTH_REQUIRED
     officialState == OfficialAuthState.TRANSIENT_FAILURE ||
         compatibilityState == CompatibilityAuthState.TRANSIENT_FAILURE -> AuthHealth.UNKNOWN
     officialState == OfficialAuthState.IDLE -> {
@@ -35,5 +35,5 @@ internal fun classifyAuthHealth(
     compatibilityState == CompatibilityAuthState.AVAILABLE &&
         structuredCompatibilityPresent &&
         compatibilityUserMatches -> AuthHealth.HEALTHY
-    else -> AuthHealth.REAUTH_REQUIRED
+    else -> AuthHealth.ENHANCED_FEATURES_UNAVAILABLE
 }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/auth/AuthSessionMaintainer.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/auth/AuthSessionMaintainer.kt
@@ -137,7 +137,7 @@ internal suspend fun recoverCompatibilitySessionAfterUnauthorized(
             onInvalid()
             CompatibilityUnauthorizedRecovery.INVALID
         } else {
-            // AuthCoordinator validates the replacement before persisting it.
+            // AuthCoordinator durably stores the rotated pair before validating it.
             CompatibilityUnauthorizedRecovery.RECOVERED
         }
     } catch (error: CancellationException) {
@@ -334,6 +334,8 @@ class AuthSessionMaintainer(
             } else if ((!expectedUserId.isNullOrBlank() && response.userId != expectedUserId) ||
                 (!expectedLogin.isNullOrBlank() && !response.login.isNullOrBlank() && !response.login.equals(expectedLogin, ignoreCase = true))
             ) {
+                ValidationResult.INVALID
+            } else if (!hasRequiredOfficialScopes(response.scopes)) {
                 ValidationResult.INVALID
             } else {
                 applicationContext.tokenPrefs().edit {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/auth/AuthSessionStore.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/auth/AuthSessionStore.kt
@@ -50,6 +50,11 @@ data class PrivateGqlCredential(
     val userId: String,
 )
 
+internal data class PendingAccountCleanup(
+    val userId: String?,
+    val login: String?,
+)
+
 data class StoredCredentials(
     val helixClientId: String?,
     val helixToken: String?,
@@ -84,6 +89,35 @@ class AuthSessionStore(
     private val preferences: SharedPreferences,
     private val tokenPreferences: SharedPreferences,
 ) {
+    internal fun pendingAccountCleanups(): List<PendingAccountCleanup> =
+        tokenPreferences.getStringSet(C.ACCOUNT_CLEANUP_TARGETS, mutableSetOf())
+            .orEmpty()
+            .mapNotNull(::decodePendingAccountCleanup)
+
+    fun markAccountCleanupPending(userId: String?, login: String?): Boolean {
+        if (userId.isNullOrBlank() && login.isNullOrBlank()) return true
+        val targets = pendingAccountCleanupValues()
+        targets += encodePendingAccountCleanup(userId, login)
+        return tokenPreferences.edit()
+            .putBoolean(C.ACCOUNT_CLEANUP_PENDING, true)
+            .putStringSet(C.ACCOUNT_CLEANUP_TARGETS, targets)
+            .commit()
+    }
+
+    internal fun clearAccountCleanup(target: PendingAccountCleanup): Boolean {
+        val targets = pendingAccountCleanupValues()
+        if (!targets.remove(encodePendingAccountCleanup(target.userId, target.login))) return true
+        val editor = tokenPreferences.edit()
+        if (targets.isEmpty()) {
+            editor.remove(C.ACCOUNT_CLEANUP_PENDING)
+            editor.remove(C.ACCOUNT_CLEANUP_TARGETS)
+        } else {
+            editor.putBoolean(C.ACCOUNT_CLEANUP_PENDING, true)
+            editor.putStringSet(C.ACCOUNT_CLEANUP_TARGETS, targets)
+        }
+        return editor.commit()
+    }
+
     fun read(): AuthSession? {
         val accessToken = tokenPreferences.getString(C.TOKEN, null)?.takeIf { it.isNotBlank() } ?: return null
         val clientId = tokenPreferences.getString(C.TOKEN_CLIENT_ID, null)
@@ -246,6 +280,7 @@ class AuthSessionStore(
         }
         val editor = tokenPreferences.edit()
         editor.apply {
+            appendAccountCleanupTarget(this, official.userId, official.login)
             putString(C.TOKEN, official.accessToken)
             putString(C.TOKEN_REFRESH, official.refreshToken)
             putLong(C.TOKEN_EXPIRES_AT, official.expiresAtMillis)
@@ -270,6 +305,41 @@ class AuthSessionStore(
             remove(C.GQL_TOKEN_WEB)
             remove(C.GQL_TOKEN_WEB_USER_ID)
             putLong(C.INTEGRITY_EXPIRATION, 0)
+        }
+        return editor.commit()
+    }
+
+    /** Persists the official account without requiring compatibility GQL to be available. */
+    fun commitOfficialSession(official: AuthSession): Boolean {
+        if (official.refreshToken.isNullOrBlank()) return false
+        val compatibilityBelongsToAccount =
+            tokenPreferences.getString(C.GQL_TOKEN2_USER_ID, null) == official.userId
+        val editor = tokenPreferences.edit()
+        editor.apply {
+            appendAccountCleanupTarget(this, official.userId, official.login)
+            putString(C.TOKEN, official.accessToken)
+            putString(C.TOKEN_REFRESH, official.refreshToken)
+            putLong(C.TOKEN_EXPIRES_AT, official.expiresAtMillis)
+            putString(C.TOKEN_CLIENT_ID, official.clientId)
+            putString(C.TOKEN_SCOPES, official.scopes.sorted().joinToString(" "))
+            putLong(C.TOKEN_VALIDATED_AT, System.currentTimeMillis())
+            putString(C.USER_ID, official.userId)
+            putString(C.USERNAME, official.login)
+
+            if (!compatibilityBelongsToAccount) {
+                remove(C.GQL_TOKEN2)
+                remove(C.GQL_TOKEN2_REFRESH)
+                remove(C.GQL_TOKEN2_EXPIRES_AT)
+                remove(C.GQL_TOKEN2_CLIENT_ID)
+                remove(C.GQL_TOKEN2_USER_ID)
+                remove(C.GQL_TOKEN2_SCOPES)
+                remove(C.GQL_TOKEN2_TYPE)
+                remove(C.GQL_HEADERS)
+                remove(C.GQL_TOKEN)
+                remove(C.GQL_TOKEN_WEB)
+                remove(C.GQL_TOKEN_WEB_USER_ID)
+                putLong(C.INTEGRITY_EXPIRATION, 0)
+            }
         }
         return editor.commit()
     }
@@ -313,7 +383,7 @@ class AuthSessionStore(
         return tokenPreferences.edit().putString(C.GQL_TOKEN_WEB_USER_ID, userId).commit()
     }
 
-    /** Writes rotated access/refresh tokens only after the replacement has been validated. */
+    /** Durably writes a replacement access/refresh pair returned by Twitch. */
     fun updateTokens(
         accessToken: String,
         refreshToken: String?,
@@ -322,6 +392,7 @@ class AuthSessionStore(
         userId: String,
         login: String?,
         scopes: Collection<String>,
+        validatedAtMillis: Long? = System.currentTimeMillis(),
     ): Boolean {
         val editor = tokenPreferences.edit()
         editor.apply {
@@ -330,7 +401,7 @@ class AuthSessionStore(
             putLong(C.TOKEN_EXPIRES_AT, expiresAtMillis)
             putString(C.TOKEN_CLIENT_ID, clientId)
             putString(C.TOKEN_SCOPES, scopes.sorted().joinToString(" "))
-            putLong(C.TOKEN_VALIDATED_AT, System.currentTimeMillis())
+            validatedAtMillis?.let { putLong(C.TOKEN_VALIDATED_AT, it) }
             putString(C.USER_ID, userId)
             putString(C.USERNAME, login)
         }
@@ -338,8 +409,18 @@ class AuthSessionStore(
     }
 
     fun clearAll(): Boolean {
-        val editor = tokenPreferences.edit()
-        editor.clear()
+        val targets = pendingAccountCleanupValues()
+        val previousUserId = tokenPreferences.getString(C.USER_ID, null)
+        val previousLogin = tokenPreferences.getString(C.USERNAME, null)
+        if (!previousUserId.isNullOrBlank() || !previousLogin.isNullOrBlank()) {
+            targets += encodePendingAccountCleanup(previousUserId, previousLogin)
+        }
+        val editor = tokenPreferences.edit().clear()
+        if (targets.isNotEmpty()) {
+            editor
+                .putBoolean(C.ACCOUNT_CLEANUP_PENDING, true)
+                .putStringSet(C.ACCOUNT_CLEANUP_TARGETS, targets)
+        }
         return editor.commit()
     }
 
@@ -348,4 +429,46 @@ class AuthSessionStore(
             ?.let { runCatching { JSONObject(it) }.getOrNull() }
 
     private fun String?.hasText(): Boolean = !isNullOrBlank()
+
+    private fun pendingAccountCleanupValues(): MutableSet<String> =
+        tokenPreferences.getStringSet(C.ACCOUNT_CLEANUP_TARGETS, mutableSetOf())?.toMutableSet()
+            ?: mutableSetOf()
+
+    private fun appendAccountCleanupTarget(
+        editor: SharedPreferences.Editor,
+        newUserId: String,
+        newLogin: String?,
+    ) {
+        val previousUserId = tokenPreferences.getString(C.USER_ID, null)
+        val previousLogin = tokenPreferences.getString(C.USERNAME, null)
+        val accountChanged = when {
+            !previousUserId.isNullOrBlank() -> previousUserId != newUserId
+            !previousLogin.isNullOrBlank() -> !previousLogin.equals(newLogin, ignoreCase = true)
+            else -> false
+        }
+        if (!accountChanged || (previousUserId.isNullOrBlank() && previousLogin.isNullOrBlank())) return
+        val targets = pendingAccountCleanupValues()
+        targets += encodePendingAccountCleanup(previousUserId, previousLogin)
+        editor
+            .putBoolean(C.ACCOUNT_CLEANUP_PENDING, true)
+            .putStringSet(C.ACCOUNT_CLEANUP_TARGETS, targets)
+    }
+
+    private fun encodePendingAccountCleanup(userId: String?, login: String?): String =
+        "${userId.orEmpty()}$ACCOUNT_CLEANUP_SEPARATOR${login.orEmpty()}"
+
+    private fun decodePendingAccountCleanup(value: String): PendingAccountCleanup? {
+        val separator = value.indexOf(ACCOUNT_CLEANUP_SEPARATOR)
+        val userId = if (separator >= 0) value.substring(0, separator) else value
+        val login = if (separator >= 0) value.substring(separator + 1) else ""
+        if (userId.isBlank() && login.isBlank()) return null
+        return PendingAccountCleanup(
+            userId = userId.takeIf { it.isNotBlank() },
+            login = login.takeIf { it.isNotBlank() },
+        )
+    }
+
+    private companion object {
+        const val ACCOUNT_CLEANUP_SEPARATOR = '|'
+    }
 }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/account/AccountActivity.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/account/AccountActivity.kt
@@ -211,6 +211,13 @@ class AccountActivity : AppCompatActivity() {
                 action = R.string.auth_health_reconnect,
                 reauthorize = true,
             )
+            AuthHealth.ENHANCED_FEATURES_UNAVAILABLE -> AuthHealthCardSpec(
+                title = R.string.auth_health_compatibility_title,
+                message = R.string.auth_health_compatibility_message,
+                action = R.string.auth_health_compatibility_reconnect,
+                reauthorize = false,
+                compatibilityOnly = true,
+            )
             AuthHealth.SIGNED_OUT,
             AuthHealth.HEALTHY,
             AuthHealth.UNKNOWN,
@@ -225,6 +232,7 @@ class AccountActivity : AppCompatActivity() {
             loginLauncher.launch(
                 Intent(this, LoginActivity::class.java).apply {
                     putExtra(LoginActivity.EXTRA_REAUTHORIZE, spec.reauthorize)
+                    putExtra(LoginActivity.EXTRA_COMPATIBILITY_ONLY, spec.compatibilityOnly)
                 },
             )
         }
@@ -819,6 +827,7 @@ class AccountActivity : AppCompatActivity() {
         val message: Int,
         val action: Int,
         val reauthorize: Boolean,
+        val compatibilityOnly: Boolean = false,
     )
 
     companion object {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/login/LoginActivity.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/login/LoginActivity.kt
@@ -14,7 +14,6 @@ import androidx.activity.addCallback
 import androidx.appcompat.app.AppCompatActivity
 import androidx.browser.customtabs.CustomTabsClient
 import androidx.browser.customtabs.CustomTabsIntent
-import androidx.core.content.edit
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.updateLayoutParams
@@ -23,28 +22,13 @@ import androidx.lifecycle.lifecycleScope
 import com.github.andreyasadchy.xtra.R
 import com.github.andreyasadchy.xtra.XtraApp
 import com.github.andreyasadchy.xtra.databinding.ActivityLoginBinding
-import com.github.andreyasadchy.xtra.ui.main.LiveNotificationScheduler
 import com.github.andreyasadchy.xtra.ui.main.MainActivity
 import com.github.andreyasadchy.xtra.util.C
 import com.github.andreyasadchy.xtra.util.TwitchApiHelper
 import com.github.andreyasadchy.xtra.util.applyTheme
-import com.github.andreyasadchy.xtra.util.prefs
 import com.github.andreyasadchy.xtra.util.tokenPrefs
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlin.math.ceil
-
-internal suspend fun clearAccountScopedState(
-    disableScheduler: () -> Unit,
-    disableNotifications: () -> Unit,
-    clearNotificationState: suspend () -> Unit,
-    clearAccountMetadata: suspend () -> Unit,
-) {
-    disableScheduler()
-    disableNotifications()
-    clearNotificationState()
-    clearAccountMetadata()
-}
 
 class LoginActivity : AppCompatActivity() {
     private lateinit var binding: ActivityLoginBinding
@@ -64,10 +48,11 @@ class LoginActivity : AppCompatActivity() {
         setContentView(binding.root)
 
         val reauthorize = intent.getBooleanExtra(EXTRA_REAUTHORIZE, false)
+        val compatibilityOnly = intent.getBooleanExtra(EXTRA_COMPATIBILITY_ONLY, false)
         val logout = intent.getBooleanExtra(EXTRA_LOGOUT, false)
         previousUserId = tokenPrefs().getString(C.USER_ID, null)
         previousUserLogin = tokenPrefs().getString(C.USERNAME, null)
-        if (reauthorize && previousUserId.isNullOrBlank() && !logout) {
+        if ((reauthorize || compatibilityOnly) && previousUserId.isNullOrBlank() && !logout) {
             Toast.makeText(this, R.string.account_reauthorize_identity_unknown, Toast.LENGTH_LONG).show()
             setResult(RESULT_CANCELED)
             finish()
@@ -76,7 +61,7 @@ class LoginActivity : AppCompatActivity() {
 
         viewModel = ViewModelProvider(
             this,
-            LoginViewModel.Factory(application, reauthorize),
+            LoginViewModel.Factory(application, reauthorize, compatibilityOnly),
         )[LoginViewModel::class.java]
         ViewCompat.setOnApplyWindowInsetsListener(binding.root) { _, windowInsets ->
             val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout())
@@ -282,7 +267,14 @@ class LoginActivity : AppCompatActivity() {
     private fun cancelLogin() {
         if (finished) return
         if (!viewModel.cancel()) return
-        setResult(RESULT_CANCELED)
+        if (viewModel.didChangeOfficialAccount()) scheduleAccountScopedStateCleanup()
+        if (viewModel.hasCommittedOfficialSession()) {
+            TwitchApiHelper.checkedValidation = true
+            xtraApp.xtraModule.authSessionMaintainer.onAuthenticationStateChanged()
+            setResult(RESULT_OK)
+        } else {
+            setResult(RESULT_CANCELED)
+        }
         finish()
     }
 
@@ -318,20 +310,7 @@ class LoginActivity : AppCompatActivity() {
     }
 
     private fun scheduleAccountScopedStateCleanup() {
-        val context = applicationContext
-        val module = xtraApp.xtraModule
-        val userId = previousUserId
-        val userLogin = previousUserLogin
-        xtraApp.applicationScope.launch(Dispatchers.IO) {
-            clearAccountScopedState(
-                disableScheduler = { LiveNotificationScheduler.disable(context) },
-                disableNotifications = {
-                    context.prefs().edit { putBoolean(C.LIVE_NOTIFICATIONS_ENABLED, false) }
-                },
-                clearNotificationState = { module.notificationsRepository.clearNotificationState() },
-                clearAccountMetadata = { module.metadataCache.clearAccount(userId, userLogin) },
-            )
-        }
+        xtraApp.scheduleAccountScopedStateCleanup(previousUserId, previousUserLogin)
     }
 
     /**
@@ -367,6 +346,7 @@ class LoginActivity : AppCompatActivity() {
 
     companion object {
         const val EXTRA_REAUTHORIZE = "com.github.andreyasadchy.xtra.REAUTHORIZE"
+        const val EXTRA_COMPATIBILITY_ONLY = "com.github.andreyasadchy.xtra.COMPATIBILITY_ONLY"
         const val EXTRA_LOGOUT = "com.github.andreyasadchy.xtra.LOGOUT"
     }
 }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/login/LoginUiState.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/login/LoginUiState.kt
@@ -2,6 +2,7 @@ package com.github.andreyasadchy.xtra.ui.login
 
 import android.net.Uri
 import com.github.andreyasadchy.xtra.model.id.DeviceCodeResponse
+import com.github.andreyasadchy.xtra.repository.auth.REQUIRED_OFFICIAL_SCOPES
 
 enum class LoginError {
     SETUP_REQUIRED,
@@ -36,7 +37,7 @@ sealed interface LoginUiState {
         val isPolling: Boolean,
     ) : LoginUiState
 
-    /** The first grant is staged; the second approval is still required before Xtra is signed in. */
+    /** The official grant is active; the second approval enables enhanced compatibility features. */
     data object CompatibilityReady : LoginUiState
 
     data object Validating : LoginUiState
@@ -64,33 +65,7 @@ sealed interface LoginUiState {
     ) : LoginUiState
 }
 
-internal val HELIX_LOGIN_SCOPES = listOf(
-    "channel:edit:commercial", // ChannelPage / commercials.
-    "channel:manage:broadcast", // Stream markers and broadcast settings.
-    "channel:manage:moderators", // Channel moderation management.
-    "channel:manage:raids", // Channel raids.
-    "channel:manage:vips", // Channel VIP management.
-    "channel:moderate", // Channel moderation actions.
-    "channel:read:polls", // Own-channel poll/EventSub activity.
-    "channel:read:predictions", // Own-channel prediction/EventSub activity.
-    "chat:edit", // IRC chat commands.
-    "chat:read", // IRC chat messages.
-    "moderator:manage:announcements", // Chat announcements.
-    "moderator:manage:banned_users", // Moderation bans.
-    "moderator:manage:chat_messages", // Moderation chat actions.
-    "moderator:manage:chat_settings", // Chat settings.
-    "moderator:read:chatters", // Chatter lists.
-    "moderator:read:followers", // Channel followers.
-    "user:manage:chat_color", // Chat color.
-    "user:manage:whispers", // Whispers.
-    "user:edit", // Account/profile editing.
-    "user:read:blocked_users", // Account blocked-user list.
-    "user:manage:blocked_users", // Account blocked-user actions.
-    "user:read:chat", // Chat identity and permissions.
-    "user:read:emotes", // User chat emotes.
-    "user:read:follows", // Followed streams/channels.
-    "user:write:chat", // Helix chat messages.
-)
+internal val HELIX_LOGIN_SCOPES = REQUIRED_OFFICIAL_SCOPES.toList()
 
 internal val GQL_COMPATIBILITY_SCOPES = listOf(
     "channel_read",

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/login/LoginViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/login/LoginViewModel.kt
@@ -36,16 +36,21 @@ import java.io.IOException
 
 internal fun canCancelLogin(finalCommitStarted: Boolean): Boolean = !finalCommitStarted
 
+internal fun isCompatibilityLoginPhase(
+    compatibilityOnly: Boolean,
+    officialCommittedThisFlow: Boolean,
+): Boolean = compatibilityOnly || officialCommittedThisFlow
+
 /**
- * Runs the two Twitch grants as one Xtra login transaction.
+ * Runs the official Twitch grant and the optional compatibility grant for an Xtra login.
  *
- * The grants are intentionally held only in memory until [AuthCoordinator.commitCompleteSession]
- * succeeds. This keeps a cancelled or failed second step from publishing a partial account, and
- * keeps an existing account intact during reauthorization.
+ * The official grant is committed as soon as it validates. Compatibility remains staged until its
+ * own validation and can be repaired without changing the official account.
  */
 class LoginViewModel(
     application: Application,
     private val reauthorize: Boolean,
+    private val compatibilityOnly: Boolean = false,
 ) : ViewModel() {
     private val app = application as XtraApp
     private val networkLibrary = application.prefs().getString(C.NETWORK_LIBRARY, C.OKHTTP)
@@ -58,15 +63,21 @@ class LoginViewModel(
     private var stagedOfficial: AuthSession? = null
     private var stagedCompatibility: CompatibilitySession? = null
     private var finalCommitStarted = false
+    private var officialCommittedThisFlow = false
+    private var officialAccountChanged = false
 
     val state: StateFlow<LoginUiState> = _state.asStateFlow()
     val browserRequest = browserRequests.receiveAsFlow()
+
+    fun hasCommittedOfficialSession(): Boolean = officialCommittedThisFlow
+
+    fun didChangeOfficialAccount(): Boolean = officialAccountChanged
 
     fun startAuthorization() {
         if (authorizationJob?.isActive == true) return
         LoginAuthorizationService.start(app)
         authorizationJob = viewModelScope.launch {
-            runOfficialAuthorization()
+            if (compatibilityOnly) runCompatibilityOnlyAuthorization() else runOfficialAuthorization()
         }
     }
 
@@ -107,13 +118,13 @@ class LoginViewModel(
         if (finalCommitStarted) return
         authorizationJob?.cancel()
         LoginAuthorizationService.stop(app)
-        _state.value = if (stagedOfficial == null) {
-            LoginUiState.Error(LoginError.BROWSER_UNAVAILABLE, recoverable = true)
-        } else {
+        _state.value = if (isCompatibilityLoginPhase(compatibilityOnly, officialCommittedThisFlow)) {
             LoginUiState.CompatibilityError(
                 type = LoginError.BROWSER_UNAVAILABLE,
                 recoverable = true,
             )
+        } else {
+            LoginUiState.Error(LoginError.BROWSER_UNAVAILABLE, recoverable = true)
         }
     }
 
@@ -187,14 +198,21 @@ class LoginViewModel(
                 requestToken = { deviceCode, scopes -> repository.pollDeviceAuthorization(configuredClientId, deviceCode, scopes) },
             ).poll(deviceAuthorization, HELIX_LOGIN_SCOPES)
             _state.value = LoginUiState.Validating
-            stagedOfficial = coordinator.validateOfficial(
+            val official = coordinator.validateOfficial(
                 tokenResponse = tokenResponse,
                 expectedClientId = configuredClientId,
                 reauthorize = reauthorize,
             )
+            stagedOfficial = official
             tokenResponse = null
-            // The official grant is staged, not committed. Let the user clearly start the
-            // second Twitch page and keep retrying that page possible on account mismatch.
+            val commit = withContext(NonCancellable) {
+                coordinator.commitOfficialSession(official, reauthorize)
+            }
+            officialCommittedThisFlow = true
+            officialAccountChanged = commit.accountChanged
+            stagedOfficial = null
+            // The official grant is usable on its own. The second page only enables enhanced
+            // compatibility features and can be retried without restarting official OAuth.
             _state.value = LoginUiState.CompatibilityReady
         } catch (e: CancellationException) {
             revokeTokenAfterCancellation(clientId, tokenResponse)
@@ -210,20 +228,54 @@ class LoginViewModel(
 
     private suspend fun runCompatibilityAuthorization() {
         try {
-            val official = stagedOfficial
-                ?: throw TwitchAuthProtocolException("The first Twitch authorization is no longer available")
+            val official = stagedOfficial ?: sessionStore.read()
+                ?: throw TwitchAuthProtocolException("The official Twitch authorization is no longer available")
             val compatibility = acquireCompatibility(official.userId)
             stagedCompatibility = compatibility
             finalCommitStarted = true
             _state.value = LoginUiState.Committing
             val commit = withContext(NonCancellable) {
-                coordinator.commitCompleteSession(
-                    official = official,
-                    compatibility = compatibility,
-                    reauthorize = reauthorize,
-                )
+                coordinator.commitCompatibilitySession(compatibility)
             }
             stagedOfficial = null
+            stagedCompatibility = null
+            finalCommitStarted = false
+            LoginAuthorizationService.stop(app)
+            _state.value = LoginUiState.Complete(
+                accountChanged = officialAccountChanged || commit.accountChanged,
+                revocationFailures = commit.revocationFailures,
+            )
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            finalCommitStarted = false
+            // A failed compatibility validation leaves the official grant active so the user can
+            // retry only step 2. A failure after a validated compatibility grant exists must
+            // discard that grant because it is not active.
+            if (stagedCompatibility != null || e is TwitchAuthException &&
+                e.message?.contains("save", ignoreCase = true) == true
+            ) {
+                discardStagedCredentials()
+            }
+            LoginAuthorizationService.stop(app)
+            _state.value = LoginUiState.CompatibilityError(
+                type = mapError(e),
+                recoverable = isRecoverable(e),
+            )
+        }
+    }
+
+    private suspend fun runCompatibilityOnlyAuthorization() {
+        try {
+            val official = sessionStore.read()
+                ?: throw TwitchAuthProtocolException("The official Twitch authorization is no longer available")
+            val compatibility = acquireCompatibility(official.userId)
+            stagedCompatibility = compatibility
+            finalCommitStarted = true
+            _state.value = LoginUiState.Committing
+            val commit = withContext(NonCancellable) {
+                coordinator.commitCompatibilitySession(compatibility)
+            }
             stagedCompatibility = null
             finalCommitStarted = false
             LoginAuthorizationService.stop(app)
@@ -235,9 +287,6 @@ class LoginViewModel(
             throw e
         } catch (e: Exception) {
             finalCommitStarted = false
-            // A failed compatibility validation keeps the official grant staged so the user can
-            // retry only step 2. A failure after a validated pair exists (for example persistence)
-            // must discard both grants because neither is active.
             if (stagedCompatibility != null || e is TwitchAuthException &&
                 e.message?.contains("save", ignoreCase = true) == true
             ) {
@@ -322,7 +371,7 @@ class LoginViewModel(
         if (authorizationJob?.isActive == true) return
         LoginAuthorizationService.start(app)
         authorizationJob = viewModelScope.launch {
-            runCompatibilityAuthorization()
+            if (compatibilityOnly) runCompatibilityOnlyAuthorization() else runCompatibilityAuthorization()
         }
     }
 
@@ -356,11 +405,12 @@ class LoginViewModel(
     class Factory(
         private val application: Application,
         private val reauthorize: Boolean,
+        private val compatibilityOnly: Boolean = false,
     ) : ViewModelProvider.Factory {
         @Suppress("UNCHECKED_CAST")
         override fun <T : ViewModel> create(modelClass: Class<T>): T {
             require(modelClass.isAssignableFrom(LoginViewModel::class.java))
-            return LoginViewModel(application, reauthorize) as T
+            return LoginViewModel(application, reauthorize, compatibilityOnly) as T
         }
     }
 }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/main/MainActivity.kt
@@ -646,10 +646,10 @@ class MainActivity : AppCompatActivity() {
             }
             AuthSessionMaintenanceState.COMPATIBILITY_REAUTHORIZATION_REQUIRED -> {
                 if (authSessionMaintainer.consumeReauthorizationRequest() == state) {
-                    Toast.makeText(this, R.string.token_expired, Toast.LENGTH_LONG).show()
+                    Toast.makeText(this, R.string.auth_health_compatibility_message, Toast.LENGTH_LONG).show()
                     launcher.launch(
                         Intent(this, LoginActivity::class.java)
-                            .putExtra(LoginActivity.EXTRA_REAUTHORIZE, true),
+                            .putExtra(LoginActivity.EXTRA_COMPATIBILITY_ONLY, true),
                     )
                 }
             }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/main/ProfileMenuBinder.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/main/ProfileMenuBinder.kt
@@ -187,6 +187,13 @@ object ProfileMenuBinder {
                 intent = Intent(activity, LoginActivity::class.java)
                     .putExtra(LoginActivity.EXTRA_REAUTHORIZE, true),
             )
+            AuthHealth.ENHANCED_FEATURES_UNAVAILABLE -> AuthHealthDialogSpec(
+                title = R.string.auth_health_compatibility_title,
+                message = R.string.auth_health_compatibility_message,
+                actionLabel = R.string.auth_health_compatibility_reconnect,
+                intent = Intent(activity, LoginActivity::class.java)
+                    .putExtra(LoginActivity.EXTRA_COMPATIBILITY_ONLY, true),
+            )
             else -> return
         }
         MaterialAlertDialogBuilder(activity)

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/settings/SettingsActivity.kt
@@ -135,7 +135,9 @@ internal fun serializeSpeedOptions(items: List<SettingsDragListItem>): String =
     items.joinToString(",") { "${it.key}:${if (it.enabled) "1" else "0"}" }
 
 internal fun isSettingsAccountConnected(health: AuthHealth): Boolean =
-    health == AuthHealth.HEALTHY || health == AuthHealth.UNKNOWN
+    health == AuthHealth.HEALTHY ||
+        health == AuthHealth.ENHANCED_FEATURES_UNAVAILABLE ||
+        health == AuthHealth.UNKNOWN
 
 internal fun needsUpdateNotificationUserAction(
     permissionMissing: Boolean,
@@ -242,7 +244,7 @@ class SettingsActivity : AppCompatActivity() {
 
     fun openAccountAction() {
         val health = (application as XtraApp).xtraModule.authSessionMaintainer.authHealth.value
-        accountActionIsLogout = health == AuthHealth.HEALTHY
+        accountActionIsLogout = isSettingsAccountConnected(health)
         loginResultLauncher?.launch(Intent(this, LoginActivity::class.java).apply {
             if (health == AuthHealth.REAUTH_REQUIRED) {
                 putExtra(LoginActivity.EXTRA_REAUTHORIZE, true)

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/C.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/C.kt
@@ -49,6 +49,8 @@ object C {
     const val TOKEN_CLIENT_ID = "token_client_id"
     const val TOKEN_SCOPES = "token_scopes"
     const val TOKEN_VALIDATED_AT = "token_validated_at"
+    const val ACCOUNT_CLEANUP_PENDING = "account_cleanup_pending"
+    const val ACCOUNT_CLEANUP_TARGETS = "account_cleanup_targets"
     const val USERNAME = "username"
     const val USER_ID = "user_id"
     const val PROFILE_IMAGE_URL = "profile_image_url"

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -1431,4 +1431,7 @@
     <string name="settings_layout_preview">معاينة</string>
     <string name="settings_tabs_preview_help">تتبع المعاينة الترتيب والعناصر الظاهرة أدناه.</string>
     <string name="settings_sections_preview_help">تعرض المعاينة الرفوف الظاهرة بالترتيب الحالي.</string>
+    <string name="auth_health_compatibility_title">ميزات Twitch المحسّنة غير متاحة</string>
+    <string name="auth_health_compatibility_message">لا يزال حساب Twitch متصلاً. أعد الاتصال بالميزات المحسّنة لاستعادة وظائف التوافق.</string>
+    <string name="auth_health_compatibility_reconnect">إعادة الاتصال بالميزات المحسّنة</string>
 </resources>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -1455,4 +1455,7 @@
     <string name="settings_layout_preview">Náhled</string>
     <string name="settings_tabs_preview_help">Náhled sleduje pořadí a viditelnost níže.</string>
     <string name="settings_sections_preview_help">Náhled zobrazuje viditelné police v aktuálním pořadí.</string>
+    <string name="auth_health_compatibility_title">Rozšířené funkce Twitch nejsou dostupné</string>
+    <string name="auth_health_compatibility_message">Váš účet Twitch je stále připojen. Znovu připojte rozšířené funkce a obnovte funkce kompatibility.</string>
+    <string name="auth_health_compatibility_reconnect">Znovu připojit rozšířené funkce</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1431,4 +1431,7 @@
     <string name="settings_layout_preview">Vorschau</string>
     <string name="settings_tabs_preview_help">Die Vorschau folgt der unten angezeigten Reihenfolge und Sichtbarkeit.</string>
     <string name="settings_sections_preview_help">Die Vorschau zeigt die sichtbaren Bereiche in ihrer aktuellen Reihenfolge.</string>
+    <string name="auth_health_compatibility_title">Erweiterte Twitch-Funktionen nicht verfügbar</string>
+    <string name="auth_health_compatibility_message">Dein Twitch-Konto ist weiterhin verbunden. Verbinde die erweiterten Funktionen erneut, um die Kompatibilitätsfunktionen wiederherzustellen.</string>
+    <string name="auth_health_compatibility_reconnect">Erweiterte Funktionen erneut verbinden</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1436,4 +1436,7 @@
     <string name="settings_layout_preview">Vista previa</string>
     <string name="settings_tabs_preview_help">La vista previa sigue el orden y la visibilidad indicados abajo.</string>
     <string name="settings_sections_preview_help">La vista previa muestra las secciones visibles en su orden actual.</string>
+    <string name="auth_health_compatibility_title">Funciones mejoradas de Twitch no disponibles</string>
+    <string name="auth_health_compatibility_message">Tu cuenta de Twitch sigue conectada. Vuelve a conectar las funciones mejoradas para restaurar la funcionalidad de compatibilidad.</string>
+    <string name="auth_health_compatibility_reconnect">Volver a conectar funciones mejoradas</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1431,4 +1431,7 @@
     <string name="settings_layout_preview">Aperçu</string>
     <string name="settings_tabs_preview_help">L’aperçu suit l’ordre et la visibilité indiqués ci-dessous.</string>
     <string name="settings_sections_preview_help">L’aperçu affiche les sections visibles dans leur ordre actuel.</string>
+    <string name="auth_health_compatibility_title">Fonctionnalités Twitch avancées indisponibles</string>
+    <string name="auth_health_compatibility_message">Votre compte Twitch est toujours connecté. Reconnectez les fonctionnalités avancées pour rétablir les fonctions de compatibilité.</string>
+    <string name="auth_health_compatibility_reconnect">Reconnecter les fonctionnalités avancées</string>
 </resources>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -1431,4 +1431,7 @@
     <string name="settings_layout_preview">Vista previa</string>
     <string name="settings_tabs_preview_help">A vista previa segue a orde e visibilidade que aparecen abaixo.</string>
     <string name="settings_sections_preview_help">A vista previa mostra as seccións visibles na súa orde actual.</string>
+    <string name="auth_health_compatibility_title">Funcións melloradas de Twitch non dispoñibles</string>
+    <string name="auth_health_compatibility_message">A túa conta de Twitch segue conectada. Volve conectar as funcións melloradas para restaurar a funcionalidade de compatibilidade.</string>
+    <string name="auth_health_compatibility_reconnect">Volver conectar funcións melloradas</string>
 </resources>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -1432,4 +1432,7 @@
     <string name="settings_layout_preview">Pratinjau</string>
     <string name="settings_tabs_preview_help">Pratinjau mengikuti urutan dan visibilitas di bawah.</string>
     <string name="settings_sections_preview_help">Pratinjau menampilkan bagian yang terlihat dalam urutan saat ini.</string>
+    <string name="auth_health_compatibility_title">Fitur Twitch lanjutan tidak tersedia</string>
+    <string name="auth_health_compatibility_message">Akun Twitch Anda masih terhubung. Hubungkan kembali fitur lanjutan untuk memulihkan fungsi kompatibilitas.</string>
+    <string name="auth_health_compatibility_reconnect">Hubungkan kembali fitur lanjutan</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1431,4 +1431,7 @@
     <string name="settings_layout_preview">Anteprima</string>
     <string name="settings_tabs_preview_help">L’anteprima segue l’ordine e la visibilità indicati sotto.</string>
     <string name="settings_sections_preview_help">L’anteprima mostra le sezioni visibili nell’ordine attuale.</string>
+    <string name="auth_health_compatibility_title">Funzionalità Twitch avanzate non disponibili</string>
+    <string name="auth_health_compatibility_message">Il tuo account Twitch è ancora connesso. Riconnetti le funzionalità avanzate per ripristinare le funzioni di compatibilità.</string>
+    <string name="auth_health_compatibility_reconnect">Riconnetti le funzionalità avanzate</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1431,4 +1431,7 @@
     <string name="settings_layout_preview">プレビュー</string>
     <string name="settings_tabs_preview_help">プレビューには下の順序と表示状態が反映されます。</string>
     <string name="settings_sections_preview_help">プレビューには現在の順序で表示されるセクションが表示されます。</string>
+    <string name="auth_health_compatibility_title">Twitch の拡張機能を利用できません</string>
+    <string name="auth_health_compatibility_message">Twitch アカウントは接続されたままです。互換性機能を復元するには、拡張機能に再接続してください。</string>
+    <string name="auth_health_compatibility_reconnect">拡張機能に再接続</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -1433,4 +1433,7 @@
     <string name="settings_layout_preview">Podgląd</string>
     <string name="settings_tabs_preview_help">Podgląd odzwierciedla kolejność i widoczność poniżej.</string>
     <string name="settings_sections_preview_help">Podgląd pokazuje widoczne sekcje w bieżącej kolejności.</string>
+    <string name="auth_health_compatibility_title">Rozszerzone funkcje Twitcha są niedostępne</string>
+    <string name="auth_health_compatibility_message">Twoje konto Twitch jest nadal połączone. Połącz ponownie rozszerzone funkcje, aby przywrócić funkcje zgodności.</string>
+    <string name="auth_health_compatibility_reconnect">Połącz ponownie rozszerzone funkcje</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -1431,4 +1431,7 @@
     <string name="settings_layout_preview">Prévia</string>
     <string name="settings_tabs_preview_help">A prévia segue a ordem e a visibilidade abaixo.</string>
     <string name="settings_sections_preview_help">A prévia mostra as seções visíveis na ordem atual.</string>
+    <string name="auth_health_compatibility_title">Recursos avançados da Twitch indisponíveis</string>
+    <string name="auth_health_compatibility_message">Sua conta da Twitch ainda está conectada. Reconecte os recursos avançados para restaurar a funcionalidade de compatibilidade.</string>
+    <string name="auth_health_compatibility_reconnect">Reconectar recursos avançados</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1431,4 +1431,7 @@
     <string name="settings_layout_preview">Предпросмотр</string>
     <string name="settings_tabs_preview_help">Предпросмотр учитывает порядок и видимость ниже.</string>
     <string name="settings_sections_preview_help">Предпросмотр показывает видимые разделы в текущем порядке.</string>
+    <string name="auth_health_compatibility_title">Расширенные функции Twitch недоступны</string>
+    <string name="auth_health_compatibility_message">Ваш аккаунт Twitch по-прежнему подключён. Подключите расширенные функции повторно, чтобы восстановить функции совместимости.</string>
+    <string name="auth_health_compatibility_reconnect">Подключить расширенные функции повторно</string>
 </resources>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -1455,4 +1455,7 @@
     <string name="settings_layout_preview">Náhľad</string>
     <string name="settings_tabs_preview_help">Náhľad sleduje poradie a viditeľnosť uvedené nižšie.</string>
     <string name="settings_sections_preview_help">Náhľad zobrazuje viditeľné sekcie v aktuálnom poradí.</string>
+    <string name="auth_health_compatibility_title">Rozšírené funkcie Twitchu nie sú dostupné</string>
+    <string name="auth_health_compatibility_message">Váš účet Twitch je stále pripojený. Znova pripojte rozšírené funkcie a obnovte funkcie kompatibility.</string>
+    <string name="auth_health_compatibility_reconnect">Znova pripojiť rozšírené funkcie</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -1432,4 +1432,7 @@
     <string name="settings_layout_preview">Önizleme</string>
     <string name="settings_tabs_preview_help">Önizleme, aşağıdaki sırayı ve görünürlüğü izler.</string>
     <string name="settings_sections_preview_help">Önizleme, görünür bölümleri geçerli sıralarında gösterir.</string>
+    <string name="auth_health_compatibility_title">Gelişmiş Twitch özellikleri kullanılamıyor</string>
+    <string name="auth_health_compatibility_message">Twitch hesabınız bağlı olmaya devam ediyor. Uyumluluk işlevlerini geri yüklemek için gelişmiş özellikleri yeniden bağlayın.</string>
+    <string name="auth_health_compatibility_reconnect">Gelişmiş özellikleri yeniden bağla</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1431,4 +1431,7 @@
     <string name="settings_layout_preview">预览</string>
     <string name="settings_tabs_preview_help">预览会按照下方的顺序和可见性显示。</string>
     <string name="settings_sections_preview_help">预览会按当前顺序显示可见分区。</string>
+    <string name="auth_health_compatibility_title">Twitch 增强功能不可用</string>
+    <string name="auth_health_compatibility_message">您的 Twitch 账户仍处于连接状态。请重新连接增强功能，以恢复兼容性功能。</string>
+    <string name="auth_health_compatibility_reconnect">重新连接增强功能</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -1431,4 +1431,7 @@
     <string name="settings_layout_preview">預覽</string>
     <string name="settings_tabs_preview_help">預覽會依照下方的順序和可見性顯示。</string>
     <string name="settings_sections_preview_help">預覽會依目前順序顯示可見區段。</string>
+    <string name="auth_health_compatibility_title">Twitch 增強功能無法使用</string>
+    <string name="auth_health_compatibility_message">您的 Twitch 帳戶仍保持連線。請重新連線增強功能，以恢復相容性功能。</string>
+    <string name="auth_health_compatibility_reconnect">重新連線增強功能</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -276,6 +276,9 @@
     <string name="auth_health_reauth_title">Reconnect to Twitch</string>
     <string name="auth_health_reauth_message">Your Xtra sign-in is incomplete or no longer valid. Reconnect to Twitch to enable all account features.</string>
     <string name="auth_health_reconnect">Reconnect to Twitch</string>
+    <string name="auth_health_compatibility_title">Enhanced Twitch features unavailable</string>
+    <string name="auth_health_compatibility_message">Your Twitch account is still connected. Reconnect enhanced features to restore compatibility functionality.</string>
+    <string name="auth_health_compatibility_reconnect">Reconnect enhanced features</string>
     <string name="auth_health_account_details">Account details</string>
     <string name="auth_health_not_now">Not now</string>
     <string name="account_open_twitch">Open Twitch</string>

--- a/app/src/test/java/com/github/andreyasadchy/xtra/repository/auth/AuthCoordinatorTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/repository/auth/AuthCoordinatorTest.kt
@@ -154,6 +154,116 @@ class AuthCoordinatorTest {
     }
 
     @Test
+    fun `compatibility-only replacement preserves the official session`() {
+        val (store, tokenPreferences) = seededStore()
+        val coordinator = AuthCoordinator(FakeAuthOperations(), store)
+
+        runBlocking {
+            coordinator.commitCompatibilitySession(oldCompatibility().copy(accessToken = "replacement-gql"))
+        }
+
+        assertEquals("old-access", store.read()?.accessToken)
+        assertEquals("old-refresh", store.read()?.refreshToken)
+        assertEquals("replacement-gql", tokenPreferences.getString(C.GQL_TOKEN2, null))
+    }
+
+    @Test
+    fun `official session can be committed without compatibility credentials`() {
+        val preferences = MemoryPreferences()
+        val tokenPreferences = MemoryPreferences()
+        val store = AuthSessionStore(preferences, tokenPreferences)
+        val coordinator = AuthCoordinator(FakeAuthOperations(), store)
+
+        runBlocking {
+            coordinator.commitOfficialSession(oldOfficial(), reauthorize = false)
+        }
+
+        assertEquals("old-access", store.read()?.accessToken)
+        assertEquals("old-refresh", store.read()?.refreshToken)
+        assertNull(store.readCompatibility())
+    }
+
+    @Test
+    fun `official account replacement clears compatibility from another account`() {
+        val (store, tokenPreferences) = seededStore()
+        val coordinator = AuthCoordinator(FakeAuthOperations(), store)
+        val replacement = oldOfficial().copy(userId = "other-user", accessToken = "other-access")
+
+        runBlocking {
+            coordinator.commitOfficialSession(replacement, reauthorize = false)
+        }
+
+        assertEquals("other-access", store.read()?.accessToken)
+        assertNull(store.readCompatibility())
+        assertNull(tokenPreferences.getString(C.GQL_TOKEN2, null))
+        assertTrue(tokenPreferences.getBoolean(C.ACCOUNT_CLEANUP_PENDING, false))
+        assertEquals(
+            listOf(PendingAccountCleanup(userId = "user", login = "viewer")),
+            store.pendingAccountCleanups(),
+        )
+    }
+
+    @Test
+    fun `pending account cleanup can be acknowledged after process recovery`() {
+        val (store, tokenPreferences) = seededStore()
+        val coordinator = AuthCoordinator(FakeAuthOperations(), store)
+        val replacement = oldOfficial().copy(userId = "other-user", accessToken = "other-access")
+
+        runBlocking {
+            coordinator.commitOfficialSession(replacement, reauthorize = false)
+        }
+
+        val target = store.pendingAccountCleanups().single()
+        assertTrue(store.clearAccountCleanup(target))
+        assertTrue(store.pendingAccountCleanups().isEmpty())
+        assertFalse(tokenPreferences.getBoolean(C.ACCOUNT_CLEANUP_PENDING, false))
+    }
+
+    @Test
+    fun `clearing auth credentials preserves pending account cleanup`() {
+        val (store, tokenPreferences) = seededStore()
+        val target = PendingAccountCleanup(userId = "previous-user", login = "previous-viewer")
+
+        assertTrue(store.markAccountCleanupPending(target.userId, target.login))
+        assertTrue(store.clearAll())
+
+        assertTrue(store.pendingAccountCleanups().contains(target))
+        assertTrue(
+            store.pendingAccountCleanups().contains(
+                PendingAccountCleanup(userId = "user", login = "viewer"),
+            ),
+        )
+        assertTrue(tokenPreferences.getBoolean(C.ACCOUNT_CLEANUP_PENDING, false))
+    }
+
+    @Test
+    fun `fresh login rejects an incomplete official scope grant`() {
+        val preferences = MemoryPreferences()
+        val tokenPreferences = MemoryPreferences()
+        val store = AuthSessionStore(preferences, tokenPreferences)
+        val repository = FakeAuthOperations(
+            officialValidation = ValidationResponse(
+                "new-helix",
+                userId = "new-user",
+                scopes = (REQUIRED_OFFICIAL_SCOPES - "user:write:chat").toList(),
+            ),
+        )
+
+        val error = runCatching {
+            runBlocking {
+                AuthCoordinator(repository, store).validateOfficial(
+                    officialToken("incomplete-access"),
+                    "new-helix",
+                    reauthorize = false,
+                )
+            }
+        }.exceptionOrNull()
+
+        assertTrue(error is TwitchAuthMissingScopesException)
+        assertNull(store.read())
+    }
+
+    @Test
     fun `compatibility account mismatch leaves the active pair untouched`() {
         val (store, tokenPreferences) = seededStore()
         val repository = FakeAuthOperations(
@@ -289,6 +399,46 @@ class AuthCoordinatorTest {
     }
 
     @Test
+    fun `official refresh persists the rotated pair before validation`() {
+        val (store, tokenPreferences) = seededStore(expired = true)
+        val validatedAt = tokenPreferences.getLong(C.TOKEN_VALIDATED_AT, 0L)
+        val repository = FakeAuthOperations(
+            officialValidationError = TwitchAuthHttpException(statusCode = 503),
+            refresh = officialToken("refreshed-access", refreshToken = "rotated-refresh"),
+        )
+
+        runCatching {
+            runBlocking {
+                AuthCoordinator(repository, store, nowMillis = { 10_000L }).refreshIfNeeded()
+            }
+        }
+
+        assertEquals("refreshed-access", store.read()?.accessToken)
+        assertEquals("rotated-refresh", store.read()?.refreshToken)
+        assertEquals(validatedAt, tokenPreferences.getLong(C.TOKEN_VALIDATED_AT, 0L))
+        assertEquals("old-gql", tokenPreferences.getString(C.GQL_TOKEN2, null))
+    }
+
+    @Test
+    fun `compatibility refresh persists the rotated pair before validation`() {
+        val (store, tokenPreferences) = seededStore()
+        tokenPreferences.edit().putLong(C.GQL_TOKEN2_EXPIRES_AT, 1L).commit()
+        val repository = FakeAuthOperations(
+            compatibilityValidationError = TwitchAuthHttpException(statusCode = 503),
+            refresh = compatibilityToken("refreshed-gql").copy(refreshToken = "rotated-gql-refresh"),
+        )
+
+        runCatching {
+            runBlocking {
+                AuthCoordinator(repository, store, nowMillis = { 10_000L }).refreshCompatibilityIfNeeded()
+            }
+        }
+
+        assertEquals("refreshed-gql", tokenPreferences.getString(C.GQL_TOKEN2, null))
+        assertEquals("rotated-gql-refresh", tokenPreferences.getString(C.GQL_TOKEN2_REFRESH, null))
+    }
+
+    @Test
     fun `raw legacy compatibility credentials are not a complete session`() {
         val preferences = MemoryPreferences()
         val tokenPreferences = MemoryPreferences()
@@ -392,6 +542,8 @@ class AuthCoordinatorTest {
     private class FakeAuthOperations(
         private val officialValidation: ValidationResponse = ValidationResponse("old-helix", userId = "user", scopes = HELIX_SCOPES),
         private val compatibilityValidation: ValidationResponse = ValidationResponse("old-gql-client", userId = "user", scopes = GQL_SCOPES),
+        private val officialValidationError: Exception? = null,
+        private val compatibilityValidationError: Exception? = null,
         private val refresh: TokenResponse = TokenResponse(),
     ) : TwitchAuthOperations {
         val revoked = mutableListOf<Pair<String, String>>()
@@ -400,8 +552,10 @@ class AuthCoordinatorTest {
         override suspend fun startDeviceAuthorization(clientId: String, scopes: Collection<String>) = DeviceCodeResponse()
         override suspend fun pollDeviceAuthorization(clientId: String, deviceCode: String, scopes: Collection<String>) = TokenResponse()
         override suspend fun refreshUserToken(clientId: String, refreshToken: String) = refresh
-        override suspend fun validate(accessToken: String) = officialValidation
-        override suspend fun validateCompatibility(accessToken: String) = compatibilityValidation
+        override suspend fun validate(accessToken: String): ValidationResponse =
+            officialValidationError?.let { throw it } ?: officialValidation
+        override suspend fun validateCompatibility(accessToken: String): ValidationResponse =
+            compatibilityValidationError?.let { throw it } ?: compatibilityValidation
         override suspend fun revoke(clientId: String, accessToken: String) {
             revoked += clientId to accessToken
             onRevoke(clientId, accessToken)
@@ -468,8 +622,8 @@ class AuthCoordinatorTest {
     }
 
     private companion object {
-        val HELIX_SCOPES = listOf("user:edit", "user:read:follows")
-        val REAUTH_SCOPES = HELIX_SCOPES + REAUTHORIZATION_ACCOUNT_SCOPES
+        val HELIX_SCOPES = REQUIRED_OFFICIAL_SCOPES.toList()
+        val REAUTH_SCOPES = HELIX_SCOPES
         val GQL_SCOPES = listOf("channel_read", "chat:read")
     }
 }

--- a/app/src/test/java/com/github/andreyasadchy/xtra/repository/auth/AuthSessionMaintainerTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/repository/auth/AuthSessionMaintainerTest.kt
@@ -7,8 +7,9 @@ import org.junit.Test
 
 class AuthSessionMaintainerTest {
     @Test
-    fun `only incomplete authentication requests user attention`() {
+    fun `only invalid authentication requests user attention`() {
         assertTrue(AuthHealth.REAUTH_REQUIRED.requiresUserAction)
+        assertTrue(AuthHealth.ENHANCED_FEATURES_UNAVAILABLE.requiresUserAction)
         assertFalse(AuthHealth.SIGNED_OUT.requiresUserAction)
         assertFalse(AuthHealth.HEALTHY.requiresUserAction)
         assertFalse(AuthHealth.UNKNOWN.requiresUserAction)
@@ -30,9 +31,9 @@ class AuthSessionMaintainerTest {
     }
 
     @Test
-    fun `missing compatibility is reconnect-required rather than limited`() {
+    fun `missing compatibility keeps the official account connected`() {
         assertEquals(
-            AuthHealth.REAUTH_REQUIRED,
+            AuthHealth.ENHANCED_FEATURES_UNAVAILABLE,
             classifyAuthHealth(
                 officialState = OfficialAuthState.VALID,
                 compatibilityState = CompatibilityAuthState.UNAVAILABLE,
@@ -47,14 +48,15 @@ class AuthSessionMaintainerTest {
     @Test
     fun `legacy and incomplete credential topologies require full reconnect`() {
         val cases = listOf(
-            Triple(OfficialAuthState.VALID, false, true),
-            Triple(OfficialAuthState.VALID, false, false),
-            Triple(OfficialAuthState.IDLE, false, true),
-            Triple(OfficialAuthState.VALID, true, false),
+            Triple(OfficialAuthState.VALID, false, true) to AuthHealth.ENHANCED_FEATURES_UNAVAILABLE,
+            Triple(OfficialAuthState.VALID, false, false) to AuthHealth.REAUTH_REQUIRED,
+            Triple(OfficialAuthState.IDLE, false, true) to AuthHealth.REAUTH_REQUIRED,
+            Triple(OfficialAuthState.VALID, true, false) to AuthHealth.REAUTH_REQUIRED,
         )
-        cases.forEach { (officialState, identityPresent, legacyPresent) ->
+        cases.forEach { (case, expectedHealth) ->
+            val (officialState, identityPresent, legacyPresent) = case
             assertEquals(
-                AuthHealth.REAUTH_REQUIRED,
+                expectedHealth,
                 classifyAuthHealth(
                     officialState = officialState,
                     compatibilityState = CompatibilityAuthState.UNAVAILABLE,
@@ -71,7 +73,7 @@ class AuthSessionMaintainerTest {
     @Test
     fun `wrong compatibility account is never healthy`() {
         assertEquals(
-            AuthHealth.REAUTH_REQUIRED,
+            AuthHealth.ENHANCED_FEATURES_UNAVAILABLE,
             classifyAuthHealth(
                 officialState = OfficialAuthState.VALID,
                 compatibilityState = CompatibilityAuthState.AVAILABLE,
@@ -127,7 +129,7 @@ class AuthSessionMaintainerTest {
     @Test
     fun `successful complete replacement clears reconnect-required state`() {
         assertEquals(
-            AuthHealth.REAUTH_REQUIRED,
+            AuthHealth.ENHANCED_FEATURES_UNAVAILABLE,
             classifyAuthHealth(
                 officialState = OfficialAuthState.VALID,
                 compatibilityState = CompatibilityAuthState.REAUTHORIZATION_REQUIRED,
@@ -188,6 +190,20 @@ class AuthSessionMaintainerTest {
 
         assertEquals(OfficialAuthState.VALID, state.officialState)
         assertEquals(CompatibilityAuthState.AVAILABLE, state.compatibilityState)
+        assertFalse(state.shouldSkipOfficialValidation())
+        assertEquals(AuthSessionMaintenanceState.VALID, state.maintenanceState)
+    }
+
+    @Test
+    fun `official-only authentication replacement clears official reauthorization`() {
+        val state = AuthSessionMaintenanceStateMachine()
+        state.setOfficialState(OfficialAuthState.REAUTHORIZATION_REQUIRED)
+        state.setCompatibilityState(CompatibilityAuthState.REAUTHORIZATION_REQUIRED)
+
+        state.onAuthenticationStateChanged(hasOfficialSession = true, hasCompatibilitySession = false)
+
+        assertEquals(OfficialAuthState.VALID, state.officialState)
+        assertEquals(CompatibilityAuthState.UNAVAILABLE, state.compatibilityState)
         assertFalse(state.shouldSkipOfficialValidation())
         assertEquals(AuthSessionMaintenanceState.VALID, state.maintenanceState)
     }

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/login/LoginTransactionTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/login/LoginTransactionTest.kt
@@ -1,5 +1,6 @@
 package com.github.andreyasadchy.xtra.ui.login
 
+import com.github.andreyasadchy.xtra.clearAccountScopedState
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -12,6 +13,13 @@ class LoginTransactionTest {
     fun `cancellation is rejected once the complete session commit starts`() {
         assertTrue(canCancelLogin(finalCommitStarted = false))
         assertFalse(canCancelLogin(finalCommitStarted = true))
+    }
+
+    @Test
+    fun `browser failure after official commit stays in compatibility recovery`() {
+        assertTrue(isCompatibilityLoginPhase(compatibilityOnly = false, officialCommittedThisFlow = true))
+        assertTrue(isCompatibilityLoginPhase(compatibilityOnly = true, officialCommittedThisFlow = false))
+        assertFalse(isCompatibilityLoginPhase(compatibilityOnly = false, officialCommittedThisFlow = false))
     }
 
     @Test

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/settings/SettingsViewModelTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/settings/SettingsViewModelTest.kt
@@ -15,6 +15,7 @@ class SettingsViewModelTest {
     @Test
     fun `transient auth health keeps the existing account connected`() {
         assertTrue(isSettingsAccountConnected(AuthHealth.UNKNOWN))
+        assertTrue(isSettingsAccountConnected(AuthHealth.ENHANCED_FEATURES_UNAVAILABLE))
         assertFalse(isSettingsAccountConnected(AuthHealth.SIGNED_OUT))
         assertFalse(isSettingsAccountConnected(AuthHealth.REAUTH_REQUIRED))
     }


### PR DESCRIPTION
Keep the official Twitch session usable when compatibility GQL fails, and persist rotated refresh credentials before validation. Compatibility repair now uses its own login path, and auth health distinguishes enhanced-feature loss from a full sign-out.