### PR TITLE
Fix feed preview cancellation crash

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/StreamPreviewCoordinator.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/StreamPreviewCoordinator.kt
@@ -631,9 +631,10 @@ class StreamPreviewCoordinator(
     }
 
     private fun cancelPendingStarts() {
-        pendingStarts.values.forEach(Job::cancel)
+        val jobs = pendingStarts.values.toList()
         pendingStarts.clear()
         dwellStarts.clear()
+        jobs.forEach(Job::cancel)
     }
 
     private fun scheduleLifecycleReconciliation(delayMs: Long, callback: () -> Unit): () -> Unit {


### PR DESCRIPTION
Fix a crash that occurred when cancelling delayed feed-preview starts during scrolling or player return. The fix removes pending jobs before cancelling them so cancellation callbacks cannot modify the map being traversed.