### PR TITLE
Keep channel points balance live

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChannelPointsBalanceReducer.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChannelPointsBalanceReducer.kt
@@ -1,0 +1,198 @@
+package com.github.andreyasadchy.xtra.ui.chat
+
+import com.github.andreyasadchy.xtra.util.chat.ChannelPointsBalanceEvent
+
+/**
+ * Keeps the viewer's balance live while GQL catches up.
+ *
+ * A delta is retained as a pending adjustment until a matching absolute
+ * snapshot arrives. That is what prevents an older ChannelPointsContext
+ * response, or the matching Hermes spend notification, from undoing or
+ * repeating a change already shown to the user.
+ */
+class ChannelPointsBalanceReducer(
+    private val pendingAdjustmentWindowMillis: Long = DEFAULT_PENDING_ADJUSTMENT_WINDOW_MILLIS,
+) {
+    data class PendingAdjustment(
+        val channelId: String,
+        val type: ChannelPointsBalanceEvent.Type,
+        val amount: Int,
+        val appliedAtMs: Long,
+        val transactionId: String? = null,
+    )
+
+    data class State(
+        val balance: Int? = null,
+        val revision: Long = 0L,
+        val pendingAdjustments: List<PendingAdjustment> = emptyList(),
+        val handledMessageIds: Set<String> = emptySet(),
+    )
+
+    fun applyLiveEvent(
+        state: State,
+        event: ChannelPointsBalanceEvent,
+        nowMs: Long,
+    ): State {
+        val messageId = event.messageId?.takeIf { it.isNotBlank() }
+        if (messageId != null && messageId in state.handledMessageIds) return state
+
+        val handledMessageIds = messageId?.let {
+            (state.handledMessageIds + it).toList().takeLast(MAX_HANDLED_MESSAGE_IDS).toSet()
+        } ?: state.handledMessageIds
+        val activePending = pruneExpired(state.pendingAdjustments, nowMs)
+        val nextRevision = state.revision + 1L
+        val absoluteBalance = event.absoluteBalance
+        if (absoluteBalance != null) {
+            return state.copy(
+                balance = absoluteBalance,
+                revision = nextRevision,
+                pendingAdjustments = if (event.channelId == null) {
+                    emptyList()
+                } else {
+                    activePending.filter { it.channelId != event.channelId }
+                },
+                handledMessageIds = handledMessageIds,
+            )
+        }
+
+        val amount = event.delta?.takeIf { it > 0 }
+        if (amount == null || event.channelId.isNullOrBlank()) {
+            return state.copy(
+                revision = nextRevision,
+                pendingAdjustments = activePending,
+                handledMessageIds = handledMessageIds,
+            )
+        }
+
+        val matchingPending = activePending.firstOrNull { pending ->
+            pending.channelId == event.channelId &&
+                pending.type == event.type &&
+                pending.amount == amount &&
+                ((event.transactionId != null && pending.transactionId != null &&
+                    event.transactionId == pending.transactionId) ||
+                    nowMs - pending.appliedAtMs in 0..pendingAdjustmentWindowMillis)
+        }
+        val nextPending = if (matchingPending != null) {
+            activePending - matchingPending
+        } else {
+            activePending + PendingAdjustment(
+                channelId = event.channelId,
+                type = event.type,
+                amount = amount,
+                appliedAtMs = nowMs,
+                transactionId = event.transactionId,
+            )
+        }
+        val nextBalance = if (matchingPending == null) {
+            state.balance?.let { balance -> applyDelta(balance, event.type, amount) }
+        } else {
+            state.balance
+        }
+        return state.copy(
+            balance = nextBalance,
+            revision = nextRevision,
+            pendingAdjustments = nextPending,
+            handledMessageIds = handledMessageIds,
+        )
+    }
+
+    fun applyLocalSpend(
+        state: State,
+        channelId: String,
+        amount: Int,
+        nowMs: Long,
+        transactionId: String? = null,
+    ): State {
+        if (channelId.isBlank() || amount <= 0) return state
+        val activePending = pruneExpired(state.pendingAdjustments, nowMs)
+        return state.copy(
+            balance = state.balance?.let { (it - amount).coerceAtLeast(0) },
+            revision = state.revision + 1L,
+            pendingAdjustments = activePending + PendingAdjustment(
+                channelId = channelId,
+                type = ChannelPointsBalanceEvent.Type.SPENT,
+                amount = amount,
+                appliedAtMs = nowMs,
+                transactionId = transactionId,
+            ),
+        )
+    }
+
+    /**
+     * Applies a GQL balance only when it is not an older view of a live
+     * mutation. Catalog data can still be merged by the caller in either
+     * case.
+     */
+    fun applySnapshot(
+        state: State,
+        snapshotBalance: Int,
+        nowMs: Long,
+        requestRevision: Long? = null,
+    ): State {
+        if (requestRevision != null && requestRevision < state.revision) return state
+        val activePending = pruneExpired(state.pendingAdjustments, nowMs)
+        if (activePending.isEmpty()) {
+            return state.copy(
+                balance = snapshotBalance,
+                revision = state.revision + 1L,
+                pendingAdjustments = emptyList(),
+            )
+        }
+
+        val currentBalance = state.balance
+        val pendingDelta = activePending.sumOf { signedDelta(it.type, it.amount) }
+        val preMutationBalance = currentBalance?.let { it - pendingDelta }
+        val pendingExpired = activePending.all {
+            nowMs - it.appliedAtMs > pendingAdjustmentWindowMillis
+        }
+        return when {
+            snapshotBalance == currentBalance -> state.copy(
+                balance = snapshotBalance,
+                revision = state.revision + 1L,
+                // Keep the short-lived adjustment so a Hermes confirmation
+                // that arrives after this snapshot cannot subtract twice.
+                pendingAdjustments = activePending,
+            )
+            currentBalance == null && !pendingExpired -> state.copy(
+                balance = (snapshotBalance + pendingDelta).coerceAtLeast(0),
+                revision = state.revision + 1L,
+                pendingAdjustments = activePending,
+            )
+            !pendingExpired && snapshotBalance == preMutationBalance -> state
+            !pendingExpired -> state
+            else -> state.copy(
+                balance = snapshotBalance,
+                revision = state.revision + 1L,
+                pendingAdjustments = emptyList(),
+            )
+        }
+    }
+
+    fun reset(): State = State()
+
+    private fun pruneExpired(
+        pending: List<PendingAdjustment>,
+        nowMs: Long,
+    ): List<PendingAdjustment> = pending.filter {
+        nowMs - it.appliedAtMs <= pendingAdjustmentWindowMillis
+    }
+
+    private fun signedDelta(type: ChannelPointsBalanceEvent.Type, amount: Int): Int = when (type) {
+        ChannelPointsBalanceEvent.Type.EARNED -> amount
+        ChannelPointsBalanceEvent.Type.SPENT -> -amount
+    }
+
+    private fun applyDelta(
+        balance: Int,
+        type: ChannelPointsBalanceEvent.Type,
+        amount: Int,
+    ): Int = when (type) {
+        ChannelPointsBalanceEvent.Type.EARNED -> balance + amount
+        ChannelPointsBalanceEvent.Type.SPENT -> (balance - amount).coerceAtLeast(0)
+    }
+
+    private companion object {
+        const val DEFAULT_PENDING_ADJUSTMENT_WINDOW_MILLIS = 30_000L
+        const val MAX_HANDLED_MESSAGE_IDS = 200
+    }
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChannelPointsBalanceReducer.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChannelPointsBalanceReducer.kt
@@ -5,20 +5,26 @@ import com.github.andreyasadchy.xtra.util.chat.ChannelPointsBalanceEvent
 /**
  * Keeps the viewer's balance live while GQL catches up.
  *
- * A delta is retained as a pending adjustment until a matching absolute
- * snapshot arrives. That is what prevents an older ChannelPointsContext
- * response, or the matching Hermes spend notification, from undoing or
- * repeating a change already shown to the user.
+ * A delta is retained as a pending adjustment until ChannelPointsContext
+ * catches up. That prevents an older snapshot from undoing a change already
+ * shown to the user. Local spends also stay pending until Hermes confirms
+ * them, while each distinct live event is applied exactly once.
  */
 class ChannelPointsBalanceReducer(
     private val pendingAdjustmentWindowMillis: Long = DEFAULT_PENDING_ADJUSTMENT_WINDOW_MILLIS,
 ) {
+    enum class PendingOrigin {
+        LOCAL_OPTIMISTIC,
+        LIVE_EVENT,
+    }
+
     data class PendingAdjustment(
         val channelId: String,
         val type: ChannelPointsBalanceEvent.Type,
         val amount: Int,
         val appliedAtMs: Long,
         val transactionId: String? = null,
+        val origin: PendingOrigin,
     )
 
     data class State(
@@ -64,14 +70,12 @@ class ChannelPointsBalanceReducer(
             )
         }
 
-        val matchingPending = activePending.firstOrNull { pending ->
-            pending.channelId == event.channelId &&
-                pending.type == event.type &&
-                pending.amount == amount &&
-                ((event.transactionId != null && pending.transactionId != null &&
-                    event.transactionId == pending.transactionId) ||
-                    nowMs - pending.appliedAtMs in 0..pendingAdjustmentWindowMillis)
-        }
+        val matchingPending = findMatchingLocalSpend(
+            pending = activePending,
+            event = event,
+            amount = amount,
+            nowMs = nowMs,
+        )
         val nextPending = if (matchingPending != null) {
             activePending - matchingPending
         } else {
@@ -81,6 +85,7 @@ class ChannelPointsBalanceReducer(
                 amount = amount,
                 appliedAtMs = nowMs,
                 transactionId = event.transactionId,
+                origin = PendingOrigin.LIVE_EVENT,
             )
         }
         val nextBalance = if (matchingPending == null) {
@@ -114,6 +119,7 @@ class ChannelPointsBalanceReducer(
                 amount = amount,
                 appliedAtMs = nowMs,
                 transactionId = transactionId,
+                origin = PendingOrigin.LOCAL_OPTIMISTIC,
             ),
         )
     }
@@ -145,18 +151,30 @@ class ChannelPointsBalanceReducer(
         val pendingExpired = activePending.all {
             nowMs - it.appliedAtMs > pendingAdjustmentWindowMillis
         }
+        if (currentBalance == null) {
+            return state.copy(
+                // The snapshot is the first baseline. A pre-baseline live
+                // event may already be included in it, so never add pending
+                // deltas to this value.
+                balance = snapshotBalance,
+                revision = state.revision + 1L,
+                // Keep local spends matchable until Hermes confirms them.
+                // Live events only caused this reconciliation and must not
+                // affect the next snapshot's arithmetic.
+                pendingAdjustments = activePending.filter {
+                    it.origin == PendingOrigin.LOCAL_OPTIMISTIC
+                },
+            )
+        }
         return when {
             snapshotBalance == currentBalance -> state.copy(
                 balance = snapshotBalance,
                 revision = state.revision + 1L,
-                // Keep the short-lived adjustment so a Hermes confirmation
-                // that arrives after this snapshot cannot subtract twice.
-                pendingAdjustments = activePending,
-            )
-            currentBalance == null && !pendingExpired -> state.copy(
-                balance = (snapshotBalance + pendingDelta).coerceAtLeast(0),
-                revision = state.revision + 1L,
-                pendingAdjustments = activePending,
+                // A matching snapshot confirms live events. Local spends
+                // remain until their Hermes confirmation arrives.
+                pendingAdjustments = activePending.filter {
+                    it.origin == PendingOrigin.LOCAL_OPTIMISTIC
+                },
             )
             !pendingExpired && snapshotBalance == preMutationBalance -> state
             !pendingExpired -> state
@@ -165,6 +183,27 @@ class ChannelPointsBalanceReducer(
                 revision = state.revision + 1L,
                 pendingAdjustments = emptyList(),
             )
+        }
+    }
+
+    private fun findMatchingLocalSpend(
+        pending: List<PendingAdjustment>,
+        event: ChannelPointsBalanceEvent,
+        amount: Int,
+        nowMs: Long,
+    ): PendingAdjustment? {
+        if (event.type != ChannelPointsBalanceEvent.Type.SPENT) return null
+        val localSpends = pending.filter {
+            it.origin == PendingOrigin.LOCAL_OPTIMISTIC &&
+                it.channelId == event.channelId &&
+                it.type == event.type &&
+                it.amount == amount
+        }
+        if (event.transactionId != null) {
+            return localSpends.firstOrNull { it.transactionId == event.transactionId }
+        }
+        return localSpends.firstOrNull {
+            nowMs - it.appliedAtMs in 0..pendingAdjustmentWindowMillis
         }
     }
 

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChannelPointsBalanceReducer.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChannelPointsBalanceReducer.kt
@@ -200,9 +200,12 @@ class ChannelPointsBalanceReducer(
                 it.amount == amount
         }
         if (event.transactionId != null) {
-            return localSpends.firstOrNull { it.transactionId == event.transactionId }
+            localSpends.firstOrNull {
+                it.transactionId != null && it.transactionId == event.transactionId
+            }?.let { return it }
         }
         return localSpends.firstOrNull {
+            it.transactionId == null &&
             nowMs - it.appliedAtMs in 0..pendingAdjustmentWindowMillis
         }
     }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatViewModel.kt
