### PR TITLE
Reduce CI artifact retention and stale runs

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -9,7 +9,7 @@ on:
 
 concurrency:
   group: android-${{ github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read
@@ -226,12 +226,13 @@ jobs:
         fi
 
     - name: Upload a Build Artifact
-      if: always()
+      if: always() && (github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch')
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: apk
         path: app/build/outputs/apk/release/*.apk
         if-no-files-found: warn
+        retention-days: 1
 
     - name: Generate release notes
       if: github.event_name != 'pull_request' && github.ref == 'refs/heads/master'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,6 +9,10 @@ on:
     - cron: '30 1 * * 0'
   workflow_dispatch:
 
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   analyze-actions:
     name: Analyze (actions)

--- a/.github/workflows/custom-geckoview.yml
+++ b/.github/workflows/custom-geckoview.yml
@@ -70,7 +70,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          if [[ "$GITHUB_EVENT_NAME" == pull_request ]]; then
+          if [[ "$GITHUB_EVENT_NAME" == pull_request || "$GITHUB_EVENT_NAME" == push ]]; then
             run_heavy=false
             release_both=false
             matrix='{"include":[{"abi":"arm64-v8a","label":"ARM64"}]}'
@@ -340,6 +340,7 @@ jobs:
             geckoview/artifacts/*.target.maven.zip
             geckoview/artifacts/*.json
           if-no-files-found: error
+          retention-days: 1
 
       - name: Upload compact failure diagnostics
         if: failure()
@@ -352,6 +353,7 @@ jobs:
             ${{ runner.temp }}/sccache-stats.txt
             geckoview/artifacts/*.json
           if-no-files-found: ignore
+          retention-days: 7
 
   experimental-nowebrtc:
     name: ARM64 / nowebrtc (experimental)
@@ -500,6 +502,7 @@ jobs:
             geckoview/artifacts/*.target.maven.zip
             geckoview/artifacts/*.json
           if-no-files-found: error
+          retention-days: 7
 
   fat-aar:
     name: Universal ARM GeckoView AAR
@@ -658,6 +661,7 @@ jobs:
           name: xtra-geckoview-universal-safe
           path: geckoview/artifacts/*universal-safe*
           if-no-files-found: error
+          retention-days: 1
 
   integration:
     name: Xtra release with custom GeckoView
@@ -723,6 +727,7 @@ jobs:
           name: xtra-custom-gecko-app-release
           path: app/build/outputs/apk/release/app-release.apk
           if-no-files-found: error
+          retention-days: 3
 
   publish:
     name: Publish universal custom GeckoView


### PR DESCRIPTION
Keep the existing CI coverage while reducing unnecessary work and storage. Superseded Android and CodeQL PR runs are cancelled, PR APKs are retained for 3 days, GeckoView artifacts are short-lived, and GeckoView native builds now run only from manual dispatch.