### PR TITLE
Add debug Twitch authentication lab

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -66,6 +66,16 @@
             </intent-filter>
         </activity>
         <activity android:name=".ui.settings.SettingsActivity" />
+        <activity
+            android:name=".ui.settings.AuthLabActivity"
+            android:exported="false"
+            android:screenOrientation="unspecified"
+            android:windowSoftInputMode="adjustResize" />
+        <activity
+            android:name=".ui.settings.AuthLabWebLoginActivity"
+            android:exported="false"
+            android:screenOrientation="unspecified"
+            android:windowSoftInputMode="adjustResize" />
         <provider
             android:name="androidx.core.content.FileProvider"
             android:authorities="${applicationId}.fileprovider"

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/AuthRepository.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/AuthRepository.kt
@@ -35,8 +35,9 @@ private const val TOKEN_URL = "https://id.twitch.tv/oauth2/token"
 private const val VALIDATE_URL = "https://id.twitch.tv/oauth2/validate"
 private const val REVOKE_URL = "https://id.twitch.tv/oauth2/revoke"
 private val FORM_MEDIA_TYPE = "application/x-www-form-urlencoded".toMediaType()
+private val JSON_MEDIA_TYPE = "application/json".toMediaType()
 
-private data class AuthHttpResponse(
+internal data class AuthHttpResponse(
     val statusCode: Int,
     val body: String,
 )
@@ -163,6 +164,34 @@ class AuthRepository(
         ensureSuccess(response)
     }
 
+    /** Raw read-only transport for the debug authentication lab. */
+    internal suspend fun diagnosticGet(
+        networkLibrary: String?,
+        url: String,
+        headers: Map<String, String>,
+    ): AuthHttpResponse {
+        val authorization = headers.entries
+            .firstOrNull { it.key.equals("Authorization", ignoreCase = true) }
+            ?.value
+            ?.takeIf { it.isNotBlank() }
+            ?: throw TwitchAuthProtocolException("Authentication lab request has no authorization")
+        return executeGet(networkLibrary, url, authorization, headers)
+    }
+
+    /** Raw JSON POST transport for the debug authentication lab. */
+    internal suspend fun diagnosticPost(
+        networkLibrary: String?,
+        url: String,
+        headers: Map<String, String>,
+        body: String,
+    ): AuthHttpResponse = executePost(
+        networkLibrary = networkLibrary,
+        url = url,
+        body = body,
+        headers = headers,
+        mediaType = JSON_MEDIA_TYPE,
+    )
+
     /** Legacy raw-body entry point retained for developer tooling during migration. */
     @Deprecated("Use startDeviceAuthorization")
     suspend fun getDeviceCode(networkLibrary: String?, body: String): DeviceCodeResponse = withContext(Dispatchers.IO) {
@@ -188,7 +217,9 @@ class AuthRepository(
         networkLibrary: String?,
         url: String,
         authorization: String,
+        headers: Map<String, String> = emptyMap(),
     ): AuthHttpResponse {
+        val requestHeaders = headers.filterKeys { !it.equals("Authorization", ignoreCase = true) }
         return try {
             when {
                 networkLibrary == C.HTTP_ENGINE && httpEngine.value != null -> @SuppressLint("NewApi") {
@@ -199,6 +230,7 @@ class AuthRepository(
                         cronetExecutor.value,
                         NetworkUtils.ByteArrayUrlCallback(continuation, timeout),
                     ).apply {
+                        requestHeaders.forEach { (name, value) -> addHeader(name, value) }
                         addHeader("Authorization", authorization)
                     }.build()
                     timeout.start(request, continuation)
@@ -218,6 +250,7 @@ class AuthRepository(
                         NetworkUtils.ByteArrayCronetCallback(continuation, timeout),
                         cronetExecutor.value,
                     ).apply {
+                        requestHeaders.forEach { (name, value) -> addHeader(name, value) }
                         addHeader("Authorization", authorization)
                     }.build()
                     timeout.start(request, continuation)
@@ -233,6 +266,9 @@ class AuthRepository(
                     okHttpClient.value.newCall(
                         Request.Builder()
                             .url(url)
+                            .apply {
+                                requestHeaders.forEach { (name, value) -> header(name, value) }
+                            }
                             .header("Authorization", authorization)
                             .build(),
                     ).executeAsync().use { response ->
@@ -251,6 +287,8 @@ class AuthRepository(
         networkLibrary: String?,
         url: String,
         body: String,
+        headers: Map<String, String> = emptyMap(),
+        mediaType: okhttp3.MediaType = FORM_MEDIA_TYPE,
     ): AuthHttpResponse {
         val bodyBytes = body.toByteArray()
         return try {
@@ -263,7 +301,8 @@ class AuthRepository(
                         cronetExecutor.value,
                         NetworkUtils.ByteArrayUrlCallback(continuation, timeout),
                     ).apply {
-                        addHeader("Content-Type", FORM_MEDIA_TYPE.toString())
+                        headers.forEach { (name, value) -> addHeader(name, value) }
+                        addHeader("Content-Type", mediaType.toString())
                         setUploadDataProvider(NetworkUtils.ByteArrayUploadProvider(bodyBytes), cronetExecutor.value)
                     }.build()
                     timeout.start(request, continuation)
@@ -283,7 +322,8 @@ class AuthRepository(
                         NetworkUtils.ByteArrayCronetCallback(continuation, timeout),
                         cronetExecutor.value,
                     ).apply {
-                        addHeader("Content-Type", FORM_MEDIA_TYPE.toString())
+                        headers.forEach { (name, value) -> addHeader(name, value) }
+                        addHeader("Content-Type", mediaType.toString())
                         setUploadDataProvider(UploadDataProviders.create(bodyBytes), cronetExecutor.value)
                     }.build()
                     timeout.start(request, continuation)
@@ -299,8 +339,11 @@ class AuthRepository(
                     okHttpClient.value.newCall(
                         Request.Builder()
                             .url(url)
-                            .header("Content-Type", FORM_MEDIA_TYPE.toString())
-                            .post(body.toRequestBody(FORM_MEDIA_TYPE))
+                            .apply {
+                                headers.forEach { (name, value) -> header(name, value) }
+                            }
+                            .header("Content-Type", mediaType.toString())
+                            .post(body.toRequestBody(mediaType))
                             .build(),
                     ).executeAsync().use { response ->
                         AuthHttpResponse(response.code, response.body.string())

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/auth/AuthCoordinator.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/auth/AuthCoordinator.kt
@@ -11,10 +11,28 @@ data class AuthCommitResult(
     val revocationFailures: Int,
 )
 
+enum class AuthFaultPoint {
+    BEFORE_OFFICIAL_REFRESH_REQUEST,
+    AFTER_OFFICIAL_REFRESH_RESPONSE_BEFORE_PERSISTENCE,
+    AFTER_OFFICIAL_PERSISTENCE_BEFORE_VALIDATION,
+    AFTER_OFFICIAL_VALIDATION_BEFORE_FINAL_PERSISTENCE,
+    AFTER_OFFICIAL_FINAL_PERSISTENCE,
+    BEFORE_COMPATIBILITY_REFRESH_REQUEST,
+    AFTER_COMPATIBILITY_REFRESH_RESPONSE_BEFORE_PERSISTENCE,
+    AFTER_COMPATIBILITY_PERSISTENCE_BEFORE_VALIDATION,
+    AFTER_COMPATIBILITY_VALIDATION_BEFORE_FINAL_PERSISTENCE,
+    AFTER_COMPATIBILITY_FINAL_PERSISTENCE,
+}
+
+fun interface AuthFaultInjector {
+    suspend fun hit(point: AuthFaultPoint)
+}
+
 class AuthCoordinator(
     private val repository: TwitchAuthOperations,
     private val sessionStore: AuthSessionStore,
     private val nowMillis: () -> Long = { System.currentTimeMillis() },
+    private val faultInjector: AuthFaultInjector = AuthFaultInjector { },
 ) {
     /** Validates the official grant without publishing it to the active account. */
     suspend fun validateOfficial(
@@ -140,11 +158,19 @@ class AuthCoordinator(
         )
     }
 
-    suspend fun refreshIfNeeded(force: Boolean = false): AuthSession? = SESSION_MUTEX.withLock {
+    suspend fun refreshIfNeeded(
+        force: Boolean = false,
+        expectedAccessToken: String? = null,
+    ): AuthSession? = SESSION_MUTEX.withLock {
         val current = sessionStore.read() ?: return null
+        // A caller that saw an old 401 must join a refresh another caller already completed.
+        // Without this check, every concurrent 401 would consume the same one-time refresh grant.
+        if (expectedAccessToken != null && current.accessToken != expectedAccessToken) return current
         if (!force && !current.isAccessTokenExpired(nowMillis())) return current
         val refreshToken = current.refreshToken ?: return current
+        faultInjector.hit(AuthFaultPoint.BEFORE_OFFICIAL_REFRESH_REQUEST)
         val response = repository.refreshUserToken(current.clientId, refreshToken)
+        faultInjector.hit(AuthFaultPoint.AFTER_OFFICIAL_REFRESH_RESPONSE_BEFORE_PERSISTENCE)
         val accessToken = response.accessToken?.takeIf { it.isNotBlank() }
             ?: throw TwitchAuthProtocolException("Twitch did not return a refreshed access token")
         val expiresIn = response.expiresIn?.takeIf { it > 0 }
@@ -165,6 +191,7 @@ class AuthCoordinator(
         ) {
             throw TwitchAuthException("Unable to save the refreshed Twitch session")
         }
+        faultInjector.hit(AuthFaultPoint.AFTER_OFFICIAL_PERSISTENCE_BEFORE_VALIDATION)
         val validation = repository.validate(accessToken)
         if (validation.clientId != current.clientId || validation.userId != current.userId) {
             throw TwitchAuthAccountMismatchException()
@@ -172,6 +199,7 @@ class AuthCoordinator(
         if (!hasRequiredOfficialScopes(validation.scopes)) {
             throw TwitchAuthMissingScopesException()
         }
+        faultInjector.hit(AuthFaultPoint.AFTER_OFFICIAL_VALIDATION_BEFORE_FINAL_PERSISTENCE)
         val refreshed = current.copy(
             accessToken = accessToken,
             refreshToken = rotatedRefreshToken,
@@ -191,8 +219,13 @@ class AuthCoordinator(
         ) {
             throw TwitchAuthException("Unable to save the refreshed Twitch session")
         }
+        faultInjector.hit(AuthFaultPoint.AFTER_OFFICIAL_FINAL_PERSISTENCE)
         return refreshed
     }
+
+    /** Refreshes once for a request that was sent with [expectedAccessToken]. */
+    suspend fun refreshAfterUnauthorized(expectedAccessToken: String): AuthSession? =
+        refreshIfNeeded(force = true, expectedAccessToken = expectedAccessToken)
 
     /** Validates the compatibility grant without persisting it. */
     suspend fun validateCompatibility(
@@ -248,12 +281,18 @@ class AuthCoordinator(
             if (accessToken.isNullOrBlank()) 0 else revoke(clientId, accessToken)
         }
 
-    suspend fun refreshCompatibilityIfNeeded(force: Boolean = false): CompatibilitySession? = SESSION_MUTEX.withLock {
+    suspend fun refreshCompatibilityIfNeeded(
+        force: Boolean = false,
+        expectedAccessToken: String? = null,
+    ): CompatibilitySession? = SESSION_MUTEX.withLock {
         val current = sessionStore.readCompatibility() ?: return null
+        if (expectedAccessToken != null && current.accessToken != expectedAccessToken) return current
         if (!force && !current.isAccessTokenExpired(nowMillis())) return current
         val refreshToken = current.refreshToken?.takeIf { it.isNotBlank() }
             ?: throw TwitchAuthProtocolException("Twitch compatibility session has no refresh token")
+        faultInjector.hit(AuthFaultPoint.BEFORE_COMPATIBILITY_REFRESH_REQUEST)
         val response = repository.refreshUserToken(current.clientId, refreshToken)
+        faultInjector.hit(AuthFaultPoint.AFTER_COMPATIBILITY_REFRESH_RESPONSE_BEFORE_PERSISTENCE)
         val accessToken = response.accessToken?.takeIf { it.isNotBlank() }
             ?: throw TwitchAuthProtocolException("Twitch did not return a refreshed compatibility access token")
         val replacementRefreshToken = response.refreshToken?.takeIf { it.isNotBlank() }
@@ -270,6 +309,7 @@ class AuthCoordinator(
         if (!sessionStore.updateCompatibilitySession(replacement)) {
             throw TwitchAuthException("Unable to save the refreshed Twitch compatibility session")
         }
+        faultInjector.hit(AuthFaultPoint.AFTER_COMPATIBILITY_PERSISTENCE_BEFORE_VALIDATION)
         val validation = repository.validateCompatibility(accessToken)
         if (validation.clientId != current.clientId || validation.userId != current.userId) {
             throw TwitchAuthAccountMismatchException()
@@ -281,11 +321,17 @@ class AuthCoordinator(
             scopes = validation.scopes.toSet().ifEmpty { response.scopes.toSet().ifEmpty { current.scopes } },
             tokenType = response.tokenType ?: current.tokenType,
         )
+        faultInjector.hit(AuthFaultPoint.AFTER_COMPATIBILITY_VALIDATION_BEFORE_FINAL_PERSISTENCE)
         if (!sessionStore.updateCompatibilitySession(refreshed)) {
             throw TwitchAuthException("Unable to save the refreshed Twitch compatibility session")
         }
+        faultInjector.hit(AuthFaultPoint.AFTER_COMPATIBILITY_FINAL_PERSISTENCE)
         return refreshed
     }
+
+    /** Refreshes compatibility once for a request that was sent with [expectedAccessToken]. */
+    suspend fun refreshCompatibilityAfterUnauthorized(expectedAccessToken: String): CompatibilitySession? =
+        refreshCompatibilityIfNeeded(force = true, expectedAccessToken = expectedAccessToken)
 
     suspend fun clearCompatibility() = SESSION_MUTEX.withLock {
         if (!sessionStore.clearCompatibilitySession()) {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/auth/AuthLabRepository.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/auth/AuthLabRepository.kt
@@ -1,0 +1,593 @@
+package com.github.andreyasadchy.xtra.repository.auth
+
+import android.content.SharedPreferences
+import androidx.core.content.edit
+import androidx.core.net.toUri
+import com.github.andreyasadchy.xtra.model.id.ValidationResponse
+import com.github.andreyasadchy.xtra.repository.AuthRepository
+import com.github.andreyasadchy.xtra.util.C
+import java.security.MessageDigest
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonArray
+import kotlinx.serialization.json.putJsonObject
+import org.json.JSONArray
+import org.json.JSONObject
+
+private const val VALIDATE_URL = "https://id.twitch.tv/oauth2/validate"
+private const val HELIX_USERS_URL = "https://api.twitch.tv/helix/users"
+private const val HELIX_FOLLOWED_CHANNELS_URL = "https://api.twitch.tv/helix/channels/followed"
+private const val GQL_URL = "https://gql.twitch.tv/gql"
+private const val AUTH_EVENT_HISTORY_LIMIT = 100
+
+enum class AuthLabCredentialSource {
+    OFFICIAL,
+    COMPATIBILITY,
+    WEB,
+}
+
+enum class AuthLabOperation(val label: String) {
+    HELIX_VALIDATE("/oauth2/validate"),
+    HELIX_GET_USERS("Helix Get Users"),
+    HELIX_FOLLOWED_CHANNELS("Helix followed channels"),
+    GQL_CHANNEL_POINTS_CONTEXT("GQL ChannelPointsContext"),
+    GQL_REWARD_LIST("GQL RewardList / watch streak"),
+    GQL_CURRENT_PREDICTION("GQL current prediction"),
+    GQL_PERSONAL_RECOMMENDATIONS("GQL personalized recommendations"),
+    GQL_PLAYBACK_ACCESS_TOKEN("GQL playback access token"),
+    HERMES_SUBSCRIPTIONS("Hermes authenticated subscriptions"),
+}
+
+data class AuthLabCredentialSummary(
+    val source: AuthLabCredentialSource,
+    val available: Boolean,
+    val clientId: String? = null,
+    val userId: String? = null,
+    val login: String? = null,
+    val accessFingerprint: String? = null,
+    val refreshFingerprint: String? = null,
+)
+
+data class AuthLabValidationResult(
+    val source: AuthLabCredentialSource,
+    val httpStatus: Int? = null,
+    val accepted: Boolean = false,
+    val clientId: String? = null,
+    val userId: String? = null,
+    val login: String? = null,
+    val scopes: List<String> = emptyList(),
+    val expiresIn: Int? = null,
+    val accessFingerprint: String? = null,
+    val refreshFingerprint: String? = null,
+    val classification: String,
+    val message: String? = null,
+)
+
+data class AuthLabProbeResult(
+    val source: AuthLabCredentialSource,
+    val operation: AuthLabOperation,
+    val httpStatus: Int? = null,
+    val success: Boolean,
+    val gqlSuccess: Boolean? = null,
+    val classification: String,
+    val message: String? = null,
+)
+
+data class AuthDiagnosticEvent(
+    val timestampMillis: Long,
+    val credential: String,
+    val operation: String,
+    val httpStatus: Int?,
+    val classification: String,
+    val message: String?,
+    val accessFingerprint: String? = null,
+    val refreshFingerprint: String? = null,
+)
+
+/** Stores only diagnostic metadata. It never accepts or serializes a raw credential. */
+class AuthDiagnosticLog(
+    private val preferences: SharedPreferences,
+    private val nowMillis: () -> Long = { System.currentTimeMillis() },
+) {
+    @Synchronized
+    fun record(
+        credential: AuthLabCredentialSource,
+        operation: String,
+        httpStatus: Int?,
+        classification: String,
+        message: String? = null,
+        accessToken: String? = null,
+        refreshToken: String? = null,
+    ) {
+        val events = read().toMutableList()
+        events += AuthDiagnosticEvent(
+            timestampMillis = nowMillis(),
+            credential = credential.name,
+            operation = operation,
+            httpStatus = httpStatus,
+            classification = classification,
+                message = message.redactCredentials(accessToken, refreshToken)?.take(160),
+            accessFingerprint = accessToken?.let(::tokenFingerprint),
+            refreshFingerprint = refreshToken?.let(::tokenFingerprint),
+        )
+        val encoded = JSONArray()
+        events.takeLast(AUTH_EVENT_HISTORY_LIMIT).forEach { event ->
+            encoded.put(JSONObject().apply {
+                put("timestamp", event.timestampMillis)
+                put("credential", event.credential)
+                put("operation", event.operation)
+                event.httpStatus?.let { put("http", it) }
+                put("classification", event.classification)
+                event.message?.let { put("message", it) }
+                event.accessFingerprint?.let { put("access", it) }
+                event.refreshFingerprint?.let { put("refresh", it) }
+            })
+        }
+        preferences.edit(commit = true) { putString(C.AUTH_EVENT_HISTORY, encoded.toString()) }
+    }
+
+    @Synchronized
+    fun read(): List<AuthDiagnosticEvent> {
+        val raw = preferences.getString(C.AUTH_EVENT_HISTORY, null) ?: return emptyList()
+        val array = runCatching { JSONArray(raw) }.getOrNull() ?: return emptyList()
+        return buildList(array.length()) {
+            for (index in 0 until array.length()) {
+                val item = array.optJSONObject(index) ?: continue
+                add(
+                    AuthDiagnosticEvent(
+                        timestampMillis = item.optLong("timestamp"),
+                        credential = item.optString("credential"),
+                        operation = item.optString("operation"),
+                        httpStatus = item.optInt("http", Int.MIN_VALUE).takeUnless { it == Int.MIN_VALUE },
+                        classification = item.optString("classification"),
+                        message = item.optString("message").takeIf { it.isNotBlank() },
+                        accessFingerprint = item.optString("access").takeIf { it.isNotBlank() },
+                        refreshFingerprint = item.optString("refresh").takeIf { it.isNotBlank() },
+                    ),
+                )
+            }
+        }
+    }
+
+    @Synchronized
+    fun clear() {
+        preferences.edit(commit = true) { remove(C.AUTH_EVENT_HISTORY) }
+    }
+}
+
+private fun String?.redactCredentials(
+    accessToken: String?,
+    refreshToken: String?,
+): String? = this?.let { message ->
+    sequenceOf(accessToken, refreshToken)
+        .filter { !it.isNullOrBlank() }
+        .map { it!! }
+        .fold(message) { redacted, credential -> redacted.replace(credential, "<redacted>") }
+}
+
+fun tokenFingerprint(token: String): String = MessageDigest
+    .getInstance("SHA-256")
+    .digest(token.toByteArray(Charsets.UTF_8))
+    .joinToString("") { byte -> "%02x".format(byte) }
+    .take(8)
+
+private data class AuthLabCredential(
+    val source: AuthLabCredentialSource,
+    val clientId: String,
+    val accessToken: String,
+    val refreshToken: String?,
+    val userId: String?,
+    val login: String?,
+    val authorizationScheme: String,
+)
+
+class AuthLabRepository(
+    private val authRepository: AuthRepository,
+    private val sessionStore: AuthSessionStore,
+    private val networkLibrary: String?,
+    private val json: Json,
+    private val diagnosticLog: AuthDiagnosticLog,
+) {
+    fun summarize(
+        source: AuthLabCredentialSource,
+        browserToken: String? = null,
+        browserClientId: String? = null,
+    ): AuthLabCredentialSummary {
+        val credential = resolve(source, browserToken, browserClientId) ?:
+            return AuthLabCredentialSummary(source = source, available = false)
+        return AuthLabCredentialSummary(
+            source = source,
+            available = true,
+            clientId = credential.clientId,
+            userId = credential.userId,
+            login = credential.login,
+            accessFingerprint = tokenFingerprint(credential.accessToken),
+            refreshFingerprint = credential.refreshToken?.let(::tokenFingerprint),
+        )
+    }
+
+    suspend fun validate(
+        source: AuthLabCredentialSource,
+        browserToken: String? = null,
+        browserClientId: String? = null,
+    ): AuthLabValidationResult {
+        val credential = resolve(source, browserToken, browserClientId)
+            ?: return unavailableValidation(source, "No credential is available")
+        val result = runCatching {
+            val response = authRepository.diagnosticGet(
+                networkLibrary = networkLibrary,
+                url = VALIDATE_URL,
+                headers = authHeaders(credential),
+            )
+            val validation = response.body
+                .takeIf { response.statusCode in 200..299 }
+                ?.let { json.decodeFromString<ValidationResponse>(it) }
+            val accepted = response.statusCode in 200..299 && validation?.clientId?.isNotBlank() == true
+            AuthLabValidationResult(
+                source = source,
+                httpStatus = response.statusCode,
+                accepted = accepted,
+                clientId = validation?.clientId,
+                userId = validation?.userId,
+                login = validation?.login,
+                scopes = validation?.scopes.orEmpty(),
+                expiresIn = validation?.expiresIn,
+                accessFingerprint = tokenFingerprint(credential.accessToken),
+                refreshFingerprint = credential.refreshToken?.let(::tokenFingerprint),
+                classification = classify(response.statusCode, accepted),
+                message = if (accepted) null else response.body.errorMessage()
+                    .redactCredentials(credential.accessToken, credential.refreshToken),
+            )
+        }.getOrElse { error ->
+            AuthLabValidationResult(
+                source = source,
+                accepted = false,
+                accessFingerprint = tokenFingerprint(credential.accessToken),
+                refreshFingerprint = credential.refreshToken?.let(::tokenFingerprint),
+                classification = "TRANSIENT_FAILURE",
+                message = error.safeMessage().redactCredentials(credential.accessToken, credential.refreshToken),
+            )
+        }
+        diagnosticLog.record(
+            credential = source,
+            operation = AuthLabOperation.HELIX_VALIDATE.label,
+            httpStatus = result.httpStatus,
+            classification = result.classification,
+            message = result.message,
+            accessToken = credential.accessToken,
+            refreshToken = credential.refreshToken,
+        )
+        return result
+    }
+
+    suspend fun runReadOnlyMatrix(
+        source: AuthLabCredentialSource,
+        channelLogin: String? = null,
+        channelId: String? = null,
+        browserToken: String? = null,
+        browserClientId: String? = null,
+    ): List<AuthLabProbeResult> {
+        val credential = resolve(source, browserToken, browserClientId)
+            ?: return AuthLabOperation.entries
+                .filter { it != AuthLabOperation.HELIX_VALIDATE }
+                .map { operation ->
+                    AuthLabProbeResult(
+                        source = source,
+                        operation = operation,
+                        success = false,
+                        classification = "NO_CREDENTIAL",
+                        message = "No credential is available",
+                    )
+                }
+        val resolvedLogin = channelLogin?.trim().takeUnless { it.isNullOrBlank() } ?: credential.login.orEmpty()
+        val resolvedChannelId = channelId?.trim().takeUnless { it.isNullOrBlank() } ?: credential.userId.orEmpty()
+        val operations = listOf(
+            AuthLabOperation.HELIX_GET_USERS,
+            AuthLabOperation.HELIX_FOLLOWED_CHANNELS,
+            AuthLabOperation.GQL_CHANNEL_POINTS_CONTEXT,
+            AuthLabOperation.GQL_REWARD_LIST,
+            AuthLabOperation.GQL_CURRENT_PREDICTION,
+            AuthLabOperation.GQL_PERSONAL_RECOMMENDATIONS,
+            AuthLabOperation.GQL_PLAYBACK_ACCESS_TOKEN,
+            AuthLabOperation.HERMES_SUBSCRIPTIONS,
+        )
+        return operations.map { operation ->
+            val result = if (operation == AuthLabOperation.HERMES_SUBSCRIPTIONS) {
+                AuthLabProbeResult(
+                    source = source,
+                    operation = operation,
+                    success = false,
+                    classification = "MANUAL_ONLY",
+                    message = "Hermes is a long-lived WebSocket; run it from a live chat session",
+                )
+            } else {
+                runProbe(credential, operation, resolvedLogin, resolvedChannelId)
+            }
+            diagnosticLog.record(
+                credential = source,
+                operation = operation.label,
+                httpStatus = result.httpStatus,
+                classification = result.classification,
+                message = result.message,
+                accessToken = credential.accessToken,
+                refreshToken = credential.refreshToken,
+            )
+            result
+        }
+    }
+
+    fun readHistory(): List<AuthDiagnosticEvent> = diagnosticLog.read()
+
+    fun clearHistory() = diagnosticLog.clear()
+
+    private suspend fun runProbe(
+        credential: AuthLabCredential,
+        operation: AuthLabOperation,
+        channelLogin: String,
+        channelId: String,
+    ): AuthLabProbeResult {
+        val response = runCatching {
+            when (operation) {
+                AuthLabOperation.HELIX_GET_USERS -> authRepository.diagnosticGet(
+                    networkLibrary,
+                    HELIX_USERS_URL.toUri().buildUpon().appendQueryParameter("id", credential.userId).build().toString(),
+                    helixHeaders(credential),
+                )
+                AuthLabOperation.HELIX_FOLLOWED_CHANNELS -> authRepository.diagnosticGet(
+                    networkLibrary,
+                    HELIX_FOLLOWED_CHANNELS_URL.toUri().buildUpon()
+                        .appendQueryParameter("user_id", credential.userId)
+                        .appendQueryParameter("first", "1")
+                        .build().toString(),
+                    helixHeaders(credential),
+                )
+                AuthLabOperation.GQL_CHANNEL_POINTS_CONTEXT -> authRepository.diagnosticPost(
+                    networkLibrary,
+                    GQL_URL,
+                    gqlHeaders(credential),
+                    channelPointsContextBody(channelLogin),
+                )
+                AuthLabOperation.GQL_REWARD_LIST -> authRepository.diagnosticPost(
+                    networkLibrary,
+                    GQL_URL,
+                    gqlHeaders(credential),
+                    rewardListBody(channelId),
+                )
+                AuthLabOperation.GQL_CURRENT_PREDICTION -> authRepository.diagnosticPost(
+                    networkLibrary,
+                    GQL_URL,
+                    gqlHeaders(credential),
+                    predictionBody(channelLogin),
+                )
+                AuthLabOperation.GQL_PERSONAL_RECOMMENDATIONS -> authRepository.diagnosticPost(
+                    networkLibrary,
+                    GQL_URL,
+                    gqlHeaders(credential),
+                    personalSectionsBody(),
+                )
+                AuthLabOperation.GQL_PLAYBACK_ACCESS_TOKEN -> authRepository.diagnosticPost(
+                    networkLibrary,
+                    GQL_URL,
+                    gqlHeaders(credential),
+                    playbackAccessTokenBody(channelLogin),
+                )
+                AuthLabOperation.HELIX_VALIDATE,
+                AuthLabOperation.HERMES_SUBSCRIPTIONS,
+                -> error("Unsupported lab operation")
+            }
+        }.getOrElse { error ->
+            return AuthLabProbeResult(
+                source = credential.source,
+                operation = operation,
+                success = false,
+                classification = "TRANSIENT_FAILURE",
+                message = error.safeMessage().redactCredentials(credential.accessToken, credential.refreshToken),
+            )
+        }
+        val gqlSuccess = if (operation.name.startsWith("GQL_")) response.body.gqlSuccess() else null
+        val success = response.statusCode in 200..299 && gqlSuccess != false
+        return AuthLabProbeResult(
+            source = credential.source,
+            operation = operation,
+            httpStatus = response.statusCode,
+            success = success,
+            gqlSuccess = gqlSuccess,
+            classification = classify(response.statusCode, success),
+            message = (if (success) response.body.gqlMessage() else response.body.errorMessage())
+                .redactCredentials(credential.accessToken, credential.refreshToken),
+        )
+    }
+
+    private fun resolve(
+        source: AuthLabCredentialSource,
+        browserToken: String?,
+        browserClientId: String?,
+    ): AuthLabCredential? = when (source) {
+        AuthLabCredentialSource.OFFICIAL -> sessionStore.read()?.let {
+            AuthLabCredential(
+                source = source,
+                clientId = it.clientId,
+                accessToken = it.accessToken,
+                refreshToken = it.refreshToken,
+                userId = it.userId,
+                login = it.login,
+                authorizationScheme = "Bearer",
+            )
+        }
+        AuthLabCredentialSource.COMPATIBILITY -> sessionStore.readCompatibility()?.let {
+            AuthLabCredential(
+                source = source,
+                clientId = it.clientId,
+                accessToken = it.accessToken,
+                refreshToken = it.refreshToken,
+                userId = it.userId,
+                login = sessionStore.read()?.login,
+                authorizationScheme = "OAuth",
+            )
+        }
+        AuthLabCredentialSource.WEB -> browserToken?.trim()?.takeIf { it.isNotBlank() }?.let {
+            AuthLabCredential(
+                source = source,
+                clientId = browserClientId?.trim()?.takeIf { id -> id.isNotBlank() }
+                    ?: C.DEFAULT_GQL_CLIENT_ID_WEB,
+                accessToken = it,
+                refreshToken = null,
+                userId = null,
+                login = null,
+                authorizationScheme = "OAuth",
+            )
+        }
+    }
+
+    private fun authHeaders(credential: AuthLabCredential): Map<String, String> = mapOf(
+        C.HEADER_CLIENT_ID to credential.clientId,
+        C.HEADER_TOKEN to "${credential.authorizationScheme} ${credential.accessToken}",
+    )
+
+    private fun helixHeaders(credential: AuthLabCredential): Map<String, String> = authHeaders(credential)
+
+    private fun gqlHeaders(credential: AuthLabCredential): Map<String, String> = authHeaders(credential) + mapOf(
+        "Origin" to "https://www.twitch.tv",
+        "Referer" to "https://www.twitch.tv/",
+        "User-Agent" to "Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 Chrome/131.0.0.0 Mobile Safari/537.36",
+    )
+
+    private fun unavailableValidation(source: AuthLabCredentialSource, message: String) = AuthLabValidationResult(
+        source = source,
+        classification = "NO_CREDENTIAL",
+        message = message,
+    )
+
+    private fun classify(status: Int, success: Boolean): String = when {
+        success -> "SUCCESS"
+        status == 401 -> "UNAUTHORIZED"
+        status == 408 || status == 429 || status >= 500 -> "TRANSIENT_FAILURE"
+        else -> "FAILURE"
+    }
+
+    private fun String.errorMessage(): String? = runCatching {
+        json.parseToJsonElement(this).jsonObject["message"]?.toString()
+            ?: json.parseToJsonElement(this).jsonObject["error"]?.toString()
+    }.getOrNull()?.trim('"')?.takeIf { it.isNotBlank() }
+
+    private fun String.gqlSuccess(): Boolean? = runCatching {
+        json.parseToJsonElement(this).jsonObject["errors"]?.jsonArray?.isEmpty() ?: true
+    }.getOrNull()
+
+    private fun String.gqlMessage(): String? = runCatching {
+        val root = json.parseToJsonElement(this).jsonObject
+        root["errors"]?.jsonArray?.firstOrNull()?.jsonObject?.get("message")?.toString()?.trim('"')
+    }.getOrNull()?.takeIf { it.isNotBlank() }
+
+    private fun Throwable.safeMessage(): String = message?.take(160) ?: this::class.simpleName.orEmpty()
+
+    private fun channelPointsContextBody(channelLogin: String) = buildJsonObject {
+        putJsonObject("extensions") {
+            putJsonObject("persistedQuery") {
+                put("sha256Hash", "7fe050e3761eb2cf258d70ee1a21cbd76fa8cf3d7e7b12fc437e7029d446b5e3")
+                put("version", 1)
+            }
+        }
+        put("operationName", "ChannelPointsContext")
+        putJsonObject("variables") {
+            put("channelLogin", channelLogin)
+            putJsonArray("includeGoalTypes") {
+                add(JsonPrimitive("CREATOR"))
+                add(JsonPrimitive("BOOST"))
+            }
+        }
+    }.toString()
+
+    private fun rewardListBody(channelId: String) = buildJsonObject {
+        put("operationName", "RewardList")
+        put("query", REWARD_LIST_QUERY)
+        putJsonObject("variables") {
+            put("channelID", channelId)
+            put("shouldIncludeAllSuspendedStreaks", false)
+        }
+    }.toString()
+
+    private fun predictionBody(channelLogin: String) = buildJsonObject {
+        putJsonObject("extensions") {
+            putJsonObject("persistedQuery") {
+                put("sha256Hash", "beb846598256b75bd7c1fe54a80431335996153e358ca9c7837ce7bb83d7d383")
+                put("version", 1)
+            }
+        }
+        put("operationName", "ChannelPointsPredictionContext")
+        putJsonObject("variables") {
+            put("count", 1)
+            put("channelLogin", channelLogin)
+        }
+    }.toString()
+
+    private fun personalSectionsBody() = buildJsonObject {
+        put("operationName", "PersonalSections")
+        put("query", PERSONAL_SECTIONS_QUERY)
+        putJsonObject("variables") {
+            putJsonObject("input") {
+                putJsonArray("sectionInputs") { add(JsonPrimitive("RECOMMENDED_SECTION")) }
+                putJsonObject("recommendationContext") {
+                    put("platform", "web")
+                    put("clientApp", "twilight")
+                    put("location", "following")
+                }
+            }
+        }
+    }.toString()
+
+    private fun playbackAccessTokenBody(channelLogin: String) = buildJsonObject {
+        putJsonObject("extensions") {
+            putJsonObject("persistedQuery") {
+                put("sha256Hash", "ed230aa1e33e07eebb8928504583da78a5173989fadfb1ac94be06a04f3cdbe9")
+                put("version", 1)
+            }
+        }
+        put("operationName", "PlaybackAccessToken")
+        putJsonObject("variables") {
+            put("isLive", true)
+            put("login", channelLogin)
+            put("isVod", false)
+            put("vodID", "")
+            put("platform", "web")
+            put("playerType", "site")
+        }
+    }.toString()
+
+    private companion object {
+        val REWARD_LIST_QUERY = """
+            query RewardList(${'$'}channelID: ID!, ${'$'}shouldIncludeAllSuspendedStreaks: Boolean = false) {
+              channel(id: ${'$'}channelID) {
+                self {
+                  watchStreakMilestone(shouldIncludeAllSuspendedStreaks: ${'$'}shouldIncludeAllSuspendedStreaks) {
+                    watchStreakMilestone { id value shareStatus }
+                    watchStreakThreshold
+                    watchStreakCopoBonus
+                  }
+                }
+              }
+            }
+        """.trimIndent()
+
+        val PERSONAL_SECTIONS_QUERY = """
+            query PersonalSections(${'$'}input: PersonalSectionInput!) {
+              personalSections(input: ${'$'}input) {
+                type
+                items {
+                  ... on PersonalSectionChannel {
+                    user { id login displayName profileImageURL(width: 300) }
+                    content {
+                      __typename
+                      ... on Stream { id title viewersCount createdAt previewImageURL game { id slug displayName } }
+                    }
+                  }
+                }
+              }
+            }
+        """.trimIndent()
+    }
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/auth/AuthSessionMaintainer.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/auth/AuthSessionMaintainer.kt
@@ -132,7 +132,7 @@ internal suspend fun recoverCompatibilitySessionAfterUnauthorized(
             return CompatibilityUnauthorizedRecovery.INVALID
         }
     return try {
-        val refreshed = coordinator.refreshCompatibilityIfNeeded(force = true)
+        val refreshed = coordinator.refreshCompatibilityAfterUnauthorized(previousToken)
         if (refreshed == null || refreshed.accessToken == previousToken) {
             onInvalid()
             CompatibilityUnauthorizedRecovery.INVALID
@@ -267,7 +267,10 @@ class AuthSessionMaintainer(
         if (helixResult == ValidationResult.UNAUTHORIZED) {
             val previousToken = sessionStore.read()?.accessToken
             helixResult = try {
-                val refreshed = coordinator.refreshIfNeeded(force = true)
+                val refreshed = coordinator.refreshIfNeeded(
+                    force = true,
+                    expectedAccessToken = previousToken,
+                )
                 if (refreshed == null || refreshed.accessToken == previousToken) {
                     ValidationResult.INVALID
                 } else {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/settings/AuthLabActivity.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/settings/AuthLabActivity.kt
@@ -1,0 +1,320 @@
+package com.github.andreyasadchy.xtra.ui.settings
+
+import android.os.Bundle
+import android.content.Intent
+import android.text.InputType
+import android.text.method.PasswordTransformationMethod
+import android.view.View
+import android.widget.Button
+import android.widget.EditText
+import android.widget.LinearLayout
+import android.widget.RadioButton
+import android.widget.RadioGroup
+import android.widget.ScrollView
+import android.widget.TextView
+import android.widget.Toast
+import androidx.appcompat.app.AppCompatActivity
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.lifecycle.lifecycleScope
+import com.github.andreyasadchy.xtra.BuildConfig
+import com.github.andreyasadchy.xtra.R
+import com.github.andreyasadchy.xtra.XtraApp
+import com.github.andreyasadchy.xtra.repository.auth.AuthDiagnosticLog
+import com.github.andreyasadchy.xtra.repository.auth.AuthLabCredentialSource
+import com.github.andreyasadchy.xtra.repository.auth.AuthLabProbeResult
+import com.github.andreyasadchy.xtra.repository.auth.AuthLabRepository
+import com.github.andreyasadchy.xtra.repository.auth.AuthLabValidationResult
+import com.github.andreyasadchy.xtra.repository.auth.AuthDiagnosticEvent
+import com.github.andreyasadchy.xtra.repository.auth.AuthSessionStore
+import com.github.andreyasadchy.xtra.util.C
+import com.github.andreyasadchy.xtra.util.prefs
+import com.github.andreyasadchy.xtra.util.tokenPrefs
+import kotlinx.coroutines.launch
+import java.text.DateFormat
+import java.util.Date
+
+class AuthLabActivity : AppCompatActivity() {
+    private lateinit var sourceGroup: RadioGroup
+    private lateinit var browserToken: EditText
+    private lateinit var browserClientId: EditText
+    private lateinit var channelLogin: EditText
+    private lateinit var channelId: EditText
+    private lateinit var output: TextView
+    private lateinit var validateButton: Button
+    private lateinit var matrixButton: Button
+    private lateinit var repository: AuthLabRepository
+    private val webLoginLauncher = registerForActivityResult(
+        ActivityResultContracts.StartActivityForResult(),
+    ) { result ->
+        if (result.resultCode != RESULT_OK) return@registerForActivityResult
+        val token = result.data?.getStringExtra(AuthLabWebLoginActivity.EXTRA_AUTH_TOKEN)
+            ?.takeIf { it.isNotBlank() }
+            ?: return@registerForActivityResult
+        result.data?.getStringExtra(AuthLabWebLoginActivity.EXTRA_CLIENT_ID)
+            ?.takeIf { it.isNotBlank() }
+            ?.let(browserClientId::setText)
+        browserToken.setText(token)
+        sourceGroup.check(AuthLabCredentialSource.WEB.ordinal + 1)
+        output.text = "Twitch web session imported in memory. Press Validate selected credential."
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        if (!BuildConfig.DEBUG) {
+            finish()
+            return
+        }
+        window.addFlags(android.view.WindowManager.LayoutParams.FLAG_SECURE)
+        title = getString(R.string.auth_lab_title)
+        supportActionBar?.setDisplayHomeAsUpEnabled(true)
+
+        val app = application as XtraApp
+        val module = app.xtraModule
+        val context = applicationContext
+        repository = AuthLabRepository(
+            authRepository = module.authRepository,
+            sessionStore = AuthSessionStore(context.prefs(), context.tokenPrefs()),
+            networkLibrary = context.prefs().getString(C.NETWORK_LIBRARY, C.OKHTTP),
+            json = module.json,
+            diagnosticLog = AuthDiagnosticLog(context.prefs()),
+        )
+
+        setContentView(buildContent())
+        renderCredentialSummary()
+    }
+
+    override fun onSupportNavigateUp(): Boolean {
+        finish()
+        return true
+    }
+
+    private fun buildContent(): View {
+        val scroll = ScrollView(this)
+        val root = LinearLayout(this).apply {
+            orientation = LinearLayout.VERTICAL
+            setPadding(dp(20), dp(16), dp(20), dp(24))
+        }
+        scroll.addView(root)
+
+        root.addView(text("Run read-only Twitch checks with the same credential paths Xtra uses. Tokens stay in memory and are never written to the event history."))
+        root.addView(text("Browser auth-token warning: this credential grants extensive access to the Twitch account. Never share it or include it in a report."))
+
+        root.addView(label("Credential"))
+        sourceGroup = RadioGroup(this).apply { orientation = RadioGroup.VERTICAL }
+        AuthLabCredentialSource.entries.forEach { source ->
+            sourceGroup.addView(RadioButton(this).apply {
+                id = source.ordinal + 1
+                text = source.displayName()
+                isChecked = source == AuthLabCredentialSource.OFFICIAL
+            })
+        }
+        root.addView(sourceGroup)
+
+        browserToken = edit("Browser auth-token, memory only", password = true)
+        browserClientId = edit("Browser client ID", C.DEFAULT_GQL_CLIENT_ID_WEB)
+        root.addView(label("Browser credential"))
+        root.addView(browserToken)
+        root.addView(browserClientId)
+        root.addView(button("Open Twitch page login") {
+            webLoginLauncher.launch(Intent(this, AuthLabWebLoginActivity::class.java))
+        })
+
+        val store = AuthSessionStore(applicationContext.prefs(), applicationContext.tokenPrefs())
+        val current = store.read()
+        channelLogin = edit("Channel login for read-only GQL checks", current?.login.orEmpty())
+        channelId = edit("Channel ID for RewardList", current?.userId.orEmpty())
+        root.addView(label("Probe inputs"))
+        root.addView(channelLogin)
+        root.addView(channelId)
+
+        validateButton = button("Validate selected credential") {
+            runValidation()
+        }
+        matrixButton = button("Run read-only matrix") {
+            runMatrix()
+        }
+        root.addView(validateButton)
+        root.addView(matrixButton)
+
+        val validateAll = button("Validate all available credentials") {
+            runValidationAll()
+        }
+        root.addView(validateAll)
+
+        root.addView(label("Redacted result"))
+        output = text("")
+        output.setTextIsSelectable(true)
+        output.typeface = android.graphics.Typeface.MONOSPACE
+        root.addView(output)
+
+        val copy = button("Copy redacted report") {
+            val clipboard = getSystemService(android.content.ClipboardManager::class.java)
+            clipboard?.setPrimaryClip(android.content.ClipData.newPlainText("Xtra auth lab", output.text))
+            Toast.makeText(this, "Copied redacted report", Toast.LENGTH_SHORT).show()
+        }
+        root.addView(copy)
+        root.addView(button("Clear event history") {
+            repository.clearHistory()
+            output.text = getString(R.string.auth_lab_history_cleared)
+        })
+        root.addView(button("Show event history") {
+            output.text = repository.readHistory().joinToString("\n") { event -> formatEvent(event) }
+                .ifBlank { "No diagnostic events recorded." }
+        })
+        return scroll
+    }
+
+    private fun runValidation() {
+        val selected = selectedSource()
+        setBusy(true)
+        lifecycleScope.launch {
+            val result = repository.validate(selected, browserToken.value(), browserClientId.value())
+            output.text = formatValidation(result)
+            renderCredentialSummary()
+            setBusy(false)
+        }
+    }
+
+    private fun runValidationAll() {
+        setBusy(true)
+        lifecycleScope.launch {
+            val report = buildList {
+                AuthLabCredentialSource.entries.forEach { source ->
+                    add(formatValidation(repository.validate(source, browserToken.value(), browserClientId.value())))
+                }
+            }.joinToString("\n\n")
+            output.text = report
+            renderCredentialSummary()
+            setBusy(false)
+        }
+    }
+
+    private fun runMatrix() {
+        val selected = selectedSource()
+        setBusy(true)
+        lifecycleScope.launch {
+            val results = repository.runReadOnlyMatrix(
+                source = selected,
+                channelLogin = channelLogin.value(),
+                channelId = channelId.value(),
+                browserToken = browserToken.value(),
+                browserClientId = browserClientId.value(),
+            )
+            output.text = results.joinToString("\n") { formatProbe(it) }
+            setBusy(false)
+        }
+    }
+
+    private fun renderCredentialSummary() {
+        val summaries = AuthLabCredentialSource.entries.joinToString("\n") { source ->
+            val value = repository.summarize(source, browserToken.valueOrNull(), browserClientId.valueOrNull())
+            val identity = listOfNotNull(value.login, value.userId?.let { "user=$it" }).joinToString(" ")
+            "${source.displayName()}: ${if (value.available) "available" else "not configured"}" +
+                listOfNotNull(value.clientId?.let { "client=$it" }, identity, value.accessFingerprint?.let { "access=$it" }).joinToString(" ").let { suffix ->
+                    if (suffix.isBlank()) "" else " ($suffix)"
+                }
+        }
+        if (::output.isInitialized && output.text.isNullOrBlank()) output.text = summaries
+    }
+
+    private fun formatValidation(result: AuthLabValidationResult): String = buildString {
+        append(result.source.displayName())
+        append(" /validate")
+        append(" HTTP=")
+        append(result.httpStatus ?: "-")
+        append(" result=")
+        append(result.classification.lowercase())
+        result.clientId?.let { append(" client=$it") }
+        result.userId?.let { append(" user=$it") }
+        result.login?.let { append(" login=$it") }
+        append(" scopes=${result.scopes.size}")
+        result.expiresIn?.let { append(" expires_in=$it") }
+        result.accessFingerprint?.let { append(" access=$it") }
+        result.refreshFingerprint?.let { append(" refresh=$it") }
+        result.message?.let { append(" message=$it") }
+    }
+
+    private fun formatProbe(result: AuthLabProbeResult): String = buildString {
+        append(result.source.name)
+        append(" / ")
+        append(result.operation.label)
+        append(" HTTP=")
+        append(result.httpStatus ?: "-")
+        append(" result=")
+        append(result.classification.lowercase())
+        result.gqlSuccess?.let { append(" gql=${if (it) "success" else "errors"}") }
+        result.message?.let { append(" message=$it") }
+    }
+
+    private fun formatEvent(event: AuthDiagnosticEvent): String = buildString {
+        append(DateFormat.getDateTimeInstance().format(Date(event.timestampMillis)))
+        append(" ")
+        append(event.credential)
+        append(" / ")
+        append(event.operation)
+        append(" HTTP=")
+        append(event.httpStatus ?: "-")
+        append(" result=")
+        append(event.classification.lowercase())
+        event.accessFingerprint?.let { append(" access=$it") }
+        event.refreshFingerprint?.let { append(" refresh=$it") }
+        event.message?.let { append(" message=$it") }
+    }
+
+    private fun selectedSource(): AuthLabCredentialSource = AuthLabCredentialSource.entries.firstOrNull {
+        sourceGroup.checkedRadioButtonId == it.ordinal + 1
+    } ?: AuthLabCredentialSource.OFFICIAL
+
+    private fun setBusy(busy: Boolean) {
+        validateButton.isEnabled = !busy
+        matrixButton.isEnabled = !busy
+    }
+
+    private fun label(value: String) = TextView(this).apply {
+        text = value
+        setTypeface(null, android.graphics.Typeface.BOLD)
+        setPadding(0, dp(18), 0, dp(6))
+    }
+
+    private fun text(value: String) = TextView(this).apply {
+        text = value
+        setPadding(0, dp(6), 0, dp(6))
+    }
+
+    private fun edit(hintText: String, value: String? = null, password: Boolean = false) = EditText(this).apply {
+        hint = hintText
+        setSingleLine(true)
+        value?.let { setText(it) }
+        inputType = if (password) {
+            InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_VARIATION_PASSWORD
+        } else {
+            InputType.TYPE_CLASS_TEXT
+        }
+        if (password) transformationMethod = PasswordTransformationMethod.getInstance()
+        layoutParams = LinearLayout.LayoutParams(
+            LinearLayout.LayoutParams.MATCH_PARENT,
+            LinearLayout.LayoutParams.WRAP_CONTENT,
+        ).apply { bottomMargin = dp(4) }
+    }
+
+    private fun button(title: String, action: () -> Unit) = Button(this).apply {
+        text = title
+        setOnClickListener { action() }
+        layoutParams = LinearLayout.LayoutParams(
+            LinearLayout.LayoutParams.MATCH_PARENT,
+            LinearLayout.LayoutParams.WRAP_CONTENT,
+        ).apply { topMargin = dp(8) }
+    }
+
+    private fun EditText.value(): String = text?.toString()?.trim().orEmpty()
+
+    private fun EditText.valueOrNull(): String? = value().takeIf { it.isNotBlank() }
+
+    private fun AuthLabCredentialSource.displayName(): String = when (this) {
+        AuthLabCredentialSource.OFFICIAL -> "Official Xtra OAuth"
+        AuthLabCredentialSource.COMPATIBILITY -> "Xtra compatibility OAuth"
+        AuthLabCredentialSource.WEB -> "Twitch web session"
+    }
+
+    private fun dp(value: Int): Int = (value * resources.displayMetrics.density).toInt()
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/settings/AuthLabWebLoginActivity.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/settings/AuthLabWebLoginActivity.kt
@@ -1,0 +1,267 @@
+package com.github.andreyasadchy.xtra.ui.settings
+
+import android.annotation.SuppressLint
+import android.graphics.Color
+import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
+import android.util.Log
+import android.webkit.CookieManager
+import android.webkit.WebChromeClient
+import android.webkit.WebResourceRequest
+import android.webkit.WebResourceResponse
+import android.webkit.WebSettings
+import android.webkit.WebView
+import android.widget.Button
+import android.widget.LinearLayout
+import android.widget.TextView
+import androidx.appcompat.app.AppCompatActivity
+import androidx.webkit.UserAgentMetadata
+import androidx.webkit.WebSettingsCompat
+import androidx.webkit.WebViewFeature
+import androidx.webkit.WebViewClientCompat
+import com.github.andreyasadchy.xtra.BuildConfig
+import com.github.andreyasadchy.xtra.R
+import com.github.andreyasadchy.xtra.util.C
+
+/** Debug-only Twitch web login used to import an auth-token into Auth Lab memory. */
+class AuthLabWebLoginActivity : AppCompatActivity() {
+    private lateinit var webView: WebView
+    private lateinit var status: TextView
+    private lateinit var useButton: Button
+    private val handler = Handler(Looper.getMainLooper())
+    private var detectedToken: String? = null
+
+    private val cookiePoller = object : Runnable {
+        override fun run() {
+            inspectAuthCookie()
+            if (!isFinishing && !isDestroyed) handler.postDelayed(this, COOKIE_POLL_INTERVAL_MS)
+        }
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        if (!BuildConfig.DEBUG) {
+            finish()
+            return
+        }
+        window.addFlags(android.view.WindowManager.LayoutParams.FLAG_SECURE)
+        title = getString(R.string.auth_lab_web_login_title)
+        supportActionBar?.setDisplayHomeAsUpEnabled(true)
+
+        val root = LinearLayout(this).apply {
+            orientation = LinearLayout.VERTICAL
+            setPadding(dp(16), dp(12), dp(16), dp(12))
+        }
+        status = TextView(this).apply {
+            text = "Log in to Twitch. The token will remain in memory only."
+            setPadding(0, 0, 0, dp(8))
+        }
+        root.addView(status)
+
+        webView = WebView(this).apply {
+            setBackgroundColor(Color.WHITE)
+            configureSettings()
+            webChromeClient = WebChromeClient()
+            webViewClient = LoginWebViewClient()
+        }
+        root.addView(
+            webView,
+            LinearLayout.LayoutParams(
+                LinearLayout.LayoutParams.MATCH_PARENT,
+                0,
+                1f,
+            ),
+        )
+
+        useButton = Button(this).apply {
+            text = "Use this Twitch web session"
+            isEnabled = false
+            setOnClickListener { returnDetectedToken() }
+        }
+        root.addView(useButton)
+        root.addView(Button(this).apply {
+            text = "Cancel"
+            setOnClickListener { finish() }
+        })
+        setContentView(root)
+
+        webView.loadUrl(TWITCH_LOGIN_URL)
+        handler.post(cookiePoller)
+    }
+
+    override fun onSupportNavigateUp(): Boolean {
+        finish()
+        return true
+    }
+
+    @SuppressLint("SetJavaScriptEnabled")
+    private fun WebView.configureSettings() {
+        val cookieManager = CookieManager.getInstance()
+        cookieManager.setAcceptCookie(true)
+        cookieManager.setAcceptThirdPartyCookies(this, false)
+        settings.javaScriptEnabled = true
+        settings.domStorageEnabled = true
+        settings.allowFileAccess = false
+        settings.allowContentAccess = false
+        settings.mixedContentMode = WebSettings.MIXED_CONTENT_NEVER_ALLOW
+        settings.setSupportMultipleWindows(false)
+        settings.loadWithOverviewMode = true
+        settings.useWideViewPort = true
+        // Android WebView's default UA contains `; wv` and `Version/4.0`. Twitch
+        // rejects that UA before rendering the login form. Keep the request in
+        // this WebView, but identify it as the Chrome version shipped in the
+        // shared AVD so its cookie store remains readable by Xtra.
+        settings.userAgentString = CHROME_USER_AGENT
+        if (WebViewFeature.isFeatureSupported(WebViewFeature.USER_AGENT_METADATA)) {
+            val chromeBrand = UserAgentMetadata.BrandVersion.Builder()
+                .setBrand("Google Chrome")
+                .setMajorVersion(CHROME_MAJOR_VERSION)
+                .setFullVersion(CHROME_FULL_VERSION)
+                .build()
+            val chromiumBrand = UserAgentMetadata.BrandVersion.Builder()
+                .setBrand("Chromium")
+                .setMajorVersion(CHROME_MAJOR_VERSION)
+                .setFullVersion(CHROME_FULL_VERSION)
+                .build()
+            val greaseBrand = UserAgentMetadata.BrandVersion.Builder()
+                .setBrand("Not_A Brand")
+                .setMajorVersion("99")
+                .setFullVersion("99.0.0.0")
+                .build()
+            WebSettingsCompat.setUserAgentMetadata(
+                settings,
+                UserAgentMetadata.Builder()
+                    .setBrandVersionList(listOf(greaseBrand, chromiumBrand, chromeBrand))
+                    .setFullVersion(CHROME_FULL_VERSION)
+                    .setPlatform("Android")
+                    .setPlatformVersion("15.0.0")
+                    .setMobile(true)
+                    .build(),
+            )
+        }
+    }
+
+    private fun inspectAuthCookie() {
+        val cookie = listOf(
+            CookieManager.getInstance().getCookie("https://www.twitch.tv"),
+            CookieManager.getInstance().getCookie("https://passport.twitch.tv"),
+            CookieManager.getInstance().getCookie("https://twitch.tv"),
+        ).firstNotNullOfOrNull { cookies ->
+            cookies?.split(';')
+                ?.asSequence()
+                ?.map { it.trim() }
+                ?.firstOrNull { it.startsWith("auth-token=") }
+                ?.substringAfter('=')
+                ?.takeIf { it.isNotBlank() }
+        }
+        if (cookie == null || cookie == detectedToken) return
+        detectedToken = cookie
+        status.text = "Twitch web session detected. Press the button below to import it into Auth Lab."
+        useButton.isEnabled = true
+    }
+
+    private fun returnDetectedToken() {
+        val token = detectedToken ?: return
+        setResult(
+            RESULT_OK,
+            intent
+                .putExtra(EXTRA_AUTH_TOKEN, token)
+                .putExtra(EXTRA_CLIENT_ID, C.DEFAULT_GQL_CLIENT_ID_WEB),
+        )
+        clearAuthCookie()
+        finish()
+    }
+
+    override fun onDestroy() {
+        handler.removeCallbacks(cookiePoller)
+        clearAuthCookie()
+        if (::webView.isInitialized) {
+            webView.stopLoading()
+            webView.loadUrl("about:blank")
+            webView.clearHistory()
+            webView.removeAllViews()
+            webView.destroy()
+        }
+        super.onDestroy()
+    }
+
+    private fun clearAuthCookie() {
+        CookieManager.getInstance().setCookie(
+            TWITCH_ROOT_URL,
+            "auth-token=; Path=/; Max-Age=0; Secure; HttpOnly; SameSite=Lax",
+        ) { CookieManager.getInstance().flush() }
+    }
+
+    private fun dp(value: Int): Int = (value * resources.displayMetrics.density).toInt()
+
+    private inner class LoginWebViewClient : WebViewClientCompat() {
+        override fun shouldInterceptRequest(
+            view: WebView,
+            request: WebResourceRequest,
+        ): WebResourceResponse? {
+            if (request.url.isTrustedTwitchUrl()) logRequest(request)
+            return super.shouldInterceptRequest(view, request)
+        }
+
+        override fun shouldOverrideUrlLoading(view: WebView, request: WebResourceRequest): Boolean =
+            request.isForMainFrame && !request.url.isTrustedTwitchUrl()
+
+        override fun onPageFinished(view: WebView, url: String) {
+            super.onPageFinished(view, url)
+            inspectAuthCookie()
+        }
+
+    }
+
+    private fun logRequest(request: WebResourceRequest) {
+        val headers = request.requestHeaders
+        val names = headers.keys
+            .map(String::lowercase)
+            .sorted()
+            .joinToString(",")
+        val safeValues = headers.entries
+            .filter { (name, _) -> name.lowercase() in SAFE_HEADER_VALUES }
+            .sortedBy { (name, _) -> name.lowercase() }
+            .joinToString(",") { (name, value) -> "${name.lowercase()}=${value ?: "<null>"}" }
+        Log.d(
+            LOG_TAG,
+            "Twitch request method=${request.method} main=${request.isForMainFrame} " +
+                "path=${request.url.path} headers=[$names] safeValues=[$safeValues]",
+        )
+    }
+
+    companion object {
+        const val EXTRA_AUTH_TOKEN = "auth_lab_auth_token"
+        const val EXTRA_CLIENT_ID = "auth_lab_client_id"
+        private const val TWITCH_LOGIN_URL = "https://www.twitch.tv/login"
+        private const val TWITCH_ROOT_URL = "https://www.twitch.tv"
+        private const val COOKIE_POLL_INTERVAL_MS = 500L
+        private const val LOG_TAG = "AuthLabWebLogin"
+        private val SAFE_HEADER_VALUES = setOf(
+            "accept",
+            "accept-language",
+            "content-type",
+            "origin",
+            "sec-ch-ua",
+            "sec-ch-ua-mobile",
+            "sec-ch-ua-platform",
+            "sec-fetch-dest",
+            "sec-fetch-mode",
+            "sec-fetch-site",
+            "user-agent",
+            "x-requested-with",
+        )
+        private const val CHROME_MAJOR_VERSION = "151"
+        private const val CHROME_FULL_VERSION = "151.0.7922.137"
+        private const val CHROME_USER_AGENT =
+            "Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 " +
+                "(KHTML, like Gecko) Chrome/$CHROME_FULL_VERSION Mobile Safari/537.36"
+    }
+}
+
+private fun android.net.Uri.isTrustedTwitchUrl(): Boolean {
+    if (scheme != "https") return false
+    val domain = host?.lowercase() ?: return false
+    return domain == "twitch.tv" || domain.endsWith(".twitch.tv")
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/settings/SettingsActivity.kt
@@ -1455,6 +1455,13 @@ class SettingsActivity : AppCompatActivity() {
         }
 
         private fun configureDeveloperCredentials() {
+            findPreference<Preference>("auth_lab")?.apply {
+                isVisible = BuildConfig.DEBUG
+                setOnPreferenceClickListener {
+                    startActivity(Intent(requireContext(), AuthLabActivity::class.java))
+                    true
+                }
+            }
             listOf(C.USER_ID, C.USERNAME, C.TOKEN, C.GQL_TOKEN2, C.GQL_TOKEN_WEB).forEach { key ->
                 findPreference<EditTextPreference>(key)?.apply {
                     isPersistent = false

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/C.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/C.kt
@@ -51,6 +51,7 @@ object C {
     const val TOKEN_VALIDATED_AT = "token_validated_at"
     const val ACCOUNT_CLEANUP_PENDING = "account_cleanup_pending"
     const val ACCOUNT_CLEANUP_TARGETS = "account_cleanup_targets"
+    const val AUTH_EVENT_HISTORY = "auth_event_history"
     const val USERNAME = "username"
     const val USER_ID = "user_id"
     const val PROFILE_IMAGE_URL = "profile_image_url"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -498,6 +498,10 @@
     <string name="settings_developer_unlocking">%d more taps to enable Developer options</string>
     <string name="settings_developer_unlocked">Developer options enabled</string>
     <string name="settings_api_authentication">API &amp; authentication</string>
+    <string name="auth_lab_title">Authentication Lab</string>
+    <string name="auth_lab_summary">Compare credential validation and read-only Twitch operations. Debug only.</string>
+    <string name="auth_lab_history_cleared">History cleared.</string>
+    <string name="auth_lab_web_login_title">Twitch page login</string>
     <string name="settings_networking">Networking</string>
     <string name="settings_network_engine">Network engine</string>
     <string name="settings_stream_preloading">Smart stream preloading</string>

--- a/app/src/main/res/xml/developer_api_preferences.xml
+++ b/app/src/main/res/xml/developer_api_preferences.xml
@@ -1,4 +1,5 @@
 <androidx.preference.PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android" xmlns:app="http://schemas.android.com/apk/res-auto">
+    <Preference android:key="auth_lab" android:title="@string/auth_lab_title" android:summary="@string/auth_lab_summary" app:iconSpaceReserved="false" />
     <ListPreference android:defaultValue="0" android:entries="@array/loginApiEntries" android:entryValues="@array/miscValues" android:key="api_login" android:summary="%s" android:title="@string/settings_api_login" app:iconSpaceReserved="false" />
     <EditTextPreference android:key="helix_client_id" android:title="@string/api_helix_client_id_sensitive" app:iconSpaceReserved="false" />
     <EditTextPreference android:key="helix_redirect" android:title="@string/api_helix_redirect_sensitive" app:iconSpaceReserved="false" />

--- a/app/src/test/java/com/github/andreyasadchy/xtra/repository/AuthRepositoryTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/repository/AuthRepositoryTest.kt
@@ -9,6 +9,7 @@ import kotlinx.serialization.json.Json
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Protocol
+import okhttp3.Request
 import okhttp3.Response
 import okhttp3.ResponseBody.Companion.toResponseBody
 import org.junit.Assert.assertEquals
@@ -51,6 +52,46 @@ class AuthRepositoryTest {
             listOf("Bearer raw-helix-token", "OAuth raw-gql-token"),
             authorizationHeaders,
         )
+    }
+
+    @Test
+    fun `diagnostic transport preserves the browser OAuth scheme and probe headers`() {
+        var captured: Request? = null
+        val client = OkHttpClient.Builder()
+            .addInterceptor { chain ->
+                captured = chain.request()
+                Response.Builder()
+                    .request(chain.request())
+                    .protocol(Protocol.HTTP_1_1)
+                    .code(200)
+                    .message("OK")
+                    .body("{}".toResponseBody("application/json".toMediaType()))
+                    .build()
+            }
+            .build()
+        val repository = AuthRepository(
+            httpEngine = lazy { null },
+            cronetEngine = lazy { null },
+            cronetExecutor = lazy { Executors.newSingleThreadExecutor() },
+            okHttpClient = lazy { client },
+            json = Json { ignoreUnknownKeys = true },
+        )
+
+        runBlocking {
+            repository.diagnosticGet(
+                networkLibrary = "okhttp",
+                url = "https://id.twitch.tv/oauth2/validate",
+                headers = mapOf(
+                    "Authorization" to "OAuth browser-token",
+                    "Client-Id" to "web-client",
+                    "Origin" to "https://www.twitch.tv",
+                ),
+            )
+        }
+
+        assertEquals("OAuth browser-token", captured?.header("Authorization"))
+        assertEquals("web-client", captured?.header("Client-Id"))
+        assertEquals("https://www.twitch.tv", captured?.header("Origin"))
     }
 
     @Test

--- a/app/src/test/java/com/github/andreyasadchy/xtra/repository/auth/AuthCoordinatorTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/repository/auth/AuthCoordinatorTest.kt
@@ -5,6 +5,9 @@ import com.github.andreyasadchy.xtra.model.id.DeviceCodeResponse
 import com.github.andreyasadchy.xtra.model.id.TokenResponse
 import com.github.andreyasadchy.xtra.model.id.ValidationResponse
 import com.github.andreyasadchy.xtra.util.C
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -420,6 +423,104 @@ class AuthCoordinatorTest {
     }
 
     @Test
+    fun `concurrent unauthorized callers share one official refresh`() {
+        val (store, _) = seededStore(expired = true)
+        val repository = FakeAuthOperations(
+            officialValidation = ValidationResponse("old-helix", userId = "user", scopes = HELIX_SCOPES),
+            refresh = officialToken("rotated-access", refreshToken = "rotated-refresh"),
+        )
+        val coordinator = AuthCoordinator(repository, store, nowMillis = { 10_000L })
+
+        val sessions = runBlocking {
+            coroutineScope {
+                (1..20).map {
+                    async { coordinator.refreshAfterUnauthorized("old-access") }
+                }.awaitAll()
+            }
+        }
+
+        assertEquals(1, repository.refreshCalls)
+        assertTrue(sessions.all { it?.accessToken == "rotated-access" })
+        assertEquals("rotated-refresh", store.read()?.refreshToken)
+    }
+
+    @Test
+    fun `refresh response fault before persistence keeps the old pair`() {
+        val (store, tokenPreferences) = seededStore(expired = true)
+        val repository = FakeAuthOperations(
+            refresh = officialToken("rotated-access", refreshToken = "rotated-refresh"),
+        )
+        val error = runCatching {
+            runBlocking {
+                AuthCoordinator(
+                    repository = repository,
+                    sessionStore = store,
+                    nowMillis = { 10_000L },
+                    faultInjector = AuthFaultInjector { point ->
+                        if (point == AuthFaultPoint.AFTER_OFFICIAL_REFRESH_RESPONSE_BEFORE_PERSISTENCE) {
+                            error("injected process death")
+                        }
+                    },
+                ).refreshIfNeeded()
+            }
+        }.exceptionOrNull()
+
+        assertTrue(error is IllegalStateException)
+        assertEquals("old-access", store.read()?.accessToken)
+        assertEquals("old-refresh", store.read()?.refreshToken)
+        assertEquals("old-access", tokenPreferences.getString(C.TOKEN, null))
+    }
+
+    @Test
+    fun `refresh persistence fault keeps the rotated pair for restart recovery`() {
+        val (store, _) = seededStore(expired = true)
+        val repository = FakeAuthOperations(
+            officialValidation = ValidationResponse("old-helix", userId = "user", scopes = HELIX_SCOPES),
+            refresh = officialToken("rotated-access", refreshToken = "rotated-refresh"),
+        )
+        val error = runCatching {
+            runBlocking {
+                AuthCoordinator(
+                    repository = repository,
+                    sessionStore = store,
+                    nowMillis = { 10_000L },
+                    faultInjector = AuthFaultInjector { point ->
+                        if (point == AuthFaultPoint.AFTER_OFFICIAL_PERSISTENCE_BEFORE_VALIDATION) {
+                            error("injected process death")
+                        }
+                    },
+                ).refreshIfNeeded()
+            }
+        }.exceptionOrNull()
+
+        assertTrue(error is IllegalStateException)
+        assertEquals("rotated-access", store.read()?.accessToken)
+        assertEquals("rotated-refresh", store.read()?.refreshToken)
+    }
+
+    @Test
+    fun `diagnostic history stores fingerprints and redacts credential text`() {
+        val preferences = MemoryPreferences()
+        val log = AuthDiagnosticLog(preferences, nowMillis = { 1234L })
+
+        log.record(
+            credential = AuthLabCredentialSource.WEB,
+            operation = "/oauth2/validate",
+            httpStatus = 401,
+            classification = "UNAUTHORIZED",
+            message = "server echoed access-token and refresh-token",
+            accessToken = "access-token",
+            refreshToken = "refresh-token",
+        )
+
+        val raw = preferences.getString(C.AUTH_EVENT_HISTORY, null).orEmpty()
+        assertFalse(raw.contains("access-token"))
+        assertFalse(raw.contains("refresh-token"))
+        assertEquals(tokenFingerprint("access-token"), log.read().single().accessFingerprint)
+        assertEquals(tokenFingerprint("refresh-token"), log.read().single().refreshFingerprint)
+    }
+
+    @Test
     fun `compatibility refresh persists the rotated pair before validation`() {
         val (store, tokenPreferences) = seededStore()
         tokenPreferences.edit().putLong(C.GQL_TOKEN2_EXPIRES_AT, 1L).commit()
@@ -547,11 +648,15 @@ class AuthCoordinatorTest {
         private val refresh: TokenResponse = TokenResponse(),
     ) : TwitchAuthOperations {
         val revoked = mutableListOf<Pair<String, String>>()
+        var refreshCalls = 0
         var onRevoke: suspend (String, String) -> Unit = { _, _ -> }
 
         override suspend fun startDeviceAuthorization(clientId: String, scopes: Collection<String>) = DeviceCodeResponse()
         override suspend fun pollDeviceAuthorization(clientId: String, deviceCode: String, scopes: Collection<String>) = TokenResponse()
-        override suspend fun refreshUserToken(clientId: String, refreshToken: String) = refresh
+        override suspend fun refreshUserToken(clientId: String, refreshToken: String): TokenResponse {
+            refreshCalls++
+            return refresh
+        }
         override suspend fun validate(accessToken: String): ValidationResponse =
             officialValidationError?.let { throw it } ?: officialValidation
         override suspend fun validateCompatibility(accessToken: String): ValidationResponse =


### PR DESCRIPTION
Adds a debug-only Authentication Lab for comparing official, compatibility, and imported Twitch web credentials. It records redacted validation/probe results and hardens refresh rotation against transient failures, process death, and concurrent 401s.