@@ -62,6 +62,7 @@ import com.github.andreyasadchy.xtra.util.chat.ChatReadWebSocket
 import com.github.andreyasadchy.xtra.util.chat.ChatUtils
 import com.github.andreyasadchy.xtra.util.chat.ChatWriteIRCSocket
 import com.github.andreyasadchy.xtra.util.chat.ChatWriteWebSocket
+import com.github.andreyasadchy.xtra.util.chat.ChannelPointsBalanceEvent
 import com.github.andreyasadchy.xtra.util.chat.EventSubConnectionAnnouncementState
 import com.github.andreyasadchy.xtra.util.chat.EventSubChatConnectionState
 import com.github.andreyasadchy.xtra.util.chat.EventSubChatConnectionStatus
@@ -170,6 +171,7 @@ class ChatViewModel(
     private var hermesWebSocket: HermesWebSocket? = null
     private var pubSubJob: Job? = null
     private var channelPointsJob: Job? = null
+    private var channelPointsReconciliationJob: Job? = null
     private var claimJob: Job? = null
     private var watchStreakWorkerJob: Job? = null
     private var watchStreakRefreshJob: Job? = null
@@ -202,6 +204,9 @@ class ChatViewModel(
     private var activeChannelLogin: String? = null
     private var loggedInUserId: String? = null
     private var loggedInUserLogin: String? = null
+    private val channelPointsBalanceReducer = ChannelPointsBalanceReducer()
+    private val channelPointsBalanceLock = Any()
+    private var channelPointsBalanceState = ChannelPointsBalanceReducer.State()
     private var slowModeLastMessageElapsedRealtime: Long? = null
     private var slowModeCountdownJob: Job? = null
     private val slowModeMessageDedupe = SlowModeMessageDedupe()
@@ -1299,9 +1304,72 @@ class ChatViewModel(
         }
     }
 
-    private fun updateChannelPoints(response: ChannelPointContextResponse) {
+    private fun channelPointsBalanceRevision(): Long = synchronized(channelPointsBalanceLock) {
+        channelPointsBalanceState.revision
+    }
+
+    private fun resetChannelPointsBalance() {
+        synchronized(channelPointsBalanceLock) {
+            channelPointsBalanceState = channelPointsBalanceReducer.reset()
+        }
+    }
+
+    private fun applyChannelPointsBalanceEvent(event: ChannelPointsBalanceEvent): Boolean {
+        val nextState = synchronized(channelPointsBalanceLock) {
+            channelPointsBalanceState = channelPointsBalanceReducer.applyLiveEvent(
+                state = channelPointsBalanceState,
+                event = event,
+                nowMs = System.currentTimeMillis(),
+            )
+            channelPointsBalanceState
+        }
+        val current = channelPoints.value ?: return false
+        val balance = nextState.balance ?: return false
+        if (current.balance != balance) {
+            channelPoints.value = current.copy(balance = balance)
+        }
+        return true
+    }
+
+    private fun applyLocalChannelPointsSpend(
+        channelId: String,
+        amount: Int,
+        transactionId: String? = null,
+    ) {
+        val nextState = synchronized(channelPointsBalanceLock) {
+            channelPointsBalanceState = channelPointsBalanceReducer.applyLocalSpend(
+                state = channelPointsBalanceState,
+                channelId = channelId,
+                amount = amount,
+                nowMs = System.currentTimeMillis(),
+                transactionId = transactionId,
+            )
+            channelPointsBalanceState
+        }
+        val current = channelPoints.value ?: return
+        nextState.balance?.let { balance ->
+            if (current.balance != balance) {
+                channelPoints.value = current.copy(balance = balance)
+            }
+        }
+    }
+
+    private fun updateChannelPoints(
+        response: ChannelPointContextResponse,
+        requestRevision: Long? = null,
+    ) {
         val channel = response.data?.community?.channel ?: return
-        val balance = channel.self.communityPoints?.balance ?: return
+        val snapshotBalance = channel.self.communityPoints?.balance ?: return
+        val balanceState = synchronized(channelPointsBalanceLock) {
+            channelPointsBalanceState = channelPointsBalanceReducer.applySnapshot(
+                state = channelPointsBalanceState,
+                snapshotBalance = snapshotBalance,
+                nowMs = System.currentTimeMillis(),
+                requestRevision = requestRevision,
+            )
+            channelPointsBalanceState
+        }
+        val balance = balanceState.balance ?: snapshotBalance
         val settings = channel.communityPointsSettings
         updateChannelPointModifiedEmotes(settings)
         val hasModifiedEmotes = synchronized(channelPointModifiedEmotes) {
@@ -1731,22 +1799,52 @@ class ChatViewModel(
         networkLibrary: String?,
         gqlHeaders: Map<String, String>,
         channelLogin: String?,
+        delayMillis: Long = 0L,
     ) {
         if (channelLogin.isNullOrBlank() || gqlHeaders[C.HEADER_TOKEN].isNullOrBlank()) {
             return
         }
         val expectedChannelId = activeChannelId
+        val requestRevision = channelPointsBalanceRevision()
         channelPointsJob?.cancel()
         channelPointsJob = viewModelScope.launch {
             try {
+                if (delayMillis > 0L) delay(delayMillis)
                 val response = graphQLRepository.loadChannelPointsContext(networkLibrary, gqlHeaders, channelLogin)
                 if (activeChannelId != expectedChannelId || activeChannelLogin != channelLogin) {
                     return@launch
                 }
-                updateChannelPoints(response)
+                updateChannelPoints(response, requestRevision)
             } catch (_: Exception) {
             }
         }
+    }
+
+    private fun scheduleChannelPointsReconciliation(
+        networkLibrary: String?,
+        gqlHeaders: Map<String, String>,
+        channelLogin: String?,
+    ) {
+        channelPointsReconciliationJob?.cancel()
+        val expectedChannelId = activeChannelId
+        val expectedChannelLogin = channelLogin
+        lateinit var reconciliationJob: Job
+        reconciliationJob = viewModelScope.launch {
+            try {
+                for (delayMillis in CHANNEL_POINTS_RECONCILIATION_DELAYS_MILLIS) {
+                    delay(delayMillis)
+                    if (activeChannelId != expectedChannelId || activeChannelLogin != expectedChannelLogin) {
+                        return@launch
+                    }
+                    loadChannelPoints(networkLibrary, gqlHeaders, expectedChannelLogin)
+                }
+            } finally {
+                if (channelPointsReconciliationJob === reconciliationJob) {
+                    channelPointsReconciliationJob = null
+                }
+            }
+        }
+        channelPointsReconciliationJob = reconciliationJob
     }
 
     fun redeemChannelPointReward(reward: ChannelPointRewardInfo, textInput: String?, emoteId: String?) {
@@ -1827,6 +1925,7 @@ class ChatViewModel(
                         ),
                     )
                 } else {
+                    applyLocalChannelPointsSpend(channelId, reward.cost)
                     channelPointRedemptionEvents.send(
                         ChannelPointRedemptionResult(
                             reward.title,
@@ -1835,6 +1934,7 @@ class ChatViewModel(
                         ),
                     )
                     loadChannelPoints(networkLibrary, gqlHeaders, channelLogin)
+                    scheduleChannelPointsReconciliation(networkLibrary, gqlHeaders, channelLogin)
                 }
             } catch (e: CancellationException) {
                 throw e
@@ -2054,6 +2154,8 @@ class ChatViewModel(
         val networkLibrary = applicationContext.prefs().getString(C.NETWORK_LIBRARY, C.OKHTTP)
         val accountId = applicationContext.tokenPrefs().getString(C.USER_ID, null)
         val accountLogin = applicationContext.tokenPrefs().getString(C.USERNAME, null)
+        val gqlWebToken = applicationContext.tokenPrefs().getString(C.GQL_TOKEN_WEB, null)?.takeIf { it.isNotBlank() }
+        val hasHermesUserAuth = !accountId.isNullOrBlank() && !gqlWebToken.isNullOrBlank()
         loggedInUserId = accountId
         loggedInUserLogin = accountLogin
         val isLoggedIn = !accountLogin.isNullOrBlank() && (!gqlHeaders[C.HEADER_TOKEN].isNullOrBlank() || !helixHeaders[C.HEADER_TOKEN].isNullOrBlank())
@@ -2128,22 +2230,27 @@ class ChatViewModel(
         if (usePubSub && !channelId.isNullOrBlank()) {
             val collectPoints = applicationContext.prefs().getBoolean(C.CHAT_POINTS_COLLECT, true)
             val gqlWebClientId = applicationContext.prefs().getString(C.GQL_CLIENT_ID_WEB, C.DEFAULT_GQL_CLIENT_ID_WEB)
-            val gqlWebToken = applicationContext.tokenPrefs().getString(C.GQL_TOKEN_WEB, null)
             val notifyPoints = applicationContext.prefs().getBoolean(C.CHAT_POINTS_NOTIFY, false)
             val showRaids = applicationContext.prefs().getBoolean(C.CHAT_RAIDS_SHOW, true)
             hermesWebSocket = HermesWebSocket(
                 channelId = channelId,
                 userId = accountId,
                 gqlClientId = gqlWebClientId,
-                gqlToken = gqlWebToken?.takeIf { it.isNotBlank() },
+                gqlToken = gqlWebToken,
                 collectPoints = collectPoints,
-                listenForPoints = isLoggedIn,
+                listenForPoints = hasHermesUserAuth,
                 showRaids = showRaids,
                 showPolls = showPolls,
                 showPredictions = showPredictions,
                 trustManager = trustManager,
                 listener = PubSubListener(channelLogin, collectPoints, notifyPoints, showRaids, showPolls, showPredictions, networkLibrary, gqlHeaders, isLoggedIn, accountId, channelId, showWebSocketDebugInfo, sessionToken)
             )
+            if (isLoggedIn && !hasHermesUserAuth) {
+                Log.w(
+                    WatchCreditTelemetry.LOG_TAG,
+                    "Hermes user-points subscription skipped: GQL web token or account id is missing",
+                )
+            }
             pubSubJob = hermesWebSocket?.connect(viewModelScope)
         }
         // Get Polls/Predictions is broadcaster-scoped in Helix. Only reconcile
@@ -2199,6 +2306,8 @@ class ChatViewModel(
         }
         channelPointsJob?.cancel()
         channelPointsJob = null
+        channelPointsReconciliationJob?.cancel()
+        channelPointsReconciliationJob = null
         claimJob?.cancel()
         claimJob = null
         watchStreakRefreshJob?.cancel()
@@ -2206,6 +2315,7 @@ class ChatViewModel(
         watchStreakWorkerJob?.cancel()
         watchStreakWorkerJob = null
         pendingWatchStreakRequests.clear()
+        resetChannelPointsBalance()
         channelPoints.value = null
         watchStreak.value = null
         clearPollPresentation()
@@ -2986,6 +3096,8 @@ class ChatViewModel(
                 isActiveWatchCreditSession() &&
                 !channelId.isNullOrBlank()
             ) {
+                Log.d(WatchCreditTelemetry.LOG_TAG, "Hermes re-subscription healing channel-points balance and watch-streak")
+                loadChannelPoints(networkLibrary, gqlHeaders, channelLogin)
                 Log.d(WatchCreditTelemetry.LOG_TAG, "Hermes re-subscription healing watch-streak")
                 loadWatchStreak(networkLibrary, gqlHeaders, channelId)
             }
@@ -3042,13 +3154,23 @@ class ChatViewModel(
             }
             val result = PubSubUtils.parsePointsEarned(message)
             val points = result.first
-            val messageChannelId = result.second
+            val balanceEvent = PubSubUtils.parseChannelPointsBalanceEvent(
+                message,
+                ChannelPointsBalanceEvent.Type.EARNED,
+            )
+            val messageChannelId = balanceEvent?.channelId ?: result.second
             Log.d(
                 WatchCreditTelemetry.LOG_TAG,
                 "Hermes points-earned channelMatched=${channelId == messageChannelId} channelIdPresent=${!messageChannelId.isNullOrBlank()} reason=${points.reasonCode ?: "unknown"}",
             )
-            if (channelId == messageChannelId) {
-                loadChannelPoints(networkLibrary, gqlHeaders, channelLogin)
+            if (channelId == messageChannelId && balanceEvent != null) {
+                applyChannelPointsBalanceEvent(balanceEvent)
+                scheduleChannelPointsReconciliation(networkLibrary, gqlHeaders, channelLogin)
+                if (balanceEvent.reasonCode.equals("WATCH_STREAK", ignoreCase = true)) {
+                    balanceEvent.streakCount?.let { streakCount ->
+                        updateWatchStreak(streakCount, balanceEvent.delta)
+                    }
+                }
             }
             watchStreakInvalidationForPointsEarned(
                 activeChannelId = channelId,
@@ -3075,6 +3197,23 @@ class ChatViewModel(
                         fullMsg = points.fullMsg
                     ))
                 }
+            }
+        }
+
+        override suspend fun onPointsSpent(message: JSONObject) {
+            if (!isActiveWatchCreditSession()) {
+                Log.d(WatchCreditTelemetry.LOG_TAG, "Hermes points-spent ignored for inactive watch session")
+                return
+            }
+            val balanceEvent = PubSubUtils.parsePointsSpent(message)
+            val messageChannelId = balanceEvent?.channelId
+            Log.d(
+                WatchCreditTelemetry.LOG_TAG,
+                "Hermes points-spent channelMatched=${channelId == messageChannelId} channelIdPresent=${!messageChannelId.isNullOrBlank()} amount=${balanceEvent?.delta}",
+            )
+            if (channelId == messageChannelId && balanceEvent != null) {
+                applyChannelPointsBalanceEvent(balanceEvent)
+                scheduleChannelPointsReconciliation(networkLibrary, gqlHeaders, channelLogin)
             }
         }
 
@@ -3755,7 +3894,15 @@ class ChatViewModel(
                     )
                 }
                 if (success && activeChannelLogin == channelLogin) {
+                    activeChannelId?.let { activeId ->
+                        applyLocalChannelPointsSpend(activeId, points, transactionId = predictionId)
+                    }
                     loadChannelPoints(
+                        networkLibrary = networkLibrary,
+                        gqlHeaders = headers,
+                        channelLogin = channelLogin,
+                    )
+                    scheduleChannelPointsReconciliation(
                         networkLibrary = networkLibrary,
                         gqlHeaders = headers,
                         channelLogin = channelLogin,
@@ -5108,6 +5255,7 @@ class ChatViewModel(
 
     companion object {
         private const val WATCH_STREAK_RECONCILIATION_DELAY_MILLIS = 750L
+        private val CHANNEL_POINTS_RECONCILIATION_DELAYS_MILLIS = listOf(750L, 3_000L, 10_000L)
         private const val METERED_CACHE_MAX_AGE_MS = 604_800_000L
         private const val MAX_BADGE_CACHE_FILES = 100
         private const val DEFAULT_REWARD_COLOR = "#9146FF"

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatViewModel.kt
@@ -1338,7 +1338,6 @@ class ChatViewModel(
     private fun applyLocalChannelPointsSpend(
         channelId: String,
         amount: Int,
-        transactionId: String? = null,
     ) {
         synchronized(channelPointsBalanceLock) {
             channelPointsBalanceState = channelPointsBalanceReducer.applyLocalSpend(
@@ -1346,7 +1345,6 @@ class ChatViewModel(
                 channelId = channelId,
                 amount = amount,
                 nowMs = System.currentTimeMillis(),
-                transactionId = transactionId,
             )
             val balance = channelPointsBalanceState.balance
             val current = channelPoints.value
@@ -3897,7 +3895,7 @@ class ChatViewModel(
                 }
                 if (success && activeChannelLogin == channelLogin) {
                     activeChannelId?.let { activeId ->
-                        applyLocalChannelPointsSpend(activeId, points, transactionId = predictionId)
+                        applyLocalChannelPointsSpend(activeId, points)
                     }
                     loadChannelPoints(
                         networkLibrary = networkLibrary,
@@ -5257,7 +5255,7 @@ class ChatViewModel(
 
     companion object {
         private const val WATCH_STREAK_RECONCILIATION_DELAY_MILLIS = 750L
-        private val CHANNEL_POINTS_RECONCILIATION_DELAYS_MILLIS = listOf(750L, 3_000L, 10_000L)
+        private val CHANNEL_POINTS_RECONCILIATION_DELAYS_MILLIS = listOf(750L, 3_000L, 10_000L, 20_000L)
         private const val METERED_CACHE_MAX_AGE_MS = 604_800_000L
         private const val MAX_BADGE_CACHE_FILES = 100
         private const val DEFAULT_REWARD_COLOR = "#9146FF"

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatViewModel.kt
@@ -1311,24 +1311,28 @@ class ChatViewModel(
     private fun resetChannelPointsBalance() {
         synchronized(channelPointsBalanceLock) {
             channelPointsBalanceState = channelPointsBalanceReducer.reset()
+            channelPoints.value = null
         }
     }
 
     private fun applyChannelPointsBalanceEvent(event: ChannelPointsBalanceEvent): Boolean {
-        val nextState = synchronized(channelPointsBalanceLock) {
+        return synchronized(channelPointsBalanceLock) {
             channelPointsBalanceState = channelPointsBalanceReducer.applyLiveEvent(
                 state = channelPointsBalanceState,
                 event = event,
                 nowMs = System.currentTimeMillis(),
             )
-            channelPointsBalanceState
+            val balance = channelPointsBalanceState.balance
+            val current = channelPoints.value
+            if (balance == null || current == null) {
+                false
+            } else {
+                if (current.balance != balance) {
+                    channelPoints.value = current.copy(balance = balance)
+                }
+                true
+            }
         }
-        val current = channelPoints.value ?: return false
-        val balance = nextState.balance ?: return false
-        if (current.balance != balance) {
-            channelPoints.value = current.copy(balance = balance)
-        }
-        return true
     }
 
     private fun applyLocalChannelPointsSpend(
@@ -1336,7 +1340,7 @@ class ChatViewModel(
         amount: Int,
         transactionId: String? = null,
     ) {
-        val nextState = synchronized(channelPointsBalanceLock) {
+        synchronized(channelPointsBalanceLock) {
             channelPointsBalanceState = channelPointsBalanceReducer.applyLocalSpend(
                 state = channelPointsBalanceState,
                 channelId = channelId,
@@ -1344,11 +1348,9 @@ class ChatViewModel(
                 nowMs = System.currentTimeMillis(),
                 transactionId = transactionId,
             )
-            channelPointsBalanceState
-        }
-        val current = channelPoints.value ?: return
-        nextState.balance?.let { balance ->
-            if (current.balance != balance) {
+            val balance = channelPointsBalanceState.balance
+            val current = channelPoints.value
+            if (balance != null && current != null && current.balance != balance) {
                 channelPoints.value = current.copy(balance = balance)
             }
         }
@@ -1360,16 +1362,6 @@ class ChatViewModel(
     ) {
         val channel = response.data?.community?.channel ?: return
         val snapshotBalance = channel.self.communityPoints?.balance ?: return
-        val balanceState = synchronized(channelPointsBalanceLock) {
-            channelPointsBalanceState = channelPointsBalanceReducer.applySnapshot(
-                state = channelPointsBalanceState,
-                snapshotBalance = snapshotBalance,
-                nowMs = System.currentTimeMillis(),
-                requestRevision = requestRevision,
-            )
-            channelPointsBalanceState
-        }
-        val balance = balanceState.balance ?: snapshotBalance
         val settings = channel.communityPointsSettings
         updateChannelPointModifiedEmotes(settings)
         val hasModifiedEmotes = synchronized(channelPointModifiedEmotes) {
@@ -1452,12 +1444,23 @@ class ChatViewModel(
                     WatchStreakReward(streakLength = reward.streakLength ?: index + 2, points = points)
                 }
             }
-        channelPoints.value = ChannelPoints(
-            balance = balance,
-            iconUrl = iconUrl,
-            rewards = rewards,
-            watchStreakRewards = watchStreakRewards,
-        )
+        synchronized(channelPointsBalanceLock) {
+            channelPointsBalanceState = channelPointsBalanceReducer.applySnapshot(
+                state = channelPointsBalanceState,
+                snapshotBalance = snapshotBalance,
+                nowMs = System.currentTimeMillis(),
+                requestRevision = requestRevision,
+            )
+            val balance = channelPointsBalanceState.balance ?: channelPoints.value?.balance
+            if (balance != null) {
+                channelPoints.value = ChannelPoints(
+                    balance = balance,
+                    iconUrl = iconUrl,
+                    rewards = rewards,
+                    watchStreakRewards = watchStreakRewards,
+                )
+            }
+        }
     }
 
     private fun ChannelPointContextResponse.CustomReward.rewardImageUrl(): String? {
@@ -2316,7 +2319,6 @@ class ChatViewModel(
         watchStreakWorkerJob = null
         pendingWatchStreakRequests.clear()
         resetChannelPointsBalance()
-        channelPoints.value = null
         watchStreak.value = null
         clearPollPresentation()
         latestPoll = null

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/chat/HermesWebSocket.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/chat/HermesWebSocket.kt
@@ -1,6 +1,7 @@
 package com.github.andreyasadchy.xtra.util.chat
 
 import android.util.Log
+import com.github.andreyasadchy.xtra.BuildConfig
 import com.github.andreyasadchy.xtra.util.WebSocket
 import com.github.andreyasadchy.xtra.util.watch.WatchCreditTelemetry
 import kotlinx.coroutines.CancellationException
@@ -145,6 +146,7 @@ class HermesWebSocket(
         suspend fun onStreamInfo(message: JSONObject) {}
         suspend fun onRewardMessage(message: JSONObject) {}
         suspend fun onPointsEarned(message: JSONObject) {}
+        suspend fun onPointsSpent(message: JSONObject) {}
         suspend fun onClaimAvailable() {}
         suspend fun onMinuteWatched() {}
         suspend fun onRaidUpdate(message: JSONObject, openStream: Boolean) {}
@@ -202,9 +204,18 @@ class HermesWebSocket(
                                             Log.d(WatchCreditTelemetry.LOG_TAG, "Hermes points-earned received")
                                             listener.onPointsEarned(message)
                                         }
+                                        messageType.startsWith("points-spent") -> {
+                                            Log.d(WatchCreditTelemetry.LOG_TAG, "Hermes points-spent received")
+                                            listener.onPointsSpent(message)
+                                        }
                                         messageType.startsWith("claim-available") -> {
                                             Log.d(WatchCreditTelemetry.LOG_TAG, "Hermes claim-available received")
                                             listener.onClaimAvailable()
+                                        }
+                                        else -> {
+                                            if (BuildConfig.DEBUG) {
+                                                Log.w(WatchCreditTelemetry.LOG_TAG, "Hermes unknown community-points-user event type=$messageType")
+                                            }
                                         }
                                     }
                                 }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/chat/PubSubUtils.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/chat/PubSubUtils.kt
@@ -8,6 +8,26 @@ import com.github.andreyasadchy.xtra.model.chat.Raid
 import org.json.JSONObject
 import kotlin.time.Instant
 
+data class ChannelPointsBalanceEvent(
+    val channelId: String?,
+    val type: Type,
+    /** The event amount as a positive number. The reducer applies the sign. */
+    val delta: Int? = null,
+    val absoluteBalance: Int? = null,
+    val reasonCode: String? = null,
+    val timestamp: Long? = null,
+    val messageId: String? = null,
+    val transactionId: String? = null,
+    val streakCount: Int? = null,
+) {
+    enum class Type {
+        EARNED,
+        SPENT,
+    }
+}
+
+typealias ChannelPointsBalanceEventType = ChannelPointsBalanceEvent.Type
+
 object PubSubUtils {
     fun parsePlaybackMessage(message: JSONObject): PlaybackMessage? {
         val messageType = message.optString("type")
@@ -58,17 +78,94 @@ object PubSubUtils {
     }
 
     fun parsePointsEarned(message: JSONObject): Pair<PointsEarned, String?> {
-        val messageData = message.optJSONObject("data")
-        val messageChannelId = messageData?.optString("channel_id")
-        val pointGain = messageData?.optJSONObject("point_gain")
+        val event = parseChannelPointsBalanceEvent(message, ChannelPointsBalanceEvent.Type.EARNED)
         return Pair(
             PointsEarned(
-                pointsGained = pointGain?.optInt("total_points"),
-                reasonCode = pointGain?.optString("reason_code")?.takeIf { it.isNotBlank() },
-                timestamp = if (messageData?.isNull("timestamp") == false) messageData.optString("timestamp").takeIf { it.isNotBlank() }?.let { Instant.parseOrNull(it)?.toEpochMilliseconds()?.takeIf { ms -> ms > 0 } } else null,
+                pointsGained = event?.delta,
+                reasonCode = event?.reasonCode,
+                timestamp = event?.timestamp,
+                absoluteBalance = event?.absoluteBalance,
+                streakCount = event?.streakCount,
+                messageId = event?.messageId,
                 fullMsg = message.toString()
             ),
-            messageChannelId
+            event?.channelId
+        )
+    }
+
+    fun parsePointsSpent(message: JSONObject): ChannelPointsBalanceEvent? =
+        parseChannelPointsBalanceEvent(message, ChannelPointsBalanceEvent.Type.SPENT)
+
+    /**
+     * Parses the private user-points messages. Twitch has changed the nesting
+     * of these payloads several times, so all fields are optional and common
+     * aliases are checked recursively.
+     */
+    fun parseChannelPointsBalanceEvent(
+        message: JSONObject,
+        type: ChannelPointsBalanceEvent.Type? = null,
+    ): ChannelPointsBalanceEvent? {
+        val eventType = type ?: message.optionalString("type")?.lowercase()?.let { messageType ->
+            when {
+                messageType.startsWith("points-earned") || messageType.startsWith("points_earned") -> ChannelPointsBalanceEvent.Type.EARNED
+                messageType.startsWith("points-spent") || messageType.startsWith("points_spent") -> ChannelPointsBalanceEvent.Type.SPENT
+                else -> null
+            }
+        } ?: return null
+        val data = message.optJSONObject("data")
+        val detail = data?.optJSONObject(if (eventType == ChannelPointsBalanceEvent.Type.EARNED) "point_gain" else "point_spend")
+            ?: data?.optJSONObject(if (eventType == ChannelPointsBalanceEvent.Type.EARNED) "pointGain" else "pointSpend")
+            ?: data?.optJSONObject(if (eventType == ChannelPointsBalanceEvent.Type.EARNED) "points_earned" else "points_spent")
+            ?: data?.optJSONObject("points")
+            ?: message.optJSONObject(if (eventType == ChannelPointsBalanceEvent.Type.EARNED) "point_gain" else "point_spend")
+        val deltaKeys = if (eventType == ChannelPointsBalanceEvent.Type.EARNED) {
+            setOf("total_points", "points", "amount", "points_earned", "points_gained", "value")
+        } else {
+            setOf("total_points", "points", "amount", "cost", "points_spent", "value")
+        }
+        val absoluteBalanceKeys = setOf(
+            "balance",
+            "new_balance",
+            "current_balance",
+            "total_balance",
+            "points_balance",
+            "channel_points_balance",
+        )
+        val reasonKeys = setOf("reason_code", "reasonCode", "reason")
+        val streakKeys = setOf("streak_count", "streakCount", "current_streak", "watch_streak_count")
+        val channelId = findChannelId(message)
+        val delta = detail?.findNumeric(deltaKeys)
+            ?: data?.findNumeric(deltaKeys)
+            ?: message.findNumeric(deltaKeys)
+        val absoluteBalance = detail?.findNumeric(absoluteBalanceKeys)
+            ?: data?.findNumeric(absoluteBalanceKeys)
+            ?: message.findNumeric(absoluteBalanceKeys)
+        val reasonCode = detail?.findString(reasonKeys)
+            ?: data?.findString(reasonKeys)
+            ?: message.findString(reasonKeys)
+        val streakCount = detail?.findNumeric(streakKeys)
+            ?: data?.findNumeric(streakKeys)
+            ?: message.findNumeric(streakKeys)
+        val timestamp = detail?.findTimestamp()
+            ?: data?.findTimestamp()
+            ?: message.findTimestamp()
+        val messageId = detail?.findMessageId()
+            ?: data?.findMessageId()
+            ?: message.findMessageId()
+        val transactionId = detail?.findString(setOf("transaction_id", "transactionId", "redemption_id", "redemptionId"))
+            ?: data?.findString(setOf("transaction_id", "transactionId", "redemption_id", "redemptionId"))
+            ?: message.findString(setOf("transaction_id", "transactionId", "redemption_id", "redemptionId"))
+        if (channelId == null && delta == null && absoluteBalance == null) return null
+        return ChannelPointsBalanceEvent(
+            channelId = channelId,
+            type = eventType,
+            delta = delta?.takeIf { it >= 0 },
+            absoluteBalance = absoluteBalance?.takeIf { it >= 0 },
+            reasonCode = reasonCode,
+            timestamp = timestamp,
+            messageId = messageId,
+            transactionId = transactionId,
+            streakCount = streakCount?.takeIf { it > 0 },
         )
     }
 
@@ -191,6 +288,90 @@ object PubSubUtils {
     private fun JSONObject.optionalString(key: String): String? =
         if (!has(key) || isNull(key)) null else optString(key).takeIf { it.isNotBlank() }
 
+    private fun JSONObject.findString(keys: Set<String>): String? {
+        keys.firstNotNullOfOrNull { optionalString(it) }?.let { return it }
+        val iterator = keys()
+        while (iterator.hasNext()) {
+            when (val value = opt(iterator.next())) {
+                is JSONObject -> value.findString(keys)?.let { return it }
+                is org.json.JSONArray -> {
+                    for (index in 0 until value.length()) {
+                        value.optJSONObject(index)?.findString(keys)?.let { return it }
+                    }
+                }
+            }
+        }
+        return null
+    }
+
+    private fun JSONObject.findNumeric(keys: Set<String>): Int? {
+        keys.firstNotNullOfOrNull { optionalInt(it) }?.let { return it }
+        val iterator = keys()
+        while (iterator.hasNext()) {
+            when (val value = opt(iterator.next())) {
+                is JSONObject -> value.findNumeric(keys)?.let { return it }
+                is org.json.JSONArray -> {
+                    for (index in 0 until value.length()) {
+                        value.optJSONObject(index)?.findNumeric(keys)?.let { return it }
+                    }
+                }
+            }
+        }
+        return null
+    }
+
+    private fun JSONObject.findTimestamp(): Long? {
+        val timestampKeys = setOf("timestamp", "created_at", "createdAt", "event_timestamp", "eventTimestamp")
+        timestampKeys.forEach { key ->
+            if (!has(key) || isNull(key)) return@forEach
+            val value = opt(key)
+            val timestamp = when (value) {
+                null -> null
+                is Number -> value.toLong().let { if (it in 1 until 1_000_000_000_000L) it * 1_000L else it }
+                else -> value.toString().toLongOrNull()?.let { if (it in 1 until 1_000_000_000_000L) it * 1_000L else it }
+                    ?: Instant.parseOrNull(value.toString())?.toEpochMilliseconds()
+            }
+            if (timestamp != null && timestamp > 0) return timestamp
+        }
+        val iterator = keys()
+        while (iterator.hasNext()) {
+            when (val value = opt(iterator.next())) {
+                is JSONObject -> value.findTimestamp()?.let { return it }
+                is org.json.JSONArray -> {
+                    for (index in 0 until value.length()) {
+                        value.optJSONObject(index)?.findTimestamp()?.let { return it }
+                    }
+                }
+            }
+        }
+        return null
+    }
+
+    private fun JSONObject.findMessageId(): String? {
+        findString(setOf("message_id", "messageId", "event_id", "eventId"))?.let { return it }
+        optionalString("id")?.let { return it }
+        return null
+    }
+
+    private fun findChannelId(message: JSONObject): String? {
+        val channelKeys = setOf("channel_id", "channelId", "channelID")
+        channelKeys.firstNotNullOfOrNull { message.optionalString(it) }?.let { return it }
+        (message.opt("channel") as? String)?.takeIf { it.isNotBlank() }?.let { return it }
+        message.optJSONObject("channel")?.findString(setOf("id", "channel_id", "channelId"))?.let { return it }
+        val iterator = message.keys()
+        while (iterator.hasNext()) {
+            when (val value = message.opt(iterator.next())) {
+                is JSONObject -> findChannelId(value)?.let { return it }
+                is org.json.JSONArray -> {
+                    for (index in 0 until value.length()) {
+                        value.optJSONObject(index)?.let { findChannelId(it) }?.let { return it }
+                    }
+                }
+            }
+        }
+        return null
+    }
+
     private fun JSONObject.optionalInt(key: String): Int? {
         if (!has(key) || isNull(key)) return null
         return opt(key)?.toString()?.toDoubleOrNull()?.toInt()
@@ -309,6 +490,9 @@ object PubSubUtils {
         val pointsGained: Int? = null,
         val reasonCode: String? = null,
         val timestamp: Long? = null,
+        val absoluteBalance: Int? = null,
+        val streakCount: Int? = null,
+        val messageId: String? = null,
         val fullMsg: String? = null,
     )
 }

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/ChannelPointsBalanceReducerTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/ChannelPointsBalanceReducerTest.kt
@@ -28,20 +28,7 @@ class ChannelPointsBalanceReducerTest {
 
         val fresh = reducer.applySnapshot(stale, snapshotBalance = 1_300, nowMs = 1_200L)
         assertEquals(1_300, fresh.balance)
-        assertTrue(fresh.pendingAdjustments.isNotEmpty())
-
-        val confirmed = reducer.applyLiveEvent(
-            fresh,
-            ChannelPointsBalanceEvent(
-                channelId = "channel-100",
-                type = ChannelPointsBalanceEvent.Type.EARNED,
-                delta = 300,
-                messageId = "earn-1",
-            ),
-            nowMs = 1_300L,
-        )
-        assertEquals(1_300, confirmed.balance)
-        assertTrue(confirmed.pendingAdjustments.isEmpty())
+        assertTrue(fresh.pendingAdjustments.isEmpty())
     }
 
     @Test
@@ -93,5 +80,103 @@ class ChannelPointsBalanceReducerTest {
         )
         assertEquals(999, authoritative.balance)
         assertTrue(authoritative.pendingAdjustments.isEmpty())
+    }
+
+    @Test
+    fun firstSnapshotEstablishesBaselineAfterLiveEventArrives() {
+        val live = reducer.applyLiveEvent(
+            ChannelPointsBalanceReducer.State(),
+            ChannelPointsBalanceEvent(
+                channelId = "channel-100",
+                type = ChannelPointsBalanceEvent.Type.EARNED,
+                delta = 10,
+                messageId = "earn-before-baseline",
+            ),
+            nowMs = 4_000L,
+        )
+
+        val baseline = reducer.applySnapshot(live, snapshotBalance = 1_010, nowMs = 4_100L)
+
+        assertEquals(1_010, baseline.balance)
+    }
+
+    @Test
+    fun snapshotStartedBeforeLiveEventCannotReplaceNewerBalance() {
+        val baseline = reducer.applySnapshot(
+            ChannelPointsBalanceReducer.State(),
+            snapshotBalance = 1_000,
+            nowMs = 4_500L,
+        )
+        val live = reducer.applyLiveEvent(
+            baseline,
+            ChannelPointsBalanceEvent(
+                channelId = "channel-100",
+                type = ChannelPointsBalanceEvent.Type.EARNED,
+                delta = 10,
+                messageId = "earn-after-snapshot-request",
+            ),
+            nowMs = 4_600L,
+        )
+
+        val stale = reducer.applySnapshot(
+            live,
+            snapshotBalance = 1_000,
+            nowMs = 4_700L,
+            requestRevision = baseline.revision,
+        )
+
+        assertEquals(1_010, stale.balance)
+    }
+
+    @Test
+    fun distinctSameValueSpentEventsAreBothApplied() {
+        val first = reducer.applyLiveEvent(
+            ChannelPointsBalanceReducer.State(balance = 1_000),
+            ChannelPointsBalanceEvent(
+                channelId = "channel-100",
+                type = ChannelPointsBalanceEvent.Type.SPENT,
+                delta = 100,
+                messageId = "spend-1",
+            ),
+            nowMs = 5_000L,
+        )
+        val second = reducer.applyLiveEvent(
+            first,
+            ChannelPointsBalanceEvent(
+                channelId = "channel-100",
+                type = ChannelPointsBalanceEvent.Type.SPENT,
+                delta = 100,
+                messageId = "spend-2",
+            ),
+            nowMs = 10_000L,
+        )
+
+        assertEquals(800, second.balance)
+    }
+
+    @Test
+    fun distinctSameValueEarnedEventsAreBothApplied() {
+        val first = reducer.applyLiveEvent(
+            ChannelPointsBalanceReducer.State(balance = 1_000),
+            ChannelPointsBalanceEvent(
+                channelId = "channel-100",
+                type = ChannelPointsBalanceEvent.Type.EARNED,
+                delta = 10,
+                messageId = "earn-1",
+            ),
+            nowMs = 6_000L,
+        )
+        val second = reducer.applyLiveEvent(
+            first,
+            ChannelPointsBalanceEvent(
+                channelId = "channel-100",
+                type = ChannelPointsBalanceEvent.Type.EARNED,
+                delta = 10,
+                messageId = "earn-2",
+            ),
+            nowMs = 11_000L,
+        )
+
+        assertEquals(1_020, second.balance)
     }
 }

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/ChannelPointsBalanceReducerTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/ChannelPointsBalanceReducerTest.kt
@@ -38,7 +38,6 @@ class ChannelPointsBalanceReducerTest {
             channelId = "channel-100",
             amount = 500,
             nowMs = 2_000L,
-            transactionId = "redemption-1",
         )
         assertEquals(500, local.balance)
 
@@ -53,6 +52,32 @@ class ChannelPointsBalanceReducerTest {
             ),
             nowMs = 2_100L,
         )
+        assertEquals(500, confirmed.balance)
+        assertTrue(confirmed.pendingAdjustments.isEmpty())
+    }
+
+    @Test
+    fun localSpendWithoutServerIdMatchesHermesEventWithServerId() {
+        val local = reducer.applyLocalSpend(
+            state = ChannelPointsBalanceReducer.State(balance = 1_000),
+            channelId = "channel-100",
+            amount = 500,
+            nowMs = 2_500L,
+        )
+        assertEquals(null, local.pendingAdjustments.single().transactionId)
+
+        val confirmed = reducer.applyLiveEvent(
+            local,
+            ChannelPointsBalanceEvent(
+                channelId = "channel-100",
+                type = ChannelPointsBalanceEvent.Type.SPENT,
+                delta = 500,
+                transactionId = "redemption-123",
+                messageId = "spend-with-server-id",
+            ),
+            nowMs = 2_600L,
+        )
+
         assertEquals(500, confirmed.balance)
         assertTrue(confirmed.pendingAdjustments.isEmpty())
     }

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/ChannelPointsBalanceReducerTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/ChannelPointsBalanceReducerTest.kt
@@ -1,0 +1,97 @@
+package com.github.andreyasadchy.xtra.ui.chat
+
+import com.github.andreyasadchy.xtra.util.chat.ChannelPointsBalanceEvent
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ChannelPointsBalanceReducerTest {
+    private val reducer = ChannelPointsBalanceReducer()
+
+    @Test
+    fun liveEarnChangesBalanceBeforeGqlAndStaleSnapshotCannotRollItBack() {
+        val live = reducer.applyLiveEvent(
+            ChannelPointsBalanceReducer.State(balance = 1_000),
+            ChannelPointsBalanceEvent(
+                channelId = "channel-100",
+                type = ChannelPointsBalanceEvent.Type.EARNED,
+                delta = 300,
+                messageId = "earn-confirmation",
+            ),
+            nowMs = 1_000L,
+        )
+
+        assertEquals(1_300, live.balance)
+        assertTrue(live.pendingAdjustments.isNotEmpty())
+        val stale = reducer.applySnapshot(live, snapshotBalance = 1_000, nowMs = 1_100L)
+        assertEquals(1_300, stale.balance)
+
+        val fresh = reducer.applySnapshot(stale, snapshotBalance = 1_300, nowMs = 1_200L)
+        assertEquals(1_300, fresh.balance)
+        assertTrue(fresh.pendingAdjustments.isNotEmpty())
+
+        val confirmed = reducer.applyLiveEvent(
+            fresh,
+            ChannelPointsBalanceEvent(
+                channelId = "channel-100",
+                type = ChannelPointsBalanceEvent.Type.EARNED,
+                delta = 300,
+                messageId = "earn-1",
+            ),
+            nowMs = 1_300L,
+        )
+        assertEquals(1_300, confirmed.balance)
+        assertTrue(confirmed.pendingAdjustments.isEmpty())
+    }
+
+    @Test
+    fun localSpendIsImmediateAndHermesConfirmationIsNotSubtractedTwice() {
+        val local = reducer.applyLocalSpend(
+            state = ChannelPointsBalanceReducer.State(balance = 1_000),
+            channelId = "channel-100",
+            amount = 500,
+            nowMs = 2_000L,
+            transactionId = "redemption-1",
+        )
+        assertEquals(500, local.balance)
+
+        val snapshotConfirmed = reducer.applySnapshot(local, snapshotBalance = 500, nowMs = 2_050L)
+        val confirmed = reducer.applyLiveEvent(
+            snapshotConfirmed,
+            ChannelPointsBalanceEvent(
+                channelId = "channel-100",
+                type = ChannelPointsBalanceEvent.Type.SPENT,
+                delta = 500,
+                messageId = "spend-1",
+            ),
+            nowMs = 2_100L,
+        )
+        assertEquals(500, confirmed.balance)
+        assertTrue(confirmed.pendingAdjustments.isEmpty())
+    }
+
+    @Test
+    fun duplicateMessageAndAbsoluteBalanceAreIdempotent() {
+        val event = ChannelPointsBalanceEvent(
+            channelId = "channel-100",
+            type = ChannelPointsBalanceEvent.Type.EARNED,
+            delta = 10,
+            messageId = "earn-1",
+        )
+        val first = reducer.applyLiveEvent(
+            ChannelPointsBalanceReducer.State(balance = 100),
+            event,
+            nowMs = 3_000L,
+        )
+        val duplicate = reducer.applyLiveEvent(first, event, nowMs = 3_100L)
+        assertEquals(first, duplicate)
+
+        val authoritative = reducer.applyLiveEvent(
+            duplicate,
+            event.copy(absoluteBalance = 999, messageId = "earn-2"),
+            nowMs = 3_200L,
+        )
+        assertEquals(999, authoritative.balance)
+        assertTrue(authoritative.pendingAdjustments.isEmpty())
+    }
+}

--- a/app/src/test/java/com/github/andreyasadchy/xtra/util/chat/PubSubUtilsTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/util/chat/PubSubUtilsTest.kt
@@ -2,6 +2,7 @@ package com.github.andreyasadchy.xtra.util.chat
 
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Test
 
 class PubSubUtilsTest {
@@ -40,5 +41,71 @@ class PubSubUtilsTest {
         )
 
         assertEquals("WATCH", points.reasonCode)
+    }
+
+    @Test
+    fun parsesEarnedAbsoluteBalanceAndStreakVariant() {
+        val event = PubSubUtils.parseChannelPointsBalanceEvent(
+            JSONObject(
+                """
+                {
+                  "type": "points-earned",
+                  "data": {
+                    "channel": {"id": "channel-100"},
+                    "point_gain": {
+                      "points": 300,
+                      "reasonCode": "WATCH_STREAK",
+                      "balance": 1300,
+                      "streak_count": 8
+                    },
+                    "created_at": "2026-08-22T12:00:00Z",
+                    "message_id": "earn-1"
+                  }
+                }
+                """.trimIndent(),
+            ),
+        )
+
+        assertNotNull(event)
+        assertEquals("channel-100", event?.channelId)
+        assertEquals(ChannelPointsBalanceEvent.Type.EARNED, event?.type)
+        assertEquals(300, event?.delta)
+        assertEquals(1300, event?.absoluteBalance)
+        assertEquals("WATCH_STREAK", event?.reasonCode)
+        assertEquals(8, event?.streakCount)
+        assertEquals("earn-1", event?.messageId)
+    }
+
+    @Test
+    fun parsesSpentNestedPayload() {
+        val event = PubSubUtils.parsePointsSpent(
+            JSONObject(
+                """
+                {
+                  "type": "points-spent",
+                  "data": {
+                    "channel_id": "channel-100",
+                    "event": {
+                      "point_spend": {
+                        "cost": 500,
+                        "reason_code": "CUSTOM_REWARD"
+                      }
+                    },
+                    "points": {"balance": 2500},
+                    "timestamp": 1724328000000,
+                    "event_id": "spend-1"
+                  }
+                }
+                """.trimIndent(),
+            ),
+        )
+
+        assertNotNull(event)
+        assertEquals("channel-100", event?.channelId)
+        assertEquals(ChannelPointsBalanceEvent.Type.SPENT, event?.type)
+        assertEquals(500, event?.delta)
+        assertEquals(2500, event?.absoluteBalance)
+        assertEquals("CUSTOM_REWARD", event?.reasonCode)
+        assertEquals("spend-1", event?.messageId)
     }
 }


### PR DESCRIPTION
Show channel points changes from live Twitch messages immediately, including spent points and confirmed local redemptions. Keep GQL as reconciliation and preserve watch-streak recovery.