### PR TITLE
Add visibility toggles to tab customization

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/channel/ChannelPagerFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/channel/ChannelPagerFragment.kt
@@ -53,6 +53,7 @@ import com.github.andreyasadchy.xtra.ui.main.LiveNotificationScheduler
 import com.github.andreyasadchy.xtra.ui.main.MainActivity
 import com.github.andreyasadchy.xtra.ui.search.SearchPagerFragmentDirections
 import com.github.andreyasadchy.xtra.ui.settings.SettingsActivity
+import com.github.andreyasadchy.xtra.ui.settings.setTabCustomizationLongPress
 import com.github.andreyasadchy.xtra.util.C
 import com.github.andreyasadchy.xtra.util.TwitchApiHelper
 import com.github.andreyasadchy.xtra.util.getAlertDialogBuilder
@@ -507,6 +508,7 @@ class ChannelPagerFragment : BaseNetworkFragment(), Scrollable, FragmentHost {
                     else -> getString(R.string.videos)
                 }
             }.attach()
+            tabLayout.setTabCustomizationLongPress(requireContext(), C.UI_CHANNEL_TABS)
             ViewCompat.setOnApplyWindowInsetsListener(view) { _, windowInsets ->
                 val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout())
                 collapsingToolbar.updateLayoutParams<ViewGroup.MarginLayoutParams> {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/FollowMediaFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/FollowMediaFragment.kt
@@ -27,6 +27,7 @@ import com.github.andreyasadchy.xtra.ui.login.TwitchWebLoginActivity
 import com.github.andreyasadchy.xtra.ui.main.MainActivity
 import com.github.andreyasadchy.xtra.ui.search.SearchPagerFragmentDirections
 import com.github.andreyasadchy.xtra.ui.settings.SettingsActivity
+import com.github.andreyasadchy.xtra.ui.settings.setTabCustomizationLongPress
 import com.github.andreyasadchy.xtra.util.C
 import com.github.andreyasadchy.xtra.util.TwitchApiHelper
 import com.github.andreyasadchy.xtra.util.getAlertDialogBuilder
@@ -103,6 +104,8 @@ class FollowMediaFragment : Fragment(), Scrollable, FragmentHost {
             if (tabs.size > 1) {
                 spinner.visibility = View.VISIBLE
             }
+            spinner.setTabCustomizationLongPress(requireContext(), C.UI_FOLLOWING_TABS)
+            spinner.editText?.setTabCustomizationLongPress(requireContext(), C.UI_FOLLOWING_TABS)
             (spinner.editText as? MaterialAutoCompleteTextView)?.apply {
                 setSimpleItems(tabs.map { getString(FollowingTabs.titleRes(it)) }.toTypedArray().ifEmpty { arrayOf(getString(R.string.live)) })
                 setOnItemClickListener { _, _, position, _ ->

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/FollowPagerFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/FollowPagerFragment.kt
@@ -25,6 +25,7 @@ import com.github.andreyasadchy.xtra.ui.login.TwitchWebLoginActivity
 import com.github.andreyasadchy.xtra.ui.main.MainActivity
 import com.github.andreyasadchy.xtra.ui.search.SearchPagerFragmentDirections
 import com.github.andreyasadchy.xtra.ui.settings.SettingsActivity
+import com.github.andreyasadchy.xtra.ui.settings.setTabCustomizationLongPress
 import com.github.andreyasadchy.xtra.util.C
 import com.github.andreyasadchy.xtra.util.TwitchApiHelper
 import com.github.andreyasadchy.xtra.util.getAlertDialogBuilder
@@ -147,6 +148,7 @@ class FollowPagerFragment : Fragment(), Scrollable, FragmentHost {
             TabLayoutMediator(tabLayout, viewPager) { tab, position ->
                 tab.text = getString(FollowingTabs.titleRes(tabs.getOrNull(position).orEmpty()))
             }.attach()
+            tabLayout.setTabCustomizationLongPress(requireContext(), C.UI_FOLLOWING_TABS)
             ViewCompat.setOnApplyWindowInsetsListener(view) { _, windowInsets ->
                 val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout())
                 toolbar.updateLayoutParams<ViewGroup.MarginLayoutParams> {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/game/GameMediaFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/game/GameMediaFragment.kt
@@ -51,6 +51,7 @@ import com.github.andreyasadchy.xtra.ui.login.TwitchWebLoginActivity
 import com.github.andreyasadchy.xtra.ui.main.MainActivity
 import com.github.andreyasadchy.xtra.ui.search.SearchPagerFragmentDirections
 import com.github.andreyasadchy.xtra.ui.settings.SettingsActivity
+import com.github.andreyasadchy.xtra.ui.settings.setTabCustomizationLongPress
 import com.github.andreyasadchy.xtra.util.C
 import com.github.andreyasadchy.xtra.util.TwitchApiHelper
 import com.github.andreyasadchy.xtra.util.getAlertDialogBuilder
@@ -250,6 +251,8 @@ class GameMediaFragment : BaseNetworkFragment(), Scrollable, FragmentHost {
             if (tabs.size > 1) {
                 spinner.visibility = View.VISIBLE
             }
+            spinner.setTabCustomizationLongPress(requireContext(), C.UI_GAME_TABS)
+            spinner.editText?.setTabCustomizationLongPress(requireContext(), C.UI_GAME_TABS)
             (spinner.editText as? MaterialAutoCompleteTextView)?.apply {
                 setSimpleItems(tabs.map {
                     when (it) {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/game/GamePagerFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/game/GamePagerFragment.kt
@@ -48,6 +48,7 @@ import com.github.andreyasadchy.xtra.ui.login.TwitchWebLoginActivity
 import com.github.andreyasadchy.xtra.ui.main.MainActivity
 import com.github.andreyasadchy.xtra.ui.search.SearchPagerFragmentDirections
 import com.github.andreyasadchy.xtra.ui.settings.SettingsActivity
+import com.github.andreyasadchy.xtra.ui.settings.setTabCustomizationLongPress
 import com.github.andreyasadchy.xtra.util.C
 import com.github.andreyasadchy.xtra.util.TwitchApiHelper
 import com.github.andreyasadchy.xtra.util.getAlertDialogBuilder
@@ -298,6 +299,7 @@ class GamePagerFragment : BaseNetworkFragment(), Scrollable, FragmentHost {
                     else -> getString(R.string.live)
                 }
             }.attach()
+            tabLayout.setTabCustomizationLongPress(requireContext(), C.UI_GAME_TABS)
             ViewCompat.setOnApplyWindowInsetsListener(view) { _, windowInsets ->
                 val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout())
                 collapsingToolbar.updateLayoutParams<ViewGroup.MarginLayoutParams> {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/main/MainActivity.kt
@@ -82,6 +82,7 @@ import com.github.andreyasadchy.xtra.ui.player.PlayerFragment
 import com.github.andreyasadchy.xtra.ui.saved.SavedMediaFragment
 import com.github.andreyasadchy.xtra.ui.saved.SavedPagerFragment
 import com.github.andreyasadchy.xtra.ui.saved.downloads.DownloadsFragment
+import com.github.andreyasadchy.xtra.ui.settings.openTabCustomization
 import com.github.andreyasadchy.xtra.ui.team.TeamFragmentDirections
 import com.github.andreyasadchy.xtra.ui.top.TopStreamsFragmentDirections
 import com.github.andreyasadchy.xtra.util.C
@@ -1375,6 +1376,15 @@ class MainActivity : AppCompatActivity() {
                 binding.navBarContainer.visibility = View.GONE
             }
             setupWithNavController(navController)
+            post {
+                val menuView = getChildAt(0) as? ViewGroup ?: return@post
+                for (index in 0 until minOf(menu.size(), menuView.childCount)) {
+                    menuView.getChildAt(index).setOnLongClickListener {
+                        openTabCustomization(C.UI_NAVIGATION_TAB_LIST)
+                        true
+                    }
+                }
+            }
             setOnItemSelectedListener {
                 NavigationUI.onNavDestinationSelected(it, navController)
                 return@setOnItemSelectedListener true

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/saved/SavedMediaFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/saved/SavedMediaFragment.kt
@@ -32,6 +32,7 @@ import com.github.andreyasadchy.xtra.ui.saved.downloads.DownloadsFragment
 import com.github.andreyasadchy.xtra.ui.saved.filters.FiltersFragment
 import com.github.andreyasadchy.xtra.ui.search.SearchPagerFragmentDirections
 import com.github.andreyasadchy.xtra.ui.settings.SettingsActivity
+import com.github.andreyasadchy.xtra.ui.settings.setTabCustomizationLongPress
 import com.github.andreyasadchy.xtra.util.C
 import com.github.andreyasadchy.xtra.util.TwitchApiHelper
 import com.github.andreyasadchy.xtra.util.getAlertDialogBuilder
@@ -167,6 +168,8 @@ class SavedMediaFragment : Fragment(), Scrollable, FragmentHost {
             if (tabs.size > 1) {
                 spinner.visibility = View.VISIBLE
             }
+            spinner.setTabCustomizationLongPress(requireContext(), C.UI_SAVED_TABS)
+            spinner.editText?.setTabCustomizationLongPress(requireContext(), C.UI_SAVED_TABS)
             (spinner.editText as? MaterialAutoCompleteTextView)?.apply {
                 setSimpleItems(tabs.map {
                     when (it) {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/saved/SavedPagerFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/saved/SavedPagerFragment.kt
@@ -30,6 +30,7 @@ import com.github.andreyasadchy.xtra.ui.saved.SavedPagerViewModel.Companion.Save
 import com.github.andreyasadchy.xtra.ui.saved.downloads.DownloadsFragment
 import com.github.andreyasadchy.xtra.ui.search.SearchPagerFragmentDirections
 import com.github.andreyasadchy.xtra.ui.settings.SettingsActivity
+import com.github.andreyasadchy.xtra.ui.settings.setTabCustomizationLongPress
 import com.github.andreyasadchy.xtra.util.C
 import com.github.andreyasadchy.xtra.util.TwitchApiHelper
 import com.github.andreyasadchy.xtra.util.getAlertDialogBuilder
@@ -219,6 +220,7 @@ class SavedPagerFragment : Fragment(), Scrollable, FragmentHost {
                     else -> getString(R.string.bookmarks)
                 }
             }.attach()
+            tabLayout.setTabCustomizationLongPress(requireContext(), C.UI_SAVED_TABS)
             ViewCompat.setOnApplyWindowInsetsListener(view) { _, windowInsets ->
                 val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout())
                 toolbar.updateLayoutParams<ViewGroup.MarginLayoutParams> {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/search/SearchPagerFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/search/SearchPagerFragment.kt
@@ -30,6 +30,7 @@ import com.github.andreyasadchy.xtra.ui.common.FragmentHost
 import com.github.andreyasadchy.xtra.ui.common.Sortable
 import com.github.andreyasadchy.xtra.ui.main.MainActivity
 import com.github.andreyasadchy.xtra.ui.search.SearchPagerViewModel.Companion.SearchPagerViewModelFactory
+import com.github.andreyasadchy.xtra.ui.settings.setTabCustomizationLongPress
 import com.github.andreyasadchy.xtra.util.C
 import com.github.andreyasadchy.xtra.util.TwitchApiHelper
 import com.github.andreyasadchy.xtra.util.getAlertDialogBuilder
@@ -145,6 +146,7 @@ class SearchPagerFragment : BaseNetworkFragment(), FragmentHost {
                     else -> getString(R.string.channels)
                 }
             }.attach()
+            tabLayout.setTabCustomizationLongPress(requireContext(), C.UI_SEARCH_TABS)
             val navController = findNavController()
             val appBarConfiguration = AppBarConfiguration(setOf(R.id.rootGamesFragment, R.id.rootTopFragment, R.id.followPagerFragment, R.id.followMediaFragment, R.id.savedPagerFragment, R.id.savedMediaFragment))
             toolbar.setupWithNavController(navController, appBarConfiguration)

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/settings/SettingsActivity.kt
@@ -257,6 +257,7 @@ class SettingsActivity : AppCompatActivity() {
         showDefaultSelector: Boolean = true,
     ) {
         val listAdapter = SettingsDragListAdapter()
+        listAdapter.showVisibilityToggle = true
         val preview = when (prefKey) {
             C.UI_NAVIGATION_TAB_LIST -> SettingsLayoutPreview(this, list, SettingsLayoutPreview.Mode.NAVIGATION)
             C.UI_FOLLOWING_TABS,
@@ -303,10 +304,20 @@ class SettingsActivity : AppCompatActivity() {
                     }
                 }
                 item.default = true
+                item.enabled = true
+                listAdapter.notifyItemChanged(list.indexOf(item))
                 preview?.refresh()
             }
         }
-        listAdapter.onItemChanged = { preview?.refresh() }
+        listAdapter.onItemChanged = {
+            if (showDefaultSelector && list.none { it.default && it.enabled }) {
+                list.firstOrNull { it.enabled }?.let { firstVisible ->
+                    list.forEach { it.default = it === firstVisible }
+                    listAdapter.notifyDataSetChanged()
+                }
+            }
+            preview?.refresh()
+        }
         itemTouchHelper.attachToRecyclerView(recyclerView)
         listAdapter.submitList(list)
         val dialogView = preview?.let { layoutPreview ->

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/settings/SettingsActivity.kt
@@ -1,6 +1,7 @@
 package com.github.andreyasadchy.xtra.ui.settings
 
 import android.Manifest
+import android.animation.ValueAnimator
 import android.annotation.SuppressLint
 import android.app.admin.DeviceAdminReceiver
 import android.app.admin.DevicePolicyManager
@@ -64,6 +65,7 @@ import androidx.preference.ListPreference
 import androidx.preference.Preference
 import androidx.preference.PreferenceCategory
 import androidx.preference.PreferenceDataStore
+import androidx.preference.PreferenceGroupAdapter
 import androidx.preference.PreferenceManager
 import androidx.preference.SeekBarPreference
 import androidx.preference.SwitchPreferenceCompat
@@ -150,6 +152,7 @@ class SettingsActivity : AppCompatActivity() {
     private var accountActionIsLogout = false
     private var loginResultLauncher: ActivityResultLauncher<Intent>? = null
     private var accountResultLauncher: ActivityResultLauncher<Intent>? = null
+    private var settingsHighlightPreference: String? = null
     var searchItem: String? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -207,6 +210,10 @@ class SettingsActivity : AppCompatActivity() {
                 else -> false
             }
         }
+        settingsHighlightPreference = intent.getStringExtra(EXTRA_SETTINGS_HIGHLIGHT_PREFERENCE)
+        if (savedInstanceState == null && intent.getStringExtra(EXTRA_SETTINGS_SCREEN) == SETTINGS_SCREEN_TABS) {
+            navController.navigate(R.id.browsingTabsFragment)
+        }
         binding.searchView.setOnQueryTextListener(object : SearchView.OnQueryTextListener {
             private var job: Job? = null
 
@@ -230,6 +237,10 @@ class SettingsActivity : AppCompatActivity() {
                 return false
             }
         })
+    }
+
+    internal fun consumeSettingsHighlightPreference(): String? {
+        return settingsHighlightPreference?.also { settingsHighlightPreference = null }
     }
 
     fun isAccountConnected(): Boolean {
@@ -257,7 +268,9 @@ class SettingsActivity : AppCompatActivity() {
         showDefaultSelector: Boolean = true,
     ) {
         val listAdapter = SettingsDragListAdapter()
-        listAdapter.showVisibilityToggle = true
+        listAdapter.minimumVisibleItems = minimumVisibleItemsForPreference(prefKey)
+        ensureMinimumVisibleItems(list, listAdapter.minimumVisibleItems)
+        if (showDefaultSelector) promoteDefaultToVisible(list)
         val preview = when (prefKey) {
             C.UI_NAVIGATION_TAB_LIST -> SettingsLayoutPreview(this, list, SettingsLayoutPreview.Mode.NAVIGATION)
             C.UI_FOLLOWING_TABS,
@@ -303,19 +316,15 @@ class SettingsActivity : AppCompatActivity() {
                         it.isClickable = true
                     }
                 }
-                item.default = true
-                item.enabled = true
-                listAdapter.notifyItemChanged(list.indexOf(item))
+                setDefaultItem(list, item)
+                listAdapter.notifyDataSetChanged()
                 preview?.refresh()
             }
         }
         listAdapter.onItemChanged = {
-            if (showDefaultSelector && list.none { it.default && it.enabled }) {
-                list.firstOrNull { it.enabled }?.let { firstVisible ->
-                    list.forEach { it.default = it === firstVisible }
-                    listAdapter.notifyDataSetChanged()
-                }
-            }
+            ensureMinimumVisibleItems(list, listAdapter.minimumVisibleItems)
+            if (showDefaultSelector) promoteDefaultToVisible(list)
+            listAdapter.notifyDataSetChanged()
             preview?.refresh()
         }
         itemTouchHelper.attachToRecyclerView(recyclerView)
@@ -349,6 +358,8 @@ class SettingsActivity : AppCompatActivity() {
             .setTitle(title)
             .setView(dialogView)
             .setPositiveButton(getString(android.R.string.ok)) { _, _ ->
+                ensureMinimumVisibleItems(list, listAdapter.minimumVisibleItems)
+                if (showDefaultSelector) promoteDefaultToVisible(list)
                 prefs().edit {
                     putString(prefKey, listAdapter.currentList.joinToString(",") {
                         "${it.key}:${if (it.default) "1" else "0"}:${if (it.enabled) "1" else "0"}"
@@ -1540,6 +1551,9 @@ class SettingsActivity : AppCompatActivity() {
 
         override fun onResume() {
             super.onResume()
+            if (settingsScreen == SCREEN_TABS) {
+                (requireActivity() as? SettingsActivity)?.consumeSettingsHighlightPreference()?.let(::highlightPreference)
+            }
             if (settingsScreen == SCREEN_PROXY) {
                 requireActivity().window.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
             }
@@ -1549,6 +1563,36 @@ class SettingsActivity : AppCompatActivity() {
                 toggleLiveNotifications(false)
             }
             updateLiveNotificationsSummary()
+        }
+
+        private fun highlightPreference(key: String) {
+            val preference = findPreference<Preference>(key) ?: return
+            val recyclerView = listView as? RecyclerView ?: return
+            val adapter = recyclerView.adapter as? PreferenceGroupAdapter ?: return
+            val position = adapter.getPreferenceAdapterPosition(preference)
+            if (position == RecyclerView.NO_POSITION) return
+            recyclerView.scrollToPosition(position)
+            recyclerView.postDelayed({
+                val itemView = recyclerView.findViewHolderForAdapterPosition(position)?.itemView ?: return@postDelayed
+                if (!ValueAnimator.areAnimatorsEnabled()) return@postDelayed
+                itemView.animate().cancel()
+                itemView.scaleX = 1f
+                itemView.scaleY = 1f
+                itemView.isPressed = true
+                itemView.postDelayed({ itemView.isPressed = false }, 180L)
+                itemView.animate()
+                    .scaleX(1.025f)
+                    .scaleY(1.025f)
+                    .setDuration(120L)
+                    .withEndAction {
+                        itemView.animate()
+                            .scaleX(1f)
+                            .scaleY(1f)
+                            .setDuration(220L)
+                            .start()
+                    }
+                    .start()
+            }, 100L)
         }
 
         override fun onPause() {
@@ -2311,7 +2355,9 @@ class SettingsActivity : AppCompatActivity() {
 
         private fun showSpeedOptionsDialog() {
             val items = readSpeedItems()
-            val listAdapter = SettingsDragListAdapter()
+            val listAdapter = SettingsDragListAdapter().apply {
+                showVisibilityToggle = true
+            }
             val itemTouchHelper = ItemTouchHelper(
                 object : ItemTouchHelper.SimpleCallback(ItemTouchHelper.UP or ItemTouchHelper.DOWN, 0) {
                     override fun onMove(recyclerView: RecyclerView, viewHolder: RecyclerView.ViewHolder, target: RecyclerView.ViewHolder): Boolean {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/settings/SettingsDragListAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/settings/SettingsDragListAdapter.kt
@@ -27,7 +27,8 @@ class SettingsDragListAdapter : ListAdapter<SettingsDragListItem, SettingsDragLi
     var itemTouchHelper: ItemTouchHelper? = null
     var setDefault: ((SettingsDragListItem) -> Unit)? = null
     var cycleGroup: ((SettingsDragListItem) -> Unit)? = null
-    var showVisibilityToggle = false
+    var showVisibilityToggle = true
+    var minimumVisibleItems = 0
     var onItemChanged: (() -> Unit)? = null
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
@@ -83,6 +84,11 @@ class SettingsDragListAdapter : ListAdapter<SettingsDragListItem, SettingsDragLi
                     checkBox.visibility = View.VISIBLE
                     checkBox.setOnCheckedChangeListener(null)
                     checkBox.isChecked = item.enabled
+                    checkBox.isEnabled = canDisableVisibleItem(
+                        itemEnabled = item.enabled,
+                        visibleItemCount = currentList.count { it.enabled },
+                        minimumVisibleItems = minimumVisibleItems,
+                    )
                     checkBox.setOnCheckedChangeListener { _, isChecked ->
                         item.enabled = isChecked
                         onItemChanged?.invoke()
@@ -93,6 +99,7 @@ class SettingsDragListAdapter : ListAdapter<SettingsDragListItem, SettingsDragLi
                     )
                 } else {
                     checkBox.setOnCheckedChangeListener(null)
+                    checkBox.isEnabled = true
                     checkBox.visibility = View.GONE
                 }
             }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/settings/SettingsDragListAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/settings/SettingsDragListAdapter.kt
@@ -27,6 +27,7 @@ class SettingsDragListAdapter : ListAdapter<SettingsDragListItem, SettingsDragLi
     var itemTouchHelper: ItemTouchHelper? = null
     var setDefault: ((SettingsDragListItem) -> Unit)? = null
     var cycleGroup: ((SettingsDragListItem) -> Unit)? = null
+    var showVisibilityToggle = false
     var onItemChanged: (() -> Unit)? = null
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
@@ -60,7 +61,6 @@ class SettingsDragListAdapter : ListAdapter<SettingsDragListItem, SettingsDragLi
                     setAsDefault.setImageResource(
                         if (item.group == "quick") R.drawable.baseline_home_black_24 else R.drawable.outline_home_black_24
                     )
-                    checkBox.visibility = View.GONE
                 } else if (setDefault != null) {
                     setAsDefault.visibility = View.VISIBLE
                     checkBox.visibility = View.GONE
@@ -78,6 +78,8 @@ class SettingsDragListAdapter : ListAdapter<SettingsDragListItem, SettingsDragLi
                     }
                 } else {
                     setAsDefault.visibility = View.GONE
+                }
+                if (cycleGroup == null && showVisibilityToggle) {
                     checkBox.visibility = View.VISIBLE
                     checkBox.setOnCheckedChangeListener(null)
                     checkBox.isChecked = item.enabled
@@ -85,6 +87,13 @@ class SettingsDragListAdapter : ListAdapter<SettingsDragListItem, SettingsDragLi
                         item.enabled = isChecked
                         onItemChanged?.invoke()
                     }
+                    checkBox.contentDescription = root.context.getString(
+                        R.string.settings_show_item,
+                        item.text,
+                    )
+                } else {
+                    checkBox.setOnCheckedChangeListener(null)
+                    checkBox.visibility = View.GONE
                 }
             }
         }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/settings/SettingsTabCustomization.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/settings/SettingsTabCustomization.kt
@@ -1,0 +1,76 @@
+package com.github.andreyasadchy.xtra.ui.settings
+
+import android.content.Context
+import android.content.Intent
+import android.view.View
+import com.github.andreyasadchy.xtra.model.ui.SettingsDragListItem
+import com.github.andreyasadchy.xtra.util.C
+import com.google.android.material.tabs.TabLayout
+
+internal const val EXTRA_SETTINGS_SCREEN = "settings_screen"
+internal const val EXTRA_SETTINGS_HIGHLIGHT_PREFERENCE = "settings_highlight_preference"
+internal const val SETTINGS_SCREEN_TABS = "tabs"
+
+internal fun Context.openTabCustomization(preferenceKey: String) {
+    startActivity(Intent(this, SettingsActivity::class.java).apply {
+        putExtra(EXTRA_SETTINGS_SCREEN, SETTINGS_SCREEN_TABS)
+        putExtra(EXTRA_SETTINGS_HIGHLIGHT_PREFERENCE, "${preferenceKey}_dialog")
+    })
+}
+
+internal fun View.setTabCustomizationLongPress(context: Context, preferenceKey: String) {
+    setOnLongClickListener {
+        context.openTabCustomization(preferenceKey)
+        true
+    }
+}
+
+internal fun TabLayout.setTabCustomizationLongPress(context: Context, preferenceKey: String) {
+    post {
+        for (index in 0 until tabCount) {
+            getTabAt(index)?.view?.setTabCustomizationLongPress(context, preferenceKey)
+        }
+    }
+}
+
+internal fun minimumVisibleItemsForPreference(preferenceKey: String): Int = when (preferenceKey) {
+    C.UI_FOLLOWING_TABS,
+    C.UI_SAVED_TABS,
+    C.UI_CHANNEL_TABS,
+    C.UI_GAME_TABS,
+    C.UI_SEARCH_TABS,
+    -> 1
+    else -> 0
+}
+
+internal fun canDisableVisibleItem(
+    itemEnabled: Boolean,
+    visibleItemCount: Int,
+    minimumVisibleItems: Int,
+): Boolean = !itemEnabled || visibleItemCount > minimumVisibleItems
+
+internal fun ensureMinimumVisibleItems(
+    items: List<SettingsDragListItem>,
+    minimumVisibleItems: Int,
+) {
+    var visibleItemCount = items.count { it.enabled }
+    items.forEach { item ->
+        if (visibleItemCount >= minimumVisibleItems) return@forEach
+        if (!item.enabled) {
+            item.enabled = true
+            visibleItemCount++
+        }
+    }
+}
+
+internal fun promoteDefaultToVisible(items: List<SettingsDragListItem>) {
+    val defaultItem = items.firstOrNull { it.default && it.enabled }
+        ?: items.firstOrNull { it.enabled }
+        ?: return
+    items.forEach { it.default = it === defaultItem }
+}
+
+internal fun setDefaultItem(items: List<SettingsDragListItem>, item: SettingsDragListItem) {
+    items.forEach { it.default = it === item }
+    item.enabled = true
+}

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -601,6 +601,7 @@
     <string name="scroll_to_top">قم بالتمرير إلى الأعلى</string>
     <string name="more_options">المزيد من الخيارات</string>
     <string name="set_as_default">تعيين كعلامة تبويب افتراضية</string>
+    <string name="settings_show_item">إظهار %1$s</string>
     <string name="list_load_error">تعذر تحميل هذا المحتوى.</string>
     <string name="list_refresh_error">لا يمكن تحديث هذا المحتوى.</string>
     <string name="list_load_more_error">لا يمكن تحميل المزيد من المحتوى.</string>
@@ -1376,7 +1377,7 @@
     <string name="settings_customize_controls_snap_hint">حرر للإرساء</string>
     <string name="settings_customize_controls_drag_action">اسحب أو اضغط %1$s</string>
     <string name="settings_layout_preview">معاينة</string>
-    <string name="settings_tabs_preview_help">تتبع المعاينة الترتيب والعناصر الظاهرة أدناه.</string>
+    <string name="settings_tabs_preview_help">اسحب لإعادة الترتيب. استخدم مربع الاختيار لإظهار عنصر أو إخفائه. تشير أيقونة المنزل إلى الإعداد الافتراضي.</string>
     <string name="settings_sections_preview_help">تعرض المعاينة الرفوف الظاهرة بالترتيب الحالي.</string>
     <string name="discover_previous_trending">البث الرائج السابق</string>
     <string name="discover_next_trending">البث الرائج التالي</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -93,6 +93,7 @@
     <string name="delete">Vymazat</string>
     <string name="more_options">Více možností</string>
     <string name="set_as_default">Nastavit jako výchozí kartu</string>
+    <string name="settings_show_item">Zobrazit %1$s</string>
     <string name="are_you_sure">Opravdu chcete toto video smazat?</string>
     <string name="token_expired">Vaše relace vypršela. Přihlaste se prosím znovu.</string>
     <string name="no_connection">Žádné připojení k internetu</string>
@@ -1399,7 +1400,7 @@
     <string name="settings_customize_controls_snap_hint">Uvolněním přichytíte</string>
     <string name="settings_customize_controls_drag_action">Přetažení nebo klepnutí na %1$s</string>
     <string name="settings_layout_preview">Náhled</string>
-    <string name="settings_tabs_preview_help">Náhled sleduje pořadí a viditelnost níže.</string>
+    <string name="settings_tabs_preview_help">Přetažením změňte pořadí. Pomocí zaškrtávacího políčka položku zobrazíte nebo skryjete. Ikona domečku označuje výchozí položku.</string>
     <string name="settings_sections_preview_help">Náhled zobrazuje viditelné police v aktuálním pořadí.</string>
     <string name="discover_previous_trending">Předchozí populární stream</string>
     <string name="discover_next_trending">Následující populární stream</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -601,6 +601,7 @@
     <string name="scroll_to_top">Scrollen Sie nach oben</string>
     <string name="more_options">Weitere Optionen</string>
     <string name="set_as_default">Als Standardregisterkarte festlegen</string>
+    <string name="settings_show_item">%1$s anzeigen</string>
     <string name="list_load_error">Dieser Inhalt konnte nicht geladen werden.</string>
     <string name="list_refresh_error">Dieser Inhalt konnte nicht aktualisiert werden.</string>
     <string name="list_load_more_error">Es konnten keine weiteren Inhalte geladen werden.</string>
@@ -1376,7 +1377,7 @@
     <string name="settings_customize_controls_snap_hint">Zum Einrasten loslassen</string>
     <string name="settings_customize_controls_drag_action">%1$s ziehen oder antippen</string>
     <string name="settings_layout_preview">Vorschau</string>
-    <string name="settings_tabs_preview_help">Die Vorschau folgt der unten angezeigten Reihenfolge und Sichtbarkeit.</string>
+    <string name="settings_tabs_preview_help">Zum Neuanordnen ziehen. Mit dem Kontrollkästchen kannst du ein Element ein- oder ausblenden. Das Haussymbol kennzeichnet den Standard.</string>
     <string name="settings_sections_preview_help">Die Vorschau zeigt die sichtbaren Bereiche in ihrer aktuellen Reihenfolge.</string>
     <string name="discover_previous_trending">Vorheriger angesagter Stream</string>
     <string name="discover_next_trending">Nächster angesagter Stream</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -606,6 +606,7 @@
     <string name="scroll_to_top">Desplazarse hacia arriba</string>
     <string name="more_options">Más opciones</string>
     <string name="set_as_default">Establecer como pestaña predeterminada</string>
+    <string name="settings_show_item">Mostrar %1$s</string>
     <string name="list_load_error">No se pudo cargar este contenido.</string>
     <string name="list_refresh_error">No se pudo actualizar este contenido.</string>
     <string name="list_load_more_error">No se pudo cargar más contenido.</string>
@@ -1381,7 +1382,7 @@
     <string name="settings_customize_controls_snap_hint">Suelta para ajustar</string>
     <string name="settings_customize_controls_drag_action">Arrastra o toca %1$s</string>
     <string name="settings_layout_preview">Vista previa</string>
-    <string name="settings_tabs_preview_help">La vista previa sigue el orden y la visibilidad indicados abajo.</string>
+    <string name="settings_tabs_preview_help">Arrastra para reordenar. Usa la casilla para mostrar u ocultar un elemento. El icono de inicio indica el valor predeterminado.</string>
     <string name="settings_sections_preview_help">La vista previa muestra las secciones visibles en su orden actual.</string>
     <string name="discover_previous_trending">Stream en tendencia anterior</string>
     <string name="discover_next_trending">Siguiente stream en tendencia</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -601,6 +601,7 @@
     <string name="scroll_to_top">Faire défiler vers le haut</string>
     <string name="more_options">Plus d\'options</string>
     <string name="set_as_default">Définir comme onglet par défaut</string>
+    <string name="settings_show_item">Afficher %1$s</string>
     <string name="list_load_error">Impossible de charger ce contenu.</string>
     <string name="list_refresh_error">Impossible d\'actualiser ce contenu.</string>
     <string name="list_load_more_error">Impossible de charger plus de contenu.</string>
@@ -1376,7 +1377,7 @@
     <string name="settings_customize_controls_snap_hint">Relâchez pour aligner</string>
     <string name="settings_customize_controls_drag_action">Faites glisser ou touchez %1$s</string>
     <string name="settings_layout_preview">Aperçu</string>
-    <string name="settings_tabs_preview_help">L’aperçu suit l’ordre et la visibilité indiqués ci-dessous.</string>
+    <string name="settings_tabs_preview_help">Faites glisser pour réorganiser. Utilisez la case à cocher pour afficher ou masquer un élément. L’icône d’accueil indique l’élément par défaut.</string>
     <string name="settings_sections_preview_help">L’aperçu affiche les sections visibles dans leur ordre actuel.</string>
     <string name="discover_previous_trending">Stream tendance précédent</string>
     <string name="discover_next_trending">Stream tendance suivant</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -601,6 +601,7 @@
     <string name="scroll_to_top">Desprácese cara arriba</string>
     <string name="more_options">Máis opcións</string>
     <string name="set_as_default">Establecer como pestana predeterminada</string>
+    <string name="settings_show_item">Mostrar %1$s</string>
     <string name="list_load_error">Non se puido cargar este contido.</string>
     <string name="list_refresh_error">Non se puido actualizar este contido.</string>
     <string name="list_load_more_error">Non se puido cargar máis contido.</string>
@@ -1376,7 +1377,7 @@
     <string name="settings_customize_controls_snap_hint">Solta para axustar</string>
     <string name="settings_customize_controls_drag_action">Arrastra ou toca %1$s</string>
     <string name="settings_layout_preview">Vista previa</string>
-    <string name="settings_tabs_preview_help">A vista previa segue a orde e visibilidade que aparecen abaixo.</string>
+    <string name="settings_tabs_preview_help">Arrastra para reordenar. Usa a caixa de verificación para mostrar ou ocultar un elemento. A icona de inicio indica o valor predeterminado.</string>
     <string name="settings_sections_preview_help">A vista previa mostra as seccións visibles na súa orde actual.</string>
     <string name="discover_previous_trending">Emisión en tendencia anterior</string>
     <string name="discover_next_trending">Seguinte emisión en tendencia</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -602,6 +602,7 @@
     <string name="scroll_to_top">Gulir ke atas</string>
     <string name="more_options">Opsi lainnya</string>
     <string name="set_as_default">Tetapkan sebagai tab default</string>
+    <string name="settings_show_item">Tampilkan %1$s</string>
     <string name="list_load_error">Tidak dapat memuat konten ini.</string>
     <string name="list_refresh_error">Tidak dapat menyegarkan konten ini.</string>
     <string name="list_load_more_error">Tidak dapat memuat konten lainnya.</string>
@@ -1377,7 +1378,7 @@
     <string name="settings_customize_controls_snap_hint">Lepaskan untuk menempel</string>
     <string name="settings_customize_controls_drag_action">Seret atau ketuk %1$s</string>
     <string name="settings_layout_preview">Pratinjau</string>
-    <string name="settings_tabs_preview_help">Pratinjau mengikuti urutan dan visibilitas di bawah.</string>
+    <string name="settings_tabs_preview_help">Seret untuk mengurutkan ulang. Gunakan kotak centang untuk menampilkan atau menyembunyikan item. Ikon beranda menandai item default.</string>
     <string name="settings_sections_preview_help">Pratinjau menampilkan bagian yang terlihat dalam urutan saat ini.</string>
     <string name="discover_previous_trending">Siaran trending sebelumnya</string>
     <string name="discover_next_trending">Siaran trending berikutnya</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -601,6 +601,7 @@
     <string name="scroll_to_top">Scorri verso l\'alto</string>
     <string name="more_options">Altre opzioni</string>
     <string name="set_as_default">Imposta come scheda predefinita</string>
+    <string name="settings_show_item">Mostra %1$s</string>
     <string name="list_load_error">Impossibile caricare questo contenuto.</string>
     <string name="list_refresh_error">Impossibile aggiornare questo contenuto.</string>
     <string name="list_load_more_error">Impossibile caricare altri contenuti.</string>
@@ -1376,7 +1377,7 @@
     <string name="settings_customize_controls_snap_hint">Rilascia per agganciare</string>
     <string name="settings_customize_controls_drag_action">Trascina o tocca %1$s</string>
     <string name="settings_layout_preview">Anteprima</string>
-    <string name="settings_tabs_preview_help">L’anteprima segue l’ordine e la visibilità indicati sotto.</string>
+    <string name="settings_tabs_preview_help">Trascina per riordinare. Usa la casella di controllo per mostrare o nascondere un elemento. L’icona Home indica l’elemento predefinito.</string>
     <string name="settings_sections_preview_help">L’anteprima mostra le sezioni visibili nell’ordine attuale.</string>
     <string name="discover_previous_trending">Stream di tendenza precedente</string>
     <string name="discover_next_trending">Stream di tendenza successivo</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -601,6 +601,7 @@
     <string name="scroll_to_top">トップにスクロール</string>
     <string name="more_options">その他のオプション</string>
     <string name="set_as_default">デフォルトのタブとして設定</string>
+    <string name="settings_show_item">%1$sを表示</string>
     <string name="list_load_error">このコンテンツを読み込めませんでした。</string>
     <string name="list_refresh_error">このコンテンツを更新できませんでした。</string>
     <string name="list_load_more_error">これ以上コンテンツを読み込めませんでした。</string>
@@ -1376,7 +1377,7 @@
     <string name="settings_customize_controls_snap_hint">離してスナップ</string>
     <string name="settings_customize_controls_drag_action">%1$sをドラッグまたはタップ</string>
     <string name="settings_layout_preview">プレビュー</string>
-    <string name="settings_tabs_preview_help">プレビューには下の順序と表示状態が反映されます。</string>
+    <string name="settings_tabs_preview_help">ドラッグして並べ替えます。チェックボックスで項目の表示と非表示を切り替えます。ホームアイコンはデフォルトを示します。</string>
     <string name="settings_sections_preview_help">プレビューには現在の順序で表示されるセクションが表示されます。</string>
     <string name="discover_previous_trending">前のトレンド配信</string>
     <string name="discover_next_trending">次のトレンド配信</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -72,6 +72,7 @@
     <string name="delete">Usuń</string>
     <string name="more_options">Więcej opcji</string>
     <string name="set_as_default">Ustaw jako kartę domyślną</string>
+    <string name="settings_show_item">Pokaż %1$s</string>
     <string name="are_you_sure">Czy na pewno chcesz usunąć ten film?</string>
     <string name="token_expired">Twoja sesja wygasła. Zaloguj się ponownie.</string>
     <string name="no_connection">Brak połączenia z Internetem</string>
@@ -1374,7 +1375,7 @@
     <string name="settings_customize_controls_snap_hint">Puść, aby przyciągnąć</string>
     <string name="settings_customize_controls_drag_action">Przeciągnij lub dotknij %1$s</string>
     <string name="settings_layout_preview">Podgląd</string>
-    <string name="settings_tabs_preview_help">Podgląd odzwierciedla kolejność i widoczność poniżej.</string>
+    <string name="settings_tabs_preview_help">Przeciągnij, aby zmienić kolejność. Użyj pola wyboru, aby pokazać lub ukryć element. Ikona domu oznacza element domyślny.</string>
     <string name="settings_sections_preview_help">Podgląd pokazuje widoczne sekcje w bieżącej kolejności.</string>
     <string name="discover_previous_trending">Poprzedni popularny stream</string>
     <string name="discover_next_trending">Następny popularny stream</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -601,6 +601,7 @@
     <string name="scroll_to_top">Rolar para o topo</string>
     <string name="more_options">Mais opções</string>
     <string name="set_as_default">Definir como guia padrão</string>
+    <string name="settings_show_item">Mostrar %1$s</string>
     <string name="list_load_error">Não foi possível carregar este conteúdo.</string>
     <string name="list_refresh_error">Não foi possível atualizar este conteúdo.</string>
     <string name="list_load_more_error">Não foi possível carregar mais conteúdo.</string>
@@ -1376,7 +1377,7 @@
     <string name="settings_customize_controls_snap_hint">Solte para encaixar</string>
     <string name="settings_customize_controls_drag_action">Arraste ou toque em %1$s</string>
     <string name="settings_layout_preview">Prévia</string>
-    <string name="settings_tabs_preview_help">A prévia segue a ordem e a visibilidade abaixo.</string>
+    <string name="settings_tabs_preview_help">Arraste para reordenar. Use a caixa de seleção para mostrar ou ocultar um item. O ícone de início indica o padrão.</string>
     <string name="settings_sections_preview_help">A prévia mostra as seções visíveis na ordem atual.</string>
     <string name="discover_previous_trending">Stream em alta anterior</string>
     <string name="discover_next_trending">Próximo stream em alta</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -601,6 +601,7 @@
     <string name="scroll_to_top">Прокрутите вверх</string>
     <string name="more_options">Дополнительные параметры</string>
     <string name="set_as_default">Установить в качестве вкладки по умолчанию</string>
+    <string name="settings_show_item">Показывать %1$s</string>
     <string name="list_load_error">Не удалось загрузить этот контент.</string>
     <string name="list_refresh_error">Не удалось обновить этот контент.</string>
     <string name="list_load_more_error">Не удалось загрузить больше контента.</string>
@@ -1376,7 +1377,7 @@
     <string name="settings_customize_controls_snap_hint">Отпустите, чтобы закрепить</string>
     <string name="settings_customize_controls_drag_action">Перетащите или нажмите %1$s</string>
     <string name="settings_layout_preview">Предпросмотр</string>
-    <string name="settings_tabs_preview_help">Предпросмотр учитывает порядок и видимость ниже.</string>
+    <string name="settings_tabs_preview_help">Перетаскивайте, чтобы изменить порядок. С помощью флажка можно показать или скрыть элемент. Значок главного экрана обозначает значение по умолчанию.</string>
     <string name="settings_sections_preview_help">Предпросмотр показывает видимые разделы в текущем порядке.</string>
     <string name="discover_previous_trending">Предыдущая популярная трансляция</string>
     <string name="discover_next_trending">Следующая популярная трансляция</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -93,6 +93,7 @@
     <string name="delete">Odstrániť</string>
     <string name="more_options">Viac možností</string>
     <string name="set_as_default">Nastaviť ako predvolenú kartu</string>
+    <string name="settings_show_item">Zobraziť %1$s</string>
     <string name="are_you_sure">Naozaj chcete odstrániť toto video?</string>
     <string name="token_expired">Platnosť vašej relácie vypršala. Prihláste sa znova.</string>
     <string name="no_connection">Žiadne internetové pripojenie</string>
@@ -1399,7 +1400,7 @@
     <string name="settings_customize_controls_snap_hint">Uvoľnením prichytíte</string>
     <string name="settings_customize_controls_drag_action">Presuňte alebo klepnite na %1$s</string>
     <string name="settings_layout_preview">Náhľad</string>
-    <string name="settings_tabs_preview_help">Náhľad sleduje poradie a viditeľnosť uvedené nižšie.</string>
+    <string name="settings_tabs_preview_help">Potiahnutím zmeníte poradie. Pomocou začiarkavacieho políčka položku zobrazíte alebo skryjete. Ikona domčeka označuje predvolené nastavenie.</string>
     <string name="settings_sections_preview_help">Náhľad zobrazuje viditeľné sekcie v aktuálnom poradí.</string>
     <string name="discover_previous_trending">Predchádzajúci populárny stream</string>
     <string name="discover_next_trending">Nasledujúci populárny stream</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -602,6 +602,7 @@
     <string name="scroll_to_top">Yukarıya kaydır</string>
     <string name="more_options">Diğer seçenekler</string>
     <string name="set_as_default">Varsayılan sekme olarak ayarla</string>
+    <string name="settings_show_item">%1$s öğesini göster</string>
     <string name="list_load_error">Bu içerik yüklenemedi.</string>
     <string name="list_refresh_error">Bu içerik yenilenemedi.</string>
     <string name="list_load_more_error">Daha fazla içerik yüklenemedi.</string>
@@ -1377,7 +1378,7 @@
     <string name="settings_customize_controls_snap_hint">Mıknatıslamak için bırakın</string>
     <string name="settings_customize_controls_drag_action">%1$s sürükleyin veya dokunun</string>
     <string name="settings_layout_preview">Önizleme</string>
-    <string name="settings_tabs_preview_help">Önizleme, aşağıdaki sırayı ve görünürlüğü izler.</string>
+    <string name="settings_tabs_preview_help">Yeniden sıralamak için sürükleyin. Bir öğeyi göstermek veya gizlemek için onay kutusunu kullanın. Ana ekran simgesi varsayılanı belirtir.</string>
     <string name="settings_sections_preview_help">Önizleme, görünür bölümleri geçerli sıralarında gösterir.</string>
     <string name="discover_previous_trending">Önceki popüler yayın</string>
     <string name="discover_next_trending">Sonraki popüler yayın</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -601,6 +601,7 @@
     <string name="scroll_to_top">滚动到顶部</string>
     <string name="more_options">更多选项</string>
     <string name="set_as_default">设置为默认选项卡</string>
+    <string name="settings_show_item">显示 %1$s</string>
     <string name="list_load_error">无法加载此内容。</string>
     <string name="list_refresh_error">无法刷新此内容。</string>
     <string name="list_load_more_error">无法加载更多内容。</string>
@@ -1376,7 +1377,7 @@
     <string name="settings_customize_controls_snap_hint">松开以吸附</string>
     <string name="settings_customize_controls_drag_action">拖动或点按%1$s</string>
     <string name="settings_layout_preview">预览</string>
-    <string name="settings_tabs_preview_help">预览会按照下方的顺序和可见性显示。</string>
+    <string name="settings_tabs_preview_help">拖动可重新排序。使用复选框显示或隐藏项目。主页图标表示默认项。</string>
     <string name="settings_sections_preview_help">预览会按当前顺序显示可见分区。</string>
     <string name="discover_previous_trending">上一个热门直播</string>
     <string name="discover_next_trending">下一个热门直播</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -601,6 +601,7 @@
     <string name="scroll_to_top">捲動到頂部</string>
     <string name="more_options">更多選擇</string>
     <string name="set_as_default">設定為預設選項卡</string>
+    <string name="settings_show_item">顯示 %1$s</string>
     <string name="list_load_error">無法載入此內容。</string>
     <string name="list_refresh_error">無法刷新此內容。</string>
     <string name="list_load_more_error">無法載入更多內容。</string>
@@ -1376,7 +1377,7 @@
     <string name="settings_customize_controls_snap_hint">放開以吸附</string>
     <string name="settings_customize_controls_drag_action">拖曳或點按%1$s</string>
     <string name="settings_layout_preview">預覽</string>
-    <string name="settings_tabs_preview_help">預覽會依照下方的順序和可見性顯示。</string>
+    <string name="settings_tabs_preview_help">拖曳即可重新排序。使用核取方塊顯示或隱藏項目。首頁圖示表示預設項目。</string>
     <string name="settings_sections_preview_help">預覽會依目前順序顯示可見區段。</string>
     <string name="discover_previous_trending">上一個熱門直播</string>
     <string name="discover_next_trending">下一個熱門直播</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -118,6 +118,7 @@
     <string name="delete">Delete</string>
     <string name="more_options">More options</string>
     <string name="set_as_default">Set as default tab</string>
+    <string name="settings_show_item">Show %1$s</string>
     <string name="are_you_sure">Are you sure you want to delete this video?</string>
     <string name="token_expired">Your session has expired. Please log in again.</string>
     <string name="no_connection">No Internet connection</string>
@@ -1420,7 +1421,7 @@
     <string name="live_notifications_following_summary">Automatically enable live alerts for channels you follow through Xtra. Twitch notification preferences are used when an authenticated web session is available.</string>
     <string name="settings_customize_controls_summary">Quick controls, More menu and Hidden</string>
     <string name="settings_layout_preview">Preview</string>
-    <string name="settings_tabs_preview_help">The preview follows the order and visibility below.</string>
+    <string name="settings_tabs_preview_help">Drag to reorder. Use the checkbox to show or hide an item. The home icon marks the default.</string>
     <string name="settings_sections_preview_help">The preview shows the visible shelves in their current order.</string>
     <string name="settings_playback_speed_options_summary">Choose and reorder speed values</string>
     <string name="settings_double_tap_chat_summary">Toggle chat with a double tap while watching.</string>

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/settings/SettingsActivityTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/settings/SettingsActivityTest.kt
@@ -1,6 +1,9 @@
 package com.github.andreyasadchy.xtra.ui.settings
 
+import com.github.andreyasadchy.xtra.model.ui.SettingsDragListItem
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -22,5 +25,49 @@ class SettingsActivityTest {
         assertTrue(needsUpdateNotificationUserAction(true, false, false))
         assertTrue(needsUpdateNotificationUserAction(false, true, false))
         assertTrue(needsUpdateNotificationUserAction(false, false, true))
+    }
+
+    @Test
+    fun hidingTheDefaultPromotesTheFirstVisibleItem() {
+        val items = listOf(
+            SettingsDragListItem("first", "First", default = true, enabled = false),
+            SettingsDragListItem("second", "Second", default = false, enabled = true),
+        )
+
+        promoteDefaultToVisible(items)
+
+        assertFalse(items[0].default)
+        assertTrue(items[1].default)
+    }
+
+    @Test
+    fun settingAHiddenItemAsDefaultMakesItVisible() {
+        val items = listOf(
+            SettingsDragListItem("first", "First", default = true, enabled = true),
+            SettingsDragListItem("second", "Second", default = false, enabled = false),
+        )
+
+        setDefaultItem(items, items[1])
+
+        assertSame(items[1], items.first { it.default })
+        assertTrue(items[1].enabled)
+    }
+
+    @Test
+    fun theFinalVisiblePageTabCannotBeDisabled() {
+        assertFalse(canDisableVisibleItem(itemEnabled = true, visibleItemCount = 1, minimumVisibleItems = 1))
+        assertTrue(canDisableVisibleItem(itemEnabled = true, visibleItemCount = 2, minimumVisibleItems = 1))
+    }
+
+    @Test
+    fun anEmptyPageTabConfigurationGetsOneVisibleItemBack() {
+        val items = listOf(
+            SettingsDragListItem("first", "First", default = false, enabled = false),
+            SettingsDragListItem("second", "Second", default = false, enabled = false),
+        )
+
+        ensureMinimumVisibleItems(items, minimumVisibleItems = 1)
+
+        assertEquals(1, items.count { it.enabled })
     }
 }


### PR DESCRIPTION
Let users show or hide each navigation and page tab directly in the existing reorder dialog. The preview updates as toggles change.