### PR TITLE
Protect playback and refresh watch streaks

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/preload/StreamMedia3PlaybackOwnership.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/preload/StreamMedia3PlaybackOwnership.kt
@@ -1,0 +1,20 @@
+package com.github.andreyasadchy.xtra.repository.preload
+
+import androidx.media3.common.MediaItem
+
+/** Keeps the exact MediaItem handed from the preload manager to primary playback alive. */
+internal class StreamMedia3PlaybackOwnership {
+    private var primaryMediaItem: MediaItem? = null
+
+    fun setPrimaryMediaItem(mediaItem: MediaItem?): Boolean {
+        val changed = primaryMediaItem !== mediaItem
+        primaryMediaItem = mediaItem
+        return changed
+    }
+
+    fun currentMediaItem(): MediaItem? = primaryMediaItem
+
+    fun protects(mediaItem: MediaItem): Boolean = primaryMediaItem === mediaItem
+
+    fun release(): Boolean = setPrimaryMediaItem(null)
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/preload/StreamMedia3PreloadEntries.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/preload/StreamMedia3PreloadEntries.kt
@@ -1,0 +1,31 @@
+package com.github.andreyasadchy.xtra.repository.preload
+
+/** Keeps a protected manager entry addressable until primary playback releases it. */
+internal class StreamMedia3PreloadEntries<T> {
+    private val entries = linkedMapOf<String, T>()
+
+    val values: Collection<T>
+        get() = entries.values
+
+    operator fun get(channelLogin: String): T? = entries[channelLogin]
+
+    operator fun set(channelLogin: String, entry: T) {
+        entries[channelLogin] = entry
+    }
+
+    fun remove(channelLogin: String): T? = entries.remove(channelLogin)
+
+    fun clear() {
+        entries.clear()
+    }
+
+    fun replaceUnlessProtected(
+        channelLogin: String,
+        replacement: T,
+        isProtected: (T) -> Boolean,
+    ): Boolean {
+        if (entries[channelLogin]?.let(isProtected) == true) return false
+        entries[channelLogin] = replacement
+        return true
+    }
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/preload/StreamMedia3Runtime.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/preload/StreamMedia3Runtime.kt
@@ -40,6 +40,18 @@ data class PreloadedLiveMediaSource(
     val targetStage: Int,
 )
 
+internal fun shouldResetPreloadManager(hasPrimaryPlaybackPlayer: Boolean): Boolean = !hasPrimaryPlaybackPlayer
+
+internal fun shouldReleasePreloadGeneration(
+    isCurrentGeneration: Boolean,
+    wasPrimaryPlaybackGeneration: Boolean,
+): Boolean = wasPrimaryPlaybackGeneration || !isCurrentGeneration
+
+internal fun shouldDeferProtectedPreloadReplacement(
+    mediaItem: MediaItem,
+    ownership: StreamMedia3PlaybackOwnership,
+): Boolean = ownership.protects(mediaItem)
+
 /** Shared Media3 builder/configuration owner for real live playback and speculative media. */
 @UnstableApi
 class StreamMedia3Runtime(
@@ -139,7 +151,12 @@ class StreamMedia3Runtime(
             staleAfterMs = SAMPLE_PRELOAD_MAX_AGE_MS,
         )
         plan.removed.forEach { removed ->
-            val entry = generation.entries.remove(removed.channelLogin) ?: return@forEach
+            val entry = generation.entries[removed.channelLogin] ?: return@forEach
+            if (generation.playbackOwnership.protects(entry.mediaItem)) {
+                debug("preload_protected", entry.channelLogin)
+                return@forEach
+            }
+            generation.entries.remove(removed.channelLogin)
             if (removed.rank == 0 && removed.samplesLoadedAtMs != null &&
                 now - removed.samplesLoadedAtMs >= SAMPLE_PRELOAD_MAX_AGE_MS &&
                 desired[removed.channelLogin]?.url == removed.url
@@ -161,13 +178,19 @@ class StreamMedia3Runtime(
                 channelName = candidate.channelName,
                 channelLogo = candidate.channelLogo,
             )
-            generation.entries[login] = Entry(
+            val entry = Entry(
                 channelLogin = login,
                 url = candidate.url,
                 mediaItem = item,
                 rank = candidate.rank,
                 addedAtMs = now,
             )
+            if (!generation.entries.replaceUnlessProtected(login, entry) {
+                    shouldDeferProtectedPreloadReplacement(it.mediaItem, generation.playbackOwnership)
+                }) {
+                debug("preload_replacement_deferred", login)
+                return@forEach
+            }
             generation.manager.add(item, candidate.rank)
         }
         generation.manager.setCurrentPlayingIndex(0)
@@ -183,11 +206,25 @@ class StreamMedia3Runtime(
         currentGeneration?.let { generation ->
             val keep = keepChannelLogin?.trim()?.lowercase()
             if (keep == null) {
-                generation.manager.reset()
-                generation.entries.clear()
+                if (shouldResetPreloadManager(generation.player != null)) {
+                    generation.manager.reset()
+                    generation.entries.clear()
+                } else {
+                    generation.entries.values.toList()
+                        .filterNot { generation.playbackOwnership.protects(it.mediaItem) }
+                        .forEach {
+                            generation.manager.remove(it.mediaItem)
+                            generation.entries.remove(it.channelLogin)
+                        }
+                    generation.manager.setCurrentPlayingIndex(0)
+                    generation.manager.invalidate()
+                }
             } else {
                 generation.entries.values.toList()
-                    .filter { it.channelLogin != keep }
+                    .filter {
+                        it.channelLogin != keep &&
+                            !generation.playbackOwnership.protects(it.mediaItem)
+                    }
                     .forEach {
                         generation.manager.remove(it.mediaItem)
                         generation.entries.remove(it.channelLogin)
@@ -204,13 +241,17 @@ class StreamMedia3Runtime(
         mainHandler.removeCallbacks(staleRefresh)
         desiredCandidates = emptyList()
         currentGeneration?.let { generation ->
-            generation.manager.reset()
-            generation.entries.clear()
-            if (generation.player == null) {
+            if (shouldResetPreloadManager(generation.player != null)) {
+                generation.manager.reset()
+                generation.entries.clear()
                 generation.manager.release()
                 states.remove(generation)
+                currentGeneration = null
+            } else {
+                // The primary player may still be reading a source owned by this
+                // generation. Retain it until PlaybackService releases the player.
+                currentGeneration = null
             }
-            currentGeneration = null
         }
     }
 
@@ -276,6 +317,24 @@ class StreamMedia3Runtime(
     }
 
     @Synchronized
+    fun setPrimaryPlaybackMediaItem(mediaItem: MediaItem?) {
+        check(Looper.myLooper() == Looper.getMainLooper()) { "Media3 playback handoff must run on the main looper" }
+        val targetGeneration = mediaItem?.let { target ->
+            states.asReversed().firstOrNull { generation ->
+                generation.entries.values.any { it.mediaItem === target }
+            }
+        }
+        val currentMediaItem = states.asReversed()
+            .firstOrNull { it.playbackOwnership.currentMediaItem() != null }
+            ?.playbackOwnership
+            ?.currentMediaItem()
+        if (currentMediaItem === mediaItem && (mediaItem == null || targetGeneration != null)) return
+        states.forEach { it.playbackOwnership.release() }
+        targetGeneration?.playbackOwnership?.setPrimaryMediaItem(mediaItem)
+        if (desiredCandidates.isNotEmpty()) reconcile(desiredCandidates)
+    }
+
+    @Synchronized
     fun createLiveMediaSource(mediaItem: MediaItem): MediaSource {
         check(Looper.myLooper() == Looper.getMainLooper()) { "Media3 live source creation must run on the main looper" }
         return ensureGeneration().hlsFactory.createMediaSource(mediaItem)
@@ -321,26 +380,36 @@ class StreamMedia3Runtime(
     @Synchronized
     fun releasePlaybackPlayer(player: ExoPlayer?) {
         if (player == null) return
+        val playbackGenerations = states.filter { it.player === player }.toSet()
         states.forEach { generation ->
-            if (generation.player === player) generation.player = null
+            if (generation.player === player) {
+                generation.playbackOwnership.release()
+                generation.player = null
+            }
         }
         states.toList()
-            .filter { it !== currentGeneration && it.player == null }
+            .filter {
+                it.player == null && shouldReleasePreloadGeneration(
+                    isCurrentGeneration = it === currentGeneration,
+                    wasPrimaryPlaybackGeneration = it in playbackGenerations,
+                )
+            }
             .forEach { generation ->
                 generation.manager.release()
                 states.remove(generation)
+                if (currentGeneration === generation) currentGeneration = null
             }
     }
 
     private fun ensureGeneration(): Generation {
         val configuration = StreamPlaybackConfiguration.from(context)
         currentGeneration?.takeIf { it.configuration.fingerprint == configuration.fingerprint }?.let { return it }
-        currentGeneration?.takeIf { it.player == null }?.let { old ->
-            old.manager.release()
-            states.remove(old)
+        currentGeneration?.let { old ->
+            if (shouldResetPreloadManager(old.player != null)) {
+                old.manager.release()
+                states.remove(old)
+            }
         }
-        currentGeneration?.takeIf { it.player != null }?.manager?.reset()
-        currentGeneration?.takeIf { it.player != null }?.entries?.clear()
         currentGeneration = null
         val loadControl = DefaultLoadControl.Builder()
             .setBufferDurationsMs(15_000, 50_000, 2_000, 2_000)
@@ -409,7 +478,9 @@ class StreamMedia3Runtime(
 
     private fun scheduleStaleRefresh(generation: Generation) {
         mainHandler.removeCallbacks(staleRefresh)
-        if (generation.entries.values.any { it.rank == 0 }) {
+        if (generation.entries.values.any {
+                it.rank == 0 && !generation.playbackOwnership.protects(it.mediaItem)
+            }) {
             mainHandler.postDelayed(staleRefresh, SAMPLE_PRELOAD_MAX_AGE_MS)
         }
     }
@@ -429,8 +500,9 @@ class StreamMedia3Runtime(
         val hlsFactory: StreamHlsMediaSourceFactory,
         val builder: DefaultPreloadManager.Builder,
         val manager: DefaultPreloadManager,
-        val entries: MutableMap<String, Entry> = linkedMapOf(),
+        val entries: StreamMedia3PreloadEntries<Entry> = StreamMedia3PreloadEntries(),
         var player: ExoPlayer? = null,
+        val playbackOwnership: StreamMedia3PlaybackOwnership = StreamMedia3PlaybackOwnership(),
     )
 
 }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatViewModel.kt
@@ -89,6 +89,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.Flow
@@ -101,6 +102,8 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
@@ -170,9 +173,15 @@ class ChatViewModel(
     private var pubSubJob: Job? = null
     private var channelPointsJob: Job? = null
     private var claimJob: Job? = null
-    private var watchStreakJob: Job? = null
-    private var watchStreakRetryJob: Job? = null
+    private var watchStreakWorkerJob: Job? = null
+    private var watchStreakRefreshJob: Job? = null
     private var watchStreakSession = 0L
+    private var lastWatchStreakReconciliationElapsedRealtime: Long? = null
+    private val watchStreakRequestMutex = Mutex()
+    private val watchStreakRequestSignal = Channel<Unit>(Channel.CONFLATED)
+    private val pendingWatchStreakRequests = WatchStreakReconciliationQueue<WatchStreakRequest> {
+        it.reconciliation
+    }
     private var stvEventApi: STVEventApiWebSocket? = null
     private var stvEventApiJob: Job? = null
     private var stvUserId: String? = null
@@ -1546,6 +1555,75 @@ class ChatViewModel(
         )
     }
 
+    private fun startWatchStreakRefresh(
+        networkLibrary: String?,
+        gqlHeaders: Map<String, String>,
+        channelId: String?,
+    ) {
+        watchStreakRefreshJob?.cancel()
+        watchStreakRefreshJob = null
+        val expectedChannelId = channelId
+        val expectedChannelLogin = activeChannelLogin
+        val expectedUserId = loggedInUserId
+        val expectedSession = watchStreakSession
+        if (!shouldContinueWatchStreakRefresh(
+                expectedSession = expectedSession,
+                currentSession = watchStreakSession,
+                expectedChannelId = expectedChannelId,
+                currentChannelId = activeChannelId,
+                expectedChannelLogin = expectedChannelLogin,
+                currentChannelLogin = activeChannelLogin,
+                expectedUserId = expectedUserId,
+                currentUserId = loggedInUserId,
+                gqlToken = gqlHeaders[C.HEADER_TOKEN],
+            )
+        ) {
+            return
+        }
+        lateinit var refreshJob: Job
+        refreshJob = viewModelScope.launch {
+            while (isActive) {
+                delay(WATCH_STREAK_REFRESH_INTERVAL_MILLIS)
+                val currentGqlHeaders = TwitchApiHelper.getGQLHeaders(applicationContext, true)
+                val currentUserId = applicationContext.tokenPrefs().getString(C.USER_ID, null)
+                if (!shouldContinueWatchStreakRefresh(
+                        expectedSession = expectedSession,
+                        currentSession = watchStreakSession,
+                        expectedChannelId = expectedChannelId,
+                        currentChannelId = activeChannelId,
+                        expectedChannelLogin = expectedChannelLogin,
+                        currentChannelLogin = activeChannelLogin,
+                        expectedUserId = expectedUserId,
+                        currentUserId = currentUserId,
+                        gqlToken = currentGqlHeaders[C.HEADER_TOKEN],
+                    )
+                ) {
+                    break
+                }
+                // A live notice is optional. This request keeps the snapshot
+                // fresh when Twitch omits the notice entirely.
+                loadWatchStreak(networkLibrary, currentGqlHeaders, expectedChannelId)
+            }
+        }
+        watchStreakRefreshJob = refreshJob
+        refreshJob.invokeOnCompletion {
+            if (watchStreakRefreshJob === refreshJob) {
+                watchStreakRefreshJob = null
+            }
+        }
+    }
+
+    private data class WatchStreakRequest(
+        val networkLibrary: String?,
+        val gqlHeaders: Map<String, String>,
+        val channelId: String,
+        val delayMillis: Long,
+        val reconciliation: WatchStreakReconciliation,
+        val expectedSession: Long,
+        val expectedChannelLogin: String?,
+        val expectedUserId: String?,
+    )
+
     private fun loadWatchStreak(
         networkLibrary: String?,
         gqlHeaders: Map<String, String>,
@@ -1553,112 +1631,116 @@ class ChatViewModel(
         delayMillis: Long = 0L,
         reconciliation: WatchStreakReconciliation? = null,
     ) {
-        if (channelId.isNullOrBlank() || gqlHeaders[C.HEADER_TOKEN].isNullOrBlank()) {
-            return
-        }
-        val expectedChannelId = channelId
-        val expectedChannelLogin = activeChannelLogin
-        val expectedSession = watchStreakSession
-        watchStreakJob?.cancel()
-        watchStreakRetryJob?.cancel()
-        watchStreakRetryJob = null
-        watchStreakJob = viewModelScope.launch {
-            try {
-                if (delayMillis > 0L) delay(delayMillis)
-                if (watchStreakSession != expectedSession ||
-                    activeChannelId != expectedChannelId ||
-                    activeChannelLogin != expectedChannelLogin
-                ) {
-                    return@launch
-                }
-                val response = graphQLRepository.loadWatchStreak(networkLibrary, gqlHeaders, channelId)
-                if (watchStreakSession != expectedSession ||
-                    activeChannelId != expectedChannelId ||
-                    activeChannelLogin != expectedChannelLogin
-                ) {
-                    return@launch
-                }
-                val responseCount = watchStreakCount(response)
-                updateWatchStreakStatus(response)
-                if (reconciliation != null) {
-                    val snapshotStatus = watchStreakSnapshotStatus(reconciliation, responseCount)
-                    Log.d(
-                        WatchCreditTelemetry.LOG_TAG,
-                        "watch-streak reconciliation first snapshot source=${reconciliation.source} status=$snapshotStatus",
-                    )
-                    if (shouldRetryWatchStreakReconciliation(reconciliation, responseCount, retryAttempt = 0)) {
-                        scheduleWatchStreakRetry(
-                            networkLibrary = networkLibrary,
-                            gqlHeaders = gqlHeaders,
-                            channelId = channelId,
-                            expectedChannelId = expectedChannelId,
-                            expectedChannelLogin = expectedChannelLogin,
-                            expectedSession = expectedSession,
-                            reconciliation = reconciliation,
-                            retryAttempt = 1,
-                        )
-                    }
-                }
-            } catch (e: CancellationException) {
-                throw e
-            } catch (_: Exception) {
+        val expectedChannelId = channelId?.takeUnless { it.isBlank() } ?: return
+        if (gqlHeaders[C.HEADER_TOKEN].isNullOrBlank()) return
+        pendingWatchStreakRequests.enqueue(
+            WatchStreakRequest(
+                networkLibrary = networkLibrary,
+                gqlHeaders = gqlHeaders,
+                channelId = expectedChannelId,
+                delayMillis = delayMillis,
+                reconciliation = reconciliation ?: WatchStreakReconciliation(
+                    source = WatchStreakReconciliationSource.PERIODIC,
+                    countBeforeEvent = null,
+                ),
+                expectedSession = watchStreakSession,
+                expectedChannelLogin = activeChannelLogin,
+                expectedUserId = loggedInUserId,
+            ),
+        )
+        watchStreakRequestSignal.trySend(Unit)
+        if (watchStreakWorkerJob?.isActive != true) {
+            watchStreakWorkerJob = viewModelScope.launch {
+                runWatchStreakWorker()
             }
         }
     }
 
-    private fun scheduleWatchStreakRetry(
-        networkLibrary: String?,
-        gqlHeaders: Map<String, String>,
-        channelId: String,
-        expectedChannelId: String?,
-        expectedChannelLogin: String?,
-        expectedSession: Long,
-        reconciliation: WatchStreakReconciliation,
-        retryAttempt: Int,
-    ) {
-        val retryDelayMillis = watchStreakReconciliationRetryDelaysMillis.getOrNull(retryAttempt - 1) ?: return
-        if (watchStreakRetryJob?.isActive == true) return
-        watchStreakRetryJob = viewModelScope.launch {
-            try {
-                delay(retryDelayMillis)
-                if (watchStreakSession != expectedSession ||
-                    activeChannelId != expectedChannelId ||
-                    activeChannelLogin != expectedChannelLogin
-                ) {
-                    return@launch
-                }
-                val response = graphQLRepository.loadWatchStreak(networkLibrary, gqlHeaders, channelId)
-                if (watchStreakSession != expectedSession ||
-                    activeChannelId != expectedChannelId ||
-                    activeChannelLogin != expectedChannelLogin
-                ) {
-                    return@launch
-                }
-                val responseCount = watchStreakCount(response)
-                updateWatchStreakStatus(response)
-                val snapshotStatus = watchStreakSnapshotStatus(reconciliation, responseCount)
-                Log.d(
-                    WatchCreditTelemetry.LOG_TAG,
-                    "watch-streak reconciliation retry attempt=$retryAttempt source=${reconciliation.source} status=$snapshotStatus",
+    private suspend fun runWatchStreakWorker() {
+        while (currentCoroutineContext().isActive) {
+            val request = pendingWatchStreakRequests.take()
+            if (request == null) {
+                watchStreakRequestSignal.receive()
+                continue
+            }
+            processWatchStreakRequest(request)
+        }
+    }
+
+    private suspend fun processWatchStreakRequest(request: WatchStreakRequest) {
+        try {
+            if (request.delayMillis > 0L) delay(request.delayMillis)
+            if (pendingWatchStreakRequests.hasHigherPriorityThan(request.reconciliation)) return
+            if (!isCurrentWatchStreakRequest(request)) return
+            var response = watchStreakRequestMutex.withLock {
+                graphQLRepository.loadWatchStreak(
+                    request.networkLibrary,
+                    request.gqlHeaders,
+                    request.channelId,
                 )
-                if (shouldRetryWatchStreakReconciliation(reconciliation, responseCount, retryAttempt)) {
-                    watchStreakRetryJob = null
-                    scheduleWatchStreakRetry(
-                        networkLibrary = networkLibrary,
-                        gqlHeaders = gqlHeaders,
-                        channelId = channelId,
-                        expectedChannelId = expectedChannelId,
-                        expectedChannelLogin = expectedChannelLogin,
-                        expectedSession = expectedSession,
-                        reconciliation = reconciliation,
-                        retryAttempt = retryAttempt + 1,
+            }
+            if (!isCurrentWatchStreakRequest(request)) return
+            var responseCount = watchStreakCount(response)
+            updateWatchStreakStatus(response)
+            if (request.reconciliation.source != WatchStreakReconciliationSource.PERIODIC) {
+                logWatchStreakReconciliation(
+                    request.reconciliation,
+                    responseCount,
+                    retryAttempt = null,
+                )
+            }
+
+            var retryAttempt = 0
+            while (shouldRetryWatchStreakReconciliation(request.reconciliation, responseCount, retryAttempt)) {
+                if (pendingWatchStreakRequests.hasHigherPriorityThan(request.reconciliation)) return
+                val retryDelayMillis = watchStreakReconciliationRetryDelaysMillis.getOrNull(retryAttempt) ?: return
+                delay(retryDelayMillis)
+                if (pendingWatchStreakRequests.hasHigherPriorityThan(request.reconciliation)) return
+                if (!isCurrentWatchStreakRequest(request)) return
+                response = watchStreakRequestMutex.withLock {
+                    graphQLRepository.loadWatchStreak(
+                        request.networkLibrary,
+                        request.gqlHeaders,
+                        request.channelId,
                     )
                 }
-            } catch (e: CancellationException) {
-                throw e
-            } catch (_: Exception) {
+                if (!isCurrentWatchStreakRequest(request)) return
+                responseCount = watchStreakCount(response)
+                updateWatchStreakStatus(response)
+                logWatchStreakReconciliation(
+                    request.reconciliation,
+                    responseCount,
+                    retryAttempt = retryAttempt + 1,
+                )
+                retryAttempt++
             }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (_: Exception) {
         }
+    }
+
+    private fun isCurrentWatchStreakRequest(request: WatchStreakRequest): Boolean =
+        watchStreakSession == request.expectedSession &&
+            activeChannelId == request.channelId &&
+            activeChannelLogin == request.expectedChannelLogin &&
+            loggedInUserId == request.expectedUserId
+
+    private fun logWatchStreakReconciliation(
+        reconciliation: WatchStreakReconciliation,
+        responseCount: Int?,
+        retryAttempt: Int?,
+    ) {
+        val status = watchStreakSnapshotStatus(reconciliation, responseCount)
+        val phase = if (retryAttempt == null) {
+            "first snapshot"
+        } else {
+            "retry attempt=$retryAttempt"
+        }
+        Log.d(
+            WatchCreditTelemetry.LOG_TAG,
+            "watch-streak reconciliation $phase source=${reconciliation.source} status=$status",
+        )
     }
 
     private fun loadChannelPoints(
@@ -2045,6 +2127,7 @@ class ChatViewModel(
         if (isLoggedIn) {
             loadChannelPoints(networkLibrary, gqlHeaders, channelLogin, enableIntegrity)
             loadWatchStreak(networkLibrary, gqlHeaders, channelId)
+            startWatchStreakRefresh(networkLibrary, gqlHeaders, channelId)
         }
         if (applicationContext.prefs().getBoolean(C.DEBUG_EVENT_SUB_CHAT, false) && !helixHeaders[C.HEADER_TOKEN].isNullOrBlank()) {
             eventSub = EventSubWebSocket(trustManager, EventSubListener(helixHeaders, gqlHeaders, channelLogin, showUserNotice, showClearChat, usePubSub, networkLibrary, isLoggedIn, accountId, channelId))
@@ -2138,6 +2221,7 @@ class ChatViewModel(
         resetSlowModeState()
         _connectionState.value = ConnectionState.IDLE
         watchStreakSession++
+        lastWatchStreakReconciliationElapsedRealtime = null
         activeChannelId = null
         activeChannelLogin = null
         synchronized(channelEmotes) {
@@ -2150,10 +2234,11 @@ class ChatViewModel(
         channelPointsJob = null
         claimJob?.cancel()
         claimJob = null
-        watchStreakJob?.cancel()
-        watchStreakJob = null
-        watchStreakRetryJob?.cancel()
-        watchStreakRetryJob = null
+        watchStreakRefreshJob?.cancel()
+        watchStreakRefreshJob = null
+        watchStreakWorkerJob?.cancel()
+        watchStreakWorkerJob = null
+        pendingWatchStreakRequests.clear()
         channelPoints.value = null
         watchStreak.value = null
         clearPollPresentation()
@@ -3004,7 +3089,10 @@ class ChatViewModel(
                 messageChannelId = messageChannelId,
                 reasonCode = points.reasonCode,
                 currentCount = watchStreak.value?.streakCount,
+                nowMs = SystemClock.elapsedRealtime(),
+                lastReconciliationAtMs = lastWatchStreakReconciliationElapsedRealtime,
             )?.let { reconciliation ->
+                lastWatchStreakReconciliationElapsedRealtime = SystemClock.elapsedRealtime()
                 reconcileWatchStreak(
                     networkLibrary = networkLibrary,
                     gqlHeaders = gqlHeaders,

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/WatchStreakReconciliation.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/WatchStreakReconciliation.kt
@@ -3,7 +3,9 @@ package com.github.andreyasadchy.xtra.ui.chat
 import com.github.andreyasadchy.xtra.model.ui.WatchStreak
 
 internal enum class WatchStreakReconciliationSource {
-    POINTS_EARNED,
+    PERIODIC,
+    WATCH_CREDIT,
+    WATCH_STREAK_CREDIT,
     LIVE_NOTIFICATION,
 }
 
@@ -18,21 +20,98 @@ internal val watchStreakReconciliationRetryDelaysMillis = listOf(
     10_000L,
 )
 
+internal const val WATCH_STREAK_REFRESH_INTERVAL_MILLIS = 3 * 60 * 1_000L
+internal const val WATCH_STREAK_EVENT_RECONCILIATION_THROTTLE_MILLIS = 30_000L
+
+internal fun watchStreakReconciliationPriority(
+    source: WatchStreakReconciliationSource,
+): Int = when (source) {
+    WatchStreakReconciliationSource.PERIODIC -> 0
+    WatchStreakReconciliationSource.WATCH_CREDIT -> 1
+    WatchStreakReconciliationSource.WATCH_STREAK_CREDIT -> 2
+    WatchStreakReconciliationSource.LIVE_NOTIFICATION -> 3
+}
+
+/** Coalesces requests while retaining the strongest and newest invalidation. */
+internal class WatchStreakReconciliationQueue<T>(
+    private val reconciliationOf: (T) -> WatchStreakReconciliation,
+) {
+    private var pending: T? = null
+
+    @Synchronized
+    fun enqueue(request: T) {
+        val current = pending
+        if (current == null ||
+            watchStreakReconciliationPriority(reconciliationOf(request).source) >=
+                watchStreakReconciliationPriority(reconciliationOf(current).source)
+        ) {
+            pending = request
+        }
+    }
+
+    @Synchronized
+    fun take(): T? = pending.also { pending = null }
+
+    @Synchronized
+    fun hasHigherPriorityThan(reconciliation: WatchStreakReconciliation): Boolean =
+        pending?.let {
+            watchStreakReconciliationPriority(reconciliationOf(it).source) >
+                watchStreakReconciliationPriority(reconciliation.source)
+        } == true
+
+    @Synchronized
+    fun clear() {
+        pending = null
+    }
+}
+
+internal fun shouldContinueWatchStreakRefresh(
+    expectedSession: Long,
+    currentSession: Long,
+    expectedChannelId: String?,
+    currentChannelId: String?,
+    expectedChannelLogin: String?,
+    currentChannelLogin: String?,
+    expectedUserId: String?,
+    currentUserId: String?,
+    gqlToken: String?,
+): Boolean = expectedSession == currentSession &&
+        expectedChannelId == currentChannelId &&
+        expectedChannelLogin == currentChannelLogin &&
+        expectedUserId == currentUserId &&
+        !expectedChannelId.isNullOrBlank() &&
+        !expectedUserId.isNullOrBlank() &&
+        !gqlToken.isNullOrBlank()
+
 internal fun watchStreakInvalidationForPointsEarned(
     activeChannelId: String?,
     messageChannelId: String?,
     reasonCode: String?,
     currentCount: Int?,
+    nowMs: Long? = null,
+    lastReconciliationAtMs: Long? = null,
 ): WatchStreakReconciliation? {
     if (activeChannelId.isNullOrBlank() ||
         messageChannelId.isNullOrBlank() ||
         activeChannelId != messageChannelId ||
-        !reasonCode.equals("WATCH_STREAK", ignoreCase = true)
+        !(reasonCode.equals("WATCH_STREAK", ignoreCase = true) ||
+            reasonCode.equals("WATCH", ignoreCase = true))
+    ) {
+        return null
+    }
+    val isWatchStreakCredit = reasonCode.equals("WATCH_STREAK", ignoreCase = true)
+    if (!isWatchStreakCredit && nowMs != null && lastReconciliationAtMs != null &&
+        nowMs >= lastReconciliationAtMs &&
+        nowMs - lastReconciliationAtMs < WATCH_STREAK_EVENT_RECONCILIATION_THROTTLE_MILLIS
     ) {
         return null
     }
     return WatchStreakReconciliation(
-        source = WatchStreakReconciliationSource.POINTS_EARNED,
+        source = if (isWatchStreakCredit) {
+            WatchStreakReconciliationSource.WATCH_STREAK_CREDIT
+        } else {
+            WatchStreakReconciliationSource.WATCH_CREDIT
+        },
         countBeforeEvent = currentCount,
     )
 }
@@ -44,7 +123,7 @@ internal fun shouldRetryWatchStreakReconciliation(
 ): Boolean {
     if (retryAttempt !in 0 until watchStreakReconciliationRetryDelaysMillis.size) return false
     return when (reconciliation.source) {
-        WatchStreakReconciliationSource.POINTS_EARNED -> when {
+        WatchStreakReconciliationSource.WATCH_STREAK_CREDIT -> when {
             responseCount == null -> true
             reconciliation.countBeforeEvent == null -> false
             else -> responseCount <= reconciliation.countBeforeEvent
@@ -53,6 +132,9 @@ internal fun shouldRetryWatchStreakReconciliation(
             reconciliation.observedLiveCount?.let {
                 responseCount == null || responseCount < it
             } == true
+        WatchStreakReconciliationSource.PERIODIC,
+        WatchStreakReconciliationSource.WATCH_CREDIT,
+        -> false
     }
 }
 

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/PlaybackService.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/PlaybackService.kt
@@ -140,6 +140,10 @@ class PlaybackService : MediaSessionService() {
                     }
                 }
 
+                override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) {
+                    xtraModule.streamMedia3Runtime.setPrimaryPlaybackMediaItem(mediaItem)
+                }
+
                 override fun onRenderedFirstFrame() {
                     streamStartupTrace?.markFirstFrame()
                     streamStartupTrace?.let { xtraModule.streamPreviewCoordinator.onFullscreenPlaybackFirstFrame(it.channelLogin) }
@@ -286,6 +290,7 @@ class PlaybackService : MediaSessionService() {
                                         }.build()
                                     )
                                 )
+                                xtraModule.streamMedia3Runtime.setPrimaryPlaybackMediaItem(null)
                                 session.player.volume = prefs().getInt(C.PLAYER_VOLUME, 100) / 100f
                                 session.player.setPlaybackSpeed(prefs().getFloat(C.PLAYER_SPEED, 1f))
                                 session.player.prepare()
@@ -336,6 +341,7 @@ class PlaybackService : MediaSessionService() {
                                         }.build()
                                     )
                                 )
+                                xtraModule.streamMedia3Runtime.setPrimaryPlaybackMediaItem(null)
                                 session.player.volume = prefs().getInt(C.PLAYER_VOLUME, 100) / 100f
                                 session.player.setPlaybackSpeed(prefs().getFloat(C.PLAYER_SPEED, 1f))
                                 session.player.prepare()
@@ -373,6 +379,7 @@ class PlaybackService : MediaSessionService() {
                                         )
                                     }.build()
                                 )
+                                xtraModule.streamMedia3Runtime.setPrimaryPlaybackMediaItem(null)
                                 session.player.volume = prefs().getInt(C.PLAYER_VOLUME, 100) / 100f
                                 session.player.setPlaybackSpeed(prefs().getFloat(C.PLAYER_SPEED, 1f))
                                 session.player.prepare()
@@ -425,6 +432,7 @@ class PlaybackService : MediaSessionService() {
                                                 savePosition()
                                                 runAfterPlaybackPersistence {
                                                     mediaSession?.player?.clearMediaItems()
+                                                    xtraModule.streamMedia3Runtime.setPrimaryPlaybackMediaItem(null)
                                                     pauseAllPlayersAndStopSelf()
                                                 }
                                             }
@@ -566,11 +574,10 @@ class PlaybackService : MediaSessionService() {
                     "tapToStartStreamMs=${streamStartupTrace?.tapToStartStreamMs() ?: -1}",
             )
         }
-        if (preloaded != null) {
-            player.setMediaSource(preloaded.mediaSource)
-        } else {
-            player.setMediaSource(runtime.createLiveMediaSource(mediaItem))
-        }
+        player.setMediaSource(
+            preloaded?.mediaSource ?: runtime.createLiveMediaSource(mediaItem)
+        )
+        runtime.setPrimaryPlaybackMediaItem(preloaded?.mediaItem)
         player.volume = prefs().getInt(C.PLAYER_VOLUME, 100) / 100f
         player.setPlaybackSpeed(1f)
         player.prepare()
@@ -799,6 +806,7 @@ class PlaybackService : MediaSessionService() {
             return
         }
         player?.clearMediaItems()
+        xtraModule.streamMedia3Runtime.setPrimaryPlaybackMediaItem(null)
         runAfterPlaybackPersistence {
             pauseAllPlayersAndStopSelf()
         }

--- a/app/src/test/java/com/github/andreyasadchy/xtra/repository/preload/StreamMedia3RuntimeLifecycleTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/repository/preload/StreamMedia3RuntimeLifecycleTest.kt
@@ -1,0 +1,113 @@
+package com.github.andreyasadchy.xtra.repository.preload
+
+import androidx.media3.common.MediaItem
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class StreamMedia3RuntimeLifecycleTest {
+    @Test
+    fun backgroundCleanupPreservesManagerOwnedByPrimaryPlayback() {
+        assertFalse(shouldResetPreloadManager(hasPrimaryPlaybackPlayer = true))
+    }
+
+    @Test
+    fun browsingCleanupCanResetManagerWithoutPrimaryPlayback() {
+        assertTrue(shouldResetPreloadManager(hasPrimaryPlaybackPlayer = false))
+    }
+
+    @Test
+    fun currentBrowsingGenerationSurvivesPlaybackServiceRelease() {
+        assertFalse(
+            shouldReleasePreloadGeneration(
+                isCurrentGeneration = true,
+                wasPrimaryPlaybackGeneration = false,
+            ),
+        )
+        assertTrue(
+            shouldReleasePreloadGeneration(
+                isCurrentGeneration = true,
+                wasPrimaryPlaybackGeneration = true,
+            ),
+        )
+        assertTrue(
+            shouldReleasePreloadGeneration(
+                isCurrentGeneration = false,
+                wasPrimaryPlaybackGeneration = false,
+            ),
+        )
+    }
+
+    @Test
+    fun primaryPlaybackOwnershipFollowsTheInstalledMediaItem() {
+        val ownership = StreamMedia3PlaybackOwnership()
+        val first = MediaItem.Builder().setMediaId("first").build()
+        val second = MediaItem.Builder().setMediaId("second").build()
+
+        assertTrue(ownership.setPrimaryMediaItem(first))
+
+        assertTrue(ownership.protects(first))
+        assertFalse(ownership.protects(second))
+
+        assertFalse(ownership.setPrimaryMediaItem(first))
+        assertTrue(ownership.setPrimaryMediaItem(second))
+
+        assertFalse(ownership.protects(first))
+        assertTrue(ownership.protects(second))
+
+        ownership.setPrimaryMediaItem(null)
+
+        assertFalse(ownership.protects(second))
+    }
+
+    @Test
+    fun protectedReplacementWaitsUntilTheOldPrimarySourceIsReleased() {
+        val ownership = StreamMedia3PlaybackOwnership()
+        val oldSource = MediaItem.Builder().setMediaId("old").build()
+        val replacement = MediaItem.Builder().setMediaId("replacement").build()
+        val entries = StreamMedia3PreloadEntries<MediaItem>().apply {
+            this["channel"] = oldSource
+        }
+        val plan = StreamMediaPreloadPlan.reconcile(
+            existing = listOf(MediaPreloadPlanEntry("channel", "old-url", rank = 0)),
+            candidates = listOf(MediaPreloadPlanEntry("channel", "new-url", rank = 1)),
+            nowMs = 100L,
+            staleAfterMs = 4_500L,
+        )
+
+        assertEquals(listOf("old-url"), plan.removed.map { it.url })
+        assertEquals(listOf("new-url"), plan.added.map { it.url })
+
+        ownership.setPrimaryMediaItem(oldSource)
+
+        assertFalse(
+            entries.replaceUnlessProtected("channel", replacement) {
+                shouldDeferProtectedPreloadReplacement(it, ownership)
+            }
+        )
+        assertTrue(entries["channel"] === oldSource)
+
+        ownership.setPrimaryMediaItem(null)
+
+        assertTrue(
+            entries.replaceUnlessProtected("channel", replacement) {
+                shouldDeferProtectedPreloadReplacement(it, ownership)
+            }
+        )
+        assertTrue(entries["channel"] === replacement)
+    }
+
+    @Test
+    fun switchingBetweenPreloadedSourcesMakesThePreviousSourceEvictable() {
+        val ownership = StreamMedia3PlaybackOwnership()
+        val first = MediaItem.Builder().setMediaId("first").build()
+        val second = MediaItem.Builder().setMediaId("second").build()
+
+        ownership.setPrimaryMediaItem(first)
+        ownership.setPrimaryMediaItem(second)
+
+        assertFalse(ownership.protects(first))
+        assertTrue(ownership.protects(second))
+    }
+}

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/WatchStreakReconciliationTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/WatchStreakReconciliationTest.kt
@@ -17,8 +17,73 @@ class WatchStreakReconciliationTest {
     }
 
     @Test
-    fun ordinaryWatchDoesNotCreateStreakInvalidation() {
-        assertNull(
+    fun periodicRefreshRunsWithoutAWatchStreakNotice() {
+        assertEquals(180_000L, WATCH_STREAK_REFRESH_INTERVAL_MILLIS)
+        assertTrue(
+            shouldContinueWatchStreakRefresh(
+                expectedSession = 7L,
+                currentSession = 7L,
+                expectedChannelId = "channel-100",
+                currentChannelId = "channel-100",
+                expectedChannelLogin = "channel",
+                currentChannelLogin = "channel",
+                expectedUserId = "user-1",
+                currentUserId = "user-1",
+                gqlToken = "OAuth token",
+            ),
+        )
+    }
+
+    @Test
+    fun periodicRefreshStopsAfterChannelOrSessionChanges() {
+        assertFalse(
+            shouldContinueWatchStreakRefresh(
+                expectedSession = 7L,
+                currentSession = 8L,
+                expectedChannelId = "channel-100",
+                currentChannelId = "channel-100",
+                expectedChannelLogin = "channel",
+                currentChannelLogin = "channel",
+                expectedUserId = "user-1",
+                currentUserId = "user-1",
+                gqlToken = "OAuth token",
+            ),
+        )
+        assertFalse(
+            shouldContinueWatchStreakRefresh(
+                expectedSession = 7L,
+                currentSession = 7L,
+                expectedChannelId = "channel-100",
+                currentChannelId = "channel-200",
+                expectedChannelLogin = "channel",
+                currentChannelLogin = "other-channel",
+                expectedUserId = "user-1",
+                currentUserId = "user-1",
+                gqlToken = "OAuth token",
+            ),
+        )
+        assertFalse(
+            shouldContinueWatchStreakRefresh(
+                expectedSession = 7L,
+                currentSession = 7L,
+                expectedChannelId = "channel-100",
+                currentChannelId = "channel-100",
+                expectedChannelLogin = "channel",
+                currentChannelLogin = "channel",
+                expectedUserId = "user-1",
+                currentUserId = null,
+                gqlToken = null,
+            ),
+        )
+    }
+
+    @Test
+    fun ordinaryWatchCreatesAReconciliation() {
+        assertEquals(
+            WatchStreakReconciliation(
+                source = WatchStreakReconciliationSource.WATCH_CREDIT,
+                countBeforeEvent = 4,
+            ),
             watchStreakInvalidationForPointsEarned(
                 activeChannelId = "channel-100",
                 messageChannelId = "channel-100",
@@ -29,10 +94,38 @@ class WatchStreakReconciliationTest {
     }
 
     @Test
+    fun watchCreditReconciliationIsThrottled() {
+        assertNull(
+            watchStreakInvalidationForPointsEarned(
+                activeChannelId = "channel-100",
+                messageChannelId = "channel-100",
+                reasonCode = "WATCH",
+                currentCount = 4,
+                nowMs = 125_000L,
+                lastReconciliationAtMs = 100_000L,
+            ),
+        )
+        assertEquals(
+            WatchStreakReconciliation(
+                source = WatchStreakReconciliationSource.WATCH_CREDIT,
+                countBeforeEvent = 4,
+            ),
+            watchStreakInvalidationForPointsEarned(
+                activeChannelId = "channel-100",
+                messageChannelId = "channel-100",
+                reasonCode = "WATCH",
+                currentCount = 4,
+                nowMs = 130_000L,
+                lastReconciliationAtMs = 100_000L,
+            ),
+        )
+    }
+
+    @Test
     fun watchStreakForActiveChannelCapturesPreEventCount() {
         assertEquals(
             WatchStreakReconciliation(
-                source = WatchStreakReconciliationSource.POINTS_EARNED,
+                source = WatchStreakReconciliationSource.WATCH_STREAK_CREDIT,
                 countBeforeEvent = 4,
             ),
             watchStreakInvalidationForPointsEarned(
@@ -59,7 +152,7 @@ class WatchStreakReconciliationTest {
     @Test
     fun staleFirstSnapshotAndFreshSecondSnapshotUpdateState() {
         val reconciliation = WatchStreakReconciliation(
-            source = WatchStreakReconciliationSource.POINTS_EARNED,
+            source = WatchStreakReconciliationSource.WATCH_STREAK_CREDIT,
             countBeforeEvent = 4,
         )
         assertTrue(shouldRetryWatchStreakReconciliation(reconciliation, responseCount = 4, retryAttempt = 0))
@@ -82,7 +175,7 @@ class WatchStreakReconciliationTest {
     @Test
     fun unchangedSnapshotGetsTwoBoundedRetries() {
         val reconciliation = WatchStreakReconciliation(
-            source = WatchStreakReconciliationSource.POINTS_EARNED,
+            source = WatchStreakReconciliationSource.WATCH_STREAK_CREDIT,
             countBeforeEvent = 4,
         )
 
@@ -95,7 +188,7 @@ class WatchStreakReconciliationTest {
     @Test
     fun lowerStaleSnapshotStillGetsBoundedRetry() {
         val reconciliation = WatchStreakReconciliation(
-            source = WatchStreakReconciliationSource.POINTS_EARNED,
+            source = WatchStreakReconciliationSource.WATCH_STREAK_CREDIT,
             countBeforeEvent = 4,
         )
 
@@ -108,7 +201,7 @@ class WatchStreakReconciliationTest {
     @Test
     fun snapshotStatusDistinguishesAdvancedAndMissingResponses() {
         val reconciliation = WatchStreakReconciliation(
-            source = WatchStreakReconciliationSource.POINTS_EARNED,
+            source = WatchStreakReconciliationSource.WATCH_STREAK_CREDIT,
             countBeforeEvent = 4,
         )
 
@@ -125,5 +218,60 @@ class WatchStreakReconciliationTest {
 
         assertEquals(5, updated.streakCount)
         assertEquals(300, updated.pointsAwarded)
+    }
+
+    @Test
+    fun ordinaryWatchDoesNotStartAdvancementRetries() {
+        val reconciliation = WatchStreakReconciliation(
+            source = WatchStreakReconciliationSource.WATCH_CREDIT,
+            countBeforeEvent = 37,
+        )
+
+        assertFalse(shouldRetryWatchStreakReconciliation(reconciliation, responseCount = 37, retryAttempt = 0))
+        assertFalse(shouldRetryWatchStreakReconciliation(reconciliation, responseCount = null, retryAttempt = 0))
+    }
+
+    @Test
+    fun watchStreakCreditCanBypassOrdinaryWatchThrottle() {
+        assertEquals(
+            WatchStreakReconciliationSource.WATCH_STREAK_CREDIT,
+            watchStreakInvalidationForPointsEarned(
+                activeChannelId = "channel-100",
+                messageChannelId = "channel-100",
+                reasonCode = "WATCH_STREAK",
+                currentCount = 37,
+                nowMs = 110_000L,
+                lastReconciliationAtMs = 100_000L,
+            )?.source,
+        )
+    }
+
+    @Test
+    fun queuedEventSupersedesPeriodicRefreshWithoutBeingDropped() {
+        val queue = WatchStreakReconciliationQueue<WatchStreakReconciliation> { it }
+        val periodic = WatchStreakReconciliation(WatchStreakReconciliationSource.PERIODIC, null)
+        val event = WatchStreakReconciliation(WatchStreakReconciliationSource.WATCH_STREAK_CREDIT, 37)
+
+        queue.enqueue(periodic)
+        queue.enqueue(event)
+
+        assertEquals(event, queue.take())
+        assertNull(queue.take())
+    }
+
+    @Test
+    fun liveNotificationTakesPrecedenceOverQueuedWatchCredit() {
+        val queue = WatchStreakReconciliationQueue<WatchStreakReconciliation> { it }
+        val watchCredit = WatchStreakReconciliation(WatchStreakReconciliationSource.WATCH_CREDIT, 37)
+        val liveNotification = WatchStreakReconciliation(
+            source = WatchStreakReconciliationSource.LIVE_NOTIFICATION,
+            countBeforeEvent = 37,
+            observedLiveCount = 38,
+        )
+
+        queue.enqueue(watchCredit)
+        queue.enqueue(liveNotification)
+
+        assertEquals(liveNotification, queue.take())
     }
 }


### PR DESCRIPTION
## What changed

- Protect the exact Media3 source handed to primary playback while browsing and stale cleanup continue.
- Queue watch-streak reconciliations so event refreshes are not lost behind an in-flight request.
- Keep retries for WATCH_STREAK/live notices, while ordinary WATCH performs one delayed snapshot.

## Checks

- Rebased onto current master, including #110 and #112.
- `:app:testDebugUnitTest`
- `:app:assembleDebug`
- Emulator smoke: background, network toggle, Settings, and return on `xtra-api35`.

The authenticated Media3 crash was not reproducible on the signed-out emulator. The smoke process stayed alive and the crash buffer remained empty.