### PR TITLE
Stabilize browsing stream previews

### DIFF
--- a/app/src/androidTest/java/com/github/andreyasadchy/xtra/ui/main/MainActivityPlayerLifecycleTest.kt
+++ b/app/src/androidTest/java/com/github/andreyasadchy/xtra/ui/main/MainActivityPlayerLifecycleTest.kt
@@ -1,0 +1,43 @@
+package com.github.andreyasadchy.xtra.ui.main
+
+import android.content.Intent
+import android.os.SystemClock
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.github.andreyasadchy.xtra.XtraApp
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class MainActivityPlayerLifecycleTest {
+    @Test
+    fun finishingAfterMinimizingPlaybackClearsActivePlayerState() {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val app = instrumentation.targetContext.applicationContext as XtraApp
+        val activity = instrumentation.startActivitySync(
+            Intent(app, MainActivity::class.java).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
+        )
+        val coordinator = (activity.application as XtraApp).xtraModule.streamFeedRefreshCoordinator
+        try {
+            coordinator.playbackEntered()
+            coordinator.playbackReturned(playerStillOpen = true)
+            assertTrue(coordinator.isPlayerActive)
+
+            instrumentation.runOnMainSync { activity.finish() }
+            assertTrue("Activity did not enter finishing state", activity.isFinishing)
+            val deadline = SystemClock.uptimeMillis() + 5_000L
+            while (!activity.isDestroyed && SystemClock.uptimeMillis() < deadline) {
+                instrumentation.waitForIdleSync()
+                SystemClock.sleep(50L)
+            }
+            assertTrue("Activity was not destroyed", activity.isDestroyed)
+            assertFalse(coordinator.isPlayerActive)
+        } finally {
+            if (!activity.isFinishing) {
+                instrumentation.runOnMainSync { activity.finish() }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/preload/StreamMedia3Runtime.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/preload/StreamMedia3Runtime.kt
@@ -340,6 +340,14 @@ class StreamMedia3Runtime(
         check(Looper.myLooper() == Looper.getMainLooper()) { "Preview player creation must run on the main looper" }
         val generation = ensureGeneration()
         return ExoPlayer.Builder(playerContext, generation.hlsFactory).apply {
+            setLoadControl(
+                DefaultLoadControl.Builder()
+                    .setBufferDurationsMs(1_500, 6_000, 250, 500)
+                    .setTargetBufferBytes(4 * 1024 * 1024)
+                    .setPrioritizeTimeOverSizeThresholds(true)
+                    .setBackBuffer(0, false)
+                    .build(),
+            )
             setAudioAttributes(AudioAttributes.DEFAULT, false)
             setHandleAudioBecomingNoisy(false)
         }.build().apply {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/preload/StreamPreloadCoordinator.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/preload/StreamPreloadCoordinator.kt
@@ -296,7 +296,7 @@ class StreamPreloadCoordinator(
     }
 
     private suspend fun preloadUrl(channelLogin: String, streamKey: String, forPreview: Boolean = false): String? {
-        if (!(if (forPreview) canResolvePreview() else canResolveStream()) || !isEligible(streamKey)) return null
+        if (!(if (forPreview) canResolvePreview() else canResolveStream()) || !isEligible(streamKey, forPreview)) return null
         val config = refreshConfiguration()
         cache.get(channelLogin, config.fingerprint)?.let {
             debug("url_cache_hit", channelLogin)
@@ -435,7 +435,11 @@ class StreamPreloadCoordinator(
     }
 
     private fun isEligible(streamKey: String): Boolean {
-        if (!canPreload() || viewports.values.any { it.scrolling }) return false
+        return isEligible(streamKey, forPreview = false)
+    }
+
+    private fun isEligible(streamKey: String, forPreview: Boolean): Boolean {
+        if (!(if (forPreview) canResolvePreview() else canPreload()) || viewports.values.any { it.scrolling }) return false
         val rankedKeys = StreamPreloadPolicy.rank(currentCandidates())
             .take(StreamPreloadPolicy.MAX_URL_CANDIDATES)
             .map { it.streamKey.ifBlank { it.channelLogin.trim().lowercase() } }
@@ -494,7 +498,7 @@ class StreamPreloadCoordinator(
         val prefs = context.prefs()
         if (prefs.getBoolean(C.PLAYER_STREAM_PROXY, false) && prefs.getString(C.PLAYER_PROXY_URL, null).isNullOrBlank()) return false
         if ((context as? XtraApp)?.isInForeground == false) return false
-        if (streamFeedRefreshCoordinator.isPlayerFullscreen) return false
+        if (streamFeedRefreshCoordinator.isPlayerFullscreen || streamFeedRefreshCoordinator.isPlayerActive) return false
         val powerManager = context.getSystemService(PowerManager::class.java)
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && powerManager?.isPowerSaveMode == true) return false
         return true

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/preload/StreamPreloadPolicy.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/preload/StreamPreloadPolicy.kt
@@ -26,6 +26,7 @@ data class StreamPreloadCandidate(
 
 object StreamPreloadPolicy {
     const val MAX_URL_CANDIDATES = 2
+    const val MAX_CACHED_STREAM_URLS = 12
     const val MAX_VOD_PREVIEW_URLS = 8
     const val MAX_RESOLVER_CONCURRENCY = 2
     const val URL_DWELL_MS = 350L

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/preload/StreamPreloadUrlCache.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/preload/StreamPreloadUrlCache.kt
@@ -10,7 +10,7 @@ data class ResolvedStreamPreload(
 )
 
 class StreamPreloadUrlCache(
-    private val maxEntries: Int = StreamPreloadPolicy.MAX_URL_CANDIDATES,
+    private val maxEntries: Int = StreamPreloadPolicy.MAX_CACHED_STREAM_URLS,
     private val ttlMs: Long = StreamPreloadPolicy.URL_TTL_MS,
     private val elapsedRealtimeMs: () -> Long = { SystemClock.elapsedRealtime() },
 ) {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/preload/StreamPreviewPolicy.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/preload/StreamPreviewPolicy.kt
@@ -50,7 +50,8 @@ object StreamPreviewPolicy {
         isPlayerFullscreen: Boolean,
         networkAllowed: Boolean,
         handoffPending: Boolean,
-    ): Boolean = !isPlayerFullscreen && networkAllowed && !handoffPending
+        isPlayerActive: Boolean = false,
+    ): Boolean = !isPlayerFullscreen && !isPlayerActive && networkAllowed && !handoffPending
 
     fun mode(context: Context): StreamPreviewMode {
         val preferences = context.prefs()

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/streamfeed/StreamFeedRefreshCoordinator.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/streamfeed/StreamFeedRefreshCoordinator.kt
@@ -55,6 +55,9 @@ class StreamFeedRefreshCoordinator(
     @Volatile
     private var playerFullscreen = false
 
+    @Volatile
+    private var playerActive = false
+
     fun setVisibleFeed(spec: StreamFeedSpec) {
         visibleFeed = spec
     }
@@ -301,8 +304,12 @@ class StreamFeedRefreshCoordinator(
     val isPlayerFullscreen: Boolean
         get() = playerFullscreen
 
+    val isPlayerActive: Boolean
+        get() = playerActive
+
     /** Mark any fullscreen player active; only a live stream starts the freshness timer. */
     fun playbackEntered(isLive: Boolean = true) {
+        playerActive = true
         playerFullscreen = true
         if (isLive && livePlaybackStartedElapsedMs == null) {
             livePlaybackStartedElapsedMs = elapsedRealtimeMs()
@@ -313,6 +320,7 @@ class StreamFeedRefreshCoordinator(
 
     /** Switch content while keeping the player fullscreen. */
     fun playbackChanged(isLive: Boolean) {
+        playerActive = true
         playerFullscreen = true
         if (isLive) {
             if (livePlaybackStartedElapsedMs == null) {
@@ -325,8 +333,10 @@ class StreamFeedRefreshCoordinator(
         }
     }
 
-    fun playbackReturned() {
+    fun playbackReturned(playerStillOpen: Boolean = false) {
         playerFullscreen = false
+        playerActive = playerStillOpen
+        if (playerStillOpen) return
         val started = livePlaybackStartedElapsedMs ?: return
         livePlaybackStartedElapsedMs = null
         val viewedMs = (elapsedRealtimeMs() - started).coerceAtLeast(0L)

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/StreamPreviewCoordinator.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/StreamPreviewCoordinator.kt
@@ -260,6 +260,7 @@ class StreamPreviewCoordinator(
     private fun scheduleSelection() {
         if (!StreamPreviewPolicy.canStartPreview(
                 isPlayerFullscreen = streamFeedRefreshCoordinator.isPlayerFullscreen,
+                isPlayerActive = streamFeedRefreshCoordinator.isPlayerActive,
                 networkAllowed = StreamPreviewPolicy.allowsNetwork(context),
                 handoffPending = handoffLogin != null,
             )
@@ -396,6 +397,7 @@ class StreamPreviewCoordinator(
         if (failedUntil[identity]?.let { it > SystemClock.elapsedRealtime() } == true) return
         if (!StreamPreviewPolicy.canStartPreview(
                 isPlayerFullscreen = streamFeedRefreshCoordinator.isPlayerFullscreen,
+                isPlayerActive = streamFeedRefreshCoordinator.isPlayerActive,
                 networkAllowed = StreamPreviewPolicy.allowsNetwork(context),
                 handoffPending = handoffLogin != null,
             )
@@ -421,6 +423,7 @@ class StreamPreviewCoordinator(
         if (activePreviews.size >= maxActivePreviews()) return
         if (!StreamPreviewPolicy.canStartPreview(
                 isPlayerFullscreen = streamFeedRefreshCoordinator.isPlayerFullscreen,
+                isPlayerActive = streamFeedRefreshCoordinator.isPlayerActive,
                 networkAllowed = StreamPreviewPolicy.allowsNetwork(context),
                 handoffPending = handoffLogin != null,
             )
@@ -524,6 +527,7 @@ class StreamPreviewCoordinator(
 
     private fun discardPreviewPlayer(player: ExoPlayer) {
         runCatching { player.stop() }
+        runCatching { player.clearMediaItems() }
         if (player !== sharedPreviewPlayer) runCatching { player.release() }
     }
 
@@ -631,8 +635,12 @@ class StreamPreviewCoordinator(
     }
 
     private fun cancelPendingStarts() {
-        pendingStarts.values.forEach(Job::cancel)
+        val jobs = pendingStarts.values.toList()
         pendingStarts.clear()
+        // Cancellation runs the job's finally block synchronously on the main
+        // thread. Clear the map before canceling so that block cannot mutate a
+        // LinkedHashMap iterator that is still in progress.
+        jobs.forEach(Job::cancel)
         dwellStarts.clear()
     }
 
@@ -651,6 +659,7 @@ class StreamPreviewCoordinator(
         activePreviews.remove(login)?.let { active ->
             detachPreviewSurface(active)
             runCatching { active.player.stop() }
+            runCatching { active.player.clearMediaItems() }
             if (active.player !== sharedPreviewPlayer) runCatching { active.player.release() }
         }
         urlCoordinator.setPreviewActive(activePreviews.isNotEmpty())

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/main/MainActivity.kt
@@ -845,6 +845,7 @@ class MainActivity : AppCompatActivity() {
             supportFragmentManager.unregisterFragmentLifecycleCallbacks(it)
         }
         if (isFinishing) {
+            onPlayerReturnedToBrowsing(playerStillOpen = false)
             (playerFragment as? Media3PlayerFragment)?.close() ?: (playerFragment as? PlayerFragment)?.close()
         }
         super.onDestroy()
@@ -1240,7 +1241,7 @@ class MainActivity : AppCompatActivity() {
     }
 
     fun closePlayer() {
-        onPlayerReturnedToBrowsing()
+        onPlayerReturnedToBrowsing(playerStillOpen = false)
         supportFragmentManager.beginTransaction()
             .setTransition(FragmentTransaction.TRANSIT_FRAGMENT_FADE)
             .remove(supportFragmentManager.findFragmentById(R.id.playerContainer)!!)
@@ -1255,9 +1256,9 @@ class MainActivity : AppCompatActivity() {
         currentMultiviewFragment()?.resumeAfterExternalPlayer()
     }
 
-    fun onPlayerReturnedToBrowsing() {
+    fun onPlayerReturnedToBrowsing(playerStillOpen: Boolean) {
         (application as XtraApp).xtraModule.streamPreviewCoordinator.onPlaybackReturned()
-        (application as XtraApp).xtraModule.streamFeedRefreshCoordinator.playbackReturned()
+        (application as XtraApp).xtraModule.streamFeedRefreshCoordinator.playbackReturned(playerStillOpen)
     }
 
     fun onPlayerEnteredPlayback(isLive: Boolean = true, channelLogin: String? = null) {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/Media3PlayerFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/Media3PlayerFragment.kt
@@ -2374,7 +2374,7 @@ abstract class Media3PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFr
             val wasMaximized = isMaximized
             isMaximized = false
             if (wasMaximized) {
-                (activity as? com.github.andreyasadchy.xtra.ui.main.MainActivity)?.onPlayerReturnedToBrowsing()
+                (activity as? com.github.andreyasadchy.xtra.ui.main.MainActivity)?.onPlayerReturnedToBrowsing(playerStillOpen = true)
             }
             if (videoType == STREAM && chatFragment?.emoteMenuIsVisible() == true) {
                 chatFragment?.toggleBackPressedCallback(false)

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/PlayerFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/PlayerFragment.kt
@@ -2154,7 +2154,7 @@ abstract class PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFragment
             val wasMaximized = isMaximized
             isMaximized = false
             if (wasMaximized) {
-                (activity as? com.github.andreyasadchy.xtra.ui.main.MainActivity)?.onPlayerReturnedToBrowsing()
+                (activity as? com.github.andreyasadchy.xtra.ui.main.MainActivity)?.onPlayerReturnedToBrowsing(playerStillOpen = true)
             }
             if (playbackService?.type == BasePlaybackService.STREAM && chatFragment?.emoteMenuIsVisible() == true) {
                 chatFragment?.toggleBackPressedCallback(false)

--- a/app/src/test/java/com/github/andreyasadchy/xtra/repository/preload/StreamPreloadUrlCacheTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/repository/preload/StreamPreloadUrlCacheTest.kt
@@ -44,6 +44,22 @@ class StreamPreloadUrlCacheTest {
     }
 
     @Test
+    fun defaultCacheRetainsRecentEntriesAcrossFeedChanges() {
+        val cache = StreamPreloadUrlCache(elapsedRealtimeMs = { 0L })
+
+        repeat(StreamPreloadPolicy.MAX_CACHED_STREAM_URLS + 1) { index ->
+            cache.put("creator-$index", "signed-url-$index", "config")
+        }
+
+        assertNull(cache.get("creator-0", "config"))
+        assertEquals(
+            "signed-url-${StreamPreloadPolicy.MAX_CACHED_STREAM_URLS}",
+            cache.get("creator-${StreamPreloadPolicy.MAX_CACHED_STREAM_URLS}", "config"),
+        )
+        assertEquals(StreamPreloadPolicy.MAX_CACHED_STREAM_URLS, cache.size())
+    }
+
+    @Test
     fun previewPeekPreservesTheExactUrlForFullscreenPlayback() {
         val cache = StreamPreloadUrlCache(elapsedRealtimeMs = { 0L })
         cache.put("foo", "signed-url-a", "config")

--- a/app/src/test/java/com/github/andreyasadchy/xtra/repository/preload/StreamPreviewPolicyTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/repository/preload/StreamPreviewPolicyTest.kt
@@ -45,4 +45,14 @@ class StreamPreviewPolicyTest {
         assertTrue(!StreamPreviewPolicy.canStartPreview(isPlayerFullscreen = false, networkAllowed = true, handoffPending = true))
         assertTrue(StreamPreviewPolicy.canStartPreview(isPlayerFullscreen = false, networkAllowed = true, handoffPending = false))
     }
+
+    @Test
+    fun anOpenMinimizedPlayerAlsoBlocksNewPreviewSelection() {
+        assertTrue(!StreamPreviewPolicy.canStartPreview(
+            isPlayerFullscreen = false,
+            isPlayerActive = true,
+            networkAllowed = true,
+            handoffPending = false,
+        ))
+    }
 }

--- a/app/src/test/java/com/github/andreyasadchy/xtra/repository/streamfeed/StreamFeedRefreshCoordinatorTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/repository/streamfeed/StreamFeedRefreshCoordinatorTest.kt
@@ -237,9 +237,11 @@ class StreamFeedRefreshCoordinatorTest {
 
         coordinator.playbackEntered()
         assertTrue(coordinator.isPlayerFullscreen)
+        assertTrue(coordinator.isPlayerActive)
         elapsed = StreamFeedFreshnessPolicy.PLAYBACK_RETURN_THRESHOLD_MS
         coordinator.playbackReturned()
         assertFalse(coordinator.isPlayerFullscreen)
+        assertFalse(coordinator.isPlayerActive)
         withTimeout(1_000L) {
             firstLoad.await()
             awaitScopeIdle(scope)
@@ -252,9 +254,35 @@ class StreamFeedRefreshCoordinatorTest {
         // Maximizing the minimized player must keep the original session start.
         coordinator.playbackEntered()
         elapsed += StreamFeedFreshnessPolicy.PLAYBACK_RETURN_THRESHOLD_MS / 2
+        coordinator.playbackReturned(playerStillOpen = true)
+        assertTrue(coordinator.isPlayerActive)
+        assertFalse(coordinator.isPlayerFullscreen)
         coordinator.playbackReturned()
+        assertFalse(coordinator.isPlayerActive)
         withTimeout(1_000L) { secondLoad.await() }
         assertEquals(2, loads)
+        scope.cancel()
+    }
+
+    @Test
+    fun finishingAfterMinimizingPlaybackClearsActivePlayerState() {
+        val key = StreamFeedKey("top:finishing-minimized-player")
+        val cache = FakeCache(
+            key = key,
+            rows = emptyList(),
+            currentState = StreamFeedState(key.value, lastSuccessAt = 0L),
+        )
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val coordinator = StreamFeedRefreshCoordinator(cache, scope, { 1_000_000L }, { 0L }, false)
+
+        coordinator.playbackEntered()
+        coordinator.playbackReturned(playerStillOpen = true)
+        assertTrue(coordinator.isPlayerActive)
+
+        // Activity.onDestroy() uses the terminal close path even if the player
+        // was previously minimized.
+        coordinator.playbackReturned(playerStillOpen = false)
+        assertFalse(coordinator.isPlayerActive)
         scope.cancel()
     }
 


### PR DESCRIPTION
Prevents preview and preload work while a player remains open, fixes a navigation cancellation crash, keeps recent HLS links available across feeds, and limits preview buffering.