### PR TITLE
Improve chat and browsing smoothness

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/model/chat/Image.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/model/chat/Image.kt
@@ -8,6 +8,8 @@ enum class ImageKind {
 
 class Image(
     val localData: ByteArray? = null,
+    val localDataUrl: String? = null,
+    val localDataRange: Pair<Long, Int>? = null,
     val url1x: String? = null,
     val url2x: String? = null,
     val url3x: String? = null,
@@ -19,4 +21,6 @@ class Image(
     var overlayEmote: Image? = null,
     var start: Int,
     var end: Int,
-)
+) {
+    fun withLocalData(bytes: ByteArray) = Image(bytes, localDataUrl, localDataRange, url1x, url2x, url3x, url4x, format, isAnimated, kind, thirdParty, overlayEmote, start, end)
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/ProcessLocalFeedSnapshot.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/ProcessLocalFeedSnapshot.kt
@@ -1,0 +1,64 @@
+package com.github.andreyasadchy.xtra.repository
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * Keeps the current process's active feed snapshot separate from persistence.
+ * Room remains the bootstrap/offline store; live UI collectors observe this
+ * snapshot so a persistence write does not itself create a UI invalidation.
+ */
+internal class ProcessLocalFeedSnapshot<T> {
+    private data class Snapshot<T>(
+        val loaded: Boolean = false,
+        val items: List<T> = emptyList(),
+    )
+
+    private val snapshots = ConcurrentHashMap<String, MutableStateFlow<Snapshot<T>>>()
+    private val loadLocks = ConcurrentHashMap<String, Mutex>()
+    private val revisions = ConcurrentHashMap<String, AtomicLong>()
+
+    fun flow(
+        key: String,
+        limit: Int,
+        load: suspend () -> List<T>,
+    ): Flow<List<T>> = flow {
+        val state = snapshots.computeIfAbsent(key) { MutableStateFlow(Snapshot()) }
+        val revision = revisions.computeIfAbsent(key) { AtomicLong() }
+        if (!state.value.loaded) {
+            loadLocks.computeIfAbsent(key) { Mutex() }.withLock {
+                if (!state.value.loaded) {
+                    val revisionAtStart = revision.get()
+                    val items = load()
+                    // A refresh can publish while the bootstrap query is in
+                    // flight. Never overwrite that newer process-local state
+                    // with the older Room result.
+                    if (!state.value.loaded && revision.get() == revisionAtStart) {
+                        state.value = Snapshot(loaded = true, items = items.toList())
+                    }
+                }
+            }
+        }
+        emitAll(state.map { snapshot -> snapshot.items.take(limit) })
+    }
+
+    fun publish(key: String, items: List<T>) {
+        val state = snapshots[key] ?: return
+        revisions.computeIfAbsent(key) { AtomicLong() }.incrementAndGet()
+        state.value = Snapshot(loaded = true, items = items.toList())
+    }
+
+    fun clear(key: String) {
+        snapshots[key]?.let { state ->
+            revisions.computeIfAbsent(key) { AtomicLong() }.incrementAndGet()
+            state.value = Snapshot(loaded = true)
+        }
+    }
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/gamefeed/GameFeedCache.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/gamefeed/GameFeedCache.kt
@@ -7,8 +7,10 @@ import com.github.andreyasadchy.xtra.db.GameFeedState
 import com.github.andreyasadchy.xtra.model.ui.Game
 import com.github.andreyasadchy.xtra.model.ui.Tag
 import com.github.andreyasadchy.xtra.repository.datasource.GameFeedPage
+import com.github.andreyasadchy.xtra.repository.ProcessLocalFeedSnapshot
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
 import org.json.JSONArray
 import org.json.JSONObject
@@ -133,10 +135,16 @@ class GameFeedCache(
     private val dao: GameFeedDao = database.gameFeedDao(),
 ) : GameFeedCacheStore {
 
+    private val activeSnapshot = ProcessLocalFeedSnapshot<CachedGameFeedItem>()
+
     override fun pagingSource(feedKey: GameFeedKey) = dao.pagingSource(feedKey.value)
 
     fun activeItemsFlow(feedKey: GameFeedKey, limit: Int): Flow<List<CachedGameFeedItem>> =
-        dao.activeItemsFlow(feedKey.value, limit)
+        activeSnapshot.flow(feedKey.value, limit) {
+            withContext(Dispatchers.IO) {
+                dao.activeItemsFlow(feedKey.value, Int.MAX_VALUE).first()
+            }
+        }
 
     override suspend fun state(feedKey: GameFeedKey): GameFeedState? = withContext(Dispatchers.IO) { dao.state(feedKey.value) }
 
@@ -174,6 +182,7 @@ class GameFeedCache(
         preserveTail: Boolean,
         pruneStaleOnEnd: Boolean,
     ) = withContext(Dispatchers.IO) {
+        var activeItems: List<CachedGameFeedItem> = emptyList()
         database.runInTransaction {
             val current = dao.state(feedKey.value)
             val generation = (current?.activeGeneration ?: 0L) + 1L
@@ -187,6 +196,7 @@ class GameFeedCache(
             if (!preserveTail) dao.deleteItems(feedKey.value)
             if (items.isNotEmpty()) dao.insertItems(items)
             if (page.nextCursor == null && pruneStaleOnEnd) dao.deleteItemsExceptGeneration(feedKey.value, generation)
+            activeItems = items.filter { it.generation == generation }
             val retainsTail = preserveTail && !(page.nextCursor == null && pruneStaleOnEnd) && items.any { it.generation != generation }
             dao.insertState(GameFeedState(
                 feedKey = feedKey.value,
@@ -199,9 +209,11 @@ class GameFeedCache(
                 staleTailRetainedAt = if (retainsTail) current?.staleTailRetainedAt?.takeUnless { expired } ?: nowMs else null,
             ))
         }
+        activeSnapshot.publish(feedKey.value, activeItems)
     }
 
     override suspend fun appendPage(feedKey: GameFeedKey, page: GameFeedPage, nowMs: Long, pruneStaleOnEnd: Boolean) = withContext(Dispatchers.IO) {
+        var activeItems: List<CachedGameFeedItem> = emptyList()
         database.runInTransaction {
             val current = dao.state(feedKey.value) ?: GameFeedState(feedKey.value)
             val expired = staleTailExpired(current, nowMs)
@@ -209,6 +221,7 @@ class GameFeedCache(
             val items = appendCachedGames(feedKey.value, dao.itemsForFeed(feedKey.value), page.items, current.activeGeneration)
             if (items.isNotEmpty()) dao.insertItems(items)
             if (page.nextCursor == null && pruneStaleOnEnd) dao.deleteItemsExceptGeneration(feedKey.value, current.activeGeneration)
+            activeItems = items.filter { it.generation == current.activeGeneration }
             val retainsTail = !(page.nextCursor == null && pruneStaleOnEnd) && items.any { it.generation != current.activeGeneration }
             dao.insertState(current.copy(
                 nextCursor = page.nextCursor?.value,
@@ -221,6 +234,7 @@ class GameFeedCache(
                 staleTailRetainedAt = if (retainsTail) current.staleTailRetainedAt?.takeUnless { expired } ?: nowMs else null,
             ))
         }
+        activeSnapshot.publish(feedKey.value, activeItems)
     }
 
     override suspend fun pruneStaleGeneration(feedKey: GameFeedKey) = withContext(Dispatchers.IO) {
@@ -248,6 +262,7 @@ class GameFeedCache(
     }
 
     override suspend fun cleanup(nowMs: Long) = withContext(Dispatchers.IO) {
+        val removedKeys = mutableSetOf<String>()
         database.runInTransaction {
             val cutoff = nowMs - FEED_RETENTION_MS
             val states = dao.allStates()
@@ -258,6 +273,7 @@ class GameFeedCache(
             states.filter { it.lastAccessAt <= cutoff }.forEach { state ->
                 dao.deleteItems(state.feedKey)
                 dao.deleteState(state.feedKey)
+                removedKeys += state.feedKey
             }
             states.asSequence()
                 .filter { it.lastAccessAt >= cutoff }
@@ -266,8 +282,10 @@ class GameFeedCache(
                 .forEach { state ->
                 dao.deleteItems(state.feedKey)
                 dao.deleteState(state.feedKey)
+                removedKeys += state.feedKey
             }
         }
+        removedKeys.forEach(activeSnapshot::clear)
     }
 
     private fun staleTailExpired(state: GameFeedState?, nowMs: Long): Boolean = state != null &&

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/gamefeed/GameFeedRefreshCoordinator.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/gamefeed/GameFeedRefreshCoordinator.kt
@@ -4,12 +4,15 @@ import com.github.andreyasadchy.xtra.repository.TwitchApiException
 import com.github.andreyasadchy.xtra.repository.datasource.GameFeedCursor
 import com.github.andreyasadchy.xtra.repository.datasource.GameFeedPage
 import com.github.andreyasadchy.xtra.repository.streamfeed.RefreshReason
+import com.github.andreyasadchy.xtra.util.UiInteractionGovernor
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import java.util.concurrent.ConcurrentHashMap
@@ -43,10 +46,15 @@ class GameFeedRefreshCoordinator(
     private val cache: GameFeedCacheStore,
     private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO),
     private val wallClockMs: () -> Long = { System.currentTimeMillis() },
+    maintenanceScope: CoroutineScope? = null,
 ) {
+    private val maintenanceScope = maintenanceScope
+        ?: CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private val refreshFlights = SingleFlight<GameRefreshResult>(scope)
     private val appendFlights = SingleFlight<GameAppendResult>(scope)
     private val feedLocks = ConcurrentHashMap<String, Mutex>()
+    private var cleanupJob: Job? = null
+    private val successfulAtByFeed = ConcurrentHashMap<String, Long>()
 
     @Volatile
     private var visibleFeed: GameFeedSpec? = null
@@ -72,7 +80,21 @@ class GameFeedRefreshCoordinator(
 
     suspend fun forceRefresh(spec: GameFeedSpec, reason: RefreshReason): GameRefreshResult = requestRefresh(spec, reason, force = true)
 
+    /** Fast path used by visible screens before launching a refresh coroutine. */
+    fun isFreshInMemory(spec: GameFeedSpec): Boolean {
+        val lastSuccessAt = successfulAtByFeed[spec.key.value] ?: return false
+        return GameFeedFreshnessPolicy.isFresh(wallClockMs(), lastSuccessAt)
+    }
+
     private suspend fun requestRefresh(spec: GameFeedSpec, reason: RefreshReason, force: Boolean): GameRefreshResult {
+        if (!force) {
+            successfulAtByFeed[spec.key.value]?.let { lastSuccessAt ->
+                val now = wallClockMs()
+                if (GameFeedFreshnessPolicy.isFresh(now, lastSuccessAt)) {
+                    return GameRefreshResult(spec.key, reason, GameRefreshDecision.SKIP_FRESH)
+                }
+            }
+        }
         val flight = refreshFlights.run(spec.key.value) { executeRefresh(spec, reason, force) }
         return flight.value.await().let { if (flight.joined) it.copy(decision = GameRefreshDecision.JOIN) else it }
     }
@@ -82,6 +104,8 @@ class GameFeedRefreshCoordinator(
         return lock.withLock {
             val now = wallClockMs()
             val state = cache.state(spec.key)
+            state?.lastSuccessAt?.let { successfulAtByFeed[spec.key.value] = it }
+                ?: successfulAtByFeed.remove(spec.key.value)
             when (gameRefreshDecision(now, state?.lastSuccessAt, state?.lastAttemptAt, state?.failureBackoffUntil, state?.rateLimitUntil, force)) {
                 GameRefreshDecision.SKIP_BACKOFF -> return@withLock GameRefreshResult(spec.key, reason, GameRefreshDecision.SKIP_BACKOFF)
                 GameRefreshDecision.SKIP_FRESH -> return@withLock GameRefreshResult(spec.key, reason, GameRefreshDecision.SKIP_FRESH)
@@ -97,6 +121,7 @@ class GameFeedRefreshCoordinator(
                 val page = spec.loader.load(null)
                 val completedAt = wallClockMs()
                 cache.replaceAfterRefresh(spec.key, page, completedAt, preserveTail, pruneStaleOnEnd = !preserveTail)
+                successfulAtByFeed[spec.key.value] = completedAt
                 if (shouldPrefetchTail(
                         reason = reason,
                         preserveTail = preserveTail,
@@ -105,7 +130,7 @@ class GameFeedRefreshCoordinator(
                         nextCursorPresent = page.nextCursor != null,
                     )
                 ) {
-                    scope.launch {
+                    UiInteractionGovernor.runWhenIdle(scope) {
                         try {
                             var prefetchedPages = 0
                             while (prefetchedPages < GameFeedFreshnessPolicy.MAX_AUTOMATIC_TAIL_PREFETCH_PAGES) {
@@ -119,7 +144,7 @@ class GameFeedRefreshCoordinator(
                         }
                     }
                 }
-                cache.cleanup(completedAt)
+                scheduleCacheCleanup()
                 GameRefreshResult(spec.key, reason, GameRefreshDecision.REFRESH)
             } catch (error: CancellationException) {
                 throw error
@@ -165,6 +190,7 @@ class GameFeedRefreshCoordinator(
             try {
                 val page = spec.loader.load(cursor)
                 cache.appendPage(spec.key, page, wallClockMs(), pruneStaleOnEnd = !speculative)
+                scheduleCacheCleanup()
                 GameAppendResult(page, page.nextCursor == null)
             } catch (error: CancellationException) {
                 throw error
@@ -193,6 +219,17 @@ class GameFeedRefreshCoordinator(
         preserveTail &&
         cachedItemCount > firstPageItemCount &&
         nextCursorPresent
+
+    private fun scheduleCacheCleanup() {
+        synchronized(this) {
+            if (cleanupJob?.isActive == true) return
+            cleanupJob = maintenanceScope.launch {
+                delay(30_000L)
+                UiInteractionGovernor.awaitIdle()
+                cache.cleanup(wallClockMs())
+            }
+        }
+    }
 
     private fun rateLimitUntil(error: Exception, nowMs: Long): Long? {
         val twitchError = error as? TwitchApiException ?: return null

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/preload/StreamPreloadCoordinator.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/preload/StreamPreloadCoordinator.kt
@@ -20,6 +20,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.yield
 import java.util.concurrent.ConcurrentHashMap
 
 /** Cancels speculative work while preserving a promoted flight for the current configuration. */
@@ -415,7 +416,8 @@ class StreamPreloadCoordinator(
         synchronized(mediaOperationLock) {
             val epoch = mediaOperationGate.begin()
             mediaReconcileJob?.cancel()
-            mediaReconcileJob = scope.launch(Dispatchers.Main.immediate) {
+            mediaReconcileJob = scope.launch(Dispatchers.Main) {
+                yield()
                 mediaOperationGate.runIfCurrent(epoch) {
                     runCatching { operation(runtime) }
                         .onFailure { debug("${event}_failed", it::class.simpleName) }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/streamfeed/StreamFeedCache.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/streamfeed/StreamFeedCache.kt
@@ -6,8 +6,10 @@ import com.github.andreyasadchy.xtra.db.StreamFeedDao
 import com.github.andreyasadchy.xtra.db.StreamFeedState
 import com.github.andreyasadchy.xtra.model.ui.Stream
 import com.github.andreyasadchy.xtra.repository.datasource.StreamFeedPage
+import com.github.andreyasadchy.xtra.repository.ProcessLocalFeedSnapshot
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
 import org.json.JSONArray
 
@@ -203,22 +205,33 @@ internal fun appendCachedPage(
 }
 
 /**
- * Room is the source of truth for stream-feed data. All replacement and page
- * application methods below run their writes in one SQLite transaction.
+ * Room is the durable bootstrap/offline store for stream-feed data. The
+ * process-local active snapshot is the live UI source; replacement and page
+ * application still persist their result in one SQLite transaction.
  */
 class StreamFeedCache(
     private val database: AppDatabase,
     private val dao: StreamFeedDao = database.streamFeedDao(),
 ) : StreamFeedCacheStore {
 
+    private val activeSnapshot = ProcessLocalFeedSnapshot<CachedStreamFeedItem>()
+
     override fun pagingSource(feedKey: StreamFeedKey) = dao.pagingSource(feedKey.value)
 
     fun activeItemsFlow(feedKey: StreamFeedKey, limit: Int): Flow<List<CachedStreamFeedItem>> {
-        return dao.activeItemsFlow(feedKey.value, limit)
+        return activeSnapshot.flow(feedKey.value, limit) {
+            withContext(Dispatchers.IO) {
+                dao.allActiveItemsFlow(feedKey.value).first()
+            }
+        }
     }
 
     fun allActiveItemsFlow(feedKey: StreamFeedKey): Flow<List<CachedStreamFeedItem>> {
-        return dao.allActiveItemsFlow(feedKey.value)
+        return activeSnapshot.flow(feedKey.value, Int.MAX_VALUE) {
+            withContext(Dispatchers.IO) {
+                dao.allActiveItemsFlow(feedKey.value).first()
+            }
+        }
     }
 
     override suspend fun state(feedKey: StreamFeedKey): StreamFeedState? = withContext(Dispatchers.IO) {
@@ -270,6 +283,7 @@ class StreamFeedCache(
         preserveTail: Boolean,
         pruneStaleOnEnd: Boolean,
     ) = withContext(Dispatchers.IO) {
+        var activeItems: List<CachedStreamFeedItem> = emptyList()
         database.runInTransaction {
             val current = dao.state(feedKey.value)
             val generation = (current?.activeGeneration ?: 0L) + 1L
@@ -299,6 +313,7 @@ class StreamFeedCache(
             if (page.nextCursor == null && pruneStaleOnEnd) {
                 dao.deleteItemsExceptGeneration(feedKey.value, generation)
             }
+            activeItems = items.filter { it.generation == generation }
             val retainsStaleTail = preserveTail &&
                     !(page.nextCursor == null && pruneStaleOnEnd) &&
                     items.any { it.generation != generation }
@@ -321,6 +336,7 @@ class StreamFeedCache(
                 )
             )
         }
+        activeSnapshot.publish(feedKey.value, activeItems)
     }
 
     /** Append a downloaded page while keeping an existing channel's position stable. */
@@ -330,6 +346,7 @@ class StreamFeedCache(
         nowMs: Long,
         pruneStaleOnEnd: Boolean,
     ) = withContext(Dispatchers.IO) {
+        var activeItems: List<CachedStreamFeedItem> = emptyList()
         database.runInTransaction {
             val current = dao.state(feedKey.value) ?: StreamFeedState(feedKey.value)
             val expiredTail = staleTailExpired(current, nowMs)
@@ -344,6 +361,7 @@ class StreamFeedCache(
             if (page.nextCursor == null && pruneStaleOnEnd) {
                 dao.deleteItemsExceptGeneration(feedKey.value, current.activeGeneration)
             }
+            activeItems = items.filter { it.generation == current.activeGeneration }
             val retainsStaleTail =
                 !(page.nextCursor == null && pruneStaleOnEnd) &&
                         items.any { it.generation != current.activeGeneration }
@@ -364,6 +382,7 @@ class StreamFeedCache(
                 )
             )
         }
+        activeSnapshot.publish(feedKey.value, activeItems)
     }
 
     override suspend fun pruneStaleGeneration(feedKey: StreamFeedKey) = withContext(Dispatchers.IO) {
@@ -416,6 +435,7 @@ class StreamFeedCache(
     }
 
     override suspend fun cleanup(nowMs: Long) = withContext(Dispatchers.IO) {
+        val removedKeys = mutableSetOf<String>()
         database.runInTransaction {
             val cutoff = nowMs - FEED_RETENTION_MS
             val states = dao.allStates()
@@ -428,6 +448,7 @@ class StreamFeedCache(
                 .forEach { state ->
                     dao.deleteItems(state.feedKey)
                     dao.deleteState(state.feedKey)
+                    removedKeys += state.feedKey
                 }
             states.asSequence()
                 .filter { it.lastAccessAt >= cutoff }
@@ -435,7 +456,9 @@ class StreamFeedCache(
                 .forEach { state ->
                     dao.deleteItems(state.feedKey)
                     dao.deleteState(state.feedKey)
+                    removedKeys += state.feedKey
                 }
         }
+        removedKeys.forEach(activeSnapshot::clear)
     }
 }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/streamfeed/StreamFeedPolicy.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/streamfeed/StreamFeedPolicy.kt
@@ -92,7 +92,7 @@ enum class RefreshDecision {
     JOIN,
 }
 
-/** Process-local signal for image loaders that must bypass the current preview bucket. */
+/** Process-local signal reserved for explicit thumbnail refreshes, not feed-data refreshes. */
 internal object StreamThumbnailRefreshSignal {
     private val forceEpoch = AtomicLong(0L)
 

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/streamfeed/StreamFeedRefreshCoordinator.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/streamfeed/StreamFeedRefreshCoordinator.kt
@@ -6,10 +6,13 @@ import com.github.andreyasadchy.xtra.BuildConfig
 import com.github.andreyasadchy.xtra.repository.TwitchApiException
 import com.github.andreyasadchy.xtra.repository.datasource.StreamFeedPage
 import com.github.andreyasadchy.xtra.repository.datasource.StreamFeedCursor
+import com.github.andreyasadchy.xtra.util.UiInteractionGovernor
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -41,10 +44,15 @@ class StreamFeedRefreshCoordinator(
     private val wallClockMs: () -> Long = { System.currentTimeMillis() },
     private val elapsedRealtimeMs: () -> Long = { SystemClock.elapsedRealtime() },
     private val debugLoggingEnabled: Boolean = BuildConfig.DEBUG,
+    maintenanceScope: CoroutineScope? = null,
 ) {
+    private val maintenanceScope = maintenanceScope
+        ?: CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private val refreshFlights = StreamFeedSingleFlight<StreamRefreshResult>(scope)
     private val appendFlights = StreamFeedSingleFlight<StreamAppendResult>(scope)
     private val feedLocks = ConcurrentHashMap<String, Mutex>()
+    private var cleanupJob: Job? = null
+    private val successfulAtByFeed = ConcurrentHashMap<String, Long>()
 
     @Volatile
     private var visibleFeed: StreamFeedSpec? = null
@@ -78,13 +86,33 @@ class StreamFeedRefreshCoordinator(
         return requestRefresh(spec, reason, force = true)
     }
 
+    /**
+     * Fast process-local check for callers on a visible-screen path. A false
+     * result only means that the durable cache must be consulted; it never
+     * makes a freshness decision without the normal coordinator lock.
+     */
+    fun isFreshInMemory(spec: StreamFeedSpec): Boolean {
+        val lastSuccessAt = successfulAtByFeed[spec.key.value] ?: return false
+        return StreamFeedFreshnessPolicy.isFresh(wallClockMs(), lastSuccessAt)
+    }
+
     private suspend fun requestRefresh(
         spec: StreamFeedSpec,
         reason: RefreshReason,
         force: Boolean,
     ): StreamRefreshResult {
-        if (force) {
-            StreamThumbnailRefreshSignal.requestForceRefresh()
+        if (!force) {
+            successfulAtByFeed[spec.key.value]?.let { lastSuccessAt ->
+                val now = wallClockMs()
+                if (StreamFeedFreshnessPolicy.isFresh(now, lastSuccessAt)) {
+                    return StreamRefreshResult(
+                        feedKey = spec.key,
+                        reason = reason,
+                        decision = RefreshDecision.SKIP_FRESH,
+                        cacheAgeMs = StreamFeedFreshnessPolicy.cacheAge(now, lastSuccessAt),
+                    )
+                }
+            }
         }
         val result = refreshFlights.run(spec.key.value) {
             executeRefresh(spec, reason, force)
@@ -105,6 +133,8 @@ class StreamFeedRefreshCoordinator(
         return lock.withLock {
             val now = wallClockMs()
             val state = cache.state(spec.key)
+            state?.lastSuccessAt?.let { successfulAtByFeed[spec.key.value] = it }
+                ?: successfulAtByFeed.remove(spec.key.value)
             val age = StreamFeedFreshnessPolicy.cacheAge(now, state?.lastSuccessAt)
             val rateLimitUntil = state?.rateLimitUntil ?: 0L
             val failureBackoffUntil = state?.failureBackoffUntil ?: 0L
@@ -152,6 +182,7 @@ class StreamFeedRefreshCoordinator(
                     preserveTail = preserveTail,
                     pruneStaleOnEnd = !preserveTail,
                 )
+                successfulAtByFeed[spec.key.value] = completedAt
                 if (shouldPrefetchTail(
                         reason = reason,
                         preserveTail = preserveTail,
@@ -160,7 +191,7 @@ class StreamFeedRefreshCoordinator(
                         nextCursorPresent = page.nextCursor != null,
                     )
                 ) {
-                    scope.launch {
+                    UiInteractionGovernor.runWhenIdle(scope) {
                         try {
                             var prefetchedPages = 0
                             while (prefetchedPages < StreamFeedFreshnessPolicy.MAX_AUTOMATIC_TAIL_PREFETCH_PAGES) {
@@ -180,7 +211,7 @@ class StreamFeedRefreshCoordinator(
                         }
                     }
                 }
-                cache.cleanup(completedAt)
+                scheduleCacheCleanup()
                 val duration = elapsedRealtimeMs() - started
                 debug(spec, reason, RefreshDecision.REFRESH, age, "success items=${page.items.size} duration=$duration")
                 StreamRefreshResult(spec.key, reason, RefreshDecision.REFRESH, age, page.items.size, duration)
@@ -249,7 +280,7 @@ class StreamFeedRefreshCoordinator(
                     completedAt,
                     pruneStaleOnEnd = !speculative,
                 )
-                cache.cleanup(completedAt)
+                scheduleCacheCleanup()
                 debug(spec, RefreshReason.SCREEN_VISIBLE, RefreshDecision.REFRESH, null, "append items=${page.items.size} duration=${elapsedRealtimeMs() - started}")
                 StreamAppendResult(page, page.nextCursor == null)
             } catch (error: CancellationException) {
@@ -284,6 +315,17 @@ class StreamFeedRefreshCoordinator(
                 preserveTail &&
                 cachedItemCount > firstPageItemCount &&
                 nextCursorPresent
+    }
+
+    private fun scheduleCacheCleanup() {
+        synchronized(this) {
+            if (cleanupJob?.isActive == true) return
+            cleanupJob = maintenanceScope.launch {
+                delay(30_000L)
+                UiInteractionGovernor.awaitIdle()
+                cache.cleanup(wallClockMs())
+            }
+        }
     }
 
     fun onAppForeground(awayMs: Long) {
@@ -352,6 +394,9 @@ class StreamFeedRefreshCoordinator(
         scope.launch {
             val now = wallClockMs()
             cache.invalidatePrefix("followed:", now)
+            successfulAtByFeed.keys
+                .filter { it.startsWith("followed:") }
+                .forEach(successfulAtByFeed::remove)
             visibleFeed?.takeIf { it.key.value.startsWith("followed:") }?.let {
                 runCatching { forceRefresh(it, RefreshReason.FOLLOW_STATE_CHANGED) }
             }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/browse/BrowsePagerFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/browse/BrowsePagerFragment.kt
@@ -21,6 +21,7 @@ import com.github.andreyasadchy.xtra.databinding.FragmentMediaPagerBinding
 import com.github.andreyasadchy.xtra.ui.common.FragmentHost
 import com.github.andreyasadchy.xtra.ui.common.Scrollable
 import com.github.andreyasadchy.xtra.ui.common.Sortable
+import com.github.andreyasadchy.xtra.ui.common.dispatchPagerScrollState
 import com.github.andreyasadchy.xtra.ui.games.GamesFragment
 import com.github.andreyasadchy.xtra.ui.login.TwitchWebLoginActivity
 import com.github.andreyasadchy.xtra.ui.main.MainActivity
@@ -30,6 +31,7 @@ import com.github.andreyasadchy.xtra.ui.top.TopStreamsFragment
 import com.github.andreyasadchy.xtra.util.C
 import com.github.andreyasadchy.xtra.util.TwitchApiHelper
 import com.github.andreyasadchy.xtra.util.getAlertDialogBuilder
+import com.github.andreyasadchy.xtra.util.configureForSmoothPaging
 import com.github.andreyasadchy.xtra.util.tokenPrefs
 import com.google.android.material.tabs.TabLayoutMediator
 
@@ -104,8 +106,12 @@ class BrowsePagerFragment : Fragment(), Scrollable, FragmentHost {
 
             val adapter = BrowsePagerAdapter(this@BrowsePagerFragment)
             viewPager.adapter = adapter
-            viewPager.offscreenPageLimit = adapter.itemCount
+            viewPager.configureForSmoothPaging()
             viewPager.registerOnPageChangeCallback(object : ViewPager2.OnPageChangeCallback() {
+                override fun onPageScrollStateChanged(state: Int) {
+                    dispatchPagerScrollState(state != ViewPager2.SCROLL_STATE_IDLE)
+                }
+
                 override fun onPageSelected(position: Int) {
                     viewPager.doOnLayout {
                         configureCurrentPage()
@@ -189,6 +195,7 @@ class BrowsePagerFragment : Fragment(), Scrollable, FragmentHost {
     }
 
     override fun onDestroyView() {
+        dispatchPagerScrollState(false)
         configuredRecyclerViews.clear()
         super.onDestroyView()
         _binding = null

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/channel/ChannelPagerFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/channel/ChannelPagerFragment.kt
@@ -46,6 +46,7 @@ import com.github.andreyasadchy.xtra.ui.common.BaseNetworkFragment
 import com.github.andreyasadchy.xtra.ui.common.FragmentHost
 import com.github.andreyasadchy.xtra.ui.common.Scrollable
 import com.github.andreyasadchy.xtra.ui.common.Sortable
+import com.github.andreyasadchy.xtra.ui.common.dispatchPagerScrollState
 import com.github.andreyasadchy.xtra.ui.download.DownloadDialog
 import com.github.andreyasadchy.xtra.ui.game.GamePagerFragmentDirections
 import com.github.andreyasadchy.xtra.ui.login.TwitchWebLoginActivity
@@ -55,10 +56,10 @@ import com.github.andreyasadchy.xtra.ui.search.SearchPagerFragmentDirections
 import com.github.andreyasadchy.xtra.ui.settings.SettingsActivity
 import com.github.andreyasadchy.xtra.ui.settings.setTabCustomizationLongPress
 import com.github.andreyasadchy.xtra.util.C
+import com.github.andreyasadchy.xtra.util.configureForSmoothPaging
 import com.github.andreyasadchy.xtra.util.TwitchApiHelper
 import com.github.andreyasadchy.xtra.util.getAlertDialogBuilder
 import com.github.andreyasadchy.xtra.util.prefs
-import com.github.andreyasadchy.xtra.util.reduceDragSensitivity
 import com.github.andreyasadchy.xtra.util.tokenPrefs
 import com.google.android.material.appbar.AppBarLayout
 import com.google.android.material.appbar.CollapsingToolbarLayout
@@ -460,6 +461,10 @@ class ChannelPagerFragment : BaseNetworkFragment(), Scrollable, FragmentHost {
                 private val layoutParams = collapsingToolbar.layoutParams as AppBarLayout.LayoutParams
                 private val originalScrollFlags = layoutParams.scrollFlags
 
+                override fun onPageScrollStateChanged(state: Int) {
+                    dispatchPagerScrollState(state != ViewPager2.SCROLL_STATE_IDLE)
+                }
+
                 override fun onPageSelected(position: Int) {
                     layoutParams.scrollFlags = if (tabs.getOrNull(position) != "3") {
                         originalScrollFlags
@@ -499,8 +504,7 @@ class ChannelPagerFragment : BaseNetworkFragment(), Scrollable, FragmentHost {
                 )
                 firstLaunch = false
             }
-            viewPager.offscreenPageLimit = adapter.itemCount
-            viewPager.reduceDragSensitivity()
+            viewPager.configureForSmoothPaging()
             TabLayoutMediator(tabLayout, viewPager) { tab, position ->
                 tab.text = when (tabs.getOrNull(position)) {
                     "0" -> getString(R.string.suggestions)
@@ -796,6 +800,7 @@ class ChannelPagerFragment : BaseNetworkFragment(), Scrollable, FragmentHost {
     }
 
     override fun onDestroyView() {
+        dispatchPagerScrollState(false)
         pendingNotificationEnable = null
         enableLiveNotificationsAfterChannel = false
         super.onDestroyView()

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/channel/videos/ChannelVideosFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/channel/videos/ChannelVideosFragment.kt
@@ -26,6 +26,7 @@ import com.github.andreyasadchy.xtra.ui.channel.ChannelPagerFragmentArgs
 import com.github.andreyasadchy.xtra.ui.channel.videos.ChannelVideosViewModel.Companion.ChannelVideosViewModelFactory
 import com.github.andreyasadchy.xtra.ui.common.FragmentHost
 import com.github.andreyasadchy.xtra.ui.common.PagedListFragment
+import com.github.andreyasadchy.xtra.ui.common.PagerScrollStateAware
 import com.github.andreyasadchy.xtra.ui.common.Scrollable
 import com.github.andreyasadchy.xtra.ui.common.Sortable
 import com.github.andreyasadchy.xtra.ui.common.StreamPreloadViewportController
@@ -39,7 +40,7 @@ import com.github.andreyasadchy.xtra.util.prefs
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 
-class ChannelVideosFragment : PagedListFragment(), Scrollable, Sortable, VideosSortDialog.OnFilter {
+class ChannelVideosFragment : PagedListFragment(), Scrollable, Sortable, PagerScrollStateAware, VideosSortDialog.OnFilter {
 
     private var _binding: CommonRecyclerViewLayoutBinding? = null
     private val binding get() = _binding!!
@@ -238,6 +239,12 @@ class ChannelVideosFragment : PagedListFragment(), Scrollable, Sortable, VideosS
 
     override fun onNetworkRestored() {
         pagingAdapter.retry()
+    }
+
+    override fun onPagerScrollStateChanged(scrolling: Boolean) {
+        if (::videoPreviewViewportController.isInitialized) {
+            videoPreviewViewportController.onParentScrollStateChanged(scrolling)
+        }
     }
 
     override fun onResume() {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatAdapter.kt
@@ -2,6 +2,8 @@ package com.github.andreyasadchy.xtra.ui.chat
 
 import android.graphics.drawable.Animatable
 import android.graphics.drawable.LayerDrawable
+import android.os.Handler
+import android.os.Looper
 import android.text.Spannable
 import android.text.SpannableString
 import android.text.SpannableStringBuilder
@@ -27,10 +29,23 @@ import com.github.andreyasadchy.xtra.model.chat.TwitchBadge
 import com.github.andreyasadchy.xtra.model.chat.TwitchEmote
 import com.github.andreyasadchy.xtra.ui.view.NamePaintImageSpan
 import com.github.andreyasadchy.xtra.util.chat.ChatAdapterUtils
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.yield
 import java.util.Random
+import java.util.Collections
+import java.util.IdentityHashMap
 
 class ChatAdapter(
-    private val messages: List<ChatMessage>,
+    initialMessages: List<ChatMessage>,
     private val localTwitchEmotes: List<TwitchEmote>,
     private val thirdPartyEmotes: List<Emote>,
     private val globalBadges: List<TwitchBadge>,
@@ -59,7 +74,6 @@ class ChatAdapter(
     private val showPersonalEmotes: Boolean,
     private val showSystemMessageEmotes: Boolean,
     private val chatUrl: String?,
-    private val getEmoteBytes: ((String, Pair<Long, Int>) -> ByteArray?)?,
     private val fragment: Fragment,
     private val backgroundColor: Int,
     private val dialogBackgroundColor: Int,
@@ -80,7 +94,78 @@ class ChatAdapter(
     private val imageClickListener: ((String?, String?, String?, Boolean?, Int?, Boolean?, String?) -> Unit)?,
 ) : RecyclerView.Adapter<ChatAdapter.ViewHolder>() {
 
+    /** UI-owned snapshot. ChatViewModel may continue receiving messages while a fling is active. */
+    private val messages = ArrayList(initialMessages)
+    private class RenderCacheKey(
+        val message: ChatMessage,
+        val catalogRevision: Int,
+        val translateAllMessages: Boolean,
+        val translatedMessage: String?,
+        val translationFailed: Boolean,
+        val messageLanguage: String?,
+    ) {
+        // ChatMessage translation/moderation fields are mutable. Cache by object identity so a
+        // mutation cannot change the hash of an entry that is already in the LRU map.
+        override fun equals(other: Any?): Boolean = other is RenderCacheKey &&
+            message === other.message &&
+            catalogRevision == other.catalogRevision &&
+            translateAllMessages == other.translateAllMessages &&
+            translatedMessage == other.translatedMessage &&
+            translationFailed == other.translationFailed &&
+            messageLanguage == other.messageLanguage
+
+        override fun hashCode(): Int {
+            var result = System.identityHashCode(message)
+            result = 31 * result + catalogRevision
+            result = 31 * result + translateAllMessages.hashCode()
+            result = 31 * result + (translatedMessage?.hashCode() ?: 0)
+            result = 31 * result + translationFailed.hashCode()
+            result = 31 * result + (messageLanguage?.hashCode() ?: 0)
+            return result
+        }
+    }
+
+    private data class RenderRequest(
+        val message: ChatMessage,
+        val cacheKey: RenderCacheKey,
+        val context: android.content.Context,
+        val indexes: ChatAdapterUtils.ChatCatalogIndexes,
+        val prewarmGeneration: Long?,
+    )
+
+    private val renderCache = object : LinkedHashMap<RenderCacheKey, ChatAdapterUtils.MessageResult>(256, 0.75f, true) {
+        override fun removeEldestEntry(eldest: MutableMap.MutableEntry<RenderCacheKey, ChatAdapterUtils.MessageResult>?): Boolean =
+            size > MAX_RENDER_CACHE_ENTRIES
+    }
+    private var renderScope = newRenderScope()
+    private val renderJobs = HashSet<RenderCacheKey>()
+    private val prewarmRenderJobs = HashSet<RenderCacheKey>()
+    private val visibleRenderJobs = HashSet<RenderCacheKey>()
+    private var visibleRenderQueue = Channel<RenderRequest>(VISIBLE_RENDER_QUEUE_CAPACITY)
+    private var prewarmRenderQueue = Channel<RenderRequest>(PREWARM_QUEUE_CAPACITY)
+    private var renderSignal = Channel<Unit>(Channel.CONFLATED)
+    private var renderWorkers = emptyList<Job>()
+    private val mainHandler = Handler(Looper.getMainLooper())
+    private val pendingRenderedMessages = Collections.newSetFromMap(
+        IdentityHashMap<ChatMessage, Boolean>(),
+    )
+    private var renderUpdatesPaused = false
+    private var prewarmJob: Job? = null
+    @Volatile
+    private var prewarmGeneration = 0L
+    private var prewarmPosted = false
+    private val prewarmRunnable = Runnable {
+        prewarmPosted = false
+        attachedRecyclerView?.let(::scheduleVisiblePrewarm)
+    }
+    private var directBinding = false
     var translateAllMessages = false
+        set(value) {
+            if (field != value) {
+                field = value
+                clearRenderCache()
+            }
+        }
     private var selectedMessage: ChatMessage? = null
     private val random = Random()
     private val userColors = HashMap<String, Int>()
@@ -89,29 +174,157 @@ class ChatAdapter(
     private val savedLocalBadges = mutableMapOf<String, ByteArray>()
     private val savedLocalCheerEmotes = mutableMapOf<String, ByteArray>()
     private val savedLocalEmotes = mutableMapOf<String, ByteArray>()
+    private var catalogIndexes = ChatAdapterUtils.ChatCatalogIndexes.create(
+        localTwitchEmotes, thirdPartyEmotes, globalBadges, channelBadges, stvUsers, stvBadges, namePaints, personalEmoteSets, cheerEmotes,
+    )
+    private var attachedRecyclerView: RecyclerView? = null
+    private var animationsPaused = false
+    private var catalogRevision = 0
+    private var pauseAnimationsPosted = false
+    private val pendingAnimationStops = ArrayDeque<TextView>()
+    private val runningAnimationTextViews = Collections.newSetFromMap(
+        IdentityHashMap<TextView, Boolean>(),
+    )
+    private var resumeAnimationsPosted = false
+    private var resumeAnimationIndex = 0
+    private var renderedFlushPosted = false
+    private val renderedFlushRunnable = Runnable {
+        renderedFlushPosted = false
+        flushRenderedMessages()
+    }
+    private val pauseAnimationsRunnable = object : Runnable {
+        override fun run() {
+            pauseAnimationsPosted = false
+            if (!animationsPaused) {
+                pendingAnimationStops.clear()
+                return
+            }
+            repeat(MAX_ANIMATION_OPERATIONS_PER_FRAME) {
+                pendingAnimationStops.removeFirstOrNull()?.let { textView ->
+                    if (textView.isAttachedToWindow) setAnimations(textView, start = false)
+                } ?: return@repeat
+            }
+            if (pendingAnimationStops.isNotEmpty()) {
+                pauseAnimationsPosted = true
+                attachedRecyclerView?.postOnAnimation(this)
+            }
+        }
+    }
+    private val resumeAnimationsRunnable = object : Runnable {
+        override fun run() {
+            resumeAnimationsPosted = false
+            val recyclerView = attachedRecyclerView ?: return
+            if (animationsPaused || resumeAnimationIndex >= recyclerView.childCount) return
+            (recyclerView.getChildAt(resumeAnimationIndex) as? TextView)?.let {
+                setAnimations(it, start = true)
+            }
+            resumeAnimationIndex++
+            if (!animationsPaused && resumeAnimationIndex < recyclerView.childCount) {
+                resumeAnimationsPosted = true
+                recyclerView.postOnAnimation(this)
+            }
+        }
+    }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
         return ViewHolder(LayoutInflater.from(parent.context).inflate(R.layout.chat_list_item, parent, false))
     }
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
-        val chatMessage = synchronized(messages) {
-            messages.getOrNull(position)
-        } ?: return
-        val result = ChatAdapterUtils.prepareChatMessage(
-            chatMessage, fragment.requireContext(), holder.textView, enableTimestamps, timestampFormat, firstMsgVisibility, firstChatMsg,
-            redeemedChatMsg, redeemedNoMsg, rewardChatMsg, replyMessage, null, useRandomColors, random, useReadableColors, isLightTheme,
-            nameDisplay, useBoldNames, showNamePaints, namePaints, showBadges, showSTVBadges, stvBadges, showPersonalEmotes, personalEmoteSets, stvUsers,
-            enableOverlayEmotes, showSystemMessageEmotes, loggedInUser, chatUrl, getEmoteBytes, userColors, savedColors, translateAllMessages,
-            translateMessage, showLanguageDownloadDialog, true, localTwitchEmotes, thirdPartyEmotes, globalBadges, channelBadges, cheerEmotes,
-            savedLocalTwitchEmotes, savedLocalBadges, savedLocalCheerEmotes, savedLocalEmotes
+        holder.imageRequests.cancel()
+        val bindGeneration = holder.beginBind(catalogRevision)
+        val chatMessage = messages.getOrNull(position) ?: return
+        val cacheKey = RenderCacheKey(
+            message = chatMessage,
+            catalogRevision = catalogRevision,
+            translateAllMessages = translateAllMessages,
+            translatedMessage = chatMessage.translatedMessage,
+            translationFailed = chatMessage.translationFailed,
+            messageLanguage = chatMessage.messageLanguage,
         )
-        holder.bind(chatMessage, result.builder)
+        val cachedResult = cachedRender(cacheKey)
+        val result = if (cachedResult != null) {
+            cachedResult.copyForBind()
+        } else {
+            val context = fragment.context
+            if (directBinding && context != null) {
+                prepareMessage(chatMessage, context, holder.textView, catalogIndexes, offMain = false).also { prepared ->
+                    synchronized(renderCache) { renderCache[cacheKey] = prepared }
+                }.copyForBind()
+            } else {
+                context?.let { enqueueRender(chatMessage, cacheKey, it, catalogIndexes) }
+                fastFallback(chatMessage).copyForBind()
+            }
+        }
+        ChatAdapterUtils.installImagePlaceholders(result.builder, result.images, emoteSize, badgeSize, inlineIconSize)
+        holder.bind(chatMessage, result)
         ChatAdapterUtils.loadImages(
-            fragment, holder.textView, { holder.bind(chatMessage, it) }, result.images, result.imagePaint, result.userName, result.userNameStartIndex,
+            fragment, holder.textView, { holder.bindWhenReady(bindGeneration, chatMessage, it) }, result.images, result.imagePaint, result.userName, result.userNameStartIndex,
             backgroundColor, imageLibrary, result.builder, result.translated, emoteSize, badgeSize, inlineIconSize, emoteQuality, animateGifs, enableOverlayEmotes,
-            chatMessage, savedColors, useReadableColors, isLightTheme, showLanguageDownloadDialog, true
+            chatMessage, savedColors, useReadableColors, isLightTheme, showLanguageDownloadDialog, true,
+            isCurrent = { holder.isCurrentBind(bindGeneration) },
+            shouldAnimate = { holder.canAnimate(bindGeneration) },
+            requestBag = holder.imageRequests,
+            shouldLoad = { holder.canLoadImages(bindGeneration) },
+            onLoadDeferred = { holder.hasDeferredImageLoad = true },
         )
+    }
+
+    override fun onViewRecycled(holder: ViewHolder) {
+        holder.imageRequests.cancel()
+        holder.cancelPendingBind()
+        super.onViewRecycled(holder)
+    }
+
+    fun appendMessages(incoming: List<ChatMessage>, trimCount: Int) {
+        val removed = trimCount.coerceAtMost(messages.size)
+        if (removed > 0) {
+            repeat(removed) { pendingRenderedMessages.remove(messages[it]) }
+            messages.subList(0, removed).clear()
+            notifyItemRangeRemoved(0, removed)
+        }
+        if (incoming.isNotEmpty()) {
+            val start = messages.size
+            messages.addAll(incoming)
+            notifyItemRangeInserted(start, incoming.size)
+        }
+    }
+
+    fun prependMessages(incoming: List<ChatMessage>) {
+        if (incoming.isEmpty()) return
+        messages.addAll(0, incoming)
+        notifyItemRangeInserted(0, incoming.size)
+    }
+
+    fun removeMessages(count: Int) {
+        val removed = count.coerceAtMost(messages.size)
+        if (removed <= 0) return
+        repeat(removed) { pendingRenderedMessages.remove(messages[it]) }
+        messages.subList(0, removed).clear()
+        notifyItemRangeRemoved(0, removed)
+    }
+
+    fun clearMessages() {
+        if (messages.isEmpty()) return
+        val removed = messages.size
+        messages.clear()
+        pendingRenderedMessages.clear()
+        notifyItemRangeRemoved(0, removed)
+    }
+
+    fun notifyUserMessages(userId: String) {
+        clearRenderCache()
+        messages.forEachIndexed { index, message ->
+            if (message.userId == userId) notifyItemChanged(index)
+        }
+    }
+
+    /** Used by CombinedChatFragment, which renders one message without RecyclerView ownership. */
+    fun setDirectMessage(message: ChatMessage) {
+        directBinding = true
+        messages.clear()
+        pendingRenderedMessages.clear()
+        messages += message
     }
 
     fun updateTranslation(chatMessage: ChatMessage, item: TextView, previousTranslation: String?) {
@@ -138,7 +351,7 @@ class ChatAdapter(
             { chatMessage -> selectedMessage = chatMessage; replyClickListener?.invoke() },
             { url, name, format, isAnimated, source, thirdParty, emoteId -> imageClickListener?.invoke(url, name, format, isAnimated, source, thirdParty, emoteId) },
             useRandomColors, useReadableColors, isLightTheme, nameDisplay, useBoldNames, showNamePaints, showBadges, showSTVBadges, showPersonalEmotes,
-            showSystemMessageEmotes, chatUrl, getEmoteBytes, fragment, dialogBackgroundColor, imageLibrary, messageTextSize, emoteSize, badgeSize, inlineIconSize,
+            showSystemMessageEmotes, chatUrl, fragment, dialogBackgroundColor, imageLibrary, messageTextSize, emoteSize, badgeSize, inlineIconSize,
             emoteQuality, animateGifs, enableOverlayEmotes, translateAllMessages, translateMessage, showLanguageDownloadDialog, random, userColors,
             savedColors, savedLocalTwitchEmotes, savedLocalBadges, savedLocalCheerEmotes, savedLocalEmotes, loggedInUser, selectedMessage
         )
@@ -150,123 +363,632 @@ class ChatAdapter(
             stvUsers, enableTimestamps, timestampFormat, firstMsgVisibility, firstChatMsg, redeemedChatMsg, redeemedNoMsg, rewardChatMsg, replyMessage,
             { url, name, format, isAnimated, source, thirdParty, emoteId -> imageClickListener?.invoke(url, name, format, isAnimated, source, thirdParty, emoteId) },
             useRandomColors, useReadableColors, isLightTheme, nameDisplay, useBoldNames, showNamePaints, showBadges, showSTVBadges, showPersonalEmotes,
-            showSystemMessageEmotes, chatUrl, getEmoteBytes, fragment, dialogBackgroundColor, imageLibrary, messageTextSize, emoteSize, badgeSize, inlineIconSize,
+            showSystemMessageEmotes, chatUrl, fragment, dialogBackgroundColor, imageLibrary, messageTextSize, emoteSize, badgeSize, inlineIconSize,
             emoteQuality, animateGifs, enableOverlayEmotes, translateAllMessages, translateMessage, showLanguageDownloadDialog, random, userColors,
             savedColors, savedLocalTwitchEmotes, savedLocalBadges, savedLocalCheerEmotes, savedLocalEmotes, loggedInUser, selectedMessage
         )
     }
 
-    override fun getItemCount(): Int = synchronized(messages) {
-        messages.size
-    }
+    override fun getItemCount(): Int = messages.size
 
     override fun onViewAttachedToWindow(holder: ViewHolder) {
         super.onViewAttachedToWindow(holder)
-        if (animateGifs) {
-            (holder.textView.text as? Spannable)?.let { view ->
-                view.getSpans<ImageSpan>().forEach {
-                    (it.drawable as? Animatable)?.start() ?:
-                    (it.drawable as? LayerDrawable)?.let {
-                        val lastIndex = it.numberOfLayers - 1
-                        if (lastIndex > -1) {
-                            for (i in 0..lastIndex) {
-                                (it.getDrawable(i) as? Animatable)?.start()
-                            }
-                        }
-                    }
-                }
-                view.getSpans<NamePaintImageSpan>().forEach {
-                    (it.drawable as? Animatable)?.start()
-                }
-            }
+        if (holder.catalogRevision < catalogRevision) {
+            holder.postCatalogRefresh()
+            return
         }
+        if (holder.hasDeferredImageLoad) {
+            holder.postDeferredImageReload()
+            return
+        }
+        if (animateGifs && !animationsPaused) setAnimations(holder.textView, start = true)
     }
 
     override fun onViewDetachedFromWindow(holder: ViewHolder) {
         super.onViewDetachedFromWindow(holder)
+        if (animateGifs) setAnimations(holder.textView, start = false)
+    }
+
+    override fun onDetachedFromRecyclerView(recyclerView: RecyclerView) {
+        recyclerView.removeOnScrollListener(prewarmScrollListener)
+        recyclerView.removeCallbacks(pauseAnimationsRunnable)
+        recyclerView.removeCallbacks(resumeAnimationsRunnable)
+        pauseAnimationsPosted = false
+        pendingAnimationStops.clear()
+        resumeAnimationsPosted = false
+        val childCount = recyclerView.childCount
         if (animateGifs) {
-            (holder.textView.text as? Spannable)?.let { view ->
-                view.getSpans<ImageSpan>().forEach {
-                    (it.drawable as? Animatable)?.stop() ?:
-                    (it.drawable as? LayerDrawable)?.let {
-                        val lastIndex = it.numberOfLayers - 1
-                        if (lastIndex > -1) {
-                            for (i in 0..lastIndex) {
-                                (it.getDrawable(i) as? Animatable)?.stop()
-                            }
-                        }
-                    }
-                }
-                view.getSpans<NamePaintImageSpan>().forEach {
-                    (it.drawable as? Animatable)?.stop()
-                }
+            for (i in 0 until childCount) {
+                setAnimations(recyclerView.getChildAt(i) as TextView, start = false)
+            }
+        }
+        prewarmJob?.cancel()
+        prewarmJob = null
+        recyclerView.removeCallbacks(prewarmRunnable)
+        prewarmPosted = false
+        recyclerView.removeCallbacks(renderedFlushRunnable)
+        renderedFlushPosted = false
+        visibleRenderQueue.close()
+        prewarmRenderQueue.close()
+        renderSignal.close()
+        renderWorkers.forEach(Job::cancel)
+        renderWorkers = emptyList()
+        renderScope.cancel()
+        synchronized(renderJobs) { renderJobs.clear() }
+        pendingRenderedMessages.clear()
+        attachedRecyclerView = null
+        super.onDetachedFromRecyclerView(recyclerView)
+    }
+
+    override fun onAttachedToRecyclerView(recyclerView: RecyclerView) {
+        directBinding = false
+        ensureRenderWorkers()
+        attachedRecyclerView = recyclerView
+        super.onAttachedToRecyclerView(recyclerView)
+        recyclerView.addOnScrollListener(prewarmScrollListener)
+        scheduleVisiblePrewarm(recyclerView)
+    }
+
+    private val prewarmScrollListener = object : RecyclerView.OnScrollListener() {
+        override fun onScrolled(recyclerView: RecyclerView, dx: Int, dy: Int) {
+            if (!prewarmPosted) {
+                prewarmPosted = true
+                recyclerView.postDelayed(prewarmRunnable, PREWARM_DEBOUNCE_MS)
+            }
+        }
+
+        override fun onScrollStateChanged(recyclerView: RecyclerView, newState: Int) {
+            if (newState == RecyclerView.SCROLL_STATE_IDLE && !prewarmPosted) {
+                prewarmPosted = true
+                recyclerView.postOnAnimation(prewarmRunnable)
             }
         }
     }
 
-    override fun onDetachedFromRecyclerView(recyclerView: RecyclerView) {
-        val childCount = recyclerView.childCount
-        if (animateGifs) {
-            for (i in 0 until childCount) {
-                ((recyclerView.getChildAt(i) as TextView).text as? Spannable)?.let { view ->
-                    view.getSpans<ImageSpan>().forEach {
-                        (it.drawable as? Animatable)?.stop() ?:
-                        (it.drawable as? LayerDrawable)?.let {
-                            val lastIndex = it.numberOfLayers - 1
-                            if (lastIndex > -1) {
-                                for (i in 0..lastIndex) {
-                                    (it.getDrawable(i) as? Animatable)?.stop()
-                                }
-                            }
-                        }
-                    }
-                    view.getSpans<NamePaintImageSpan>().forEach {
-                        (it.drawable as? Animatable)?.stop()
+    fun setAnimationsPaused(paused: Boolean) {
+        if (animationsPaused == paused) return
+        animationsPaused = paused
+        val recyclerView = attachedRecyclerView ?: return
+        recyclerView.removeCallbacks(pauseAnimationsRunnable)
+        recyclerView.removeCallbacks(resumeAnimationsRunnable)
+        pauseAnimationsPosted = false
+        pendingAnimationStops.clear()
+        resumeAnimationsPosted = false
+        resumeAnimationIndex = 0
+        if (paused) {
+            for (i in 0 until recyclerView.childCount) {
+                (recyclerView.getChildAt(i) as? TextView)?.let(pendingAnimationStops::addLast)
+            }
+            if (pendingAnimationStops.isNotEmpty()) {
+                pauseAnimationsPosted = true
+                recyclerView.postOnAnimation(pauseAnimationsRunnable)
+            }
+        } else {
+            for (i in 0 until recyclerView.childCount) {
+                (recyclerView.getChildViewHolder(recyclerView.getChildAt(i)) as? ViewHolder)?.let { holder ->
+                    holder.resumePendingBind()
+                    holder.postDeferredImageReload()
+                }
+            }
+            if (!animateGifs) return
+            resumeAnimationsPosted = true
+            recyclerView.postOnAnimation(resumeAnimationsRunnable)
+        }
+    }
+
+    /** Keeps completed background renders from invalidating rows while the list is flinging. */
+    fun setRenderUpdatesPaused(paused: Boolean) {
+        if (renderUpdatesPaused == paused) return
+        renderUpdatesPaused = paused
+        if (!paused) attachedRecyclerView?.postOnAnimation { flushRenderedMessages() }
+    }
+
+    fun notifyCatalogChanged() {
+        catalogIndexes = ChatAdapterUtils.ChatCatalogIndexes.create(
+            localTwitchEmotes, thirdPartyEmotes, globalBadges, channelBadges, stvUsers, stvBadges, namePaints, personalEmoteSets, cheerEmotes,
+        )
+        catalogRevision++
+        clearRenderCache()
+        attachedRecyclerView?.let { recyclerView ->
+            val layoutManager = recyclerView.layoutManager as? androidx.recyclerview.widget.LinearLayoutManager ?: return@let
+            val firstVisiblePosition = layoutManager.findFirstVisibleItemPosition()
+            val lastVisiblePosition = layoutManager.findLastVisibleItemPosition()
+            if (firstVisiblePosition != RecyclerView.NO_POSITION && lastVisiblePosition >= firstVisiblePosition) {
+                notifyItemRangeChanged(firstVisiblePosition, lastVisiblePosition - firstVisiblePosition + 1)
+            }
+        }
+    }
+
+    private fun setAnimations(textView: TextView, start: Boolean) {
+        if (start) {
+            if (!runningAnimationTextViews.add(textView)) return
+        } else if (!runningAnimationTextViews.remove(textView)) {
+            return
+        }
+        var foundAnimatable = false
+        val action: (Animatable) -> Unit = {
+            foundAnimatable = true
+            if (start) it.start() else it.stop()
+        }
+        (textView.text as? Spannable)?.let { view ->
+            view.getSpans<ImageSpan>().forEach { span ->
+                (span.drawable as? Animatable)?.let(action) ?: (span.drawable as? LayerDrawable)?.let { layers ->
+                    for (i in 0 until layers.numberOfLayers) {
+                        (layers.getDrawable(i) as? Animatable)?.let(action)
                     }
                 }
             }
+            view.getSpans<NamePaintImageSpan>().forEach { span ->
+                (span.drawable as? Animatable)?.let(action)
+            }
         }
-        super.onDetachedFromRecyclerView(recyclerView)
+        if (start && !foundAnimatable) runningAnimationTextViews.remove(textView)
     }
 
     inner class ViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
 
         val textView = itemView as TextView
+        val imageRequests = ChatAdapterUtils.ImageRequestBag()
+        private var boundMessage: ChatMessage? = null
+        private var boundReplyMessage: Boolean? = null
+        var hasDeferredImageLoad = false
+        private var bindGeneration = 0
+        private var pendingBindGeneration = 0
+        private var pendingMessage: ChatMessage? = null
+        private var pendingBuilder: SpannableStringBuilder? = null
+        private var bindPosted = false
+        private var catalogRefreshPosted = false
+        var catalogRevision = 0
+            private set
 
-        fun bind(chatMessage: ChatMessage, formattedMessage: SpannableStringBuilder) {
-            textView.apply {
-                text = formattedMessage
-                contentDescription = ChatAdapterUtils.accessibilityDescription(
-                    textView.context,
-                    chatMessage,
-                    nameDisplay,
-                    formattedMessage,
-                )
-                textSize = messageTextSize
-                if (chatMessage.type == ChatMessage.REPLY_MESSAGE) {
-                    movementMethod = null
-                    maxLines = 2
-                    ellipsize = TextUtils.TruncateAt.END
-                    TooltipCompat.setTooltipText(this, chatMessage.replyParent?.message ?: chatMessage.replyParent?.systemMsg)
-                    setOnClickListener {
-                        if (selectionStart == -1 && selectionEnd == -1) {
-                            selectedMessage = chatMessage.replyParent
-                            messageClickListener?.invoke(channelId)
-                        }
-                    }
-                } else {
-                    movementMethod = LinkMovementMethod.getInstance()
-                    maxLines = Int.MAX_VALUE
-                    ellipsize = null
-                    TooltipCompat.setTooltipText(this, chatMessage.message ?: chatMessage.systemMsg)
-                    setOnClickListener {
-                        if (selectionStart == -1 && selectionEnd == -1) {
-                            selectedMessage = chatMessage
-                            messageClickListener?.invoke(channelId)
-                        }
-                    }
+        init {
+            textView.textSize = messageTextSize
+            textView.setOnClickListener {
+                if (textView.selectionStart == -1 && textView.selectionEnd == -1) {
+                    val message = boundMessage ?: return@setOnClickListener
+                    selectedMessage = if (message.type == ChatMessage.REPLY_MESSAGE) message.replyParent else message
+                    messageClickListener?.invoke(channelId)
                 }
             }
         }
+        private val catalogRefreshRunnable = Runnable {
+            catalogRefreshPosted = false
+            val position = bindingAdapterPosition
+            if (catalogRevision < this@ChatAdapter.catalogRevision && position != RecyclerView.NO_POSITION) {
+                notifyItemChanged(position)
+            }
+        }
+        private val bindRunnable = Runnable {
+            bindPosted = false
+            val message = pendingMessage
+            val builder = pendingBuilder
+            val generation = pendingBindGeneration
+            if (!animationsPaused) {
+                pendingMessage = null
+                pendingBuilder = null
+                if (message != null && builder != null && generation == bindGeneration) {
+                    bindContent(message, builder)
+                }
+            }
+        }
+
+        fun beginBind(catalogRevision: Int): Int {
+            if (animateGifs) setAnimations(textView, start = false)
+            imageRequests.cancel()
+            hasDeferredImageLoad = false
+            itemView.removeCallbacks(catalogRefreshRunnable)
+            catalogRefreshPosted = false
+            this.catalogRevision = catalogRevision
+            itemView.removeCallbacks(bindRunnable)
+            bindPosted = false
+            pendingMessage = null
+            pendingBuilder = null
+            bindGeneration++
+            return bindGeneration
+        }
+
+        fun bindWhenReady(generation: Int, chatMessage: ChatMessage, formattedMessage: SpannableStringBuilder) {
+            if (generation != bindGeneration) return
+            pendingBindGeneration = generation
+            pendingMessage = chatMessage
+            pendingBuilder = formattedMessage
+            if (!animationsPaused) {
+                itemView.removeCallbacks(bindRunnable)
+                bindPosted = true
+                itemView.postDelayed(bindRunnable, IMAGE_UPDATE_DEBOUNCE_MS)
+            }
+        }
+
+        fun isCurrentBind(generation: Int): Boolean = generation == bindGeneration
+
+        fun canAnimate(generation: Int): Boolean = isCurrentBind(generation) && itemView.isAttachedToWindow && !animationsPaused
+
+        fun canLoadImages(generation: Int): Boolean {
+            val recyclerView = attachedRecyclerView
+            return isCurrentBind(generation) &&
+                itemView.isAttachedToWindow &&
+                !animationsPaused &&
+                (recyclerView == null || recyclerView.scrollState == RecyclerView.SCROLL_STATE_IDLE)
+        }
+
+        fun postDeferredImageReload() {
+            if (!hasDeferredImageLoad) return
+            hasDeferredImageLoad = false
+            itemView.post {
+                if (itemView.isAttachedToWindow) {
+                    bindingAdapterPosition.takeIf { it != RecyclerView.NO_POSITION }?.let(::notifyItemChanged)
+                }
+            }
+        }
+
+        fun cancelPendingBind() {
+            itemView.removeCallbacks(catalogRefreshRunnable)
+            catalogRefreshPosted = false
+            itemView.removeCallbacks(bindRunnable)
+            bindPosted = false
+            pendingMessage = null
+            pendingBuilder = null
+            bindGeneration++
+        }
+
+        fun resumePendingBind() {
+            if (pendingMessage == null || pendingBuilder == null || bindPosted) return
+            bindPosted = true
+            itemView.postOnAnimation(bindRunnable)
+        }
+
+        fun postCatalogRefresh() {
+            if (catalogRefreshPosted) return
+            catalogRefreshPosted = true
+            itemView.post(catalogRefreshRunnable)
+        }
+
+        fun bind(chatMessage: ChatMessage, result: ChatAdapterUtils.MessageResult) {
+            itemView.setBackgroundResource(result.backgroundResource)
+            bindContent(chatMessage, result.builder, result.accessibilityDescription)
+        }
+
+        private fun bindContent(chatMessage: ChatMessage, formattedMessage: SpannableStringBuilder, preparedAccessibilityDescription: String? = null) {
+            textView.apply {
+                boundMessage = chatMessage
+                text = formattedMessage
+                contentDescription = preparedAccessibilityDescription ?: ChatAdapterUtils.accessibilityDescription(
+                    textView.context, chatMessage, nameDisplay, formattedMessage,
+                )
+                val isReply = chatMessage.type == ChatMessage.REPLY_MESSAGE
+                if (boundReplyMessage != isReply) {
+                    boundReplyMessage = isReply
+                    if (isReply) {
+                        movementMethod = null
+                        maxLines = 2
+                        ellipsize = TextUtils.TruncateAt.END
+                    } else {
+                        movementMethod = LinkMovementMethod.getInstance()
+                        maxLines = Int.MAX_VALUE
+                        ellipsize = null
+                    }
+                }
+                TooltipCompat.setTooltipText(
+                    this,
+                    if (isReply) chatMessage.replyParent?.message ?: chatMessage.replyParent?.systemMsg
+                    else chatMessage.message ?: chatMessage.systemMsg,
+                )
+            }
+        }
+    }
+
+    private companion object {
+        const val MAX_RENDER_CACHE_ENTRIES = 512
+        const val MAX_ANIMATION_OPERATIONS_PER_FRAME = 4
+        const val IMAGE_UPDATE_DEBOUNCE_MS = 48L
+        const val MAX_RENDER_UPDATES_PER_FRAME = 2
+        const val MAX_RENDER_WORKERS = 2
+        const val VISIBLE_RENDER_QUEUE_CAPACITY = 32
+        const val PREWARM_QUEUE_CAPACITY = 64
+        const val PREWARM_BEFORE = 8
+        const val PREWARM_AFTER = 24
+        const val PREWARM_DEBOUNCE_MS = 100L
+    }
+
+    private fun cachedRender(key: RenderCacheKey): ChatAdapterUtils.MessageResult? = synchronized(renderCache) {
+        renderCache[key]
+    }
+
+    private fun clearRenderCache() {
+        synchronized(renderCache) { renderCache.clear() }
+        prewarmJob?.cancel()
+        prewarmJob = null
+        visibleRenderQueue.close()
+        prewarmRenderQueue.close()
+        renderSignal.close()
+        renderWorkers.forEach(Job::cancel)
+        renderWorkers = emptyList()
+        renderScope.cancel()
+        synchronized(renderJobs) {
+            renderJobs.clear()
+            prewarmRenderJobs.clear()
+            visibleRenderJobs.clear()
+        }
+        renderScope = newRenderScope()
+        visibleRenderQueue = Channel(VISIBLE_RENDER_QUEUE_CAPACITY)
+        prewarmRenderQueue = Channel(PREWARM_QUEUE_CAPACITY)
+        renderSignal = Channel(Channel.CONFLATED)
+        if (attachedRecyclerView != null) ensureRenderWorkers()
+    }
+
+    private fun enqueueRender(
+        chatMessage: ChatMessage,
+        cacheKey: RenderCacheKey,
+        context: android.content.Context,
+        indexes: ChatAdapterUtils.ChatCatalogIndexes,
+        prewarmGeneration: Long? = null,
+    ) {
+        ensureRenderWorkers()
+        val isPrewarm = prewarmGeneration != null
+        synchronized(renderJobs) {
+            if (isPrewarm) {
+                if (!renderJobs.add(cacheKey)) return
+                prewarmRenderJobs.add(cacheKey)
+            } else {
+                val promoted = prewarmRenderJobs.remove(cacheKey)
+                if (!promoted && !renderJobs.add(cacheKey)) return
+                visibleRenderJobs.add(cacheKey)
+            }
+        }
+        val queue = if (isPrewarm) prewarmRenderQueue else visibleRenderQueue
+        val result = queue.trySend(RenderRequest(chatMessage, cacheKey, context, indexes, prewarmGeneration))
+        if (result.isFailure) {
+            synchronized(renderJobs) {
+                renderJobs.remove(cacheKey)
+                prewarmRenderJobs.remove(cacheKey)
+                visibleRenderJobs.remove(cacheKey)
+            }
+        } else {
+            renderSignal.trySend(Unit)
+        }
+    }
+
+    private fun startRenderWorkers(): List<Job> = List(MAX_RENDER_WORKERS) {
+        renderScope.launch {
+            for (ignored in renderSignal) {
+                while (true) {
+                    val request = visibleRenderQueue.tryReceive().getOrNull()
+                        ?: prewarmRenderQueue.tryReceive().getOrNull()
+                        ?: break
+                    if (request.prewarmGeneration != null && request.prewarmGeneration != prewarmGeneration) {
+                        synchronized(renderJobs) {
+                            if (request.cacheKey !in visibleRenderJobs) {
+                                renderJobs.remove(request.cacheKey)
+                            }
+                            prewarmRenderJobs.remove(request.cacheKey)
+                        }
+                        continue
+                    }
+                    if (request.prewarmGeneration != null) {
+                        val shouldRender = synchronized(renderJobs) {
+                            val supersededByVisible = request.cacheKey in visibleRenderJobs
+                            val stillQueuedAsPrewarm = prewarmRenderJobs.remove(request.cacheKey)
+                            if (!supersededByVisible && !stillQueuedAsPrewarm) {
+                                renderJobs.remove(request.cacheKey)
+                            }
+                            !supersededByVisible && stillQueuedAsPrewarm
+                        }
+                        if (!shouldRender) continue
+                    }
+                    renderMessage(request)
+                }
+            }
+        }
+    }
+
+    private fun ensureRenderWorkers() {
+        if (renderWorkers.any(Job::isActive)) return
+        if (!renderScope.isActive) {
+            renderScope = newRenderScope()
+            visibleRenderQueue = Channel(VISIBLE_RENDER_QUEUE_CAPACITY)
+            prewarmRenderQueue = Channel(PREWARM_QUEUE_CAPACITY)
+            renderSignal = Channel(Channel.CONFLATED)
+        }
+        renderWorkers = startRenderWorkers()
+    }
+
+    private suspend fun renderMessage(request: RenderRequest) {
+        val chatMessage = request.message
+        val cacheKey = request.cacheKey
+        try {
+            if (cachedRender(cacheKey) != null) return
+            val prepared = prepareMessage(chatMessage, request.context, null, request.indexes, offMain = true)
+            withContext(Dispatchers.Main.immediate) {
+                if (currentRenderKey(chatMessage) == cacheKey) {
+                    synchronized(renderCache) { renderCache[cacheKey] = prepared }
+                    if (addPendingRenderedMessage(chatMessage)) {
+                        scheduleRenderedFlush()
+                    }
+                }
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (_: Exception) {
+            // A malformed chat payload must not take down the render worker. The fast fallback
+            // remains visible and the next bind can retry the message.
+        } finally {
+            synchronized(renderJobs) {
+                renderJobs.remove(cacheKey)
+                prewarmRenderJobs.remove(cacheKey)
+                visibleRenderJobs.remove(cacheKey)
+            }
+        }
+    }
+
+    private fun enqueuePrewarmRender(
+        message: ChatMessage,
+        revision: Int,
+        context: android.content.Context,
+        indexes: ChatAdapterUtils.ChatCatalogIndexes,
+        generation: Long,
+    ) {
+        enqueueRender(message, createRenderKey(message, revision), context, indexes, generation)
+    }
+
+    private fun scheduleVisiblePrewarm(recyclerView: RecyclerView) {
+        recyclerView.post {
+            if (attachedRecyclerView !== recyclerView) return@post
+            val layoutManager = recyclerView.layoutManager as? androidx.recyclerview.widget.LinearLayoutManager ?: return@post
+            val first = layoutManager.findFirstVisibleItemPosition()
+            val last = layoutManager.findLastVisibleItemPosition()
+            val context = fragment.context ?: return@post
+            if (first == RecyclerView.NO_POSITION || last < first) return@post
+            val start = (first - PREWARM_BEFORE).coerceAtLeast(0)
+            val end = (last + PREWARM_AFTER).coerceAtMost(messages.size - 1)
+            if (end < start) return@post
+            val snapshot = messages.subList(start, end + 1).toList()
+            val revision = catalogRevision
+            val indexes = catalogIndexes
+            val generation = ++prewarmGeneration
+            prewarmJob?.cancel()
+            prewarmJob = renderScope.launch {
+                snapshot.forEach { message ->
+                    enqueuePrewarmRender(message, revision, context, indexes, generation)
+                    yield()
+                }
+            }
+        }
+    }
+
+    private fun currentRenderKey(message: ChatMessage): RenderCacheKey = createRenderKey(message, catalogRevision)
+
+    private fun createRenderKey(message: ChatMessage, revision: Int = catalogRevision) = RenderCacheKey(
+        message = message,
+        catalogRevision = revision,
+        translateAllMessages = translateAllMessages,
+        translatedMessage = message.translatedMessage,
+        translationFailed = message.translationFailed,
+        messageLanguage = message.messageLanguage,
+    )
+
+    private fun addPendingRenderedMessage(message: ChatMessage): Boolean {
+        val recyclerView = attachedRecyclerView ?: return false
+        val layoutManager = recyclerView.layoutManager as? androidx.recyclerview.widget.LinearLayoutManager
+            ?: return false
+        val firstVisible = layoutManager.findFirstVisibleItemPosition()
+        val lastVisible = layoutManager.findLastVisibleItemPosition()
+        if (firstVisible == RecyclerView.NO_POSITION || lastVisible < firstVisible) return false
+        val visible = (firstVisible..lastVisible).any { position ->
+            messages.getOrNull(position) === message &&
+                recyclerView.findViewHolderForAdapterPosition(position) != null
+        }
+        if (!visible) return false
+        return pendingRenderedMessages.add(message)
+    }
+
+    private fun scheduleRenderedFlush() {
+        val recyclerView = attachedRecyclerView ?: return
+        if (renderedFlushPosted || renderUpdatesPaused || recyclerView.scrollState != RecyclerView.SCROLL_STATE_IDLE) return
+        renderedFlushPosted = true
+        recyclerView.postOnAnimation(renderedFlushRunnable)
+    }
+
+    private fun flushRenderedMessages() {
+        val recyclerView = attachedRecyclerView ?: return
+        if (renderUpdatesPaused || recyclerView.scrollState != RecyclerView.SCROLL_STATE_IDLE) return
+        if (recyclerView.isComputingLayout) {
+            recyclerView.postOnAnimation { flushRenderedMessages() }
+            return
+        }
+        if (pendingRenderedMessages.isEmpty()) return
+        val layoutManager = recyclerView.layoutManager as? androidx.recyclerview.widget.LinearLayoutManager
+            ?: return
+        val firstVisible = layoutManager.findFirstVisibleItemPosition()
+        val lastVisible = layoutManager.findLastVisibleItemPosition()
+        if (firstVisible == RecyclerView.NO_POSITION || lastVisible < firstVisible) return
+        var applied = 0
+        var hasMoreVisiblePending = false
+        for (position in firstVisible..lastVisible) {
+            val message = messages.getOrNull(position) ?: continue
+            if (!pendingRenderedMessages.contains(message)) continue
+            if (recyclerView.findViewHolderForAdapterPosition(position) == null) {
+                pendingRenderedMessages.remove(message)
+            } else if (applied < MAX_RENDER_UPDATES_PER_FRAME) {
+                pendingRenderedMessages.remove(message)
+                notifyItemChanged(position)
+                applied++
+            } else {
+                hasMoreVisiblePending = true
+            }
+        }
+        // Off-screen prewarm completions only need to remain in renderCache. Do
+        // not keep posting at display refresh rate for rows that cannot update.
+        if (!hasMoreVisiblePending) pendingRenderedMessages.clear()
+        if (hasMoreVisiblePending) scheduleRenderedFlush()
+    }
+
+    private fun newRenderScope(): CoroutineScope = CoroutineScope(
+        SupervisorJob() + Dispatchers.Default.limitedParallelism(MAX_RENDER_WORKERS),
+    )
+
+    private fun prepareMessage(
+        chatMessage: ChatMessage,
+        context: android.content.Context,
+        itemView: View?,
+        indexes: ChatAdapterUtils.ChatCatalogIndexes,
+        offMain: Boolean,
+    ): ChatAdapterUtils.MessageResult {
+        val deferredTranslate: (ChatMessage, String?) -> Unit = { message, language ->
+            if (offMain) {
+                mainHandler.post {
+                    if (attachedRecyclerView != null && fragment.isAdded) translateMessage(message, language)
+                }
+            } else {
+                translateMessage(message, language)
+            }
+        }
+        val deferredLanguageDialog: (ChatMessage, String) -> Unit = { message, language ->
+            if (offMain) {
+                mainHandler.post {
+                    if (attachedRecyclerView != null && fragment.isAdded) showLanguageDownloadDialog(message, language)
+                }
+            } else {
+                showLanguageDownloadDialog(message, language)
+            }
+        }
+        return ChatAdapterUtils.prepareChatMessage(
+            chatMessage, context, itemView, enableTimestamps, timestampFormat, firstMsgVisibility, firstChatMsg,
+            redeemedChatMsg, redeemedNoMsg, rewardChatMsg, replyMessage, null, useRandomColors, random, useReadableColors, isLightTheme,
+            nameDisplay, useBoldNames, showNamePaints, namePaints, showBadges, showSTVBadges, stvBadges, showPersonalEmotes, personalEmoteSets, stvUsers,
+            enableOverlayEmotes, showSystemMessageEmotes, loggedInUser, chatUrl, userColors, savedColors, translateAllMessages,
+            deferredTranslate, deferredLanguageDialog, true, localTwitchEmotes, thirdPartyEmotes, globalBadges, channelBadges, cheerEmotes,
+            savedLocalTwitchEmotes, savedLocalBadges, savedLocalCheerEmotes, savedLocalEmotes,
+            catalogIndexes = indexes, includeAccessibilityDescription = true,
+        )
+    }
+
+    private fun fastFallback(chatMessage: ChatMessage): ChatAdapterUtils.MessageResult {
+        val displayName = when {
+            chatMessage.userName.isNullOrBlank() -> null
+            chatMessage.userLogin.isNullOrBlank() || chatMessage.userLogin.equals(chatMessage.userName, true) -> chatMessage.userName
+            nameDisplay == "0" -> "${chatMessage.userName}(${chatMessage.userLogin})"
+            nameDisplay == "1" -> chatMessage.userName
+            else -> chatMessage.userLogin
+        }
+        val builder = SpannableStringBuilder()
+        if (chatMessage.type == ChatMessage.REPLY_MESSAGE) {
+            val replyName = chatMessage.reply?.userName ?: chatMessage.reply?.userLogin
+            builder.append(replyMessage.format(replyName, ""))
+            builder.append(chatMessage.reply?.message.orEmpty())
+        } else {
+            chatMessage.systemMsg?.takeIf { it.isNotBlank() }?.let {
+                builder.append(it)
+                builder.append('\n')
+            }
+            displayName?.let { builder.append(it).append(if (chatMessage.isAction) " " else ": ") }
+            builder.append(chatMessage.message ?: chatMessage.reward?.title.orEmpty())
+        }
+        val backgroundResource = when {
+            chatMessage.isFirst && firstMsgVisibility < 2 -> R.color.chatMessageFirst
+            chatMessage.reward?.id != null && firstMsgVisibility < 2 -> R.color.chatMessageReward
+            chatMessage.systemMsg != null || chatMessage.msgId != null -> R.color.chatMessageNotice
+            else -> 0
+        }
+        return ChatAdapterUtils.MessageResult(builder, arrayListOf(), null, displayName, null, false, backgroundResource)
     }
 }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatFragment.kt
@@ -123,6 +123,64 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
     private var composerSelectionBeforeOverlay: Int? = null
     private var messageViewWasVisibleBeforeOverlay: Boolean? = null
     private var lastSlowModeUiState = SlowModeState()
+    private var chatScrollPosted = false
+    private var chatAdapterUpdatePosted = false
+    private val pendingChatMutations = ArrayDeque<ChatViewModel.ChatMutation>()
+    private var chatMutationRevision = 0L
+    private val chatScrollRunnable = Runnable {
+        chatScrollPosted = false
+        val currentBinding = _binding ?: return@Runnable
+        if (!isChatTouched && currentBinding.btnDown.isGone) {
+            val lastIndex = adapter?.itemCount?.minus(1) ?: RecyclerView.NO_POSITION
+            currentBinding.recyclerView.scrollToPosition(lastIndex)
+        }
+    }
+    private val chatAdapterUpdateRunnable = Runnable {
+        chatAdapterUpdatePosted = false
+        val currentBinding = _binding ?: return@Runnable
+        val currentAdapter = adapter ?: return@Runnable
+        var hasNewMessages = false
+        while (pendingChatMutations.isNotEmpty()) {
+            when (val firstMutation = pendingChatMutations.removeFirst()) {
+                is ChatViewModel.ChatMutation.Append -> {
+                    val messages = ArrayList<ChatMessage>(firstMutation.messages.size)
+                    messages.addAll(firstMutation.messages)
+                    var trimCount = firstMutation.trimCount
+                    var revision = firstMutation.revision
+                    while (pendingChatMutations.firstOrNull() is ChatViewModel.ChatMutation.Append) {
+                        val next = pendingChatMutations.removeFirst() as ChatViewModel.ChatMutation.Append
+                        messages.addAll(next.messages)
+                        trimCount += next.trimCount
+                        revision = next.revision
+                    }
+                    currentAdapter.appendMessages(messages, trimCount)
+                    chatMutationRevision = revision
+                    hasNewMessages = true
+                }
+                is ChatViewModel.ChatMutation.Prepend -> {
+                    val batches = ArrayList<List<ChatMessage>>()
+                    batches += firstMutation.messages
+                    var revision = firstMutation.revision
+                    while (pendingChatMutations.firstOrNull() is ChatViewModel.ChatMutation.Prepend) {
+                        val next = pendingChatMutations.removeFirst() as ChatViewModel.ChatMutation.Prepend
+                        batches += next.messages
+                        revision = next.revision
+                    }
+                    val messages = ArrayList<ChatMessage>(batches.sumOf { it.size })
+                    batches.asReversed().forEach(messages::addAll)
+                    currentAdapter.prependMessages(messages)
+                    chatMutationRevision = revision
+                }
+                is ChatViewModel.ChatMutation.Clear -> {
+                    currentAdapter.clearMessages()
+                    chatMutationRevision = firstMutation.revision
+                }
+            }
+        }
+        if (hasNewMessages && !isChatTouched && currentBinding.btnDown.isGone) {
+            scheduleChatScrollToEnd()
+        }
+    }
 
     private var autoCompleteAdapter: AutoCompleteAdapter<Any>? = null
 
@@ -137,6 +195,20 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
 
     private val replyDialog: ReplyClickedDialog?
         get() = childFragmentManager.findFragmentByTag("replyDialog") as? ReplyClickedDialog
+
+    private fun scheduleChatScrollToEnd() {
+        if (chatScrollPosted) return
+        val recyclerView = _binding?.recyclerView ?: return
+        chatScrollPosted = true
+        recyclerView.postOnAnimation(chatScrollRunnable)
+    }
+
+    private fun scheduleChatAdapterUpdate() {
+        if (chatAdapterUpdatePosted) return
+        val recyclerView = _binding?.recyclerView ?: return
+        chatAdapterUpdatePosted = true
+        recyclerView.postDelayed(chatAdapterUpdateRunnable, CHAT_UPDATE_BATCH_MS)
+    }
 
     private var languageIdentifier: LanguageIdentifier? = null
     private val translators = mutableMapOf<String, Translator>()
@@ -287,7 +359,7 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
                     val enableMessaging = isLive && isLoggedIn
                     val sizeModifier = (requireContext().prefs().getInt(C.CHAT_SIZE_MODIFIER, 100).toFloat() / 100f)
                     adapter = ChatAdapter(
-                        messages = viewModel.chatMessages,
+                        initialMessages = viewModel.chatSnapshot().also { chatMutationRevision = it.revision }.messages,
                         localTwitchEmotes = viewModel.localTwitchEmotes,
                         thirdPartyEmotes = viewModel.thirdPartyEmotes,
                         globalBadges = viewModel.globalBadges,
@@ -318,7 +390,6 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
                         showPersonalEmotes = requireContext().prefs().getBoolean(C.CHAT_SHOW_PERSONAL_EMOTES, true),
                         showSystemMessageEmotes = requireContext().prefs().getBoolean(C.CHAT_SYSTEM_MESSAGE_EMOTES, true),
                         chatUrl = chatUrl,
-                        getEmoteBytes = viewModel::getEmoteBytes,
                         fragment = this@ChatFragment,
                         backgroundColor = MaterialColors.getColor(requireView(), com.google.android.material.R.attr.colorSurface),
                         dialogBackgroundColor = MaterialColors.getColor(
@@ -368,7 +439,13 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
                         it.addOnScrollListener(object : RecyclerView.OnScrollListener() {
                             override fun onScrollStateChanged(recyclerView: RecyclerView, newState: Int) {
                                 super.onScrollStateChanged(recyclerView, newState)
-                                isChatTouched = newState == RecyclerView.SCROLL_STATE_DRAGGING
+                                isChatTouched = newState != RecyclerView.SCROLL_STATE_IDLE
+                                if (newState != RecyclerView.SCROLL_STATE_IDLE) {
+                                    recyclerView.removeCallbacks(chatAdapterUpdateRunnable)
+                                    chatAdapterUpdatePosted = false
+                                }
+                                adapter?.setAnimationsPaused(newState != RecyclerView.SCROLL_STATE_IDLE)
+                                adapter?.setRenderUpdatesPaused(newState != RecyclerView.SCROLL_STATE_IDLE)
                                 val offset = recyclerView.computeVerticalScrollOffset()
                                 if (offset < 0) {
                                     btnDown.isVisible = false
@@ -382,14 +459,15 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
                                     chatStatus.visibility = View.VISIBLE
                                     chatStatus.postDelayed({ chatStatus.visibility = View.GONE }, 5000)
                                 }
+                                if (newState == RecyclerView.SCROLL_STATE_IDLE && pendingChatMutations.isNotEmpty()) {
+                                    scheduleChatAdapterUpdate()
+                                }
                             }
                         })
                     }
                     btnDown.setOnClickListener {
                         view.post {
-                            val lastIndex = synchronized(viewModel.chatMessages) {
-                                viewModel.chatMessages.lastIndex
-                            }
+                            val lastIndex = adapter?.itemCount?.minus(1) ?: RecyclerView.NO_POSITION
                             recyclerView.scrollToPosition(lastIndex)
                             it.visibility = View.GONE
                         }
@@ -587,10 +665,7 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
                             viewModel.reloadMessages.collectLatest {
                                 if (it) {
                                     adapter?.let { adapter ->
-                                        val size = synchronized(viewModel.chatMessages) {
-                                            viewModel.chatMessages.size
-                                        }
-                                        adapter.notifyItemRangeChanged(0, size)
+                                        adapter.notifyCatalogChanged()
                                     }
                                     messageDialog?.adapter?.let { adapter ->
                                         val size = synchronized(adapter.messages) {
@@ -728,51 +803,25 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
                     }
                     viewLifecycleOwner.lifecycleScope.launch {
                         repeatOnLifecycle(Lifecycle.State.STARTED) {
-                            viewModel.newMessage.collect { result ->
-                                val message = result.first
-                                val lastIndex = result.second
-                                val removeCount = result.third
-                                adapter?.let { adapter ->
-                                    adapter.notifyItemInserted(lastIndex)
-                                    if (removeCount > 0) {
-                                        synchronized(viewModel.chatMessages) {
-                                            repeat(removeCount) {
-                                                viewModel.chatMessages.removeAt(0)
-                                            }
+                            viewModel.chatMutations.collect { mutation ->
+                                if (mutation.revision <= chatMutationRevision) return@collect
+                                pendingChatMutations.addLast(mutation)
+                                when (mutation) {
+                                    is ChatViewModel.ChatMutation.Append -> {
+                                        mutation.messages.forEach { message ->
+                                            chatMessageListener?.invoke(message)
+                                            messageDialog?.newMessage(message)
+                                            replyDialog?.newMessage(message)
                                         }
-                                        adapter.notifyItemRangeRemoved(0, removeCount)
                                     }
-                                    if (!isChatTouched && binding.btnDown.isGone) {
-                                        binding.recyclerView.scrollToPosition(lastIndex - removeCount)
+                                    is ChatViewModel.ChatMutation.Prepend -> {
+                                        chatHistoryListener?.invoke(mutation.messages)
+                                        messageDialog?.addMessages(mutation.messages)
+                                        replyDialog?.addMessages(mutation.messages)
                                     }
+                                    is ChatViewModel.ChatMutation.Clear -> Unit
                                 }
-                                chatMessageListener?.invoke(message)
-                                messageDialog?.newMessage(message)
-                                replyDialog?.newMessage(message)
-                            }
-                        }
-                    }
-                    viewLifecycleOwner.lifecycleScope.launch {
-                        repeatOnLifecycle(Lifecycle.State.STARTED) {
-                            viewModel.addMessages.collect { result ->
-                                val messages = result.first
-                                val lastIndex = result.second
-                                adapter?.let { adapter ->
-                                    adapter.notifyItemRangeInserted(0, messages.size)
-                                    if (!isChatTouched && binding.btnDown.isGone) {
-                                        binding.recyclerView.scrollToPosition(lastIndex)
-                                    }
-                                }
-                                chatHistoryListener?.invoke(messages)
-                                messageDialog?.addMessages(messages)
-                                replyDialog?.addMessages(messages)
-                            }
-                        }
-                    }
-                    viewLifecycleOwner.lifecycleScope.launch {
-                        repeatOnLifecycle(Lifecycle.State.STARTED) {
-                            viewModel.removeMessages.collect { size ->
-                                adapter?.notifyItemRangeRemoved(0, size)
+                                if (!isChatTouched) scheduleChatAdapterUpdate()
                             }
                         }
                     }
@@ -780,15 +829,7 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
                         repeatOnLifecycle(Lifecycle.State.STARTED) {
                             viewModel.updateUserMessages.collectLatest { userId ->
                                 adapter?.let { adapter ->
-                                    synchronized(viewModel.chatMessages) {
-                                        viewModel.chatMessages.mapIndexedNotNull { index, message ->
-                                            if (message.userId != null && message.userId == userId) {
-                                                index
-                                            } else null
-                                        }
-                                    }.forEach {
-                                        adapter.notifyItemChanged(it)
-                                    }
+                                    adapter.notifyUserMessages(userId)
                                 }
                                 messageDialog?.updateUserMessages(userId)
                                 replyDialog?.updateUserMessages(userId)
@@ -967,7 +1008,7 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
         viewModel.deleteTranslatedChannel(channelId)
     }
 
-    fun emoteMenuIsVisible() = binding.emoteMenu.isVisible
+    fun emoteMenuIsVisible() = _binding?.emoteMenu?.isVisible == true
 
     fun toggleEmoteMenu(enable: Boolean) {
         if (enable) {
@@ -1677,6 +1718,11 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
     }
 
     override fun onDestroyView() {
+        _binding?.recyclerView?.removeCallbacks(chatScrollRunnable)
+        _binding?.recyclerView?.removeCallbacks(chatAdapterUpdateRunnable)
+        chatScrollPosted = false
+        chatAdapterUpdatePosted = false
+        pendingChatMutations.clear()
         disposeChannelPointsIconRequest()
         channelPointsIconRequestGeneration++
         channelPointsIconUrl = null
@@ -1796,6 +1842,7 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
     }
 
     companion object {
+        private const val CHAT_UPDATE_BATCH_MS = 32L
         private const val KEY_IS_LIVE = "isLive"
         private const val KEY_CHANNEL_ID = "channel_id"
         private const val KEY_CHANNEL_LOGIN = "channel_login"

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatViewModel.kt
@@ -4,7 +4,6 @@ import android.content.ContentResolver
 import android.content.Context
 import android.net.ConnectivityManager
 import android.os.SystemClock
-import android.util.Base64
 import android.util.JsonReader
 import android.util.JsonToken
 import android.util.Log
@@ -143,6 +142,28 @@ class ChatViewModel(
     private val trustManager: Lazy<X509TrustManager>,
     private val json: Json,
 ) : ViewModel() {
+
+    data class ChatSnapshot(
+        val revision: Long,
+        val messages: List<ChatMessage>,
+    )
+
+    sealed interface ChatMutation {
+        val revision: Long
+
+        data class Append(
+            override val revision: Long,
+            val messages: List<ChatMessage>,
+            val trimCount: Int,
+        ) : ChatMutation
+
+        data class Prepend(
+            override val revision: Long,
+            val messages: List<ChatMessage>,
+        ) : ChatMutation
+
+        data class Clear(override val revision: Long) : ChatMutation
+    }
 
     enum class ConnectionState {
         IDLE,
@@ -314,9 +335,8 @@ class ChatViewModel(
     val reloadMessages = MutableStateFlow(false)
     val hideRaid = MutableStateFlow(false)
 
-    val newMessage = MutableSharedFlow<Triple<ChatMessage, Int, Int>>()
-    val addMessages = MutableSharedFlow<Pair<List<ChatMessage>, Int>>()
-    val removeMessages = MutableSharedFlow<Int>()
+    private val chatMutationEvents = Channel<ChatMutation>(Channel.UNLIMITED)
+    val chatMutations: Flow<ChatMutation> = chatMutationEvents.receiveAsFlow()
     val updateUserMessages = MutableSharedFlow<String>()
     val userEmotesUpdated = MutableSharedFlow<Unit>()
     private val channelPointModifiedEmotesUpdated = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
@@ -324,6 +344,7 @@ class ChatViewModel(
 
     private var messageLimit = 600
     val chatMessages = mutableListOf<ChatMessage>()
+    private var chatRevision = 0L
     val autoCompleteList = mutableListOf<Any?>()
     private val chatters = ConcurrentHashMap<String, Chatter>()
 
@@ -979,19 +1000,6 @@ class ChatViewModel(
         }
     }
 
-    fun getEmoteBytes(chatUrl: String, localData: Pair<Long, Int>): ByteArray? {
-        return if (chatUrl.toUri().scheme == ContentResolver.SCHEME_CONTENT) {
-            applicationContext.contentResolver.openInputStream(chatUrl.toUri())?.bufferedReader()
-        } else {
-            FileInputStream(File(chatUrl)).bufferedReader()
-        }?.use { fileReader ->
-            val buffer = CharArray(localData.second)
-            fileReader.skip(localData.first)
-            fileReader.read(buffer, 0, localData.second)
-            Base64.decode(buffer.concatToString(), Base64.NO_WRAP or Base64.NO_PADDING)
-        }
-    }
-
     fun reloadEmotes(channelId: String?, channelLogin: String?) {
         savedGlobalBadges = null
         savedGlobalSTVEmotes = null
@@ -1047,11 +1055,8 @@ class ChatViewModel(
                             if (left > 0) {
                                 val items = list.takeLast(left)
                                 chatMessages.addAll(0, items)
-                                Pair(items, chatMessages.lastIndex)
-                            } else null
-                        }.let {
-                            if (it != null) {
-                                addMessages.emit(it)
+                                chatRevision++
+                                chatMutationEvents.trySend(ChatMutation.Prepend(chatRevision, items))
                             }
                         }
                     }
@@ -1127,18 +1132,17 @@ class ChatViewModel(
             val removeCount = if (chatMessages.size > messageLimit) {
                 chatMessages.size - messageLimit
             } else 0
-            if (newMessage.subscriptionCount.value > 0) {
-                Triple(message, chatMessages.lastIndex, removeCount)
-            } else {
-                if (removeCount > 0) {
-                    repeat(removeCount) {
-                        chatMessages.removeAt(0)
-                    }
-                }
-                null
+            if (removeCount > 0) {
+                chatMessages.subList(0, removeCount).clear()
             }
-        }?.let {
-            newMessage.emit(it)
+            chatRevision++
+            chatMutationEvents.trySend(
+                ChatMutation.Append(
+                    revision = chatRevision,
+                    messages = listOf(message),
+                    trimCount = removeCount,
+                )
+            )
         }
     }
 
@@ -1294,13 +1298,16 @@ class ChatViewModel(
         _slowModeState.value = SlowModeState()
     }
 
-    /** Trims history after a subscriber has consumed a message overflow. */
-    fun trimMessageOverflow() {
+    fun chatSnapshot(): ChatSnapshot = synchronized(chatMessages) {
+        ChatSnapshot(chatRevision, chatMessages.toList())
+    }
+
+    private fun clearChatMessages() {
         synchronized(chatMessages) {
-            val overflow = chatMessages.size - messageLimit
-            if (overflow > 0) {
-                chatMessages.subList(0, overflow).clear()
-            }
+            if (chatMessages.isEmpty()) return
+            chatMessages.clear()
+            chatRevision++
+            chatMutationEvents.trySend(ChatMutation.Clear(chatRevision))
         }
     }
 
@@ -2388,13 +2395,7 @@ class ChatViewModel(
         usedRaidId = null
         raidClosed = true
         viewModelScope.launch {
-            synchronized(chatMessages) {
-                val size = chatMessages.size
-                chatMessages.clear()
-                size
-            }.let {
-                removeMessages.emit(it)
-            }
+            clearChatMessages()
             onMessage(ChatMessage(systemMsg = ContextCompat.getString(applicationContext, R.string.disconnected)))
         }
         if (!hideRaid.value) {
@@ -4602,13 +4603,7 @@ class ChatViewModel(
         }
 
         override suspend fun clearMessages() {
-            synchronized(chatMessages) {
-                val size = chatMessages.size
-                chatMessages.clear()
-                size
-            }.let {
-                removeMessages.emit(it)
-            }
+            clearChatMessages()
         }
 
         override suspend fun getIntegrityToken() {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/MessageClickedChatAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/MessageClickedChatAdapter.kt
@@ -64,7 +64,6 @@ class MessageClickedChatAdapter(
     private val showPersonalEmotes: Boolean,
     private val showSystemMessageEmotes: Boolean,
     private val chatUrl: String?,
-    private val getEmoteBytes: ((String, Pair<Long, Int>) -> ByteArray?)?,
     private val fragment: Fragment,
     private val backgroundColor: Int,
     private val imageLibrary: String?,
@@ -122,12 +121,13 @@ class MessageClickedChatAdapter(
             redeemedChatMsg, redeemedNoMsg, rewardChatMsg, replyMessage, { url, name, format, isAnimated, source, thirdParty, emoteId -> imageClick(url, name, format, isAnimated, source, thirdParty, emoteId) },
             useRandomColors, random, useReadableColors, isLightTheme, nameDisplay, useBoldNames, showNamePaints, namePaints, showBadges, showSTVBadges,
             stvBadges, showPersonalEmotes, personalEmoteSets, stvUsers, enableOverlayEmotes, showSystemMessageEmotes, loggedInUser, chatUrl,
-            getEmoteBytes, userColors, savedColors, translateAllMessages, translateMessage, showLanguageDownloadDialog, false, localTwitchEmotes,
+            userColors, savedColors, translateAllMessages, translateMessage, showLanguageDownloadDialog, false, localTwitchEmotes,
             thirdPartyEmotes, globalBadges, channelBadges, cheerEmotes, savedLocalTwitchEmotes, savedLocalBadges, savedLocalCheerEmotes, savedLocalEmotes
         )
         if (chatMessage == selectedMessage) {
             holder.textView.setBackgroundResource(R.color.chatMessageSelected)
         }
+        ChatAdapterUtils.installImagePlaceholders(result.builder, result.images, emoteSize, badgeSize, inlineIconSize)
         holder.bind(chatMessage, result.builder)
         ChatAdapterUtils.loadImages(
             fragment, holder.textView, { holder.bind(chatMessage, it) }, result.images, result.imagePaint, result.userName, result.userNameStartIndex,

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ReplyClickedChatAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ReplyClickedChatAdapter.kt
@@ -62,7 +62,6 @@ class ReplyClickedChatAdapter(
     private val showPersonalEmotes: Boolean,
     private val showSystemMessageEmotes: Boolean,
     private val chatUrl: String?,
-    private val getEmoteBytes: ((String, Pair<Long, Int>) -> ByteArray?)?,
     private val fragment: Fragment,
     private val backgroundColor: Int,
     private val imageLibrary: String?,
@@ -111,12 +110,13 @@ class ReplyClickedChatAdapter(
             redeemedChatMsg, redeemedNoMsg, rewardChatMsg, replyMessage, { url, name, format, isAnimated, source, thirdParty, emoteId -> imageClick(url, name, format, isAnimated, source, thirdParty, emoteId) },
             useRandomColors, random, useReadableColors, isLightTheme, nameDisplay, useBoldNames, showNamePaints, namePaints, showBadges, showSTVBadges,
             stvBadges, showPersonalEmotes, personalEmoteSets, stvUsers, enableOverlayEmotes, showSystemMessageEmotes, loggedInUser, chatUrl,
-            getEmoteBytes, userColors, savedColors, translateAllMessages, translateMessage, showLanguageDownloadDialog, false, localTwitchEmotes,
+            userColors, savedColors, translateAllMessages, translateMessage, showLanguageDownloadDialog, false, localTwitchEmotes,
             thirdPartyEmotes, globalBadges, channelBadges, cheerEmotes, savedLocalTwitchEmotes, savedLocalBadges, savedLocalCheerEmotes, savedLocalEmotes
         )
         if (chatMessage == selectedMessage) {
             holder.textView.setBackgroundResource(R.color.chatMessageSelected)
         }
+        ChatAdapterUtils.installImagePlaceholders(result.builder, result.images, emoteSize, badgeSize, inlineIconSize)
         holder.bind(chatMessage, result.builder)
         ChatAdapterUtils.loadImages(
             fragment, holder.textView, { holder.bind(chatMessage, it) }, result.images, result.imagePaint, result.userName, result.userNameStartIndex,

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/ClipsAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/ClipsAdapter.kt
@@ -44,13 +44,32 @@ class ClipsAdapter(
                     oldItem.title == newItem.title
     }) {
 
+    private val imageLoadScheduler = StreamThumbnailIdleScheduler()
+
+    override fun onAttachedToRecyclerView(recyclerView: RecyclerView) {
+        super.onAttachedToRecyclerView(recyclerView)
+        imageLoadScheduler.attachTo(recyclerView)
+    }
+
+    override fun onDetachedFromRecyclerView(recyclerView: RecyclerView) {
+        imageLoadScheduler.detach()
+        super.onDetachedFromRecyclerView(recyclerView)
+    }
+
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): PagingViewHolder {
         val binding = FragmentVideosListItemBinding.inflate(LayoutInflater.from(parent.context), parent, false)
         return PagingViewHolder(binding, fragment, showGame, showChannel)
     }
 
     override fun onBindViewHolder(holder: PagingViewHolder, position: Int) {
+        holder.beginImageBind(getItem(position))
         holder.bind(getItem(position))
+    }
+
+    override fun onViewRecycled(holder: PagingViewHolder) {
+        imageLoadScheduler.clear(holder)
+        holder.cancelImageWork()
+        super.onViewRecycled(holder)
     }
 
     inner class PagingViewHolder(
@@ -58,27 +77,76 @@ class ClipsAdapter(
         private val fragment: Fragment,
         private val showGame: Boolean,
         private val showChannel: Boolean,
-    ) : RecyclerView.ViewHolder(binding.root) {
+    ) : RecyclerView.ViewHolder(binding.root), FeedImageRequestOwner {
+        private val imageRequests = FeedImageRequestBag()
+        private var boundClipId: String? = null
+        private var boundClip: Clip? = null
+
+        init {
+            binding.root.setOnClickListener {
+                boundClip?.let { (fragment.activity as? MainActivity)?.startClip(it) }
+            }
+            binding.root.setOnLongClickListener {
+                boundClip?.let {
+                    showDownloadDialog(it)
+                    true
+                } ?: false
+            }
+            binding.userImage.setOnClickListener { boundClip?.let(::openChannel) }
+            binding.username.setOnClickListener { boundClip?.let(::openChannel) }
+            binding.gameName.setOnClickListener { boundClip?.let(::openGame) }
+            binding.options.setOnClickListener { showOptions(it) }
+        }
+
+        fun beginImageBind(item: Clip?) {
+            imageLoadScheduler.clear(this)
+            imageRequests.cancel()
+            boundClipId = item?.id
+        }
+
+        override fun cancelImageRequests() {
+            imageRequests.cancel()
+        }
+
+        override fun pauseImageRequests() {
+            imageRequests.cancel(preserveRegistrations = true)
+        }
+
+        fun cancelImageWork() {
+            cancelImageRequests()
+            boundClipId = null
+            boundClip = null
+        }
+
         fun bind(item: Clip?) {
+            boundClip = item
             with(binding) {
                 if (item != null) {
                     val context = fragment.requireContext()
-                    root.setOnClickListener {
-                        (fragment.activity as MainActivity).startClip(item)
+                    val uiPreferences = FeedUiPreferencesStore.current(context)
+                    val clipId = item.id
+                    val thumbnailKey = "xtra:clip-thumbnail:$clipId|${item.thumbnail}"
+                    if (thumbnail.tag != thumbnailKey) {
+                        thumbnail.setImageDrawable(null)
+                        thumbnail.tag = thumbnailKey
                     }
-                    root.setOnLongClickListener {
-                        showDownloadDialog(item)
-                        true
+                    restoreDecodedMemoryImage(thumbnailKey, thumbnail)
+                    imageLoadScheduler.runOrDefer(this@PagingViewHolder, thumbnail) {
+                        if (!root.isAttachedToWindow || boundClipId != clipId) return@runOrDefer
+                        imageRequests.replace(
+                            thumbnail,
+                            context.imageLoader.enqueue(
+                                ImageRequest.Builder(context).apply {
+                                    data(item.thumbnail)
+                                    memoryCacheKey(thumbnailKey)
+                                    diskCachePolicy(CachePolicy.ENABLED)
+                                    crossfade(false)
+                                    target(thumbnail)
+                                    thumbnailState()
+                                }.build(),
+                            ),
+                        )
                     }
-                    fragment.requireContext().imageLoader.enqueue(
-                        ImageRequest.Builder(fragment.requireContext()).apply {
-                            data(item.thumbnail)
-                            diskCachePolicy(CachePolicy.DISABLED)
-                            crossfade(true)
-                            target(thumbnail)
-                            thumbnailState()
-                        }.build()
-                    )
                     if (item.createdAt != null) {
                         val text = Instant.parseOrNull(item.createdAt)?.toEpochMilliseconds()?.takeIf { ms -> ms > 0 }?.let {
                             TwitchApiHelper.formatDate(context, it)
@@ -98,7 +166,7 @@ class ClipsAdapter(
                         views.text = context.resources.getQuantityString(
                             R.plurals.views,
                             count,
-                            TwitchApiHelper.formatCount(count, context.prefs().getBoolean(C.UI_TRUNCATE_VIEW_COUNT, true))
+                            TwitchApiHelper.formatCount(count, uiPreferences.truncateViewCount)
                         )
                     } else {
                         views.visibility = View.GONE
@@ -110,32 +178,34 @@ class ClipsAdapter(
                         duration.visibility = View.GONE
                     }
                     if (showChannel) {
-                        val channelListener: (View) -> Unit = {
-                            fragment.findNavController().navigate(
-                                ChannelPagerFragmentDirections.actionGlobalChannelPagerFragment(
-                                    channelId = item.channelId,
-                                    channelLogin = item.channelLogin,
-                                    channelName = item.channelName,
-                                    channelImage = item.channelImage,
-                                )
-                            )
-                        }
                         if (item.channelImage != null) {
                             userImage.visibility = View.VISIBLE
                             userImage.contentDescription = item.channelName?.let {
                                 context.getString(R.string.player_open_channel, it)
                             }
-                            fragment.requireContext().imageLoader.enqueue(
-                                ImageRequest.Builder(fragment.requireContext()).apply {
-                                    data(item.channelImage)
-                                    if (context.prefs().getBoolean(C.UI_ROUND_USER_IMAGE, true)) {
-                                        transformations(CircleCropTransformation())
-                                    }
-                                    crossfade(true)
-                                    target(userImage)
-                                }.build()
-                            )
-                            userImage.setOnClickListener(channelListener)
+                            val profileKey = "xtra:clip-avatar:$clipId|${item.channelImage}|round=${uiPreferences.roundUserImage}"
+                            if (userImage.tag != profileKey) {
+                                userImage.setImageDrawable(null)
+                                userImage.tag = profileKey
+                            }
+                            restoreDecodedMemoryImage(profileKey, userImage)
+                            imageLoadScheduler.runOrDefer(this@PagingViewHolder, userImage) {
+                                if (!root.isAttachedToWindow || boundClipId != clipId) return@runOrDefer
+                                imageRequests.replace(
+                                    userImage,
+                                    context.imageLoader.enqueue(
+                                        ImageRequest.Builder(context).apply {
+                                            data(item.channelImage)
+                                            memoryCacheKey(profileKey)
+                                            if (uiPreferences.roundUserImage) {
+                                                transformations(CircleCropTransformation())
+                                            }
+                                            crossfade(false)
+                                            target(userImage)
+                                        }.build(),
+                                    ),
+                                )
+                            }
                     } else {
                         userImage.visibility = View.GONE
                         userImage.contentDescription = null
@@ -143,7 +213,7 @@ class ClipsAdapter(
                         if (item.channelName != null) {
                             username.visibility = View.VISIBLE
                             username.text = if (item.channelLogin != null && !item.channelLogin.equals(item.channelName, true)) {
-                                when (context.prefs().getString(C.UI_NAME_DISPLAY, "0")) {
+                                when (uiPreferences.nameDisplay) {
                                     "0" -> "${item.channelName}(${item.channelLogin})"
                                     "1" -> item.channelName
                                     else -> item.channelLogin
@@ -151,7 +221,6 @@ class ClipsAdapter(
                             } else {
                                 item.channelName
                             }
-                            username.setOnClickListener(channelListener)
                         } else {
                             username.visibility = View.GONE
                         }
@@ -166,43 +235,59 @@ class ClipsAdapter(
                         title.visibility = View.GONE
                     }
                     if (showGame && item.gameName != null) {
-                        val gameListener: (View) -> Unit = {
-                            fragment.findNavController().navigate(GamePagerFragmentDirections.actionGlobalGamePagerFragment(
-                                gameId = item.gameId,
-                                gameSlug = item.gameSlug,
-                                gameName = item.gameName
-                            ))
-                        }
                         gameName.visibility = View.VISIBLE
                         gameName.text = item.gameName
-                        gameName.setOnClickListener(gameListener)
                     } else {
                         gameName.visibility = View.GONE
                     }
-                    options.setOnClickListener { it ->
-                        PopupMenu(context, it).apply {
-                            inflate(R.menu.media_item)
-                            setOnMenuItemClickListener {
-                                when (it.itemId) {
-                                    R.id.download -> showDownloadDialog(item)
-                                    R.id.share -> {
-                                        context.startActivity(Intent.createChooser(Intent().apply {
-                                            action = Intent.ACTION_SEND
-                                            putExtra(Intent.EXTRA_TEXT, "https://twitch.tv/${item.channelLogin}/clip/${item.id}")
-                                            item.title?.let {
-                                                putExtra(Intent.EXTRA_TITLE, it)
-                                            }
-                                            type = "text/plain"
-                                        }, null))
-                                    }
-                                    else -> menu.close()
-                                }
-                                true
-                            }
-                            show()
-                        }
-                    }
                 }
+            }
+        }
+
+        private fun openChannel(clip: Clip) {
+            if (!showChannel) return
+            fragment.findNavController().navigate(
+                ChannelPagerFragmentDirections.actionGlobalChannelPagerFragment(
+                    channelId = clip.channelId,
+                    channelLogin = clip.channelLogin,
+                    channelName = clip.channelName,
+                    channelImage = clip.channelImage,
+                ),
+            )
+        }
+
+        private fun openGame(clip: Clip) {
+            if (!showGame || clip.gameName.isNullOrBlank()) return
+            fragment.findNavController().navigate(
+                GamePagerFragmentDirections.actionGlobalGamePagerFragment(
+                    gameId = clip.gameId,
+                    gameSlug = clip.gameSlug,
+                    gameName = clip.gameName,
+                ),
+            )
+        }
+
+        private fun showOptions(anchor: View) {
+            val clip = boundClip ?: return
+            val context = fragment.requireContext()
+            PopupMenu(context, anchor).apply {
+                inflate(R.menu.media_item)
+                setOnMenuItemClickListener {
+                    when (it.itemId) {
+                        R.id.download -> showDownloadDialog(clip)
+                        R.id.share -> {
+                            context.startActivity(Intent.createChooser(Intent().apply {
+                                action = Intent.ACTION_SEND
+                                putExtra(Intent.EXTRA_TEXT, "https://twitch.tv/${clip.channelLogin}/clip/${clip.id}")
+                                clip.title?.let { title -> putExtra(Intent.EXTRA_TITLE, title) }
+                                type = "text/plain"
+                            }, null))
+                        }
+                        else -> menu.close()
+                    }
+                    true
+                }
+                show()
             }
         }
     }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/FeedUiPreferences.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/FeedUiPreferences.kt
@@ -1,0 +1,64 @@
+package com.github.andreyasadchy.xtra.ui.common
+
+import android.content.Context
+import android.content.SharedPreferences
+import com.github.andreyasadchy.xtra.util.C
+import com.github.andreyasadchy.xtra.util.prefs
+
+/**
+ * The small set of display options read by high-frequency feed binds.
+ * Preferences are read once and replaced atomically when a setting changes;
+ * RecyclerView binds only perform one volatile snapshot read.
+ */
+internal data class FeedUiPreferences(
+    val nameDisplay: String,
+    val truncateViewCount: Boolean,
+    val showUptime: Boolean,
+    val showTags: Boolean,
+    val showBroadcastersCount: Boolean,
+    val roundUserImage: Boolean,
+)
+
+internal object FeedUiPreferencesStore : SharedPreferences.OnSharedPreferenceChangeListener {
+    private val lock = Any()
+
+    @Volatile
+    private var snapshot: FeedUiPreferences? = null
+
+    private var preferences: SharedPreferences? = null
+
+    fun current(context: Context): FeedUiPreferences {
+        snapshot?.let { return it }
+        synchronized(lock) {
+            snapshot?.let { return it }
+            val prefs = context.applicationContext.prefs()
+            preferences = prefs
+            prefs.registerOnSharedPreferenceChangeListener(this)
+            return read(prefs).also { snapshot = it }
+        }
+    }
+
+    override fun onSharedPreferenceChanged(prefs: SharedPreferences?, key: String?) {
+        if (key !in KEYS) return
+        val currentPreferences = preferences ?: return
+        snapshot = read(currentPreferences)
+    }
+
+    private fun read(prefs: SharedPreferences): FeedUiPreferences = FeedUiPreferences(
+        nameDisplay = prefs.getString(C.UI_NAME_DISPLAY, "0") ?: "0",
+        truncateViewCount = prefs.getBoolean(C.UI_TRUNCATE_VIEW_COUNT, true),
+        showUptime = prefs.getBoolean(C.UI_UPTIME, true),
+        showTags = prefs.getBoolean(C.UI_TAGS, true),
+        showBroadcastersCount = prefs.getBoolean(C.UI_BROADCASTERS_COUNT, true),
+        roundUserImage = prefs.getBoolean(C.UI_ROUND_USER_IMAGE, true),
+    )
+
+    private val KEYS = setOf(
+        C.UI_NAME_DISPLAY,
+        C.UI_TRUNCATE_VIEW_COUNT,
+        C.UI_UPTIME,
+        C.UI_TAGS,
+        C.UI_BROADCASTERS_COUNT,
+        C.UI_ROUND_USER_IMAGE,
+    )
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/FragmentTabSwitcher.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/FragmentTabSwitcher.kt
@@ -1,0 +1,63 @@
+package com.github.andreyasadchy.xtra.ui.common
+
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentManager
+import androidx.lifecycle.Lifecycle
+
+/** Adds each child tab once and keeps inactive tab views created but not active. */
+class FragmentTabSwitcher(
+    private val fragmentManager: FragmentManager,
+    private val containerId: Int,
+    private val onSelected: (Fragment) -> Unit,
+) {
+    private val fragments = linkedMapOf<String, Fragment>()
+    private val pendingAdds = mutableSetOf<String>()
+    private var requestedKey: String? = null
+    private var transactionInFlight = false
+
+    fun show(key: String, create: () -> Fragment) {
+        if (fragmentManager.isStateSaved) return
+        fragments[key]
+            ?: fragmentManager.findFragmentByTag(key)?.also { fragments[key] = it }
+            ?: create().also { fragments[key] = it }
+        requestedKey = key
+        if (transactionInFlight) return
+        commitRequestedSelection()
+    }
+
+    private fun commitRequestedSelection() {
+        if (fragmentManager.isStateSaved) {
+            transactionInFlight = false
+            return
+        }
+        val key = requestedKey ?: return
+        val target = fragments[key] ?: return
+        val transaction = fragmentManager.beginTransaction().setReorderingAllowed(true)
+        (fragments.values + fragmentManager.fragments).distinct().forEach { fragment ->
+            if (fragment !== target && fragment.isAdded) {
+                transaction.hide(fragment)
+                transaction.setMaxLifecycle(fragment, Lifecycle.State.CREATED)
+            }
+        }
+        if (target.isAdded) {
+            transaction.show(target)
+        } else if (key !in pendingAdds) {
+            transaction.add(containerId, target, key)
+            pendingAdds += key
+        }
+        transaction.setMaxLifecycle(target, Lifecycle.State.RESUMED)
+        transaction.runOnCommit {
+            transactionInFlight = false
+            pendingAdds.remove(key)
+            if (requestedKey == key) {
+                onSelected(target)
+            } else {
+                // A rapid tab sequence should settle on the latest request;
+                // do not run setup work for every intermediate selection.
+                commitRequestedSelection()
+            }
+        }
+        transactionInFlight = true
+        transaction.commit()
+    }
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/GameTags.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/GameTags.kt
@@ -1,0 +1,116 @@
+package com.github.andreyasadchy.xtra.ui.common
+
+import android.util.TypedValue
+import android.view.LayoutInflater
+import android.view.View
+import android.widget.TextView
+import androidx.constraintlayout.helper.widget.Flow
+import androidx.constraintlayout.widget.ConstraintLayout
+import androidx.core.content.res.use
+import androidx.core.widget.TextViewCompat
+import com.github.andreyasadchy.xtra.R
+import com.github.andreyasadchy.xtra.model.ui.Tag
+
+/** Reuses a fixed tag hierarchy so game row binding never creates or removes views. */
+internal class GameTagViews(
+    private val tagsLayout: ConstraintLayout,
+    private val tagViews: List<TextView>,
+) {
+    private val boundTags = arrayOfNulls<Tag>(MAX_TAGS)
+    private var onTagClick: ((Tag) -> Unit)? = null
+
+    init {
+        tagViews.forEachIndexed { index, view ->
+            view.setOnClickListener {
+                boundTags[index]?.takeIf { tag -> tag.id != null }?.let { tag ->
+                    onTagClick?.invoke(tag)
+                }
+            }
+        }
+    }
+
+    fun bind(tags: List<Tag>, onTagClick: (Tag) -> Unit) {
+        this.onTagClick = onTagClick
+        tagViews.forEachIndexed { index, view ->
+            val tag = tags.getOrNull(index)
+            boundTags[index] = tag
+            view.text = tag?.name.orEmpty()
+            view.visibility = if (tag == null) View.GONE else View.VISIBLE
+            view.isFocusable = tag?.id != null
+            view.isClickable = tag?.id != null
+        }
+        tagsLayout.visibility = if (tags.isEmpty()) View.GONE else View.VISIBLE
+    }
+
+    fun clear() {
+        boundTags.fill(null)
+        onTagClick = null
+        tagViews.forEach { view ->
+            view.text = null
+            view.visibility = View.GONE
+            view.isFocusable = false
+            view.isClickable = false
+        }
+        tagsLayout.visibility = View.GONE
+    }
+
+    private companion object {
+        const val MAX_TAGS = 10
+    }
+}
+
+internal fun createGameTagViews(tagsLayout: ConstraintLayout): GameTagViews {
+    val context = tagsLayout.context
+    val flow = Flow(context).apply {
+        id = View.generateViewId()
+        layoutParams = ConstraintLayout.LayoutParams(
+            ConstraintLayout.LayoutParams.MATCH_PARENT,
+            ConstraintLayout.LayoutParams.WRAP_CONTENT,
+        ).apply {
+            topToTop = tagsLayout.id
+            bottomToBottom = tagsLayout.id
+            startToStart = tagsLayout.id
+            endToEnd = tagsLayout.id
+        }
+        setWrapMode(Flow.WRAP_CHAIN)
+    }
+    tagsLayout.addView(flow)
+
+    val minHeight = TypedValue.applyDimension(
+        TypedValue.COMPLEX_UNIT_DIP,
+        48f,
+        context.resources.displayMetrics,
+    ).toInt()
+    val padding = TypedValue.applyDimension(
+        TypedValue.COMPLEX_UNIT_DIP,
+        5f,
+        context.resources.displayMetrics,
+    ).toInt()
+    val tagViews = List(10) {
+        TextView(context).apply {
+            id = View.generateViewId()
+            setMinHeight(minHeight)
+            isFocusable = false
+            isClickable = false
+            context.obtainStyledAttributes(intArrayOf(com.google.android.material.R.attr.textAppearanceBodyMedium)).use {
+                TextViewCompat.setTextAppearance(this, it.getResourceId(0, 0))
+            }
+            setPadding(padding, 0, padding, 0)
+            tagsLayout.addView(this)
+        }
+    }
+    flow.referencedIds = tagViews.map(TextView::getId).toIntArray()
+    return GameTagViews(tagsLayout, tagViews)
+}
+
+internal fun bindGameTags(
+    views: GameTagViews,
+    tags: List<Tag>,
+    onTagClick: (Tag) -> Unit,
+) {
+    views.bind(tags.take(10), onTagClick)
+}
+
+internal fun clearGameTags(views: GameTagViews) {
+    views.clear()
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/GamesAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/GamesAdapter.kt
@@ -1,14 +1,8 @@
 package com.github.andreyasadchy.xtra.ui.common
 
-import android.util.TypedValue
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.TextView
-import androidx.constraintlayout.helper.widget.Flow
-import androidx.constraintlayout.widget.ConstraintLayout
-import androidx.core.content.res.use
-import androidx.core.widget.TextViewCompat
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
 import androidx.paging.PagingDataAdapter
@@ -39,42 +33,109 @@ class GamesAdapter(
             oldItem.viewerCount == newItem.viewerCount
     }) {
 
+    private val imageLoadScheduler = StreamThumbnailIdleScheduler()
+
+    override fun onAttachedToRecyclerView(recyclerView: RecyclerView) {
+        super.onAttachedToRecyclerView(recyclerView)
+        imageLoadScheduler.attachTo(recyclerView)
+    }
+
+    override fun onDetachedFromRecyclerView(recyclerView: RecyclerView) {
+        imageLoadScheduler.detach()
+        super.onDetachedFromRecyclerView(recyclerView)
+    }
+
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): PagingViewHolder {
         val binding = FragmentGamesListItemBinding.inflate(LayoutInflater.from(parent.context), parent, false)
-        return PagingViewHolder(binding, fragment)
+        return PagingViewHolder(binding, fragment, createGameTagViews(binding.tagsLayout))
     }
 
     override fun onBindViewHolder(holder: PagingViewHolder, position: Int) {
+        holder.beginImageBind(getItem(position))
         holder.bind(getItem(position))
     }
 
-    inner class PagingViewHolder(
+    override fun onViewRecycled(holder: PagingViewHolder) {
+        imageLoadScheduler.clear(holder)
+        holder.cancelImageWork()
+        super.onViewRecycled(holder)
+    }
+
+    inner class PagingViewHolder internal constructor(
         private val binding: FragmentGamesListItemBinding,
         private val fragment: Fragment,
-    ) : RecyclerView.ViewHolder(binding.root) {
+        private val tagViews: GameTagViews,
+    ) : RecyclerView.ViewHolder(binding.root), FeedImageRequestOwner {
+        private val imageRequests = FeedImageRequestBag()
+        private var boundGameId: String? = null
+        private var boundGame: Game? = null
+
+        init {
+            binding.root.setOnClickListener {
+                boundGame?.let { game ->
+                    fragment.findNavController().navigate(GamePagerFragmentDirections.actionGlobalGamePagerFragment(
+                        gameId = game.id,
+                        gameSlug = game.slug,
+                        gameName = game.name,
+                        boxArt = game.boxArt,
+                    ))
+                }
+            }
+        }
+
+        fun beginImageBind(item: Game?) {
+            imageLoadScheduler.clear(this)
+            imageRequests.cancel()
+            boundGameId = item?.id
+        }
+
+        override fun cancelImageRequests() {
+            imageRequests.cancel()
+        }
+
+        override fun pauseImageRequests() {
+            imageRequests.cancel(preserveRegistrations = true)
+        }
+
+        fun cancelImageWork() {
+            cancelImageRequests()
+            boundGameId = null
+            boundGame = null
+        }
+
         fun bind(item: Game?) {
+            boundGame = item
             with(binding) {
                 if (item != null) {
                     val context = fragment.requireContext()
-                    root.setOnClickListener {
-                        fragment.findNavController().navigate(GamePagerFragmentDirections.actionGlobalGamePagerFragment(
-                            gameId = item.id,
-                            gameSlug = item.slug,
-                            gameName = item.name,
-                            boxArt = item.boxArt
-                        ))
-                    }
+                    val uiPreferences = FeedUiPreferencesStore.current(context)
                     if (item.boxArt != null) {
                         gameImage.visibility = View.VISIBLE
-                        fragment.requireContext().imageLoader.enqueue(
-                            ImageRequest.Builder(fragment.requireContext()).apply {
-                                data(item.boxArt)
-                                crossfade(true)
-                                target(gameImage)
-                            }.build()
-                        )
+                        val gameId = item.id
+                        val imageKey = "xtra:game-boxart:$gameId|${item.boxArt}"
+                        if (gameImage.tag != imageKey) {
+                            gameImage.setImageDrawable(null)
+                            gameImage.tag = imageKey
+                        }
+                        restoreDecodedMemoryImage(imageKey, gameImage)
+                        imageLoadScheduler.runOrDefer(this@PagingViewHolder, binding.gameImage) {
+                            if (!binding.root.isAttachedToWindow || boundGameId != gameId) return@runOrDefer
+                            imageRequests.replace(
+                                binding.gameImage,
+                                context.imageLoader.enqueue(
+                                    ImageRequest.Builder(context).apply {
+                                        data(item.boxArt)
+                                        memoryCacheKey(imageKey)
+                                        crossfade(false)
+                                        target(gameImage)
+                                    }.build(),
+                                ),
+                            )
+                        }
                     } else {
                         gameImage.visibility = View.GONE
+                        gameImage.setImageDrawable(null)
+                        gameImage.tag = null
                     }
                     if (item.name != null) {
                         gameName.visibility = View.VISIBLE
@@ -88,63 +149,38 @@ class GamesAdapter(
                         viewers.text = context.resources.getQuantityString(
                             R.plurals.viewers,
                             count,
-                            TwitchApiHelper.formatCount(count, context.prefs().getBoolean(C.UI_TRUNCATE_VIEW_COUNT, true))
+                            TwitchApiHelper.formatCount(count, uiPreferences.truncateViewCount)
                         )
                     } else {
                         viewers.visibility = View.GONE
                     }
-                    if (item.broadcasterCount != null && context.prefs().getBoolean(C.UI_BROADCASTERS_COUNT, true)) {
+                    if (item.broadcasterCount != null && uiPreferences.showBroadcastersCount) {
                         broadcastersCount.visibility = View.VISIBLE
                         val count = item.broadcasterCount ?: 0
                         broadcastersCount.text = context.resources.getQuantityString(
                             R.plurals.broadcasters,
                             count,
-                            TwitchApiHelper.formatCount(count, context.prefs().getBoolean(C.UI_TRUNCATE_VIEW_COUNT, true))
+                            TwitchApiHelper.formatCount(count, uiPreferences.truncateViewCount)
                         )
                     } else {
                         broadcastersCount.visibility = View.GONE
                     }
-                    if (!item.tags.isNullOrEmpty() && context.prefs().getBoolean(C.UI_TAGS, true)) {
-                        tagsLayout.removeAllViews()
-                        tagsLayout.visibility = View.VISIBLE
-                        val tagsFlowLayout = Flow(context).apply {
-                            layoutParams = ConstraintLayout.LayoutParams(
-                                ViewGroup.LayoutParams.MATCH_PARENT,
-                                ViewGroup.LayoutParams.WRAP_CONTENT
-                            ).apply {
-                                topToTop = tagsLayout.id
-                                bottomToBottom = tagsLayout.id
-                                startToStart = tagsLayout.id
-                                endToEnd = tagsLayout.id
-                            }
-                            setWrapMode(Flow.WRAP_CHAIN)
-                        }
-                        tagsLayout.addView(tagsFlowLayout)
-                        val ids = mutableListOf<Int>()
-                        for (tag in item.tags!!) {
-                            val text = TextView(context)
-                            val id = View.generateViewId()
-                            text.id = id
-                            ids.add(id)
-                            text.text = tag.name
-                            text.setMinHeight(TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 48f, context.resources.displayMetrics).toInt())
-                            text.isFocusable = tag.id != null
-                            context.obtainStyledAttributes(intArrayOf(com.google.android.material.R.attr.textAppearanceBodyMedium)).use {
-                                TextViewCompat.setTextAppearance(text, it.getResourceId(0, 0))
-                            }
-                            if (tag.id != null) {
-                                text.setOnClickListener {
-                                    selectTag(tag)
-                                }
-                            }
-                            val padding = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 5f, context.resources.displayMetrics).toInt()
-                            text.setPadding(padding, 0, padding, 0)
-                            tagsLayout.addView(text)
-                        }
-                        tagsFlowLayout.referencedIds = ids.toIntArray()
+                    if (!item.tags.isNullOrEmpty() && uiPreferences.showTags) {
+                        bindGameTags(tagViews, item.tags.orEmpty(), selectTag)
                     } else {
-                        tagsLayout.visibility = View.GONE
+                        clearGameTags(tagViews)
                     }
+                } else {
+                    boundGame = null
+                    gameImage.setImageDrawable(null)
+                    gameImage.visibility = View.GONE
+                    gameName.text = null
+                    gameName.visibility = View.GONE
+                    viewers.text = null
+                    viewers.visibility = View.GONE
+                    broadcastersCount.text = null
+                    broadcastersCount.visibility = View.GONE
+                    clearGameTags(tagViews)
                 }
             }
         }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/PagedListFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/PagedListFragment.kt
@@ -46,16 +46,13 @@ abstract class PagedListFragment : BaseNetworkFragment() {
 
     fun <T : Any, VH : RecyclerView.ViewHolder> initializeAdapter(binding: CommonRecyclerViewLayoutBinding, pagingAdapter: PagingDataAdapter<T, VH>, enableSwipeRefresh: Boolean = true, enableScrollTopButton: Boolean = true) {
         with(binding) {
+            // Live/paged feeds update frequently. Change animations keep old row
+            // holders alive and add extra layout/draw work during refreshes.
+            recyclerView.itemAnimator = null
             setupPagingControls(binding, pagingAdapter, enableSwipeRefresh)
             root.addOnLayoutChangeListener { _, _, _, _, _, _, _, _, _ ->
                 updateTopInsetGuard(binding)
             }
-            recyclerView.addOnScrollListener(object : RecyclerView.OnScrollListener() {
-                override fun onScrolled(recyclerView: RecyclerView, dx: Int, dy: Int) {
-                    super.onScrolled(recyclerView, dx, dy)
-                    updateTopInsetGuard(binding)
-                }
-            })
             root.post { updateTopInsetGuard(binding) }
             ViewCompat.requestApplyInsets(root)
             viewLifecycleOwner.lifecycleScope.launch {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/PagerScrollStateAware.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/PagerScrollStateAware.kt
@@ -1,0 +1,21 @@
+package com.github.andreyasadchy.xtra.ui.common
+
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentManager
+import com.github.andreyasadchy.xtra.XtraApp
+import com.github.andreyasadchy.xtra.util.UiInteractionGovernor
+
+/** Receives the parent ViewPager2 scroll state before child content is moved. */
+interface PagerScrollStateAware {
+    fun onPagerScrollStateChanged(scrolling: Boolean)
+}
+
+fun FragmentManager.dispatchPagerScrollState(scrolling: Boolean) {
+    fragments.forEach { (it as? PagerScrollStateAware)?.onPagerScrollStateChanged(scrolling) }
+}
+
+fun Fragment.dispatchPagerScrollState(scrolling: Boolean) {
+    UiInteractionGovernor.setInteracting(this, scrolling)
+    (activity?.application as? XtraApp)?.xtraModule?.streamPreviewCoordinator?.onPagerScrollStateChanged(scrolling)
+    childFragmentManager.dispatchPagerScrollState(scrolling)
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/RecyclerViewLiftTargetConnector.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/RecyclerViewLiftTargetConnector.kt
@@ -1,0 +1,49 @@
+package com.github.andreyasadchy.xtra.ui.common
+
+import android.view.View
+import androidx.recyclerview.widget.RecyclerView
+import com.google.android.material.appbar.AppBarLayout
+
+/** Keeps exactly one RecyclerView connected to an AppBarLayout's lift state. */
+class RecyclerViewLiftTargetConnector(
+    private val appBar: AppBarLayout,
+) {
+    private var target: RecyclerView? = null
+    private var scrollListener: RecyclerView.OnScrollListener? = null
+    private var layoutListener: View.OnLayoutChangeListener? = null
+
+    fun connect(recyclerView: RecyclerView) {
+        if (target === recyclerView) {
+            update()
+            return
+        }
+        disconnect()
+        val onScroll = object : RecyclerView.OnScrollListener() {
+            override fun onScrolled(recyclerView: RecyclerView, dx: Int, dy: Int) = update()
+        }
+        val onLayout = View.OnLayoutChangeListener { _, _, _, _, _, _, _, _, _ -> update() }
+        recyclerView.addOnScrollListener(onScroll)
+        recyclerView.addOnLayoutChangeListener(onLayout)
+        appBar.setLiftOnScrollTargetView(recyclerView)
+        target = recyclerView
+        scrollListener = onScroll
+        layoutListener = onLayout
+        update()
+    }
+
+    fun disconnect() {
+        target?.let { recyclerView ->
+            scrollListener?.let(recyclerView::removeOnScrollListener)
+            layoutListener?.let(recyclerView::removeOnLayoutChangeListener)
+        }
+        target = null
+        scrollListener = null
+        layoutListener = null
+        appBar.setLiftOnScrollTargetView(null)
+        appBar.isLifted = false
+    }
+
+    private fun update() {
+        appBar.isLifted = target?.canScrollVertically(-1) == true
+    }
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/StreamFeedScreenController.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/StreamFeedScreenController.kt
@@ -74,6 +74,7 @@ class StreamFeedScreenController(
         val spec = specProvider() ?: return
         coordinator.setVisibleFeed(spec)
         if (coordinator.isPlayerFullscreen) return
+        if (coordinator.isFreshInMemory(spec)) return
         fragment.viewLifecycleOwner.lifecycleScope.launch {
             runCatching { coordinator.maybeRefresh(spec, reason) }
         }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/StreamPreloadViewportController.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/StreamPreloadViewportController.kt
@@ -26,6 +26,7 @@ class StreamPreloadViewportController(
     private val previewAtPosition: ((Int, FrameLayout) -> StreamPreviewCandidate?)? = null,
 ) {
     private var scrollState = RecyclerView.SCROLL_STATE_IDLE
+    private var parentScrolling = false
     private var scrollingReported = false
     private var started = false
     private var publishPosted = false
@@ -97,6 +98,13 @@ class StreamPreloadViewportController(
     fun onParentScrollStateChanged() {
         updateScrollingState()
         requestPublish()
+    }
+
+    fun onParentScrollStateChanged(scrolling: Boolean) {
+        if (parentScrolling == scrolling) return
+        parentScrolling = scrolling
+        updateScrollingState()
+        if (!scrolling) requestPublish()
     }
 
     private fun requestPublish() {
@@ -208,7 +216,7 @@ class StreamPreloadViewportController(
     )
 
     private fun isScrolling(): Boolean =
-        scrollState != RecyclerView.SCROLL_STATE_IDLE || isParentScrolling()
+        scrollState != RecyclerView.SCROLL_STATE_IDLE || parentScrolling || isParentScrolling()
 
     private fun updateScrollingState() {
         val scrolling = isScrolling()

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/StreamPreviewCoordinator.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/StreamPreviewCoordinator.kt
@@ -49,6 +49,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.yield
 
 data class StreamPreviewCandidate(
     val streamKey: String,
@@ -96,6 +97,12 @@ class StreamPreviewCoordinator(
     private val pendingStarts = mutableMapOf<String, Job>()
     private val dwellStarts = mutableMapOf<String, Long>()
     private val failedUntil = mutableMapOf<String, Long>()
+    private var selectionJob: Job? = null
+    private var selectionPending = false
+    private var previewsPausedForScroll = false
+    private var pagerScrolling = false
+    private var pagerResumePending = false
+    private var pagerResumeJob: Job? = null
     private var handoffLogin: String? = null
     private val lifecycleReconciler = StreamPreviewLifecycleReconciler(
         lifecycle = previewLifecycle,
@@ -172,7 +179,42 @@ class StreamPreviewCoordinator(
     /** Scrolling is a visibility update, not a release event. */
     fun onScrolling(viewportKey: String) {
         viewports[viewportKey] = viewports[viewportKey]?.copy(scrolling = true) ?: Viewport(emptyList(), true)
+        if (!previewsPausedForScroll) {
+            activePreviews.values.forEach { it.player.playWhenReady = false }
+            previewsPausedForScroll = true
+        }
         previewLifecycle.onScrolling()
+        scheduleSelection()
+    }
+
+    /**
+     * A pager moves complete preview surfaces horizontally. Keep the player state warm, but hide
+     * its TextureView while the page animation is running; TextureView draw synchronization can
+     * otherwise block the UI thread for multiple frames.
+     */
+    fun onPagerScrollStateChanged(scrolling: Boolean) {
+        if (pagerScrolling == scrolling) return
+        pagerScrolling = scrolling
+        if (scrolling) {
+            pagerResumeJob?.cancel()
+            pagerResumeJob = null
+            pagerResumePending = false
+            activePreviews.values.forEach { active ->
+                active.player.playWhenReady = false
+                suspendPreviewSurface(active)
+            }
+            previewsPausedForScroll = true
+            previewLifecycle.onScrolling()
+            cancelPendingStarts()
+        } else {
+            pagerResumePending = true
+            pagerResumeJob = scope.launch {
+                delay(PAGER_PREVIEW_RESUME_DELAY_MS)
+                pagerResumePending = false
+                pagerResumeJob = null
+                if (!pagerScrolling) scheduleSelection()
+            }
+        }
         scheduleSelection()
     }
 
@@ -189,27 +231,13 @@ class StreamPreviewCoordinator(
     }
 
     fun onFullscreenPlaybackStarted(channelLogin: String?) {
-        val login = normalize(channelLogin)
-        val identity = login?.let(::livePreviewIdentity)
-        if (identity == null && handoffLogin != null) {
-            cancelPendingStarts()
-            activePreviews.keys.toList()
-                .filter { it != handoffLogin }
-                .forEach(::releasePreview)
-            return
-        }
-        if (identity == null || activePreviews[identity] == null) {
-            stopPreview()
-            return
-        }
-        handoffLogin = identity
-        cancelPendingStarts()
-        activePreviews.keys.toList()
-            .filter { it != identity }
-            .forEach(::releasePreview)
-        // Keep the warm player, but hide its old card surface for the duration of the handoff.
-        activePreviews[identity]?.let(::detachPreviewSurface)
-        previewLifecycle.retainOnly(identity)
+        // Full-screen playback and browsing previews are mutually exclusive. Keeping a warm
+        // preview player here is unsafe: its PlayerView can be reattached by a pending viewport
+        // reconciliation while the full-screen player is being added, producing a small stale
+        // video over the new player's opaque handoff cover. Releasing every preview also avoids
+        // decoding and composing muted browsing video while the user is watching the stream.
+        hideViewportSurfaces()
+        stopPreview()
     }
 
     fun onFullscreenPlaybackFirstFrame(channelLogin: String?) {
@@ -259,6 +287,22 @@ class StreamPreviewCoordinator(
     }
 
     private fun scheduleSelection() {
+        selectionPending = true
+        if (selectionJob?.isActive == true) return
+        selectionJob = scope.launch {
+            yield()
+            try {
+                while (selectionPending) {
+                    selectionPending = false
+                    reconcileSelection()
+                }
+            } finally {
+                selectionJob = null
+            }
+        }
+    }
+
+    private fun reconcileSelection() {
         if (!StreamPreviewPolicy.canStartPreview(
                 isPlayerFullscreen = streamFeedRefreshCoordinator.isPlayerFullscreen,
                 isPlayerActive = streamFeedRefreshCoordinator.isPlayerActive,
@@ -289,7 +333,15 @@ class StreamPreviewCoordinator(
         val reasonablyVisible = candidates
             .filter { it.visibleFraction >= StreamPreviewSelectionPolicy.STOP_VISIBLE_FRACTION }
             .mapNotNull { it.previewIdentity }
-        val scrolling = viewports.values.any { it.scrolling }
+        val scrolling = pagerScrolling || viewports.values.any { it.scrolling }
+        if (pagerScrolling || pagerResumePending) {
+            cancelPendingStarts()
+            return
+        }
+        if (!scrolling && previewsPausedForScroll) {
+            activePreviews.values.forEach { it.player.playWhenReady = true }
+            previewsPausedForScroll = false
+        }
         if (scrolling) {
             // A gesture changes which cards are visible, not whether an existing
             // preview should play. The lifecycle grace period handles cards that
@@ -542,7 +594,7 @@ class StreamPreviewCoordinator(
     }
 
     private fun attachSurfaceIfNeeded(active: ActivePreview, candidate: StreamPreviewCandidate) {
-        val surfaceChanged = active.surface !== candidate.surface || active.playerView.parent !== candidate.surface
+        val surfaceChanged = active.surface !== candidate.surface
         if (surfaceChanged) {
             // A rebound TextureView has no decoded frame yet. Keep the card thumbnail
             // visible until Media3 confirms that the new output surface has a frame.
@@ -610,9 +662,27 @@ class StreamPreviewCoordinator(
     private fun stopPreview() {
         cancelPendingStarts()
         lifecycleReconciler.cancel()
+        previewsPausedForScroll = false
+        pagerScrolling = false
+        pagerResumeJob?.cancel()
+        pagerResumeJob = null
+        pagerResumePending = false
         handoffLogin = null
         stopActivePreviews()
         previewLifecycle.clear()
+    }
+
+    /** Remove orphaned preview views as well as previews still owned by the coordinator. */
+    private fun hideViewportSurfaces() {
+        viewports.values
+            .flatMap { it.candidates }
+            .map { it.surface }
+            .distinct()
+            .forEach { surface ->
+                surface.removeAllViews()
+                surface.alpha = 0f
+                surface.visibility = View.GONE
+            }
     }
 
     private fun stopActivePreviews() {
@@ -676,6 +746,17 @@ class StreamPreviewCoordinator(
         active.surface = null
     }
 
+    private fun suspendPreviewSurface(active: ActivePreview) {
+        active.surface?.let { surface ->
+            surface.removeView(active.playerView)
+            surface.alpha = 0f
+            surface.visibility = View.GONE
+        }
+        active.playerView.player = null
+        active.playerView.alpha = 0f
+        active.playerView.visibility = View.GONE
+    }
+
     private fun normalize(login: String?): String? =
         login?.trim()?.lowercase()?.takeIf { it.isNotEmpty() }
 
@@ -700,6 +781,7 @@ class StreamPreviewCoordinator(
     )
 
     private companion object {
+        const val PAGER_PREVIEW_RESUME_DELAY_MS = 100L
         const val PLAYER_FAILURE_RETRY_MS = 10_000L
     }
 }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/StreamTags.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/StreamTags.kt
@@ -1,6 +1,5 @@
 package com.github.andreyasadchy.xtra.ui.common
 
-import android.content.Context
 import android.view.LayoutInflater
 import android.view.View
 import android.widget.TextView
@@ -8,19 +7,57 @@ import androidx.constraintlayout.helper.widget.Flow
 import androidx.constraintlayout.widget.ConstraintLayout
 import com.github.andreyasadchy.xtra.R
 
-internal fun bindStreamTags(
-    context: Context,
-    tagsLayout: ConstraintLayout,
-    tags: List<String>,
-    onTagClick: (String) -> Unit,
+internal class StreamTagViews(
+    private val tagsLayout: ConstraintLayout,
+    private val tagViews: List<TextView>,
 ) {
-    tagsLayout.removeAllViews()
-    if (tags.isEmpty()) {
-        tagsLayout.visibility = View.GONE
-        return
+    private val boundTags = arrayOfNulls<String>(MAX_TAGS)
+    private var onTagClick: ((String) -> Unit)? = null
+
+    init {
+        tagViews.forEachIndexed { index, view ->
+            view.setOnClickListener {
+                boundTags[index]?.let { tag -> onTagClick?.invoke(tag) }
+            }
+        }
     }
 
-    tagsLayout.visibility = View.VISIBLE
+    fun bind(
+        tags: List<String>,
+        onTagClick: (String) -> Unit,
+    ) {
+        this.onTagClick = onTagClick
+        val visibleTags = tags.asSequence()
+            .map(String::trim)
+            .filter(String::isNotEmpty)
+            .take(MAX_TAGS)
+            .toList()
+        tagViews.forEachIndexed { index, view ->
+            val tag = visibleTags.getOrNull(index)
+            boundTags[index] = tag
+            view.text = tag.orEmpty()
+            view.visibility = if (tag == null) View.GONE else View.VISIBLE
+        }
+        tagsLayout.visibility = if (visibleTags.isEmpty()) View.GONE else View.VISIBLE
+    }
+
+    fun clear() {
+        boundTags.fill(null)
+        onTagClick = null
+        tagViews.forEach { view ->
+            view.text = null
+            view.visibility = View.GONE
+        }
+        tagsLayout.visibility = View.GONE
+    }
+
+    private companion object {
+        const val MAX_TAGS = 8
+    }
+}
+
+internal fun createStreamTagViews(tagsLayout: ConstraintLayout): StreamTagViews {
+    val context = tagsLayout.context
     val flow = Flow(context).apply {
         id = View.generateViewId()
         layoutParams = ConstraintLayout.LayoutParams(
@@ -38,15 +75,25 @@ internal fun bindStreamTags(
     }
     tagsLayout.addView(flow)
 
-    val tagIds = IntArray(tags.size)
     val inflater = LayoutInflater.from(context)
-    tags.forEachIndexed { index, tag ->
-        val tagView = inflater.inflate(R.layout.item_stream_tag, tagsLayout, false) as TextView
-        tagView.id = View.generateViewId()
-        tagView.text = tag
-        tagView.setOnClickListener { onTagClick(tag) }
-        tagsLayout.addView(tagView)
-        tagIds[index] = tagView.id
+    val tagViews = List(8) {
+        (inflater.inflate(R.layout.item_stream_tag, tagsLayout, false) as TextView).apply {
+            id = View.generateViewId()
+            tagsLayout.addView(this)
+        }
     }
-    flow.referencedIds = tagIds
+    flow.referencedIds = tagViews.map(TextView::getId).toIntArray()
+    return StreamTagViews(tagsLayout, tagViews)
+}
+
+internal fun bindStreamTags(
+    views: StreamTagViews,
+    tags: List<String>,
+    onTagClick: (String) -> Unit,
+) {
+    views.bind(tags, onTagClick)
+}
+
+internal fun clearStreamTags(views: StreamTagViews) {
+    views.clear()
 }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/StreamsAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/StreamsAdapter.kt
@@ -35,33 +35,118 @@ class StreamsAdapter(
 
         override fun areContentsTheSame(oldItem: Stream, newItem: Stream): Boolean =
             streamContentsSame(oldItem, newItem)
+
+        override fun getChangePayload(oldItem: Stream, newItem: Stream): Any? =
+            if (streamThumbnailOnlyChanged(oldItem, newItem)) StreamThumbnailChangedPayload else null
     }) {
+
+    private val thumbnailLoadScheduler = StreamThumbnailIdleScheduler()
+
+    override fun onAttachedToRecyclerView(recyclerView: RecyclerView) {
+        super.onAttachedToRecyclerView(recyclerView)
+        thumbnailLoadScheduler.attachTo(recyclerView)
+    }
+
+    override fun onDetachedFromRecyclerView(recyclerView: RecyclerView) {
+        thumbnailLoadScheduler.detach()
+        super.onDetachedFromRecyclerView(recyclerView)
+    }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): PagingViewHolder {
         val binding = FragmentStreamsListItemBinding.inflate(LayoutInflater.from(parent.context), parent, false)
-        return PagingViewHolder(binding, fragment, showGame)
+        return PagingViewHolder(binding, fragment, showGame, createStreamTagViews(binding.tagsLayout))
     }
 
     override fun onBindViewHolder(holder: PagingViewHolder, position: Int) {
+        holder.beginImageBind(getItem(position))
         holder.bind(getItem(position))
+    }
+
+    override fun onBindViewHolder(holder: PagingViewHolder, position: Int, payloads: MutableList<Any>) {
+        if (payloads.isNotEmpty() && payloads.all { it === StreamThumbnailChangedPayload }) {
+            holder.beginImageBind(getItem(position))
+            holder.bindThumbnail(getItem(position))
+        } else {
+            super.onBindViewHolder(holder, position, payloads)
+        }
     }
 
     override fun onViewRecycled(holder: PagingViewHolder) {
         (fragment.requireContext().applicationContext as XtraApp).xtraModule.streamPreviewCoordinator
             .detachSurface(holder.previewSurface)
         holder.boundPreviewIdentity = null
+        thumbnailLoadScheduler.clear(holder)
+        holder.cancelImageWork()
         super.onViewRecycled(holder)
     }
 
-    inner class PagingViewHolder(
+    inner class PagingViewHolder internal constructor(
         private val binding: FragmentStreamsListItemBinding,
         private val fragment: Fragment,
         private val showGame: Boolean,
-    ) : RecyclerView.ViewHolder(binding.root) {
+        private val tagViews: StreamTagViews,
+    ) : RecyclerView.ViewHolder(binding.root), FeedImageRequestOwner {
         val previewSurface get() = binding.previewHost
         var boundPreviewIdentity: String? = null
+        private val imageRequests = FeedImageRequestBag()
+        private var boundImageIdentity: String? = null
+        private var boundThumbnailKey: String? = null
+        private var boundStream: Stream? = null
+
+        init {
+            binding.root.setOnClickListener { boundStream?.let(::openStream) }
+            binding.userImage.setOnClickListener { boundStream?.let(::openChannel) }
+            binding.username.setOnClickListener { boundStream?.let(::openChannel) }
+            binding.gameName.setOnClickListener { boundStream?.let(::openGame) }
+            binding.multiview.setOnClickListener { boundStream?.let(::openMultiview) }
+        }
+
+        fun beginImageBind(item: Stream?) {
+            thumbnailLoadScheduler.clear(this)
+            imageRequests.cancel()
+            boundImageIdentity = item?.streamIdentity()
+            boundThumbnailKey = null
+        }
+
+        override fun cancelImageRequests() {
+            imageRequests.cancel()
+        }
+
+        override fun pauseImageRequests() {
+            imageRequests.cancel(preserveRegistrations = true)
+        }
+
+        fun cancelImageWork() {
+            cancelImageRequests()
+            boundImageIdentity = null
+            boundThumbnailKey = null
+        }
+
+        fun bindThumbnail(item: Stream?) {
+            val stream = item ?: return
+            prepareStreamThumbnailImage(binding.thumbnail, stream)
+            restoreWarmStreamThumbnail(stream, binding.thumbnail)
+            val key = "${stream.thumbnailIdentity()}|generation=${stream.thumbnailGeneration}"
+            boundThumbnailKey = key
+            thumbnailLoadScheduler.runOrDefer(this@PagingViewHolder, binding.thumbnail) {
+                if (!binding.root.isAttachedToWindow ||
+                    boundImageIdentity != stream.streamIdentity() ||
+                    boundThumbnailKey != key
+                ) return@runOrDefer
+                loadStreamThumbnail(
+                    context = fragment.requireContext(),
+                    imageView = binding.thumbnail,
+                    stream = stream,
+                    scheduleFreshRequest = { freshRequest ->
+                        thumbnailLoadScheduler.runOrDefer(this@PagingViewHolder, binding.thumbnail, freshRequest)
+                    },
+                )
+                    ?.let { imageRequests.replace(binding.thumbnail, it) }
+            }
+        }
 
         fun bind(item: Stream?) {
+            boundStream = item
             val nextPreviewIdentity = item?.streamIdentity()
             if (boundPreviewIdentity != nextPreviewIdentity) {
                 (fragment.requireContext().applicationContext as XtraApp).xtraModule.streamPreviewCoordinator
@@ -71,43 +156,22 @@ class StreamsAdapter(
             with(binding) {
                 if (item != null) {
                     val context = fragment.requireContext()
+                    val uiPreferences = FeedUiPreferencesStore.current(context)
                     val selectionMode = onStreamClick != null
-                    val channelListener: (View) -> Unit = {
-                        if (selectionMode) {
-                            onStreamClick.invoke(item)
-                        } else {
-                            fragment.findNavController().navigate(
-                                ChannelPagerFragmentDirections.actionGlobalChannelPagerFragment(
-                                    channelId = item.channelId,
-                                    channelLogin = item.channelLogin,
-                                    channelName = item.channelName,
-                                    channelImage = item.channelImage,
-                                    streamId = item.id
-                                )
-                            )
-                        }
-                    }
-                    root.setOnClickListener {
-                        if (selectionMode) {
-                            onStreamClick.invoke(item)
-                        } else {
-                            (fragment.activity as MainActivity).startStream(item)
-                        }
-                    }
                     multiview.visibility = if (selectionMode || item.channelLogin.isNullOrBlank()) View.GONE else View.VISIBLE
-                    multiview.setOnClickListener {
-                        (fragment.activity as? MainActivity)?.let { activity ->
-                            if (activity.playerFragment != null) activity.closePlayer()
-                        }
-                        fragment.findNavController().navigate(R.id.multiviewFragment, MultiviewFragment.arguments(item))
-                    }
                     if (item.channelImage != null) {
                         userImage.visibility = View.VISIBLE
                         userImage.contentDescription = item.channelName?.let {
                             context.getString(R.string.player_open_channel, it)
                         }
-                        loadStreamProfileImage(context, userImage, item)
-                        userImage.setOnClickListener(channelListener)
+                        prepareStreamProfileImage(userImage, item)
+                        thumbnailLoadScheduler.runOrDefer(this@PagingViewHolder, binding.userImage) {
+                            if (binding.root.isAttachedToWindow && boundImageIdentity == item.streamIdentity()) {
+                                loadStreamProfileImage(context, userImage, item)?.let {
+                                    imageRequests.replace(binding.userImage, it)
+                                }
+                            }
+                        }
                     } else {
                         userImage.visibility = View.GONE
                         userImage.contentDescription = null
@@ -117,7 +181,7 @@ class StreamsAdapter(
                     if (item.channelName != null) {
                         username.visibility = View.VISIBLE
                         username.text = if (item.channelLogin != null && !item.channelLogin.equals(item.channelName, true)) {
-                            when (context.prefs().getString(C.UI_NAME_DISPLAY, "0")) {
+                            when (uiPreferences.nameDisplay) {
                                 "0" -> "${item.channelName}(${item.channelLogin})"
                                 "1" -> item.channelName
                                 else -> item.channelLogin
@@ -125,7 +189,6 @@ class StreamsAdapter(
                         } else {
                             item.channelName
                         }
-                        username.setOnClickListener(channelListener)
                     } else {
                         username.visibility = View.GONE
                     }
@@ -137,27 +200,15 @@ class StreamsAdapter(
                         title.visibility = View.GONE
                     }
                     if (showGame && item.gameName != null) {
-                        val gameListener: (View) -> Unit = {
-                            if (selectionMode) {
-                                onStreamClick.invoke(item)
-                            } else {
-                                fragment.findNavController().navigate(GamePagerFragmentDirections.actionGlobalGamePagerFragment(
-                                    gameId = item.gameId,
-                                    gameSlug = item.gameSlug,
-                                    gameName = item.gameName
-                                ))
-                            }
-                        }
                         gameName.visibility = View.VISIBLE
                         gameName.text = item.gameName
-                        gameName.setOnClickListener(gameListener)
                     } else {
                         gameName.visibility = View.GONE
                     }
                     if (item.thumbnailURL != null) {
                         thumbnail.visibility = View.VISIBLE
                         liveBadge.visibility = View.VISIBLE
-                        loadStreamThumbnail(context, thumbnail, item)
+                        bindThumbnail(item)
                     } else {
                         thumbnail.visibility = View.GONE
                         liveBadge.visibility = View.GONE
@@ -170,12 +221,12 @@ class StreamsAdapter(
                         viewers.text = context.resources.getQuantityString(
                             R.plurals.viewers,
                             count,
-                            TwitchApiHelper.formatCount(count, context.prefs().getBoolean(C.UI_TRUNCATE_VIEW_COUNT, true))
+                            TwitchApiHelper.formatCount(count, uiPreferences.truncateViewCount)
                         )
                     } else {
                         viewers.visibility = View.GONE
                     }
-                    if (context.prefs().getBoolean(C.UI_UPTIME, true) && item.createdAt != null) {
+                    if (uiPreferences.showUptime && item.createdAt != null) {
                         val text = item.createdAt?.let {
                             Instant.parseOrNull(it)?.takeIf { time -> time.toEpochMilliseconds() > 0 }?.let { createdAt ->
                                 val uptime = Clock.System.now() - createdAt
@@ -193,8 +244,8 @@ class StreamsAdapter(
                     } else {
                         uptime.visibility = View.GONE
                     }
-                    if (!item.tags.isNullOrEmpty() && context.prefs().getBoolean(C.UI_TAGS, true)) {
-                        bindStreamTags(context, tagsLayout, item.tags) { tag ->
+                    if (!item.tags.isNullOrEmpty() && uiPreferences.showTags) {
+                        bindStreamTags(tagViews, item.tags) { tag ->
                             if (selectionMode) {
                                 onStreamClick.invoke(item)
                             } else {
@@ -205,9 +256,7 @@ class StreamsAdapter(
                         tagsLayout.visibility = View.GONE
                     }
                 } else {
-                    root.setOnClickListener(null)
-                    multiview.setOnClickListener(null)
-                    userImage.setOnClickListener(null)
+                    boundStream = null
                     userImage.setImageDrawable(null)
                     userImage.tag = null
                     thumbnail.setImageDrawable(null)
@@ -217,11 +266,58 @@ class StreamsAdapter(
                     gameName.visibility = View.GONE
                     viewers.visibility = View.GONE
                     uptime.visibility = View.GONE
-                    tagsLayout.removeAllViews()
+                        clearStreamTags(tagViews)
                     tagsLayout.visibility = View.GONE
                     liveBadge.visibility = View.GONE
                 }
             }
+        }
+
+        private fun openStream(stream: Stream) {
+            if (onStreamClick != null) {
+                onStreamClick.invoke(stream)
+            } else {
+                (fragment.activity as? MainActivity)?.startStream(stream)
+            }
+        }
+
+        private fun openChannel(stream: Stream) {
+            if (onStreamClick != null) {
+                onStreamClick.invoke(stream)
+            } else {
+                fragment.findNavController().navigate(
+                    ChannelPagerFragmentDirections.actionGlobalChannelPagerFragment(
+                        channelId = stream.channelId,
+                        channelLogin = stream.channelLogin,
+                        channelName = stream.channelName,
+                        channelImage = stream.channelImage,
+                        streamId = stream.id,
+                    ),
+                )
+            }
+        }
+
+        private fun openGame(stream: Stream) {
+            if (showGame && !stream.gameName.isNullOrBlank()) {
+                if (onStreamClick != null) {
+                    onStreamClick.invoke(stream)
+                } else {
+                    fragment.findNavController().navigate(
+                        GamePagerFragmentDirections.actionGlobalGamePagerFragment(
+                            gameId = stream.gameId,
+                            gameSlug = stream.gameSlug,
+                            gameName = stream.gameName,
+                        ),
+                    )
+                }
+            }
+        }
+
+        private fun openMultiview(stream: Stream) {
+            (fragment.activity as? MainActivity)?.let { activity ->
+                if (activity.playerFragment != null) activity.closePlayer()
+            }
+            fragment.findNavController().navigate(R.id.multiviewFragment, MultiviewFragment.arguments(stream))
         }
     }
 }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/StreamsCompactAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/StreamsCompactAdapter.kt
@@ -35,33 +35,118 @@ class StreamsCompactAdapter(
 
         override fun areContentsTheSame(oldItem: Stream, newItem: Stream): Boolean =
             streamContentsSame(oldItem, newItem)
+
+        override fun getChangePayload(oldItem: Stream, newItem: Stream): Any? =
+            if (streamThumbnailOnlyChanged(oldItem, newItem)) StreamThumbnailChangedPayload else null
     }) {
+
+    private val thumbnailLoadScheduler = StreamThumbnailIdleScheduler()
+
+    override fun onAttachedToRecyclerView(recyclerView: RecyclerView) {
+        super.onAttachedToRecyclerView(recyclerView)
+        thumbnailLoadScheduler.attachTo(recyclerView)
+    }
+
+    override fun onDetachedFromRecyclerView(recyclerView: RecyclerView) {
+        thumbnailLoadScheduler.detach()
+        super.onDetachedFromRecyclerView(recyclerView)
+    }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): PagingViewHolder {
         val binding = FragmentStreamsListItemCompactBinding.inflate(LayoutInflater.from(parent.context), parent, false)
-        return PagingViewHolder(binding, fragment, showGame)
+        return PagingViewHolder(binding, fragment, showGame, createStreamTagViews(binding.tagsLayout))
     }
 
     override fun onBindViewHolder(holder: PagingViewHolder, position: Int) {
+        holder.beginImageBind(getItem(position))
         holder.bind(getItem(position))
+    }
+
+    override fun onBindViewHolder(holder: PagingViewHolder, position: Int, payloads: MutableList<Any>) {
+        if (payloads.isNotEmpty() && payloads.all { it === StreamThumbnailChangedPayload }) {
+            holder.beginImageBind(getItem(position))
+            holder.bindThumbnail(getItem(position))
+        } else {
+            super.onBindViewHolder(holder, position, payloads)
+        }
     }
 
     override fun onViewRecycled(holder: PagingViewHolder) {
         (fragment.requireContext().applicationContext as XtraApp).xtraModule.streamPreviewCoordinator
             .detachSurface(holder.previewSurface)
         holder.boundPreviewIdentity = null
+        thumbnailLoadScheduler.clear(holder)
+        holder.cancelImageWork()
         super.onViewRecycled(holder)
     }
 
-    inner class PagingViewHolder(
+    inner class PagingViewHolder internal constructor(
         private val binding: FragmentStreamsListItemCompactBinding,
         private val fragment: Fragment,
         private val showGame: Boolean,
-    ) : RecyclerView.ViewHolder(binding.root) {
+        private val tagViews: StreamTagViews,
+    ) : RecyclerView.ViewHolder(binding.root), FeedImageRequestOwner {
         val previewSurface get() = binding.previewHost
         var boundPreviewIdentity: String? = null
+        private val imageRequests = FeedImageRequestBag()
+        private var boundImageIdentity: String? = null
+        private var boundThumbnailKey: String? = null
+        private var boundStream: Stream? = null
+
+        init {
+            binding.root.setOnClickListener { boundStream?.let(::openStream) }
+            binding.userImage.setOnClickListener { boundStream?.let(::openChannel) }
+            binding.username.setOnClickListener { boundStream?.let(::openChannel) }
+            binding.gameName.setOnClickListener { boundStream?.let(::openGame) }
+            binding.multiview.setOnClickListener { boundStream?.let(::openMultiview) }
+        }
+
+        fun beginImageBind(item: Stream?) {
+            thumbnailLoadScheduler.clear(this)
+            imageRequests.cancel()
+            boundImageIdentity = item?.streamIdentity()
+            boundThumbnailKey = null
+        }
+
+        override fun cancelImageRequests() {
+            imageRequests.cancel()
+        }
+
+        override fun pauseImageRequests() {
+            imageRequests.cancel(preserveRegistrations = true)
+        }
+
+        fun cancelImageWork() {
+            cancelImageRequests()
+            boundImageIdentity = null
+            boundThumbnailKey = null
+        }
+
+        fun bindThumbnail(item: Stream?) {
+            val stream = item ?: return
+            prepareStreamThumbnailImage(binding.thumbnail, stream)
+            restoreWarmStreamThumbnail(stream, binding.thumbnail)
+            val key = "${stream.thumbnailIdentity()}|generation=${stream.thumbnailGeneration}"
+            boundThumbnailKey = key
+            thumbnailLoadScheduler.runOrDefer(this@PagingViewHolder, binding.thumbnail) {
+                if (!binding.root.isAttachedToWindow ||
+                    boundImageIdentity != stream.streamIdentity() ||
+                    boundThumbnailKey != key
+                ) return@runOrDefer
+                loadStreamThumbnail(
+                    context = fragment.requireContext(),
+                    imageView = binding.thumbnail,
+                    stream = stream,
+                    scheduleFreshRequest = { freshRequest ->
+                        thumbnailLoadScheduler.runOrDefer(this@PagingViewHolder, binding.thumbnail, freshRequest)
+                    },
+                )
+                    ?.let { imageRequests.replace(binding.thumbnail, it) }
+            }
+        }
 
         fun bind(item: Stream?) {
+            boundStream = item
             val nextPreviewIdentity = item?.streamIdentity()
             if (boundPreviewIdentity != nextPreviewIdentity) {
                 (fragment.requireContext().applicationContext as XtraApp).xtraModule.streamPreviewCoordinator
@@ -71,43 +156,22 @@ class StreamsCompactAdapter(
             with(binding) {
                 if (item != null) {
                     val context = fragment.requireContext()
+                    val uiPreferences = FeedUiPreferencesStore.current(context)
                     val selectionMode = onStreamClick != null
-                    val channelListener: (View) -> Unit = {
-                        if (selectionMode) {
-                            onStreamClick.invoke(item)
-                        } else {
-                            fragment.findNavController().navigate(
-                                ChannelPagerFragmentDirections.actionGlobalChannelPagerFragment(
-                                    channelId = item.channelId,
-                                    channelLogin = item.channelLogin,
-                                    channelName = item.channelName,
-                                    channelImage = item.channelImage,
-                                    streamId = item.id
-                                )
-                            )
-                        }
-                    }
-                    root.setOnClickListener {
-                        if (selectionMode) {
-                            onStreamClick.invoke(item)
-                        } else {
-                            (fragment.activity as MainActivity).startStream(item)
-                        }
-                    }
                     multiview.visibility = if (selectionMode || item.channelLogin.isNullOrBlank()) View.GONE else View.VISIBLE
-                    multiview.setOnClickListener {
-                        (fragment.activity as? MainActivity)?.let { activity ->
-                            if (activity.playerFragment != null) activity.closePlayer()
-                        }
-                        fragment.findNavController().navigate(R.id.multiviewFragment, MultiviewFragment.arguments(item))
-                    }
                     if (item.channelImage != null) {
                         userImage.visibility = View.VISIBLE
                         userImage.contentDescription = item.channelName?.let {
                             context.getString(R.string.player_open_channel, it)
                         }
-                        loadStreamProfileImage(context, userImage, item)
-                        userImage.setOnClickListener(channelListener)
+                        prepareStreamProfileImage(userImage, item)
+                        thumbnailLoadScheduler.runOrDefer(this@PagingViewHolder, binding.userImage) {
+                            if (binding.root.isAttachedToWindow && boundImageIdentity == item.streamIdentity()) {
+                                loadStreamProfileImage(context, userImage, item)?.let {
+                                    imageRequests.replace(binding.userImage, it)
+                                }
+                            }
+                        }
                     } else {
                         userImage.visibility = View.GONE
                         userImage.contentDescription = null
@@ -117,7 +181,7 @@ class StreamsCompactAdapter(
                     if (item.channelName != null) {
                         username.visibility = View.VISIBLE
                         username.text = if (item.channelLogin != null && !item.channelLogin.equals(item.channelName, true)) {
-                            when (context.prefs().getString(C.UI_NAME_DISPLAY, "0")) {
+                            when (uiPreferences.nameDisplay) {
                                 "0" -> "${item.channelName}(${item.channelLogin})"
                                 "1" -> item.channelName
                                 else -> item.channelLogin
@@ -125,7 +189,6 @@ class StreamsCompactAdapter(
                         } else {
                             item.channelName
                         }
-                        username.setOnClickListener(channelListener)
                     } else {
                         username.visibility = View.GONE
                     }
@@ -137,27 +200,15 @@ class StreamsCompactAdapter(
                         title.visibility = View.GONE
                     }
                     if (showGame && item.gameName != null) {
-                        val gameListener: (View) -> Unit = {
-                            if (selectionMode) {
-                                onStreamClick.invoke(item)
-                            } else {
-                                fragment.findNavController().navigate(GamePagerFragmentDirections.actionGlobalGamePagerFragment(
-                                    gameId = item.gameId,
-                                    gameSlug = item.gameSlug,
-                                    gameName = item.gameName
-                                ))
-                            }
-                        }
                         gameName.visibility = View.VISIBLE
                         gameName.text = item.gameName
-                        gameName.setOnClickListener(gameListener)
                     } else {
                         gameName.visibility = View.GONE
                     }
                     if (item.thumbnailURL != null) {
                         thumbnail.visibility = View.VISIBLE
                         liveBadge.visibility = View.VISIBLE
-                        loadStreamThumbnail(context, thumbnail, item)
+                        bindThumbnail(item)
                     } else {
                         thumbnail.visibility = View.GONE
                         liveBadge.visibility = View.GONE
@@ -170,12 +221,12 @@ class StreamsCompactAdapter(
                         viewers.text = context.resources.getQuantityString(
                             R.plurals.viewers,
                             count,
-                            TwitchApiHelper.formatCount(count, context.prefs().getBoolean(C.UI_TRUNCATE_VIEW_COUNT, true)),
+                            TwitchApiHelper.formatCount(count, uiPreferences.truncateViewCount),
                         )
                     } else {
                         viewers.visibility = View.GONE
                     }
-                    if (context.prefs().getBoolean(C.UI_UPTIME, true) && item.createdAt != null) {
+                    if (uiPreferences.showUptime && item.createdAt != null) {
                         val text = item.createdAt?.let {
                             Instant.parseOrNull(it)?.takeIf { time -> time.toEpochMilliseconds() > 0 }?.let { createdAt ->
                                 val uptime = Clock.System.now() - createdAt
@@ -193,8 +244,8 @@ class StreamsCompactAdapter(
                     } else {
                         uptime.visibility = View.GONE
                     }
-                    if (!item.tags.isNullOrEmpty() && context.prefs().getBoolean(C.UI_TAGS, true)) {
-                        bindStreamTags(context, tagsLayout, item.tags) { tag ->
+                    if (!item.tags.isNullOrEmpty() && uiPreferences.showTags) {
+                        bindStreamTags(tagViews, item.tags) { tag ->
                             if (selectionMode) {
                                 onStreamClick.invoke(item)
                             } else {
@@ -205,9 +256,7 @@ class StreamsCompactAdapter(
                         tagsLayout.visibility = View.GONE
                     }
                 } else {
-                    root.setOnClickListener(null)
-                    multiview.setOnClickListener(null)
-                    userImage.setOnClickListener(null)
+                    boundStream = null
                     userImage.setImageDrawable(null)
                     userImage.tag = null
                     thumbnail.setImageDrawable(null)
@@ -217,11 +266,58 @@ class StreamsCompactAdapter(
                     gameName.visibility = View.GONE
                     viewers.visibility = View.GONE
                     uptime.visibility = View.GONE
-                    tagsLayout.removeAllViews()
+                        clearStreamTags(tagViews)
                     tagsLayout.visibility = View.GONE
                     liveBadge.visibility = View.GONE
                 }
             }
+        }
+
+        private fun openStream(stream: Stream) {
+            if (onStreamClick != null) {
+                onStreamClick.invoke(stream)
+            } else {
+                (fragment.activity as? MainActivity)?.startStream(stream)
+            }
+        }
+
+        private fun openChannel(stream: Stream) {
+            if (onStreamClick != null) {
+                onStreamClick.invoke(stream)
+            } else {
+                fragment.findNavController().navigate(
+                    ChannelPagerFragmentDirections.actionGlobalChannelPagerFragment(
+                        channelId = stream.channelId,
+                        channelLogin = stream.channelLogin,
+                        channelName = stream.channelName,
+                        channelImage = stream.channelImage,
+                        streamId = stream.id,
+                    ),
+                )
+            }
+        }
+
+        private fun openGame(stream: Stream) {
+            if (showGame && !stream.gameName.isNullOrBlank()) {
+                if (onStreamClick != null) {
+                    onStreamClick.invoke(stream)
+                } else {
+                    fragment.findNavController().navigate(
+                        GamePagerFragmentDirections.actionGlobalGamePagerFragment(
+                            gameId = stream.gameId,
+                            gameSlug = stream.gameSlug,
+                            gameName = stream.gameName,
+                        ),
+                    )
+                }
+            }
+        }
+
+        private fun openMultiview(stream: Stream) {
+            (fragment.activity as? MainActivity)?.let { activity ->
+                if (activity.playerFragment != null) activity.closePlayer()
+            }
+            fragment.findNavController().navigate(R.id.multiviewFragment, MultiviewFragment.arguments(stream))
         }
     }
 }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/ThumbnailImageRequest.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/ThumbnailImageRequest.kt
@@ -1,12 +1,19 @@
 package com.github.andreyasadchy.xtra.ui.common
 
 import android.content.Context
+import android.graphics.drawable.Drawable
 import android.util.Log
+import android.util.LruCache
+import android.view.Choreographer
 import android.widget.ImageView
+import androidx.recyclerview.widget.RecyclerView
 import coil3.Image
+import coil3.asDrawable
 import coil3.decode.DataSource
 import coil3.imageLoader
+import coil3.memory.MemoryCache
 import coil3.request.CachePolicy
+import coil3.request.Disposable
 import coil3.request.ImageRequest
 import coil3.request.crossfade
 import coil3.request.error
@@ -20,9 +27,268 @@ import com.github.andreyasadchy.xtra.BuildConfig
 import com.github.andreyasadchy.xtra.R
 import com.github.andreyasadchy.xtra.model.ui.Stream
 import com.github.andreyasadchy.xtra.repository.streamfeed.StreamThumbnailRefreshSignal
-import com.github.andreyasadchy.xtra.util.C
-import com.github.andreyasadchy.xtra.util.prefs
+import com.github.andreyasadchy.xtra.util.UiInteractionGovernor
+import java.util.Collections
 import java.util.concurrent.ConcurrentHashMap
+import java.util.IdentityHashMap
+
+internal interface FeedImageRequestOwner {
+    /** Cancel optional work without invalidating an image that is already on screen. */
+    fun cancelImageRequests()
+
+    /** Pause active work while retaining registrations for a same-bind resume. */
+    fun pauseImageRequests()
+}
+
+/** Defers optional image work until idle without retaining work for scrolled-off rows. */
+internal class StreamThumbnailIdleScheduler {
+    private var recyclerView: RecyclerView? = null
+    private class ScheduledWork(
+        var work: () -> Unit,
+        var scheduled: Boolean = false,
+    )
+
+    /** One latest recipe per currently bound owner/slot; never one entry per row crossed. */
+    private val latestWork = IdentityHashMap<Any, IdentityHashMap<Any, ScheduledWork>>()
+    private val attachedOwners = Collections.newSetFromMap(IdentityHashMap<Any, Boolean>())
+    private var drainPosted = false
+    private var drainFrameCallback: Choreographer.FrameCallback? = null
+    private var resumeAttachedWork = false
+    private var drainFrameTimeNanos: Long? = null
+    private val governorInteractionStartListener: () -> Unit = {
+        recyclerView?.let(::cancelForInteraction)
+    }
+    private val governorIdleListener: () -> Unit = {
+        recyclerView?.let { if (it.scrollState == RecyclerView.SCROLL_STATE_IDLE) scheduleDrain(it) }
+    }
+    private val scrollListener = object : RecyclerView.OnScrollListener() {
+        override fun onScrollStateChanged(recyclerView: RecyclerView, newState: Int) {
+            UiInteractionGovernor.setInteracting(this@StreamThumbnailIdleScheduler, newState != RecyclerView.SCROLL_STATE_IDLE)
+            if (newState == RecyclerView.SCROLL_STATE_IDLE) {
+                if (!UiInteractionGovernor.isInteracting.value) scheduleDrain(recyclerView)
+            } else {
+                cancelForInteraction(recyclerView)
+            }
+        }
+    }
+    private val childAttachListener = object : RecyclerView.OnChildAttachStateChangeListener {
+        override fun onChildViewAttachedToWindow(view: android.view.View) {
+            val owner = recyclerView?.getChildViewHolder(view) as? FeedImageRequestOwner ?: return
+            attachedOwners.add(owner)
+            if (recyclerView?.scrollState == RecyclerView.SCROLL_STATE_IDLE && !UiInteractionGovernor.isInteracting.value) {
+                latestWork[owner]?.values?.forEach { it.scheduled = true }
+                recyclerView?.let(::scheduleDrain)
+            }
+        }
+
+        override fun onChildViewDetachedFromWindow(view: android.view.View) {
+            val owner = recyclerView?.getChildViewHolder(view) as? FeedImageRequestOwner
+            owner?.cancelImageRequests()
+            if (owner != null) {
+                attachedOwners.remove(owner)
+                // A detached holder may stay in RecyclerView's cache. Keep
+                // its latest bind recipe for a future reattach, but never
+                // leave executable work scheduled for it.
+                latestWork[owner]?.values?.forEach { it.scheduled = false }
+            }
+        }
+    }
+
+    fun attachTo(recyclerView: RecyclerView) {
+        if (this.recyclerView === recyclerView) return
+        detach()
+        this.recyclerView = recyclerView
+        recyclerView.addOnScrollListener(scrollListener)
+        recyclerView.addOnChildAttachStateChangeListener(childAttachListener)
+        UiInteractionGovernor.addIdleListener(governorIdleListener)
+        UiInteractionGovernor.addInteractionStartListener(governorInteractionStartListener)
+        UiInteractionGovernor.setInteracting(this, recyclerView.scrollState != RecyclerView.SCROLL_STATE_IDLE)
+        // The global governor may already be active because another list or
+        // pager is moving. In that case this scheduler does not receive a new
+        // interaction-start callback, so remember to rebuild attached work
+        // when the shared interaction returns to idle.
+        resumeAttachedWork = UiInteractionGovernor.isInteracting.value
+        for (index in 0 until recyclerView.childCount) {
+            (recyclerView.getChildViewHolder(recyclerView.getChildAt(index)) as? FeedImageRequestOwner)
+                ?.let(attachedOwners::add)
+        }
+        if (recyclerView.scrollState == RecyclerView.SCROLL_STATE_IDLE && !UiInteractionGovernor.isInteracting.value) scheduleDrain(recyclerView)
+    }
+
+    fun detach() {
+        recyclerView?.removeOnScrollListener(scrollListener)
+        recyclerView?.removeOnChildAttachStateChangeListener(childAttachListener)
+        UiInteractionGovernor.removeIdleListener(governorIdleListener)
+        UiInteractionGovernor.removeInteractionStartListener(governorInteractionStartListener)
+        UiInteractionGovernor.setInteracting(this, false)
+        recyclerView = null
+        latestWork.clear()
+        attachedOwners.clear()
+        drainFrameCallback?.let(Choreographer.getInstance()::removeFrameCallback)
+        drainFrameCallback = null
+        drainPosted = false
+        resumeAttachedWork = false
+    }
+
+    /** Drops work registered by an old bind before a holder receives a new item. */
+    fun clear(owner: Any) {
+        latestWork.remove(owner)
+    }
+
+    fun runOrDefer(owner: Any, slot: Any, work: () -> Unit) {
+        val recyclerView = recyclerView
+        val ownerWork = latestWork.getOrPut(owner) { IdentityHashMap() }
+        val scheduledWork = ownerWork[slot]
+            ?.also { it.work = work }
+            ?: ScheduledWork(work).also { ownerWork[slot] = it }
+        if (recyclerView == null ||
+            (owner !in attachedOwners)
+        ) {
+            // Prefetch can bind a holder before it is attached. Retain only
+            // its latest recipe; onChildViewAttachedToWindow will enqueue it
+            // if the holder is still relevant.
+            if (recyclerView == null) work()
+        } else if (
+            recyclerView.scrollState == RecyclerView.SCROLL_STATE_IDLE && !UiInteractionGovernor.isInteracting.value
+        ) {
+            // Keep every optional image start on the Choreographer-driven path.
+            // This makes the shared budget real at both 60 Hz and 120 Hz and
+            // prevents a callback-triggered request from bypassing it.
+            scheduledWork.scheduled = true
+            recyclerView.let(::scheduleDrain)
+        }
+    }
+
+    private fun scheduleDrain(recyclerView: RecyclerView) {
+        if (drainPosted) return
+        drainPosted = true
+        val frameCallback = object : Choreographer.FrameCallback {
+            override fun doFrame(frameTimeNanos: Long) {
+                if (drainFrameCallback !== this) return
+                drainFrameCallback = null
+                drainPosted = false
+                if (resumeAttachedWork) {
+                    resumeAttachedWork = false
+                    queueAttachedWork(recyclerView)
+                }
+                drain(recyclerView, frameTimeNanos)
+            }
+        }
+        drainFrameCallback = frameCallback
+        Choreographer.getInstance().postFrameCallback(frameCallback)
+    }
+
+    private fun drain(recyclerView: RecyclerView, frameTimeNanos: Long) {
+        val previousFrameTimeNanos = drainFrameTimeNanos
+        drainFrameTimeNanos = frameTimeNanos
+        try {
+            if (this.recyclerView !== recyclerView ||
+                recyclerView.scrollState != RecyclerView.SCROLL_STATE_IDLE ||
+                UiInteractionGovernor.isInteracting.value
+            ) return
+
+            val ownerIterator = attachedOwners.iterator()
+            while (ownerIterator.hasNext()) {
+                val owner = ownerIterator.next()
+                val slotIterator = latestWork[owner]?.values?.iterator() ?: continue
+                while (slotIterator.hasNext()) {
+                    val scheduledWork = slotIterator.next()
+                    if (!scheduledWork.scheduled) continue
+                    if (!UiInteractionGovernor.tryAcquireVisibleImageStart(drainFrameTimeNanos)) {
+                        scheduleDrain(recyclerView)
+                        return
+                    }
+                    scheduledWork.scheduled = false
+                    scheduledWork.work()
+                }
+            }
+            if (hasScheduledWork()) scheduleDrain(recyclerView)
+        } finally {
+            drainFrameTimeNanos = previousFrameTimeNanos
+        }
+    }
+
+    private fun cancelAttachedImageWork(recyclerView: RecyclerView) {
+        for (index in 0 until recyclerView.childCount) {
+            (recyclerView.getChildViewHolder(recyclerView.getChildAt(index)) as? FeedImageRequestOwner)
+                ?.pauseImageRequests()
+        }
+    }
+
+    private fun cancelForInteraction(recyclerView: RecyclerView) {
+        // Drop frame-eligible work. latestWork remains a single current-bind
+        // recipe per attached holder/slot so it can be resumed after the
+        // gesture without retaining every row crossed during the fling.
+        attachedOwners.forEach { owner ->
+            latestWork[owner]?.values?.forEach { it.scheduled = false }
+        }
+        cancelAttachedImageWork(recyclerView)
+        resumeAttachedWork = true
+    }
+
+    private fun queueAttachedWork(recyclerView: RecyclerView) {
+        for (index in 0 until recyclerView.childCount) {
+            val owner = recyclerView.getChildViewHolder(recyclerView.getChildAt(index)) as? FeedImageRequestOwner
+                ?: continue
+            attachedOwners.add(owner)
+            latestWork[owner]?.values?.forEach { it.scheduled = true }
+        }
+    }
+
+    private fun hasScheduledWork(): Boolean = attachedOwners.any { owner ->
+        latestWork[owner]?.values?.any(ScheduledWork::scheduled) == true
+    }
+}
+
+/** Owns optional image work for one recycled feed holder. */
+internal class FeedImageRequestBag {
+    private val cancellations = IdentityHashMap<Any, () -> Unit>()
+
+    fun replace(slot: Any, disposable: Disposable) {
+        cancellations.put(slot, disposable::dispose)?.invoke()
+    }
+
+    fun replace(slot: Any, handle: StreamThumbnailRequestHandle) {
+        cancellations.put(slot, handle::cancel)?.invoke()
+    }
+
+    fun cancel(preserveRegistrations: Boolean = false) {
+        cancellations.values.forEach { it() }
+        if (!preserveRegistrations) cancellations.clear()
+    }
+}
+
+/**
+ * A thumbnail consists of a cache stage and an optional fresh stage. Keep one
+ * cancellation handle for both so a recycled holder can stop either stage,
+ * including a fresh request scheduled by the cache-stage callback.
+ */
+internal class StreamThumbnailRequestHandle {
+    private var disposable: Disposable? = null
+    private var cancelled = false
+
+    @Synchronized
+    fun set(disposable: Disposable) {
+        if (cancelled) {
+            disposable.dispose()
+        } else {
+            this.disposable?.dispose()
+            this.disposable = disposable
+        }
+    }
+
+    @Synchronized
+    fun cancel() {
+        cancelled = true
+        disposable?.dispose()
+        disposable = null
+    }
+
+    @Synchronized
+    fun rearm() {
+        cancelled = false
+    }
+}
 
 internal fun ImageRequest.Builder.thumbnailState(): ImageRequest.Builder = apply {
     placeholder(R.drawable.bg_thumbnail_placeholder)
@@ -53,7 +319,9 @@ internal fun Stream.thumbnailIdentity(): String {
         ?: "fallback:${streamIdentity()}:thumbnail-hash:${thumbnailURL.orEmpty().hashCode().toString(16)}"
 }
 
-internal fun streamContentsSame(oldItem: Stream, newItem: Stream): Boolean {
+internal object StreamThumbnailChangedPayload
+
+private fun streamMetadataSame(oldItem: Stream, newItem: Stream): Boolean {
     return oldItem.id == newItem.id &&
             oldItem.channelId == newItem.channelId &&
             oldItem.channelLogin == newItem.channelLogin &&
@@ -66,8 +334,16 @@ internal fun streamContentsSame(oldItem: Stream, newItem: Stream): Boolean {
             oldItem.thumbnailURL == newItem.thumbnailURL &&
             oldItem.createdAt == newItem.createdAt &&
             oldItem.viewerCount == newItem.viewerCount &&
-            oldItem.tags == newItem.tags &&
-            oldItem.thumbnailGeneration == newItem.thumbnailGeneration
+            oldItem.tags == newItem.tags
+}
+
+internal fun streamContentsSame(oldItem: Stream, newItem: Stream): Boolean {
+    return streamMetadataSame(oldItem, newItem)
+}
+
+internal fun streamThumbnailOnlyChanged(oldItem: Stream, newItem: Stream): Boolean {
+    return streamMetadataSame(oldItem, newItem) &&
+            oldItem.thumbnailGeneration != newItem.thumbnailGeneration
 }
 
 /**
@@ -79,21 +355,28 @@ private class StreamImageTarget(
     imageView: ImageView,
     private val identity: String,
     private val preserveCurrentImage: Boolean,
+    private val requestKey: Any? = null,
+    private val thumbnailCacheKey: String? = null,
 ) : ImageViewTarget(imageView) {
 
+    private fun isCurrent(): Boolean =
+        view.tag == identity &&
+            (requestKey == null || view.getTag(R.id.stream_profile_request_key) == requestKey)
+
     override fun onStart(placeholder: Image?) {
-        if (preserveCurrentImage && view.tag == identity && view.drawable != null) return
+        if (preserveCurrentImage && isCurrent() && view.drawable != null) return
         super.onStart(placeholder)
     }
 
     override fun onSuccess(result: Image) {
-        if (view.tag == identity) {
+        if (isCurrent()) {
             super.onSuccess(result)
+            thumbnailCacheKey?.let { rememberWarmStreamThumbnail(it, view) }
         }
     }
 
     override fun onError(error: Image?) {
-        if (view.tag != identity) return
+        if (!isCurrent()) return
         if (shouldPreserveThumbnailOnFreshFailure(
                 identityMatches = true,
                 preserveCurrentImage = preserveCurrentImage,
@@ -107,6 +390,7 @@ private class StreamImageTarget(
 private class StreamThumbnailCacheTarget(
     imageView: ImageView,
     private val identity: String,
+    private val cacheKey: String,
 ) : ImageViewTarget(imageView) {
 
     override fun onStart(placeholder: Image?) {
@@ -117,6 +401,7 @@ private class StreamThumbnailCacheTarget(
     override fun onSuccess(result: Image) {
         if (view.tag == identity) {
             super.onSuccess(result)
+            rememberWarmStreamThumbnail(cacheKey, view)
         }
     }
 
@@ -134,6 +419,72 @@ internal data class StreamThumbnailRequestPlan(
     val memoryCacheKey: String,
     val networkUrl: String,
 )
+
+private data class StreamThumbnailViewRequestKey(
+    val identity: String,
+    val sourceUrl: String,
+    val memoryCacheKey: String,
+    val freshnessBucket: Long,
+    val thumbnailGeneration: Long,
+    val forceEpoch: Long,
+)
+
+private val warmStreamThumbnailCache = object : LruCache<String, Drawable.ConstantState>(16) {}
+
+private data class WarmThumbnailRequestKey(val memoryCacheKey: String)
+
+private fun rememberWarmStreamThumbnail(cacheKey: String, imageView: ImageView) {
+    imageView.drawable?.constantState?.let { state ->
+        synchronized(warmStreamThumbnailCache) {
+            warmStreamThumbnailCache.put(cacheKey, state)
+        }
+        if (BuildConfig.DEBUG) Log.d("StreamThumbnail", "warm_store keyHash=${cacheKey.hashCode().toString(16)}")
+    }
+}
+
+private fun restoreWarmStreamThumbnail(cacheKey: String, imageView: ImageView): Boolean {
+    if (imageView.drawable != null) return false
+    val state = synchronized(warmStreamThumbnailCache) {
+        warmStreamThumbnailCache.get(cacheKey)
+    } ?: return false
+    imageView.setImageDrawable(state.newDrawable(imageView.resources))
+    if (BuildConfig.DEBUG) Log.d("StreamThumbnail", "warm_restore keyHash=${cacheKey.hashCode().toString(16)}")
+    return true
+}
+
+/**
+ * Coil's decoded memory cache is the source of truth for images that were
+ * loaded by another holder. Restoring it synchronously avoids showing the
+ * layout's grey placeholder while a cache-only request posts its callback.
+ * The small ConstantState cache above remains a fallback for images Coil has
+ * already evicted from its decoded cache.
+ */
+internal fun restoreDecodedMemoryImage(cacheKey: String, imageView: ImageView): Boolean {
+    if (imageView.drawable != null) return false
+    val cachedImage = imageView.context.imageLoader.memoryCache
+        ?.get(MemoryCache.Key(cacheKey))
+        ?.image
+        ?: return false
+    imageView.setImageDrawable(cachedImage.asDrawable(imageView.resources))
+    if (BuildConfig.DEBUG) Log.d("StreamThumbnail", "memory_restore keyHash=${cacheKey.hashCode().toString(16)}")
+    return true
+}
+
+private fun restoreDecodedStreamThumbnail(cacheKey: String, imageView: ImageView): Boolean =
+    restoreDecodedMemoryImage(cacheKey, imageView)
+
+/**
+ * Restore an already-decoded thumbnail during bind. This is memory-only;
+ * disk/network work remains behind the idle scheduler.
+ */
+internal fun restoreWarmStreamThumbnail(stream: Stream, imageView: ImageView): Boolean {
+    val plan = streamThumbnailRequestPlan(stream, StreamThumbnailPolicy.bucket(System.currentTimeMillis())) ?: return false
+    if (!restoreDecodedStreamThumbnail(plan.memoryCacheKey, imageView) &&
+        !restoreWarmStreamThumbnail(plan.memoryCacheKey, imageView)
+    ) return false
+    imageView.setTag(R.id.stream_thumbnail_request_key, WarmThumbnailRequestKey(plan.memoryCacheKey))
+    return true
+}
 
 internal object StreamThumbnailPolicy {
     const val REFRESH_INTERVAL_MS = 5 * 60_000L
@@ -264,39 +615,87 @@ internal fun streamThumbnailRequestPlan(stream: Stream, bucket: Long): StreamThu
     val separator = if ('?' in thumbnail) '&' else '?'
     return StreamThumbnailRequestPlan(
         diskCacheKey = "xtra:stream-thumbnail:$identity",
-        memoryCacheKey = "xtra:stream-thumbnail-memory:$identity:bucket:$bucket",
+        // Keep one decoded in-process image per stream. The bucket belongs to
+        // freshness/revalidation, not to the identity of the image currently
+        // displayed. This lets a recreated holder render the last image from
+        // memory immediately while the optional fresh request runs later.
+        memoryCacheKey = "xtra:stream-thumbnail-memory:$identity",
         networkUrl = "$thumbnail${separator}xtra_preview_bucket=$bucket",
     )
 }
 
-internal fun loadStreamProfileImage(context: Context, imageView: ImageView, stream: Stream) {
+internal fun prepareStreamProfileImage(imageView: ImageView, stream: Stream) {
+    val identity = stream.streamIdentity()
+    if (imageView.tag != identity) {
+        imageView.setImageDrawable(null)
+        imageView.setTag(R.id.stream_profile_request_key, null)
+    }
+    imageView.tag = identity
+}
+
+internal fun prepareStreamThumbnailImage(imageView: ImageView, stream: Stream) {
+    val identity = stream.thumbnailIdentity()
+    if (imageView.tag != identity) {
+        imageView.setImageDrawable(null)
+        imageView.setTag(R.id.stream_thumbnail_request_key, null)
+    }
+    imageView.tag = identity
+}
+
+internal fun loadStreamProfileImage(
+    context: Context,
+    imageView: ImageView,
+    stream: Stream,
+): Disposable? {
     val identity = stream.streamIdentity()
     val sameIdentity = imageView.tag == identity
     if (!sameIdentity) {
         imageView.setImageDrawable(null)
+        imageView.setTag(R.id.stream_profile_request_key, null)
     }
     imageView.tag = identity
     val url = stream.channelImage
     if (url.isNullOrBlank()) {
         imageView.setImageDrawable(null)
-        return
+        imageView.setTag(R.id.stream_profile_request_key, null)
+        return null
     }
-    ImageRequest.Builder(context).apply {
+    val roundUserImage = FeedUiPreferencesStore.current(context).roundUserImage
+    val requestKey = "$identity|$url|round=$roundUserImage"
+    if (sameIdentity &&
+        imageView.drawable != null &&
+        imageView.getTag(R.id.stream_profile_request_key) == requestKey
+    ) {
+        return null
+    }
+    imageView.setTag(R.id.stream_profile_request_key, requestKey)
+    if (restoreDecodedMemoryImage(requestKey, imageView)) {
+        return null
+    }
+    return context.imageLoader.enqueue(ImageRequest.Builder(context).apply {
         data(url)
+        memoryCacheKey(requestKey)
         diskCachePolicy(CachePolicy.ENABLED)
-        if (context.prefs().getBoolean(C.UI_ROUND_USER_IMAGE, true)) {
+        if (roundUserImage) {
             transformations(CircleCropTransformation())
         }
         // Keep an already displayed image in place while a changed profile URL loads.
         crossfade(false)
-        target(StreamImageTarget(imageView, identity, preserveCurrentImage = sameIdentity))
-    }.build().let(context.imageLoader::enqueue)
+        target(StreamImageTarget(imageView, identity, preserveCurrentImage = sameIdentity, requestKey = requestKey))
+    }.build())
 }
 
-internal fun loadStreamThumbnail(context: Context, imageView: ImageView, stream: Stream) {
+internal fun loadStreamThumbnail(
+    context: Context,
+    imageView: ImageView,
+    stream: Stream,
+    scheduleFreshRequest: ((() -> Unit) -> Unit),
+): StreamThumbnailRequestHandle? {
     val identity = stream.thumbnailIdentity()
-    if (imageView.tag != identity) {
+    val sameIdentity = imageView.tag == identity
+    if (!sameIdentity) {
         imageView.setImageDrawable(null)
+        imageView.setTag(R.id.stream_thumbnail_request_key, null)
     }
     imageView.tag = identity
     val bucket = StreamThumbnailPolicy.bucket(System.currentTimeMillis())
@@ -304,16 +703,40 @@ internal fun loadStreamThumbnail(context: Context, imageView: ImageView, stream:
     val plan = streamThumbnailRequestPlan(stream, bucket)
     if (plan == null) {
         imageView.setImageDrawable(null)
-        return
+        imageView.setTag(R.id.stream_thumbnail_request_key, null)
+        return null
     }
+
+    val requestKey = StreamThumbnailViewRequestKey(
+        identity = identity,
+        sourceUrl = stream.thumbnailURL.orEmpty(),
+        memoryCacheKey = plan.memoryCacheKey,
+        freshnessBucket = bucket,
+        thumbnailGeneration = stream.thumbnailGeneration,
+        forceEpoch = forceEpoch,
+    )
+    val warmImageRestored = imageView.getTag(R.id.stream_thumbnail_request_key) ==
+            WarmThumbnailRequestKey(plan.memoryCacheKey)
+    // Paging can rebind an unchanged row while another part of the screen is
+    // updating. A cache hit still allocates a request and callback chain, so
+    // do not enqueue the same request again when its image is already shown.
+    if (sameIdentity &&
+        imageView.drawable != null &&
+        imageView.getTag(R.id.stream_thumbnail_request_key) == requestKey
+    ) {
+        return null
+    }
+    imageView.setTag(R.id.stream_thumbnail_request_key, requestKey)
+    val requestHandle = StreamThumbnailRequestHandle()
 
     fun enqueueFreshRequest() {
         val nowMs = System.currentTimeMillis()
         if (!streamThumbnailFetchGate.shouldFetch(identity, bucket, forceEpoch, nowMs)) return
         streamThumbnailFetchGate.markAttempt(identity, bucket, forceEpoch, nowMs)
+        requestHandle.rearm()
         val preserveCurrentImage = imageView.tag == identity && imageView.drawable != null
         val policies = thumbnailCachePolicies(fresh = true)
-        ImageRequest.Builder(context).apply {
+        requestHandle.set(context.imageLoader.enqueue(ImageRequest.Builder(context).apply {
             data(plan.networkUrl)
             // The fresh stage must bypass both stale memory and disk reads while
             // retaining the new response in both caches.
@@ -332,15 +755,32 @@ internal fun loadStreamThumbnail(context: Context, imageView: ImageView, stream:
                 bucket = bucket,
                 onSuccess = { streamThumbnailFetchGate.markSuccess(identity, bucket, forceEpoch) },
             )
-            target(StreamImageTarget(imageView, identity, preserveCurrentImage))
-        }.build().let(context.imageLoader::enqueue)
+            target(
+                StreamImageTarget(
+                    imageView = imageView,
+                    identity = identity,
+                    preserveCurrentImage = preserveCurrentImage,
+                    thumbnailCacheKey = plan.memoryCacheKey,
+                ),
+            )
+        }.build()))
+    }
+
+    // A warm ConstantState is already a decoded stale image. Avoid issuing a
+    // second cache-only request that would decode the same bitmap from disk;
+    // only revalidate when the fetch gate says the current bucket is due.
+    if (warmImageRestored || restoreWarmStreamThumbnail(plan.memoryCacheKey, imageView)) {
+        if (streamThumbnailFetchGate.shouldFetch(identity, bucket, forceEpoch, System.currentTimeMillis())) {
+            scheduleFreshRequest(::enqueueFreshRequest)
+        }
+        return requestHandle
     }
 
     // Stage one renders the stable last-known image without touching the
     // network. Stage two then revalidates the preview and atomically replaces
     // the displayed image and the same stable disk entry if successful.
     val policies = thumbnailCachePolicies(fresh = false)
-    ImageRequest.Builder(context).apply {
+    requestHandle.set(context.imageLoader.enqueue(ImageRequest.Builder(context).apply {
         data(plan.networkUrl)
         // READ_ONLY prevents this stale stage from populating the memory entry
         // that the fresh stage deliberately bypasses.
@@ -367,11 +807,12 @@ internal fun loadStreamThumbnail(context: Context, imageView: ImageView, stream:
                         forceRefresh = forceRefresh || retryFreshRequest,
                     )
                 ) {
-                    enqueueFreshRequest()
+                    scheduleFreshRequest(::enqueueFreshRequest)
                 }
             },
-            onError = { enqueueFreshRequest() },
+            onError = { scheduleFreshRequest(::enqueueFreshRequest) },
         )
-        target(StreamThumbnailCacheTarget(imageView, identity))
-    }.build().let(context.imageLoader::enqueue)
+        target(StreamThumbnailCacheTarget(imageView, identity, plan.memoryCacheKey))
+    }.build()))
+    return requestHandle
 }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/VideosAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/VideosAdapter.kt
@@ -50,26 +50,56 @@ class VideosAdapter(
                     oldItem.durationSeconds == newItem.durationSeconds
     }) {
 
+    private val imageLoadScheduler = StreamThumbnailIdleScheduler()
+
+    override fun onAttachedToRecyclerView(recyclerView: RecyclerView) {
+        super.onAttachedToRecyclerView(recyclerView)
+        imageLoadScheduler.attachTo(recyclerView)
+    }
+
+    override fun onDetachedFromRecyclerView(recyclerView: RecyclerView) {
+        imageLoadScheduler.detach()
+        super.onDetachedFromRecyclerView(recyclerView)
+    }
+
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): PagingViewHolder {
         val binding = FragmentVideosListItemBinding.inflate(LayoutInflater.from(parent.context), parent, false)
         return PagingViewHolder(binding, fragment, showGame, showChannel)
     }
 
     override fun onBindViewHolder(holder: PagingViewHolder, position: Int) {
+        holder.beginImageBind(getItem(position))
         holder.bind(getItem(position))
+    }
+
+    override fun onBindViewHolder(holder: PagingViewHolder, position: Int, payloads: MutableList<Any>) {
+        if (payloads.isNotEmpty() && payloads.all { it === VIDEO_POSITION_CHANGED_PAYLOAD }) {
+            holder.bindPosition(getItem(position))
+        } else {
+            super.onBindViewHolder(holder, position, payloads)
+        }
     }
 
     override fun onViewRecycled(holder: PagingViewHolder) {
         holder.detachPreview()
+        imageLoadScheduler.clear(holder)
+        holder.cancelImageWork()
         super.onViewRecycled(holder)
     }
 
-    private var positions: List<VideoPosition>? = null
+    private var positions: Map<Long, Long> = emptyMap()
 
     fun setVideoPositions(positions: List<VideoPosition>) {
-        this.positions = positions
-        if (itemCount != 0) {
-            notifyDataSetChanged()
+        val oldPositions = this.positions
+        val newPositions = positions.associate { it.id to it.position }
+        this.positions = newPositions
+        if (itemCount == 0) return
+
+        for (index in 0 until itemCount) {
+            val id = getItem(index)?.id?.toLongOrNull() ?: continue
+            if (oldPositions[id] != newPositions[id]) {
+                notifyItemChanged(index, VIDEO_POSITION_CHANGED_PAYLOAD)
+            }
         }
     }
 
@@ -84,14 +114,111 @@ class VideosAdapter(
         private val fragment: Fragment,
         private val showGame: Boolean,
         private val showChannel: Boolean,
-    ) : RecyclerView.ViewHolder(binding.root) {
+    ) : RecyclerView.ViewHolder(binding.root), FeedImageRequestOwner {
         val previewSurface get() = binding.previewHost
         private var boundPreviewIdentity: String? = null
+        private val imageRequests = FeedImageRequestBag()
+        private var boundImageIdentity: String? = null
+        private var boundVideo: Video? = null
+
+        init {
+            binding.root.setOnClickListener { boundVideo?.let(::openVideo) }
+            binding.root.setOnLongClickListener {
+                boundVideo?.let {
+                    showDownloadDialog(it)
+                    true
+                } ?: false
+            }
+            binding.userImage.setOnClickListener { boundVideo?.let(::openChannel) }
+            binding.username.setOnClickListener { boundVideo?.let(::openChannel) }
+            binding.gameName.setOnClickListener { boundVideo?.let(::openGame) }
+            binding.options.setOnClickListener { showOptions(it) }
+        }
+
+        fun beginImageBind(item: Video?) {
+            imageLoadScheduler.clear(this)
+            imageRequests.cancel()
+            boundImageIdentity = item?.id?.trim()?.takeIf { it.isNotEmpty() }?.let { "vod:$it" }
+        }
+
+        override fun cancelImageRequests() {
+            imageRequests.cancel()
+        }
+
+        override fun pauseImageRequests() {
+            imageRequests.cancel(preserveRegistrations = true)
+        }
+
+        fun cancelImageWork() {
+            cancelImageRequests()
+            boundImageIdentity = null
+            boundVideo = null
+        }
+
+        private fun bindThumbnail(item: Video, context: android.content.Context) {
+            val identity = "vod:${item.id.orEmpty()}"
+            val thumbnailUrl = item.thumbnail
+            val thumbnailKey = "xtra:vod-thumbnail:$identity|$thumbnailUrl"
+            if (binding.thumbnail.tag != thumbnailKey) {
+                binding.thumbnail.setImageDrawable(null)
+                binding.thumbnail.tag = thumbnailKey
+            }
+            restoreDecodedMemoryImage(thumbnailKey, binding.thumbnail)
+            imageLoadScheduler.runOrDefer(this@PagingViewHolder, binding.thumbnail) {
+                if (!binding.root.isAttachedToWindow || boundImageIdentity != identity) return@runOrDefer
+                imageRequests.replace(
+                    binding.thumbnail,
+                    context.imageLoader.enqueue(
+                        ImageRequest.Builder(context).apply {
+                            data(thumbnailUrl)
+                            memoryCacheKey(thumbnailKey)
+                            diskCachePolicy(CachePolicy.ENABLED)
+                            crossfade(false)
+                            target(binding.thumbnail)
+                            thumbnailState()
+                        }.build(),
+                    ),
+                )
+            }
+        }
+
+        private fun bindProfile(
+            item: Video,
+            context: android.content.Context,
+            uiPreferences: FeedUiPreferences,
+        ) {
+            val identity = "vod:${item.id.orEmpty()}"
+            val url = item.channelImage ?: return
+            val profileKey = "xtra:vod-avatar:$identity|$url|round=${uiPreferences.roundUserImage}"
+            if (binding.userImage.tag != profileKey) {
+                binding.userImage.setImageDrawable(null)
+                binding.userImage.tag = profileKey
+            }
+            restoreDecodedMemoryImage(profileKey, binding.userImage)
+            imageLoadScheduler.runOrDefer(this@PagingViewHolder, binding.userImage) {
+                if (!binding.root.isAttachedToWindow || boundImageIdentity != identity) return@runOrDefer
+                imageRequests.replace(
+                    binding.userImage,
+                    context.imageLoader.enqueue(
+                        ImageRequest.Builder(context).apply {
+                            data(url)
+                            memoryCacheKey(profileKey)
+                            if (uiPreferences.roundUserImage) {
+                                transformations(CircleCropTransformation())
+                            }
+                            crossfade(false)
+                            target(binding.userImage)
+                        }.build(),
+                    ),
+                )
+            }
+        }
 
         private val streamPreviewCoordinator
             get() = (binding.root.context.applicationContext as XtraApp).xtraModule.streamPreviewCoordinator
 
         fun bind(item: Video?) {
+            boundVideo = item
             val nextPreviewIdentity = item?.id?.trim()?.takeIf { it.isNotEmpty() }?.let { "vod:$it" }
             with(binding) {
                 if (boundPreviewIdentity != nextPreviewIdentity) {
@@ -100,32 +227,9 @@ class VideosAdapter(
                 }
                 if (item != null) {
                     val context = fragment.requireContext()
-                    val position = item.id?.toLongOrNull()?.let { id -> positions?.find { it.id == id }?.position }
-                    val startFromBeginning = position != null && item.durationSeconds != null && item.durationSeconds > 0 && position >= (item.durationSeconds * 1000)
-                    root.setOnClickListener {
-                        (fragment.activity as MainActivity).startVideo(
-                            item,
-                            if (startFromBeginning) {
-                                0
-                            } else {
-                                position
-                            },
-                            startFromBeginning
-                        )
-                    }
-                    root.setOnLongClickListener {
-                        showDownloadDialog(item)
-                        true
-                    }
-                    fragment.requireContext().imageLoader.enqueue(
-                        ImageRequest.Builder(fragment.requireContext()).apply {
-                            data(item.thumbnail)
-                            diskCachePolicy(CachePolicy.DISABLED)
-                            crossfade(true)
-                            target(thumbnail)
-                            thumbnailState()
-                        }.build()
-                    )
+                    val uiPreferences = FeedUiPreferencesStore.current(context)
+                    val position = item.id?.toLongOrNull()?.let { id -> positions[id] }
+                    bindThumbnail(item, context)
                     if (item.createdAt != null) {
                         val text = Instant.parseOrNull(item.createdAt)?.toEpochMilliseconds()?.takeIf { ms -> ms > 0 }?.let {
                             TwitchApiHelper.formatDate(context, it)
@@ -145,7 +249,7 @@ class VideosAdapter(
                         views.text = context.resources.getQuantityString(
                             R.plurals.views,
                             count,
-                            TwitchApiHelper.formatCount(count, context.prefs().getBoolean(C.UI_TRUNCATE_VIEW_COUNT, true))
+                            TwitchApiHelper.formatCount(count, uiPreferences.truncateViewCount)
                         )
                     } else {
                         views.visibility = View.GONE
@@ -167,39 +271,14 @@ class VideosAdapter(
                     } else {
                         type.visibility = View.GONE
                     }
-                    if (position != null && item.durationSeconds != null && item.durationSeconds > 0L) {
-                        progressBar.progress = (position / (item.durationSeconds * 10)).toInt()
-                        progressBar.visibility = View.VISIBLE
-                    } else {
-                        progressBar.visibility = View.GONE
-                    }
+                    bindPosition(item, position)
                     if (showChannel) {
-                        val channelListener: (View) -> Unit = {
-                            fragment.findNavController().navigate(
-                                ChannelPagerFragmentDirections.actionGlobalChannelPagerFragment(
-                                    channelId = item.channelId,
-                                    channelLogin = item.channelLogin,
-                                    channelName = item.channelName,
-                                    channelImage = item.channelImage,
-                                )
-                            )
-                        }
                         if (item.channelImage != null) {
                             userImage.visibility = View.VISIBLE
                             userImage.contentDescription = item.channelName?.let {
                                 context.getString(R.string.player_open_channel, it)
                             }
-                            fragment.requireContext().imageLoader.enqueue(
-                                ImageRequest.Builder(fragment.requireContext()).apply {
-                                    data(item.channelImage)
-                                    if (context.prefs().getBoolean(C.UI_ROUND_USER_IMAGE, true)) {
-                                        transformations(CircleCropTransformation())
-                                    }
-                                    crossfade(true)
-                                    target(userImage)
-                                }.build()
-                            )
-                            userImage.setOnClickListener(channelListener)
+                            bindProfile(item, context, uiPreferences)
                     } else {
                         userImage.visibility = View.GONE
                         userImage.contentDescription = null
@@ -207,7 +286,7 @@ class VideosAdapter(
                         if (item.channelName != null) {
                             username.visibility = View.VISIBLE
                             username.text = if (item.channelLogin != null && !item.channelLogin.equals(item.channelName, true)) {
-                                when (context.prefs().getString(C.UI_NAME_DISPLAY, "0")) {
+                                when (uiPreferences.nameDisplay) {
                                     "0" -> "${item.channelName}(${item.channelLogin})"
                                     "1" -> item.channelName
                                     else -> item.channelLogin
@@ -215,7 +294,6 @@ class VideosAdapter(
                             } else {
                                 item.channelName
                             }
-                            username.setOnClickListener(channelListener)
                         } else {
                             username.visibility = View.GONE
                         }
@@ -230,51 +308,91 @@ class VideosAdapter(
                         title.visibility = View.GONE
                     }
                     if (showGame && item.gameName != null) {
-                        val gameListener: (View) -> Unit = {
-                            fragment.findNavController().navigate(GamePagerFragmentDirections.actionGlobalGamePagerFragment(
-                                gameId = item.gameId,
-                                gameSlug = item.gameSlug,
-                                gameName = item.gameName
-                            ))
-                        }
                         gameName.visibility = View.VISIBLE
                         gameName.text = item.gameName
-                        gameName.setOnClickListener(gameListener)
                     } else {
                         gameName.visibility = View.GONE
                     }
-                    options.setOnClickListener { it ->
-                        PopupMenu(context, it).apply {
-                            inflate(R.menu.media_item)
-                            if (!item.id.isNullOrBlank()) {
-                                menu.findItem(R.id.bookmark).isVisible = true
-                                if (bookmarks?.find { it.videoId == item.id } != null) {
-                                    menu.findItem(R.id.bookmark).title = context.getString(R.string.remove_bookmark)
-                                } else {
-                                    menu.findItem(R.id.bookmark).title = context.getString(R.string.add_bookmark)
-                                }
-                            }
-                            setOnMenuItemClickListener {
-                                when (it.itemId) {
-                                    R.id.download -> showDownloadDialog(item)
-                                    R.id.bookmark -> saveBookmark(item)
-                                    R.id.share -> {
-                                        context.startActivity(Intent.createChooser(Intent().apply {
-                                            action = Intent.ACTION_SEND
-                                            putExtra(Intent.EXTRA_TEXT, "https://twitch.tv/videos/${item.id}")
-                                            item.title?.let {
-                                                putExtra(Intent.EXTRA_TITLE, it)
-                                            }
-                                            type = "text/plain"
-                                        }, null))
-                                    }
-                                    else -> menu.close()
-                                }
-                                true
-                            }
-                            show()
-                        }
+                }
+            }
+        }
+
+        private fun openVideo(video: Video) {
+            val position = video.id?.toLongOrNull()?.let { positions[it] }
+            val startFromBeginning = position != null &&
+                    video.durationSeconds != null &&
+                    video.durationSeconds > 0 &&
+                    position >= video.durationSeconds * 1000
+            (fragment.activity as? MainActivity)?.startVideo(
+                video,
+                if (startFromBeginning) 0 else position,
+                startFromBeginning,
+            )
+        }
+
+        private fun openChannel(video: Video) {
+            if (!showChannel) return
+            fragment.findNavController().navigate(
+                ChannelPagerFragmentDirections.actionGlobalChannelPagerFragment(
+                    channelId = video.channelId,
+                    channelLogin = video.channelLogin,
+                    channelName = video.channelName,
+                    channelImage = video.channelImage,
+                ),
+            )
+        }
+
+        private fun openGame(video: Video) {
+            if (!showGame || video.gameName.isNullOrBlank()) return
+            fragment.findNavController().navigate(
+                GamePagerFragmentDirections.actionGlobalGamePagerFragment(
+                    gameId = video.gameId,
+                    gameSlug = video.gameSlug,
+                    gameName = video.gameName,
+                ),
+            )
+        }
+
+        private fun showOptions(anchor: View) {
+            val video = boundVideo ?: return
+            val context = fragment.requireContext()
+            PopupMenu(context, anchor).apply {
+                inflate(R.menu.media_item)
+                if (!video.id.isNullOrBlank()) {
+                    menu.findItem(R.id.bookmark).isVisible = true
+                    menu.findItem(R.id.bookmark).title = if (bookmarks?.any { it.videoId == video.id } == true) {
+                        context.getString(R.string.remove_bookmark)
+                    } else {
+                        context.getString(R.string.add_bookmark)
                     }
+                }
+                setOnMenuItemClickListener {
+                    when (it.itemId) {
+                        R.id.download -> showDownloadDialog(video)
+                        R.id.bookmark -> saveBookmark(video)
+                        R.id.share -> {
+                            context.startActivity(Intent.createChooser(Intent().apply {
+                                action = Intent.ACTION_SEND
+                                putExtra(Intent.EXTRA_TEXT, "https://twitch.tv/videos/${video.id}")
+                                video.title?.let { title -> putExtra(Intent.EXTRA_TITLE, title) }
+                                type = "text/plain"
+                            }, null))
+                        }
+                        else -> menu.close()
+                    }
+                    true
+                }
+                show()
+            }
+        }
+
+        fun bindPosition(item: Video?, position: Long? = item?.id?.toLongOrNull()?.let { id -> positions[id] }) {
+            with(binding.progressBar) {
+                if (position != null && item?.durationSeconds != null && item.durationSeconds > 0L) {
+                    progress = (position / (item.durationSeconds * 10)).toInt()
+                    visibility = View.VISIBLE
+                } else {
+                    visibility = View.GONE
                 }
             }
         }
@@ -283,5 +401,9 @@ class VideosAdapter(
             streamPreviewCoordinator.detachSurface(previewSurface)
             boundPreviewIdentity = null
         }
+    }
+
+    private companion object {
+        val VIDEO_POSITION_CHANGED_PAYLOAD = Any()
     }
 }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/discover/DiscoverViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/discover/DiscoverViewModel.kt
@@ -23,6 +23,7 @@ import com.github.andreyasadchy.xtra.repository.streamfeed.StreamFeedCache
 import com.github.andreyasadchy.xtra.repository.streamfeed.StreamFeedRefreshCoordinator
 import com.github.andreyasadchy.xtra.repository.streamfeed.StreamFeedSpec
 import com.github.andreyasadchy.xtra.repository.streamfeed.StreamFeedSpecs
+import com.github.andreyasadchy.xtra.repository.streamfeed.StreamFeedFreshnessPolicy
 import com.github.andreyasadchy.xtra.repository.streamfeed.toStream
 import com.github.andreyasadchy.xtra.ui.common.StreamsSortDialog
 import com.github.andreyasadchy.xtra.ui.following.overview.FollowingOverviewLoadingType
@@ -38,6 +39,7 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -97,6 +99,7 @@ class DiscoverViewModel(
     private val recommendationsMutex = Mutex()
     private var recommendationsLastAttemptAt = 0L
     private var currentTrendingSpec: StreamFeedSpec? = null
+    private var lastVisibleRefreshAt = 0L
 
     @OptIn(ExperimentalCoroutinesApi::class)
     val state: StateFlow<DiscoverState> = combine(
@@ -167,6 +170,16 @@ class DiscoverViewModel(
     }
 
     fun refresh(reason: RefreshReason = RefreshReason.INITIAL, force: Boolean = false) {
+        if (!force &&
+            reason != RefreshReason.USER_PULL &&
+            reason != RefreshReason.FILTER_CHANGED
+        ) {
+            val now = System.currentTimeMillis()
+            if (now - lastVisibleRefreshAt < StreamFeedFreshnessPolicy.VISIBLE_REVALIDATION_INTERVAL_MS) {
+                return
+            }
+            lastVisibleRefreshAt = now
+        }
         refreshTopStreams(reason, force)
         refreshTopGames(reason, force)
         refreshRecommendations(force)
@@ -174,8 +187,11 @@ class DiscoverViewModel(
     }
 
     private fun refreshTopStreams(reason: RefreshReason, force: Boolean) {
+        if (!force && streamFeedRefreshCoordinator.isFreshInMemory(topStreamsSpec)) return
         viewModelScope.launch {
-            topStreamsSection.update { it.copy(refreshing = true) }
+            topStreamsSection.update { current ->
+                if (current.hasLoadedOnce) current else current.copy(refreshing = true)
+            }
             try {
                 if (force) streamFeedRefreshCoordinator.forceRefresh(topStreamsSpec, reason)
                 else streamFeedRefreshCoordinator.maybeRefresh(topStreamsSpec, reason)
@@ -189,8 +205,11 @@ class DiscoverViewModel(
     }
 
     private fun refreshTopGames(reason: RefreshReason, force: Boolean) {
+        if (!force && gameFeedRefreshCoordinator.isFreshInMemory(topGamesSpec)) return
         viewModelScope.launch {
-            topGamesSection.update { it.copy(refreshing = true) }
+            topGamesSection.update { current ->
+                if (current.hasLoadedOnce) current else current.copy(refreshing = true)
+            }
             try {
                 if (force) gameFeedRefreshCoordinator.forceRefresh(topGamesSpec, reason)
                 else gameFeedRefreshCoordinator.maybeRefresh(topGamesSpec, reason)
@@ -204,11 +223,11 @@ class DiscoverViewModel(
     }
 
     private fun refreshRecommendations(force: Boolean) {
+        val now = System.currentTimeMillis()
+        if (!force && now - recommendationsLastAttemptAt < RECOMMENDATIONS_TTL_MS) return
+        recommendationsLastAttemptAt = now
         viewModelScope.launch {
             recommendationsMutex.withLock {
-                val now = System.currentTimeMillis()
-                if (!force && now - recommendationsLastAttemptAt < RECOMMENDATIONS_TTL_MS) return@withLock
-                recommendationsLastAttemptAt = now
                 recommendationsSection.update { it.copy(refreshing = true) }
                 try {
                     val result = recommendationsRepository.getLiveRecommendations(
@@ -232,16 +251,31 @@ class DiscoverViewModel(
     }
 
     private fun refreshTrending(spec: StreamFeedSpec, reason: RefreshReason, force: Boolean) {
+        if (!force && streamFeedRefreshCoordinator.isFreshInMemory(spec)) return
         viewModelScope.launch {
-            trendingStreamsSection.update { it.copy(refreshing = true) }
-            try {
-                if (force) streamFeedRefreshCoordinator.forceRefresh(spec, reason)
-                else streamFeedRefreshCoordinator.maybeRefresh(spec, reason)
-                trendingStreamsSection.update { current -> current.copy(refreshing = false, hasLoadedOnce = current.hasLoadedOnce || current.data.isNotEmpty(), error = if (current.data.isNotEmpty()) null else current.error) }
-            } catch (error: CancellationException) {
-                throw error
-            } catch (error: Throwable) {
-                trendingStreamsSection.update { current -> current.copy(refreshing = false, error = if (current.data.isEmpty()) error else null) }
+            refreshTrendingNow(spec, reason, force)
+        }
+    }
+
+    private suspend fun refreshTrendingNow(spec: StreamFeedSpec, reason: RefreshReason, force: Boolean) {
+        trendingStreamsSection.update { current ->
+            if (current.hasLoadedOnce) current else current.copy(refreshing = true)
+        }
+        try {
+            if (force) streamFeedRefreshCoordinator.forceRefresh(spec, reason)
+            else streamFeedRefreshCoordinator.maybeRefresh(spec, reason)
+            trendingStreamsSection.update { current ->
+                current.copy(
+                    refreshing = false,
+                    hasLoadedOnce = current.hasLoadedOnce || current.data.isNotEmpty(),
+                    error = if (current.data.isNotEmpty()) null else current.error,
+                )
+            }
+        } catch (error: CancellationException) {
+            throw error
+        } catch (error: Throwable) {
+            trendingStreamsSection.update { current ->
+                current.copy(refreshing = false, error = if (current.data.isEmpty()) error else null)
             }
         }
     }
@@ -262,14 +296,19 @@ class DiscoverViewModel(
                 return@collectLatest
             }
             trendingStreamsSection.value = DiscoverSectionState(emptyList(), refreshing = true)
-            refreshTrending(spec, RefreshReason.INITIAL, force = false)
-            streamFeedCache.activeItemsFlow(spec.key, STREAM_LIMIT).collect { items ->
-                trendingStreamsSection.update { current ->
-                    current.copy(
-                        data = items.map { it.toStream() },
-                        hasLoadedOnce = current.hasLoadedOnce || items.isNotEmpty(),
-                        error = if (items.isNotEmpty()) null else current.error,
-                    )
+            coroutineScope {
+                // Both the refresh and the Room bootstrap collector are children
+                // of collectLatest. Switching the trending game cancels both;
+                // no orphaned refresh for the previous game survives.
+                launch { refreshTrendingNow(spec, RefreshReason.INITIAL, force = false) }
+                streamFeedCache.activeItemsFlow(spec.key, STREAM_LIMIT).collect { items ->
+                    trendingStreamsSection.update { current ->
+                        current.copy(
+                            data = items.map { it.toStream() },
+                            hasLoadedOnce = current.hasLoadedOnce || items.isNotEmpty(),
+                            error = if (items.isNotEmpty()) null else current.error,
+                        )
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/FollowMediaFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/FollowMediaFragment.kt
@@ -9,7 +9,6 @@ import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.updateLayoutParams
 import androidx.fragment.app.Fragment
-import androidx.fragment.app.FragmentManager
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.ui.AppBarConfiguration
 import androidx.navigation.ui.setupWithNavController
@@ -17,6 +16,8 @@ import androidx.recyclerview.widget.RecyclerView
 import com.github.andreyasadchy.xtra.R
 import com.github.andreyasadchy.xtra.databinding.FragmentMediaBinding
 import com.github.andreyasadchy.xtra.ui.common.FragmentHost
+import com.github.andreyasadchy.xtra.ui.common.FragmentTabSwitcher
+import com.github.andreyasadchy.xtra.ui.common.RecyclerViewLiftTargetConnector
 import com.github.andreyasadchy.xtra.ui.common.Scrollable
 import com.github.andreyasadchy.xtra.ui.common.Sortable
 import com.github.andreyasadchy.xtra.ui.following.channels.FollowedChannelsFragment
@@ -42,6 +43,8 @@ class FollowMediaFragment : Fragment(), Scrollable, FragmentHost {
 
     private var previousItem = -1
     private var tabKeys: List<String> = emptyList()
+    private var tabSwitcher: FragmentTabSwitcher? = null
+    private var liftTargetConnector: RecyclerViewLiftTargetConnector? = null
 
     override val currentFragment: Fragment?
         get() = childFragmentManager.findFragmentById(R.id.fragmentContainer)
@@ -58,6 +61,11 @@ class FollowMediaFragment : Fragment(), Scrollable, FragmentHost {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        liftTargetConnector = RecyclerViewLiftTargetConnector(binding.appBar)
+        tabSwitcher = FragmentTabSwitcher(childFragmentManager, R.id.fragmentContainer) { fragment ->
+            fragment.view?.findViewById<RecyclerView>(R.id.recyclerView)?.let { liftTargetConnector?.connect(it) }
+            if (fragment is Sortable) fragment.setupSortBar(binding.sortBar) else binding.sortBar.root.visibility = View.GONE
+        }
         with(binding) {
             val activity = requireActivity() as MainActivity
             val navController = findNavController()
@@ -106,20 +114,19 @@ class FollowMediaFragment : Fragment(), Scrollable, FragmentHost {
                 setSimpleItems(tabs.map { getString(FollowingTabs.titleRes(it)) }.toTypedArray().ifEmpty { arrayOf(getString(R.string.live)) })
                 setOnItemClickListener { _, _, position, _ ->
                     if (position != previousItem) {
-                        childFragmentManager.beginTransaction().replace(R.id.fragmentContainer, onSpinnerItemSelected(tabs, position)).commit()
-                        previousItem = position
+                        showTab(tabs, position)
                     }
                 }
                 if (previousItem == -1) {
                     val defaultItem = tabList.find { it.split(':')[1] != "0" }?.split(':')[0] ?: "1"
                     val position = tabs.indexOf(defaultItem).takeIf { it != -1 } ?: tabs.indexOf("1").takeIf { it != -1 } ?: 0
-                    childFragmentManager.beginTransaction().replace(R.id.fragmentContainer, onSpinnerItemSelected(tabs, position)).commit()
-                    previousItem = position
+                    showTab(tabs, position)
                 }
                 if (previousItem <= tabs.lastIndex) {
                     setText(adapter.getItem(previousItem).toString(), false)
                 }
             }
+            /* Legacy per-view listener wiring replaced by FragmentTabSwitcher.
             childFragmentManager.registerFragmentLifecycleCallbacks(object : FragmentManager.FragmentLifecycleCallbacks() {
                 override fun onFragmentViewCreated(fm: FragmentManager, f: Fragment, v: View, savedInstanceState: Bundle?) {
                     f.view?.findViewById<RecyclerView>(R.id.recyclerView)?.let {
@@ -140,7 +147,7 @@ class FollowMediaFragment : Fragment(), Scrollable, FragmentHost {
                         sortBar.root.visibility = View.GONE
                     }
                 }
-            }, false)
+            }, false) */
             ViewCompat.setOnApplyWindowInsetsListener(view) { _, windowInsets ->
                 val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout())
                 toolbar.updateLayoutParams<ViewGroup.MarginLayoutParams> {
@@ -161,6 +168,12 @@ class FollowMediaFragment : Fragment(), Scrollable, FragmentHost {
         }
     }
 
+    private fun showTab(tabs: List<String>, position: Int) {
+        if (position !in tabs.indices) return
+        previousItem = position
+        tabSwitcher?.show("media_$position") { onSpinnerItemSelected(tabs, position) }
+    }
+
     fun selectFollowingTab(key: String) {
         val position = tabKeys.indexOf(key).takeIf { it >= 0 } ?: return
         if (position == previousItem) return
@@ -168,9 +181,7 @@ class FollowMediaFragment : Fragment(), Scrollable, FragmentHost {
         (binding.spinner.editText as? MaterialAutoCompleteTextView)?.let { spinner ->
             spinner.setText(spinner.adapter?.getItem(position)?.toString().orEmpty(), false)
         }
-        childFragmentManager.beginTransaction()
-            .replace(R.id.fragmentContainer, onSpinnerItemSelected(tabKeys, position))
-            .commit()
+        tabSwitcher?.show("media_$position") { onSpinnerItemSelected(tabKeys, position) }
     }
 
     override fun onSaveInstanceState(outState: Bundle) {
@@ -184,6 +195,9 @@ class FollowMediaFragment : Fragment(), Scrollable, FragmentHost {
     }
 
     override fun onDestroyView() {
+        liftTargetConnector?.disconnect()
+        liftTargetConnector = null
+        tabSwitcher = null
         super.onDestroyView()
         _binding = null
     }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/FollowPagerFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/FollowPagerFragment.kt
@@ -14,11 +14,12 @@ import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import androidx.navigation.ui.AppBarConfiguration
 import androidx.navigation.ui.setupWithNavController
-import androidx.recyclerview.widget.RecyclerView
 import androidx.viewpager2.widget.ViewPager2
 import com.github.andreyasadchy.xtra.R
 import com.github.andreyasadchy.xtra.databinding.FragmentMediaPagerBinding
 import com.github.andreyasadchy.xtra.ui.common.FragmentHost
+import com.github.andreyasadchy.xtra.ui.common.dispatchPagerScrollState
+import com.github.andreyasadchy.xtra.ui.common.RecyclerViewLiftTargetConnector
 import com.github.andreyasadchy.xtra.ui.common.Scrollable
 import com.github.andreyasadchy.xtra.ui.common.Sortable
 import com.github.andreyasadchy.xtra.ui.login.TwitchWebLoginActivity
@@ -27,10 +28,10 @@ import com.github.andreyasadchy.xtra.ui.search.SearchPagerFragmentDirections
 import com.github.andreyasadchy.xtra.ui.settings.SettingsActivity
 import com.github.andreyasadchy.xtra.ui.settings.setTabCustomizationLongPress
 import com.github.andreyasadchy.xtra.util.C
+import com.github.andreyasadchy.xtra.util.configureForSmoothPaging
 import com.github.andreyasadchy.xtra.util.TwitchApiHelper
 import com.github.andreyasadchy.xtra.util.getAlertDialogBuilder
 import com.github.andreyasadchy.xtra.util.prefs
-import com.github.andreyasadchy.xtra.util.reduceDragSensitivity
 import com.github.andreyasadchy.xtra.util.tokenPrefs
 import com.google.android.material.tabs.TabLayout
 import com.google.android.material.tabs.TabLayoutMediator
@@ -42,6 +43,7 @@ class FollowPagerFragment : Fragment(), Scrollable, FragmentHost {
     private val binding get() = _binding!!
     private var firstLaunch = true
     private var tabKeys: List<String> = emptyList()
+    private var liftTargetConnector: RecyclerViewLiftTargetConnector? = null
 
     override val currentFragment: Fragment?
         get() = childFragmentManager.findFragmentByTag("f${binding.viewPager.currentItem}")
@@ -58,6 +60,7 @@ class FollowPagerFragment : Fragment(), Scrollable, FragmentHost {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        liftTargetConnector = RecyclerViewLiftTargetConnector(binding.appBar)
         with(binding) {
             val activity = requireActivity() as MainActivity
             val navController = findNavController()
@@ -108,27 +111,22 @@ class FollowPagerFragment : Fragment(), Scrollable, FragmentHost {
             val adapter = FollowPagerAdapter(this@FollowPagerFragment, tabs)
             viewPager.adapter = adapter
             viewPager.registerOnPageChangeCallback(object : ViewPager2.OnPageChangeCallback() {
+                override fun onPageScrollStateChanged(state: Int) {
+                    val scrolling = state != ViewPager2.SCROLL_STATE_IDLE
+                    dispatchPagerScrollState(scrolling)
+                }
+
                 override fun onPageSelected(position: Int) {
                     viewPager.doOnLayout {
                         childFragmentManager.findFragmentByTag("f${position}")?.let { fragment ->
-                            fragment.view?.findViewById<RecyclerView>(R.id.recyclerView)?.let {
-                                appBar.setLiftOnScrollTargetView(it)
-                                it.addOnScrollListener(object : RecyclerView.OnScrollListener() {
-                                    override fun onScrolled(recyclerView: RecyclerView, dx: Int, dy: Int) {
-                                        super.onScrolled(recyclerView, dx, dy)
-                                        appBar.isLifted = recyclerView.canScrollVertically(-1)
-                                    }
-                                })
-                                it.addOnLayoutChangeListener { _, _, _, _, _, _, _, _, _ ->
-                                    appBar.isLifted = it.canScrollVertically(-1)
-                                }
-                            }
+                            fragment.view?.findViewById<androidx.recyclerview.widget.RecyclerView>(R.id.recyclerView)?.let { liftTargetConnector?.connect(it) }
+                                ?: disconnectLiftTarget()
                             if (fragment is Sortable) {
                                 fragment.setupSortBar(sortBar)
                             } else {
                                 sortBar.root.visibility = View.GONE
                             }
-                        }
+                        } ?: disconnectLiftTarget()
                     }
                 }
             })
@@ -140,7 +138,7 @@ class FollowPagerFragment : Fragment(), Scrollable, FragmentHost {
                 )
                 firstLaunch = false
             }
-            viewPager.reduceDragSensitivity()
+            viewPager.configureForSmoothPaging()
             TabLayoutMediator(tabLayout, viewPager) { tab, position ->
                 tab.text = getString(FollowingTabs.titleRes(tabs.getOrNull(position).orEmpty()))
             }.attach()
@@ -155,6 +153,10 @@ class FollowPagerFragment : Fragment(), Scrollable, FragmentHost {
         }
     }
 
+    private fun disconnectLiftTarget() {
+        liftTargetConnector?.disconnect()
+    }
+
     override fun scrollToTop() {
         binding.appBar.setExpanded(true, true)
         (currentFragment as? Scrollable)?.scrollToTop()
@@ -165,6 +167,8 @@ class FollowPagerFragment : Fragment(), Scrollable, FragmentHost {
     }
 
     override fun onDestroyView() {
+        dispatchPagerScrollState(false)
+        disconnectLiftTarget()
         super.onDestroyView()
         _binding = null
     }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/channels/FollowedChannelsAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/channels/FollowedChannelsAdapter.kt
@@ -18,9 +18,12 @@ import com.github.andreyasadchy.xtra.R
 import com.github.andreyasadchy.xtra.databinding.FragmentFollowedChannelsListItemBinding
 import com.github.andreyasadchy.xtra.model.ui.User
 import com.github.andreyasadchy.xtra.ui.channel.ChannelPagerFragmentDirections
-import com.github.andreyasadchy.xtra.util.C
+import com.github.andreyasadchy.xtra.ui.common.FeedImageRequestBag
+import com.github.andreyasadchy.xtra.ui.common.FeedImageRequestOwner
+import com.github.andreyasadchy.xtra.ui.common.FeedUiPreferencesStore
+import com.github.andreyasadchy.xtra.ui.common.StreamThumbnailIdleScheduler
+import com.github.andreyasadchy.xtra.ui.common.restoreDecodedMemoryImage
 import com.github.andreyasadchy.xtra.util.TwitchApiHelper
-import com.github.andreyasadchy.xtra.util.prefs
 import kotlin.time.Instant
 
 class FollowedChannelsAdapter(
@@ -41,56 +44,122 @@ class FollowedChannelsAdapter(
                 oldItem.localFollow == newItem.localFollow
     }) {
 
+    private val imageLoadScheduler = StreamThumbnailIdleScheduler()
+
+    override fun onAttachedToRecyclerView(recyclerView: RecyclerView) {
+        super.onAttachedToRecyclerView(recyclerView)
+        imageLoadScheduler.attachTo(recyclerView)
+    }
+
+    override fun onDetachedFromRecyclerView(recyclerView: RecyclerView) {
+        imageLoadScheduler.detach()
+        super.onDetachedFromRecyclerView(recyclerView)
+    }
+
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): PagingViewHolder {
         val binding = FragmentFollowedChannelsListItemBinding.inflate(LayoutInflater.from(parent.context), parent, false)
         return PagingViewHolder(binding, fragment)
     }
 
     override fun onBindViewHolder(holder: PagingViewHolder, position: Int) {
+        holder.beginImageBind(getItem(position))
         holder.bind(getItem(position))
+    }
+
+    override fun onViewRecycled(holder: PagingViewHolder) {
+        imageLoadScheduler.clear(holder)
+        holder.cancelImageWork()
+        super.onViewRecycled(holder)
     }
 
     inner class PagingViewHolder(
         private val binding: FragmentFollowedChannelsListItemBinding,
         private val fragment: Fragment,
-    ) : RecyclerView.ViewHolder(binding.root) {
+    ) : RecyclerView.ViewHolder(binding.root), FeedImageRequestOwner {
+        private val imageRequests = FeedImageRequestBag()
+        private var boundUserId: String? = null
+        private var boundUser: User? = null
+
+        init {
+            binding.root.setOnClickListener {
+                boundUser?.let { user ->
+                    fragment.findNavController().navigate(
+                        ChannelPagerFragmentDirections.actionGlobalChannelPagerFragment(
+                            channelId = user.id,
+                            channelLogin = user.login,
+                            channelName = user.name,
+                            channelImage = user.profileImage,
+                        )
+                    )
+                }
+            }
+        }
+
+        fun beginImageBind(item: User?) {
+            imageLoadScheduler.clear(this)
+            imageRequests.cancel()
+            boundUserId = item?.id
+        }
+
+        override fun cancelImageRequests() {
+            imageRequests.cancel()
+        }
+
+        override fun pauseImageRequests() {
+            imageRequests.cancel(preserveRegistrations = true)
+        }
+
+        fun cancelImageWork() {
+            cancelImageRequests()
+            boundUserId = null
+            boundUser = null
+        }
+
         fun bind(item: User?) {
+            boundUser = item
             with(binding) {
                 if (item != null) {
                     val context = fragment.requireContext()
-                    root.setOnClickListener {
-                        fragment.findNavController().navigate(
-                            ChannelPagerFragmentDirections.actionGlobalChannelPagerFragment(
-                                channelId = item.id,
-                                channelLogin = item.login,
-                                channelName = item.name,
-                                channelImage = item.profileImage,
-                            )
-                        )
-                    }
+                    val uiPreferences = FeedUiPreferencesStore.current(context)
                     if (item.profileImage != null) {
                         userImage.visibility = View.VISIBLE
                         userImage.contentDescription = item.name?.let {
                             context.getString(R.string.player_open_channel, it)
                         }
-                        fragment.requireContext().imageLoader.enqueue(
-                            ImageRequest.Builder(fragment.requireContext()).apply {
-                                data(item.profileImage)
-                                if (context.prefs().getBoolean(C.UI_ROUND_USER_IMAGE, true)) {
-                                    transformations(CircleCropTransformation())
-                                }
-                                crossfade(true)
-                                target(userImage)
-                            }.build()
-                        )
+                        val userId = item.id
+                        val imageKey = "channel:$userId|${item.profileImage}|round=${uiPreferences.roundUserImage}"
+                        if (userImage.tag != imageKey) {
+                            userImage.setImageDrawable(null)
+                            userImage.tag = imageKey
+                        }
+                        restoreDecodedMemoryImage(imageKey, userImage)
+                        imageLoadScheduler.runOrDefer(this@PagingViewHolder, userImage) {
+                            if (!binding.root.isAttachedToWindow || boundUserId != userId) return@runOrDefer
+                            imageRequests.replace(
+                                userImage,
+                                context.imageLoader.enqueue(
+                                    ImageRequest.Builder(context).apply {
+                                        data(item.profileImage)
+                                        memoryCacheKey(imageKey)
+                                        if (uiPreferences.roundUserImage) {
+                                            transformations(CircleCropTransformation())
+                                        }
+                                        crossfade(false)
+                                        target(userImage)
+                                    }.build()
+                                ),
+                            )
+                        }
                     } else {
                         userImage.visibility = View.GONE
                         userImage.contentDescription = null
+                        userImage.setImageDrawable(null)
+                        userImage.tag = null
                     }
                     if (item.name != null) {
                         username.visibility = View.VISIBLE
                         username.text = if (item.login != null && !item.login.equals(item.name, true)) {
-                            when (context.prefs().getString(C.UI_NAME_DISPLAY, "0")) {
+                            when (uiPreferences.nameDisplay) {
                                 "0" -> "${item.name}(${item.login})"
                                 "1" -> item.name
                                 else -> item.login

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/games/FollowedGamesAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/games/FollowedGamesAdapter.kt
@@ -1,14 +1,8 @@
 package com.github.andreyasadchy.xtra.ui.following.games
 
-import android.util.TypedValue
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.TextView
-import androidx.constraintlayout.helper.widget.Flow
-import androidx.constraintlayout.widget.ConstraintLayout
-import androidx.core.content.res.use
-import androidx.core.widget.TextViewCompat
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
 import androidx.paging.PagingDataAdapter
@@ -24,9 +18,16 @@ import com.github.andreyasadchy.xtra.databinding.FragmentFollowedGamesListItemBi
 import com.github.andreyasadchy.xtra.model.ui.Game
 import com.github.andreyasadchy.xtra.model.ui.Tag
 import com.github.andreyasadchy.xtra.ui.game.GamePagerFragmentDirections
-import com.github.andreyasadchy.xtra.util.C
+import com.github.andreyasadchy.xtra.ui.common.GameTagViews
+import com.github.andreyasadchy.xtra.ui.common.bindGameTags
+import com.github.andreyasadchy.xtra.ui.common.clearGameTags
+import com.github.andreyasadchy.xtra.ui.common.createGameTagViews
+import com.github.andreyasadchy.xtra.ui.common.FeedImageRequestBag
+import com.github.andreyasadchy.xtra.ui.common.FeedImageRequestOwner
+import com.github.andreyasadchy.xtra.ui.common.FeedUiPreferencesStore
+import com.github.andreyasadchy.xtra.ui.common.StreamThumbnailIdleScheduler
+import com.github.andreyasadchy.xtra.ui.common.restoreDecodedMemoryImage
 import com.github.andreyasadchy.xtra.util.TwitchApiHelper
-import com.github.andreyasadchy.xtra.util.prefs
 
 class FollowedGamesAdapter(
     private val fragment: Fragment,
@@ -40,43 +41,110 @@ class FollowedGamesAdapter(
             oldItem.viewerCount == newItem.viewerCount
     }) {
 
+    private val imageLoadScheduler = StreamThumbnailIdleScheduler()
+
+    override fun onAttachedToRecyclerView(recyclerView: RecyclerView) {
+        super.onAttachedToRecyclerView(recyclerView)
+        imageLoadScheduler.attachTo(recyclerView)
+    }
+
+    override fun onDetachedFromRecyclerView(recyclerView: RecyclerView) {
+        imageLoadScheduler.detach()
+        super.onDetachedFromRecyclerView(recyclerView)
+    }
+
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): PagingViewHolder {
         val binding = FragmentFollowedGamesListItemBinding.inflate(LayoutInflater.from(parent.context), parent, false)
-        return PagingViewHolder(binding, fragment)
+        return PagingViewHolder(binding, fragment, createGameTagViews(binding.tagsLayout))
     }
 
     override fun onBindViewHolder(holder: PagingViewHolder, position: Int) {
+        holder.beginImageBind(getItem(position))
         holder.bind(getItem(position))
     }
 
-    inner class PagingViewHolder(
+    override fun onViewRecycled(holder: PagingViewHolder) {
+        imageLoadScheduler.clear(holder)
+        holder.cancelImageWork()
+        super.onViewRecycled(holder)
+    }
+
+    inner class PagingViewHolder internal constructor(
         private val binding: FragmentFollowedGamesListItemBinding,
         private val fragment: Fragment,
-    ) : RecyclerView.ViewHolder(binding.root) {
+        private val tagViews: GameTagViews,
+    ) : RecyclerView.ViewHolder(binding.root), FeedImageRequestOwner {
+        private val imageRequests = FeedImageRequestBag()
+        private var boundGameId: String? = null
+        private var boundGame: Game? = null
+
+        init {
+            binding.root.setOnClickListener {
+                boundGame?.let { game ->
+                    fragment.findNavController().navigate(GamePagerFragmentDirections.actionGlobalGamePagerFragment(
+                        gameId = game.id,
+                        gameSlug = game.slug,
+                        gameName = game.name,
+                        updateLocal = game.localFollow
+                    ))
+                }
+            }
+        }
+
+        fun beginImageBind(item: Game?) {
+            imageLoadScheduler.clear(this)
+            imageRequests.cancel()
+            boundGameId = item?.id
+        }
+
+        override fun cancelImageRequests() {
+            imageRequests.cancel()
+        }
+
+        override fun pauseImageRequests() {
+            imageRequests.cancel(preserveRegistrations = true)
+        }
+
+        fun cancelImageWork() {
+            cancelImageRequests()
+            boundGameId = null
+            boundGame = null
+        }
+
         fun bind(item: Game?) {
+            boundGame = item
             with(binding) {
                 if (item != null) {
                     val context = fragment.requireContext()
-                    root.setOnClickListener {
-                        fragment.findNavController().navigate(GamePagerFragmentDirections.actionGlobalGamePagerFragment(
-                            gameId = item.id,
-                            gameSlug = item.slug,
-                            gameName = item.name,
-                            updateLocal = item.localFollow
-                        ))
-                    }
+                    val uiPreferences = FeedUiPreferencesStore.current(context)
                     if (item.boxArt != null) {
                         gameImage.visibility = View.VISIBLE
-                        fragment.requireContext().imageLoader.enqueue(
-                            ImageRequest.Builder(fragment.requireContext()).apply {
+                        val gameId = item.id
+                        val imageKey = "game:$gameId|${item.boxArt}"
+                        if (gameImage.tag != imageKey) {
+                            gameImage.setImageDrawable(null)
+                            gameImage.tag = imageKey
+                        }
+                        restoreDecodedMemoryImage(imageKey, gameImage)
+                        imageLoadScheduler.runOrDefer(this@PagingViewHolder, gameImage) {
+                            if (!binding.root.isAttachedToWindow || boundGameId != gameId) return@runOrDefer
+                            imageRequests.replace(
+                                gameImage,
+                                context.imageLoader.enqueue(
+                                    ImageRequest.Builder(context).apply {
                                 data(item.boxArt)
-                                diskCachePolicy(CachePolicy.DISABLED)
-                                crossfade(true)
+                                memoryCacheKey(imageKey)
+                                diskCachePolicy(CachePolicy.ENABLED)
+                                crossfade(false)
                                 target(gameImage)
-                            }.build()
-                        )
+                                    }.build()
+                                ),
+                            )
+                        }
                     } else {
                         gameImage.visibility = View.GONE
+                        gameImage.setImageDrawable(null)
+                        gameImage.tag = null
                     }
                     if (item.name != null) {
                         gameName.visibility = View.VISIBLE
@@ -90,62 +158,26 @@ class FollowedGamesAdapter(
                         viewers.text = context.resources.getQuantityString(
                             R.plurals.viewers,
                             count,
-                            TwitchApiHelper.formatCount(count, context.prefs().getBoolean(C.UI_TRUNCATE_VIEW_COUNT, true))
+                            TwitchApiHelper.formatCount(count, uiPreferences.truncateViewCount)
                         )
                     } else {
                         viewers.visibility = View.GONE
                     }
-                    if (item.broadcasterCount != null && context.prefs().getBoolean(C.UI_BROADCASTERS_COUNT, true)) {
+                    if (item.broadcasterCount != null && uiPreferences.showBroadcastersCount) {
                         broadcastersCount.visibility = View.VISIBLE
                         val count = item.broadcasterCount ?: 0
                         broadcastersCount.text = context.resources.getQuantityString(
                             R.plurals.broadcasters,
                             count,
-                            TwitchApiHelper.formatCount(count, context.prefs().getBoolean(C.UI_TRUNCATE_VIEW_COUNT, true))
+                            TwitchApiHelper.formatCount(count, uiPreferences.truncateViewCount)
                         )
                     } else {
                         broadcastersCount.visibility = View.GONE
                     }
-                    if (!item.tags.isNullOrEmpty() && context.prefs().getBoolean(C.UI_TAGS, true)) {
-                        tagsLayout.removeAllViews()
-                        tagsLayout.visibility = View.VISIBLE
-                        val tagsFlowLayout = Flow(context).apply {
-                            layoutParams = ConstraintLayout.LayoutParams(
-                                ViewGroup.LayoutParams.MATCH_PARENT,
-                                ViewGroup.LayoutParams.WRAP_CONTENT
-                            ).apply {
-                                topToTop = tagsLayout.id
-                                bottomToBottom = tagsLayout.id
-                                startToStart = tagsLayout.id
-                                endToEnd = tagsLayout.id
-                            }
-                            setWrapMode(Flow.WRAP_CHAIN)
-                        }
-                        tagsLayout.addView(tagsFlowLayout)
-                        val ids = mutableListOf<Int>()
-                        for (tag in item.tags!!) {
-                            val text = TextView(context)
-                            val id = View.generateViewId()
-                            text.id = id
-                            ids.add(id)
-                            text.text = tag.name
-                            text.setMinHeight(TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 48f, context.resources.displayMetrics).toInt())
-                            text.isFocusable = tag.id != null
-                            context.obtainStyledAttributes(intArrayOf(com.google.android.material.R.attr.textAppearanceBodyMedium)).use {
-                                TextViewCompat.setTextAppearance(text, it.getResourceId(0, 0))
-                            }
-                            if (tag.id != null) {
-                                text.setOnClickListener {
-                                    selectTag(tag)
-                                }
-                            }
-                            val padding = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 5f, context.resources.displayMetrics).toInt()
-                            text.setPadding(padding, 0, padding, 0)
-                            tagsLayout.addView(text)
-                        }
-                        tagsFlowLayout.referencedIds = ids.toIntArray()
+                    if (!item.tags.isNullOrEmpty() && uiPreferences.showTags) {
+                        bindGameTags(tagViews, item.tags.orEmpty(), selectTag)
                     } else {
-                        tagsLayout.visibility = View.GONE
+                        clearGameTags(tagViews)
                     }
                     if (item.accountFollow) {
                         accountText.visibility = View.VISIBLE
@@ -157,6 +189,20 @@ class FollowedGamesAdapter(
                     } else {
                         localText.visibility = View.GONE
                     }
+                } else {
+                    boundGame = null
+                    gameImage.setImageDrawable(null)
+                    gameImage.tag = null
+                    gameImage.visibility = View.GONE
+                    gameName.text = null
+                    gameName.visibility = View.GONE
+                    viewers.text = null
+                    viewers.visibility = View.GONE
+                    broadcastersCount.text = null
+                    broadcastersCount.visibility = View.GONE
+                    accountText.visibility = View.GONE
+                    localText.visibility = View.GONE
+                    clearGameTags(tagViews)
                 }
             }
         }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/overview/FeaturedStreamShelfAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/overview/FeaturedStreamShelfAdapter.kt
@@ -15,8 +15,18 @@ import com.github.andreyasadchy.xtra.databinding.ItemFeaturedStreamShelfBinding
 import com.github.andreyasadchy.xtra.model.ui.Stream
 import com.github.andreyasadchy.xtra.ui.common.loadStreamProfileImage
 import com.github.andreyasadchy.xtra.ui.common.loadStreamThumbnail
+import com.github.andreyasadchy.xtra.ui.common.prepareStreamProfileImage
+import com.github.andreyasadchy.xtra.ui.common.prepareStreamThumbnailImage
+import com.github.andreyasadchy.xtra.ui.common.restoreWarmStreamThumbnail
+import com.github.andreyasadchy.xtra.ui.common.FeedImageRequestBag
+import com.github.andreyasadchy.xtra.ui.common.FeedImageRequestOwner
+import com.github.andreyasadchy.xtra.ui.common.FeedUiPreferencesStore
+import com.github.andreyasadchy.xtra.ui.common.StreamThumbnailIdleScheduler
+import com.github.andreyasadchy.xtra.ui.common.thumbnailIdentity
 import com.github.andreyasadchy.xtra.ui.common.streamContentsSame
 import com.github.andreyasadchy.xtra.ui.common.streamIdentity
+import com.github.andreyasadchy.xtra.ui.common.streamThumbnailOnlyChanged
+import com.github.andreyasadchy.xtra.ui.common.StreamThumbnailChangedPayload
 import com.github.andreyasadchy.xtra.util.C
 import com.github.andreyasadchy.xtra.util.TwitchApiHelper
 import com.github.andreyasadchy.xtra.util.prefs
@@ -27,6 +37,8 @@ import kotlin.math.max
 class FeaturedStreamShelfAdapter(
     private val onStreamClick: (Stream) -> Unit,
 ) : ListAdapter<Stream, FeaturedStreamShelfAdapter.ViewHolder>(DIFF_CALLBACK) {
+
+    private val thumbnailLoadScheduler = StreamThumbnailIdleScheduler()
 
     private var snapHelper: PagerSnapHelper? = null
     private var initialCardPositioned = false
@@ -43,18 +55,31 @@ class FeaturedStreamShelfAdapter(
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
         (holder.itemView.parent as? RecyclerView)?.let(::updateShelfLayout)
+        holder.beginImageBind(getItem(position))
         holder.bind(getItem(position))
+    }
+
+    override fun onBindViewHolder(holder: ViewHolder, position: Int, payloads: MutableList<Any>) {
+        if (payloads.isNotEmpty() && payloads.all { it === StreamThumbnailChangedPayload }) {
+            holder.beginImageBind(getItem(position))
+            holder.bindThumbnail(getItem(position))
+        } else {
+            super.onBindViewHolder(holder, position, payloads)
+        }
     }
 
     override fun onViewRecycled(holder: ViewHolder) {
         (holder.itemView.context.applicationContext as XtraApp).xtraModule.streamPreviewCoordinator
             .detachSurface(holder.previewSurface)
         holder.boundPreviewIdentity = null
+        thumbnailLoadScheduler.clear(holder)
+        holder.cancelImageWork()
         super.onViewRecycled(holder)
     }
 
     override fun onAttachedToRecyclerView(recyclerView: RecyclerView) {
         super.onAttachedToRecyclerView(recyclerView)
+        thumbnailLoadScheduler.attachTo(recyclerView)
         originalPadding = intArrayOf(
             recyclerView.paddingLeft,
             recyclerView.paddingTop,
@@ -71,6 +96,7 @@ class FeaturedStreamShelfAdapter(
     }
 
     override fun onDetachedFromRecyclerView(recyclerView: RecyclerView) {
+        thumbnailLoadScheduler.detach()
         recyclerView.removeOnScrollListener(scrollListener)
         recyclerView.removeOnLayoutChangeListener(layoutChangeListener)
         if (snapHelper != null) snapHelper?.attachToRecyclerView(null)
@@ -171,12 +197,67 @@ class FeaturedStreamShelfAdapter(
 
     inner class ViewHolder(
         private val binding: ItemFeaturedStreamShelfBinding,
-    ) : RecyclerView.ViewHolder(binding.root) {
+    ) : RecyclerView.ViewHolder(binding.root), FeedImageRequestOwner {
         val previewSurface get() = binding.previewHost
         var boundPreviewIdentity: String? = null
+        private val imageRequests = FeedImageRequestBag()
+        private var boundImageIdentity: String? = null
+        private var boundThumbnailKey: String? = null
+        private var boundStream: Stream? = null
+
+        init {
+            binding.root.setOnClickListener { boundStream?.let(onStreamClick) }
+        }
+
+        fun beginImageBind(stream: Stream?) {
+            thumbnailLoadScheduler.clear(this)
+            imageRequests.cancel()
+            boundImageIdentity = stream?.streamIdentity()
+            boundThumbnailKey = null
+        }
+
+        override fun cancelImageRequests() {
+            imageRequests.cancel()
+        }
+
+        override fun pauseImageRequests() {
+            imageRequests.cancel(preserveRegistrations = true)
+        }
+
+        fun cancelImageWork() {
+            cancelImageRequests()
+            boundImageIdentity = null
+            boundThumbnailKey = null
+            boundStream = null
+        }
+
+        fun bindThumbnail(stream: Stream?) {
+            val item = stream ?: return
+            prepareStreamThumbnailImage(binding.thumbnail, item)
+            restoreWarmStreamThumbnail(item, binding.thumbnail)
+            val key = "${item.thumbnailIdentity()}|generation=${item.thumbnailGeneration}"
+            boundThumbnailKey = key
+            thumbnailLoadScheduler.runOrDefer(this@ViewHolder, binding.thumbnail) {
+                if (!binding.root.isAttachedToWindow ||
+                    boundImageIdentity != item.streamIdentity() ||
+                    boundThumbnailKey != key
+                ) return@runOrDefer
+                loadStreamThumbnail(
+                    context = binding.root.context,
+                    imageView = binding.thumbnail,
+                    stream = item,
+                    scheduleFreshRequest = { freshRequest ->
+                        thumbnailLoadScheduler.runOrDefer(this@ViewHolder, binding.thumbnail, freshRequest)
+                    },
+                )
+                    ?.let { imageRequests.replace(binding.thumbnail, it) }
+            }
+        }
 
         fun bind(stream: Stream) {
             val context = binding.root.context
+            val uiPreferences = FeedUiPreferencesStore.current(context)
+            boundStream = stream
             val nextPreviewIdentity = stream.streamIdentity()
             if (boundPreviewIdentity != nextPreviewIdentity) {
                 (context.applicationContext as XtraApp).xtraModule.streamPreviewCoordinator
@@ -184,9 +265,7 @@ class FeaturedStreamShelfAdapter(
                 boundPreviewIdentity = nextPreviewIdentity
             }
             with(binding) {
-                root.setOnClickListener { onStreamClick(stream) }
-
-                loadStreamThumbnail(context, thumbnail, stream)
+                bindThumbnail(stream)
                 thumbnail.contentDescription = stream.title?.takeIf { it.isNotBlank() }
                     ?: context.getString(R.string.live)
                 liveBadge.text = context.getString(R.string.live)
@@ -196,7 +275,7 @@ class FeaturedStreamShelfAdapter(
                         count,
                         TwitchApiHelper.formatCount(
                             count,
-                            context.prefs().getBoolean(C.UI_TRUNCATE_VIEW_COUNT, true),
+                            uiPreferences.truncateViewCount,
                         ),
                     )
                 }.orEmpty()
@@ -209,13 +288,20 @@ class FeaturedStreamShelfAdapter(
                 category.text = stream.gameName?.trim().orEmpty()
                 category.visibility = if (category.text.isNullOrBlank()) View.GONE else View.VISIBLE
 
-                val tags = if (context.prefs().getBoolean(C.UI_TAGS, true)) stream.tags.orEmpty().take(1) else emptyList()
+                val tags = if (uiPreferences.showTags) stream.tags.orEmpty().take(1) else emptyList()
                 tagOne.text = tags.firstOrNull().orEmpty()
                 tagOne.visibility = if (tags.isNotEmpty()) View.VISIBLE else View.GONE
 
                 if (stream.channelImage != null) {
                     avatar.visibility = View.VISIBLE
-                    loadStreamProfileImage(context, avatar, stream)
+                    prepareStreamProfileImage(avatar, stream)
+                    thumbnailLoadScheduler.runOrDefer(this@ViewHolder, avatar) {
+                        if (binding.root.isAttachedToWindow && boundImageIdentity == stream.streamIdentity()) {
+                            loadStreamProfileImage(context, avatar, stream)?.let {
+                                imageRequests.replace(binding.avatar, it)
+                            }
+                        }
+                    }
                 } else {
                     avatar.visibility = View.GONE
                     avatar.setImageDrawable(null)
@@ -232,6 +318,9 @@ class FeaturedStreamShelfAdapter(
 
             override fun areContentsTheSame(oldItem: Stream, newItem: Stream): Boolean =
                 streamContentsSame(oldItem, newItem)
+
+            override fun getChangePayload(oldItem: Stream, newItem: Stream): Any? =
+                if (streamThumbnailOnlyChanged(oldItem, newItem)) StreamThumbnailChangedPayload else null
         }
     }
 }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/overview/FollowingOverviewAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/overview/FollowingOverviewAdapter.kt
@@ -25,6 +25,7 @@ data class FollowingOverviewSection(
     val videos: List<VideoHistory> = emptyList(),
     val scheduledStreams: List<UpcomingStream> = emptyList(),
     val isLoading: Boolean = false,
+    val hasResolved: Boolean = false,
     val loadingType: FollowingOverviewLoadingType = FollowingOverviewLoadingType.STREAM,
     val showSeeAll: Boolean = true,
     val isFeatured: Boolean = false,
@@ -68,6 +69,7 @@ class FollowingOverviewAdapter(
         holder.saveShelfState()
         holder.detachStreamShelf()
         holder.detachVideoShelf()
+        holder.clearBoundSection()
         super.onViewRecycled(holder)
     }
 
@@ -89,6 +91,10 @@ class FollowingOverviewAdapter(
         private var boundStreamShelfKey: String? = null
         private var boundVideoShelfKey: String? = null
         private var boundSectionKey: String? = null
+        private var submittedStreams: List<Stream>? = null
+        private var submittedGames: List<Game>? = null
+        private var submittedVideos: List<VideoHistory>? = null
+        private var submittedScheduledStreams: List<UpcomingStream>? = null
 
         init {
             configureShelfLayout(ShelfType.STREAM)
@@ -99,21 +105,33 @@ class FollowingOverviewAdapter(
                 isNestedScrollingEnabled = false
                 clipToPadding = false
             }
+            binding.seeAll.setOnClickListener {
+                boundSectionKey?.let(onSeeAll)
+            }
+            binding.heroPrevious.setOnClickListener {
+                featuredShelfAdapter.scrollBy(binding.shelfRecyclerView, -1)
+            }
+            binding.heroNext.setOnClickListener {
+                featuredShelfAdapter.scrollBy(binding.shelfRecyclerView, 1)
+            }
         }
 
         fun bind(section: FollowingOverviewSection) {
             if (boundSectionKey != section.key) {
                 saveShelfState()
                 boundSectionKey = section.key
+                submittedStreams = null
+                submittedGames = null
+                submittedVideos = null
+                submittedScheduledStreams = null
             }
             section.title?.let { binding.sectionTitle.text = it } ?: binding.sectionTitle.setText(section.titleRes)
             val hasItems = section.streams.isNotEmpty() || section.games.isNotEmpty() || section.videos.isNotEmpty() || section.scheduledStreams.isNotEmpty()
-            val showSkeleton = section.isLoading && !hasItems
+            val showSkeleton = section.isLoading && !hasItems && !section.hasResolved
             binding.emptyMessage.setText(section.emptyRes)
             binding.emptyMessage.visibility = if (hasItems || showSkeleton) android.view.View.GONE else android.view.View.VISIBLE
             binding.shelfRecyclerView.visibility = if (hasItems || showSkeleton) android.view.View.VISIBLE else android.view.View.GONE
             binding.seeAll.visibility = if (hasItems && section.showSeeAll) android.view.View.VISIBLE else android.view.View.GONE
-            binding.seeAll.setOnClickListener { onSeeAll(section.key) }
             val nextShelfType = when {
                 showSkeleton -> ShelfType.SKELETON
                 section.isFeatured && section.streams.isNotEmpty() -> ShelfType.FEATURED
@@ -129,6 +147,13 @@ class FollowingOverviewAdapter(
                 detachVideoShelf()
             }
             if (shelfType != nextShelfType) {
+                when (nextShelfType) {
+                    ShelfType.STREAM, ShelfType.FEATURED -> submittedStreams = null
+                    ShelfType.VIDEO -> submittedVideos = null
+                    ShelfType.UPCOMING -> submittedScheduledStreams = null
+                    ShelfType.GAME -> submittedGames = null
+                    ShelfType.SKELETON -> Unit
+                }
                 configureShelfLayout(nextShelfType)
                 when (nextShelfType) {
                     ShelfType.VIDEO -> {
@@ -160,11 +185,12 @@ class FollowingOverviewAdapter(
             }
             binding.heroPrevious.visibility = if (section.isFeatured && section.streams.size > 1) android.view.View.VISIBLE else android.view.View.GONE
             binding.heroNext.visibility = if (section.isFeatured && section.streams.size > 1) android.view.View.VISIBLE else android.view.View.GONE
-            binding.heroPrevious.setOnClickListener { featuredShelfAdapter.scrollBy(binding.shelfRecyclerView, -1) }
-            binding.heroNext.setOnClickListener { featuredShelfAdapter.scrollBy(binding.shelfRecyclerView, 1) }
             when (nextShelfType) {
                 ShelfType.VIDEO -> {
-                    videoShelfAdapter.submitList(section.videos)
+                    if (submittedVideos != section.videos) {
+                        videoShelfAdapter.submitList(section.videos)
+                        submittedVideos = section.videos
+                    }
                     restoreShelfState(section.key)
                     if (hasItems && boundVideoShelfKey != section.key) {
                         detachVideoShelf()
@@ -175,15 +201,24 @@ class FollowingOverviewAdapter(
                     }
                 }
                 ShelfType.UPCOMING -> {
-                    upcomingShelfAdapter.submitList(section.scheduledStreams)
+                    if (submittedScheduledStreams != section.scheduledStreams) {
+                        upcomingShelfAdapter.submitList(section.scheduledStreams)
+                        submittedScheduledStreams = section.scheduledStreams
+                    }
                     restoreShelfState(section.key)
                 }
                 ShelfType.GAME -> {
-                    gameShelfAdapter.submitList(section.games)
+                    if (submittedGames != section.games) {
+                        gameShelfAdapter.submitList(section.games)
+                        submittedGames = section.games
+                    }
                     restoreShelfState(section.key)
                 }
                 ShelfType.FEATURED -> {
-                    featuredShelfAdapter.submitList(section.streams)
+                    if (submittedStreams != section.streams) {
+                        featuredShelfAdapter.submitList(section.streams)
+                        submittedStreams = section.streams
+                    }
                     if (shelfLayoutStates[section.key] == null) {
                         featuredShelfAdapter.centerInitialCard(binding.shelfRecyclerView)
                     }
@@ -198,7 +233,10 @@ class FollowingOverviewAdapter(
                 }
                 ShelfType.SKELETON -> skeletonShelfAdapter.setLoadingType(section.loadingType)
                 ShelfType.STREAM -> {
-                    shelfAdapter.submitList(section.streams)
+                    if (submittedStreams != section.streams) {
+                        shelfAdapter.submitList(section.streams)
+                        submittedStreams = section.streams
+                    }
                     restoreShelfState(section.key)
                     if (hasItems && boundStreamShelfKey != section.key) {
                         detachStreamShelf()
@@ -252,6 +290,10 @@ class FollowingOverviewAdapter(
         fun detachVideoShelf() {
             boundVideoShelfKey?.let(onVideoShelfDetached ?: {})
             boundVideoShelfKey = null
+        }
+
+        fun clearBoundSection() {
+            boundSectionKey = null
         }
     }
 

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/overview/FollowingOverviewFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/overview/FollowingOverviewFragment.kt
@@ -38,6 +38,24 @@ import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
 
+private data class RecommendationState(
+    val streams: List<Stream>,
+    val isLoading: Boolean,
+    val hasResolved: Boolean,
+    val source: RecommendationSource,
+)
+
+private data class LoadingState(
+    val isLoading: Boolean,
+    val hasResolved: Boolean,
+)
+
+private data class UpcomingState(
+    val streams: List<com.github.andreyasadchy.xtra.model.ui.UpcomingStream>,
+    val isLoading: Boolean,
+    val hasResolved: Boolean,
+)
+
 class FollowingOverviewFragment : BaseNetworkFragment(), Scrollable {
 
     override val initializeWithoutNetwork = true
@@ -166,9 +184,10 @@ class FollowingOverviewFragment : BaseNetworkFragment(), Scrollable {
                 val recommendationState = combine(
                     viewModel.recommendedStreams,
                     viewModel.recommendationsLoading,
+                    viewModel.recommendationsResolved,
                     viewModel.recommendationSource,
-                ) { recommended, recommendationsLoading, recommendationSource ->
-                    Triple(recommended, recommendationsLoading, recommendationSource)
+                ) { recommended, recommendationsLoading, recommendationsResolved, recommendationSource ->
+                    RecommendationState(recommended, recommendationsLoading, recommendationsResolved, recommendationSource)
                 }
                 val sections = combine(
                     viewModel.liveStreams,
@@ -176,7 +195,7 @@ class FollowingOverviewFragment : BaseNetworkFragment(), Scrollable {
                     viewModel.continueWatching,
                     viewModel.overviewSectionKeys,
                 ) { live, recommendation, continueWatching, sectionKeys ->
-                    val (recommended, recommendationsLoading, recommendationSource) = recommendation
+                    val recommended = recommendation.streams
                     val availableSections = mapOf(
                         FollowingOverviewSections.LIVE to FollowingOverviewSection(
                             key = FollowingOverviewSections.LIVE,
@@ -186,14 +205,15 @@ class FollowingOverviewFragment : BaseNetworkFragment(), Scrollable {
                         ),
                         FollowingOverviewSections.RECOMMENDED to FollowingOverviewSection(
                             key = FollowingOverviewSections.RECOMMENDED,
-                            titleRes = if (recommendationSource == RecommendationSource.FALLBACK) {
+                            titleRes = if (recommendation.source == RecommendationSource.FALLBACK) {
                                 R.string.following_popular_live_channels
                             } else {
                                 R.string.following_recommended_channels
                             },
                             emptyRes = R.string.following_no_recommended_channels,
                             streams = recommended,
-                            isLoading = recommendationsLoading && recommended.isEmpty(),
+                            isLoading = recommendation.isLoading && recommended.isEmpty() && !recommendation.hasResolved,
+                            hasResolved = recommendation.hasResolved,
                             showSeeAll = false,
                         ),
                         FollowingOverviewSections.CONTINUE to FollowingOverviewSection(
@@ -213,20 +233,30 @@ class FollowingOverviewFragment : BaseNetworkFragment(), Scrollable {
                     )
                     sectionKeys.mapNotNull(availableSections::get)
                 }
-                combine(
-                    sections,
+                val recentVideosState = combine(
                     viewModel.recentVideosLoading,
+                    viewModel.recentVideosResolved,
+                ) { isLoading, hasResolved -> LoadingState(isLoading, hasResolved) }
+                val upcomingStreamsState = combine(
                     viewModel.upcomingStreams,
                     viewModel.upcomingStreamsLoading,
-                ) { currentSections, recentVideosLoading, upcomingStreams, upcomingStreamsLoading ->
+                    viewModel.upcomingStreamsResolved,
+                ) { streams, isLoading, hasResolved -> UpcomingState(streams, isLoading, hasResolved) }
+                combine(
+                    sections,
+                    recentVideosState,
+                    upcomingStreamsState,
+                ) { currentSections, recentVideos, upcoming ->
                     currentSections.map { section ->
                         when (section.key) {
                             FollowingOverviewSections.CONTINUE -> section.copy(
-                                isLoading = recentVideosLoading && section.videos.isEmpty(),
+                                isLoading = recentVideos.isLoading && section.videos.isEmpty() && !recentVideos.hasResolved,
+                                hasResolved = recentVideos.hasResolved,
                             )
                             FollowingOverviewSections.UPCOMING -> section.copy(
-                                scheduledStreams = upcomingStreams,
-                                isLoading = upcomingStreamsLoading && upcomingStreams.isEmpty(),
+                                scheduledStreams = upcoming.streams,
+                                isLoading = upcoming.isLoading && upcoming.streams.isEmpty() && !upcoming.hasResolved,
+                                hasResolved = upcoming.hasResolved,
                             )
                             else -> section
                         }
@@ -241,7 +271,7 @@ class FollowingOverviewFragment : BaseNetworkFragment(), Scrollable {
 
     override fun onNetworkRestored() {
         viewModel.syncCurrentAccount()
-        viewModel.refreshOverviewSections()
+        viewModel.refreshOverviewSections(force = true)
         viewModel.refreshCurrent(RefreshReason.NETWORK_RESTORED, force = true)
     }
 

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/overview/FollowingOverviewViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/overview/FollowingOverviewViewModel.kt
@@ -73,6 +73,9 @@ class FollowingOverviewViewModel(
     private var recommendationsGeneration = 0L
     private var overviewContentJob: Job? = null
     private var overviewContentGeneration = 0L
+    private var lastRecommendationsRefreshAt = 0L
+    private var lastRecentVideosRefreshAt = 0L
+    private var lastUpcomingStreamsRefreshAt = 0L
 
     val liveStreams: Flow<List<Stream>> = combine(accountId, streamSort) { userId, sort -> userId to sort }.flatMapLatest { (userId, sort) ->
         streamFeedCache.activeItemsFlow(
@@ -97,11 +100,17 @@ class FollowingOverviewViewModel(
     private val _recentVideosLoading = MutableStateFlow(false)
     val recentVideosLoading: StateFlow<Boolean> = _recentVideosLoading
 
+    private val _recentVideosResolved = MutableStateFlow(false)
+    val recentVideosResolved: StateFlow<Boolean> = _recentVideosResolved
+
     private val _upcomingStreams = MutableStateFlow<List<UpcomingStream>>(emptyList())
     val upcomingStreams: StateFlow<List<UpcomingStream>> = _upcomingStreams
 
     private val _upcomingStreamsLoading = MutableStateFlow(false)
     val upcomingStreamsLoading: StateFlow<Boolean> = _upcomingStreamsLoading
+
+    private val _upcomingStreamsResolved = MutableStateFlow(false)
+    val upcomingStreamsResolved: StateFlow<Boolean> = _upcomingStreamsResolved
 
     private val _overviewSectionKeys = MutableStateFlow(readOverviewSectionKeys())
     val overviewSectionKeys: StateFlow<List<String>> = _overviewSectionKeys
@@ -114,6 +123,9 @@ class FollowingOverviewViewModel(
     private val _recommendationsLoading = MutableStateFlow(false)
     val recommendationsLoading: StateFlow<Boolean> = _recommendationsLoading
 
+    private val _recommendationsResolved = MutableStateFlow(false)
+    val recommendationsResolved: StateFlow<Boolean> = _recommendationsResolved
+
     private val _recommendationSource = MutableStateFlow(RecommendationSource.UNAVAILABLE)
     val recommendationSource: StateFlow<RecommendationSource> = _recommendationSource
 
@@ -124,44 +136,75 @@ class FollowingOverviewViewModel(
         val newAccountId = readCurrentUserId()
         if (accountId.value != newAccountId) {
             accountId.value = newAccountId
-            cancelRecommendations()
+            cancelRecommendations(clearData = true)
             cancelOverviewContent()
+            lastRecommendationsRefreshAt = 0L
+            lastRecentVideosRefreshAt = 0L
+            lastUpcomingStreamsRefreshAt = 0L
         }
         streamSort.value = readStreamSort()
     }
 
-    fun refreshOverviewSections() {
+    fun refreshOverviewSections(force: Boolean = false) {
         val keys = readOverviewSectionKeys()
+        val now = System.currentTimeMillis()
+        val keysChanged = keys != _overviewSectionKeys.value
+        val recommendationsDue = FollowingOverviewSections.RECOMMENDED in keys &&
+            (force || now - lastRecommendationsRefreshAt >= RECOMMENDATIONS_TTL_MS)
+        val recentVideosDue = FollowingOverviewSections.CONTINUE in keys &&
+            (force || now - lastRecentVideosRefreshAt >= RECENT_VIDEOS_TTL_MS)
+        val upcomingStreamsDue = FollowingOverviewSections.UPCOMING in keys &&
+            (force || now - lastUpcomingStreamsRefreshAt >= UPCOMING_STREAMS_TTL_MS)
+        if (!force && !keysChanged && !recommendationsDue && !recentVideosDue && !upcomingStreamsDue) {
+            return
+        }
         _overviewSectionKeys.value = keys
         if (FollowingOverviewSections.RECOMMENDED !in keys) {
-            cancelRecommendations()
-        } else {
+            cancelRecommendations(clearData = false)
+        } else if (force || recommendationsDue) {
+            lastRecommendationsRefreshAt = now
             refreshRecommendations()
         }
-        refreshOverviewContent()
+        if (recentVideosDue) lastRecentVideosRefreshAt = now
+        if (upcomingStreamsDue) lastUpcomingStreamsRefreshAt = now
+        refreshOverviewContent(
+            reloadRecentVideos = recentVideosDue,
+            reloadUpcomingStreams = upcomingStreamsDue,
+        )
     }
 
-    private fun refreshOverviewContent() {
+    private fun refreshOverviewContent(
+        reloadRecentVideos: Boolean,
+        reloadUpcomingStreams: Boolean,
+    ) {
         val keys = _overviewSectionKeys.value
         val shouldLoadRecentVideos = FollowingOverviewSections.CONTINUE in keys
         val shouldLoadUpcomingStreams = FollowingOverviewSections.UPCOMING in keys
-        val generation = ++overviewContentGeneration
-        overviewContentJob?.cancel()
-        val requestAccountId = accountId.value
+        val loadRecentVideos = shouldLoadRecentVideos && reloadRecentVideos
+        val loadUpcomingStreams = shouldLoadUpcomingStreams && reloadUpcomingStreams
 
         if (!shouldLoadRecentVideos) {
-            recentFollowedVideos.value = emptyList()
             _recentVideosLoading.value = false
-        } else {
+        } else if (loadRecentVideos) {
             _recentVideosLoading.value = true
         }
         if (!shouldLoadUpcomingStreams) {
-            _upcomingStreams.value = emptyList()
             _upcomingStreamsLoading.value = false
-        } else {
+        } else if (loadUpcomingStreams) {
             _upcomingStreamsLoading.value = true
         }
-        if (!shouldLoadRecentVideos && !shouldLoadUpcomingStreams) return
+        if (!loadRecentVideos && !loadUpcomingStreams) {
+            if (!shouldLoadRecentVideos && !shouldLoadUpcomingStreams) {
+                overviewContentGeneration++
+                overviewContentJob?.cancel()
+                overviewContentJob = null
+            }
+            return
+        }
+
+        val generation = ++overviewContentGeneration
+        overviewContentJob?.cancel()
+        val requestAccountId = accountId.value
 
         overviewContentJob = viewModelScope.launch {
             try {
@@ -169,31 +212,41 @@ class FollowingOverviewViewModel(
                     metadataCache.readFollowingOverview(requestAccountId)
                 }
                 if (isCurrentOverviewRequest(generation, requestAccountId)) {
-                    if (shouldLoadRecentVideos) {
-                        recentFollowedVideos.value = cachedOverview?.recentVideos.orEmpty()
-                    }
-                    if (shouldLoadUpcomingStreams) {
-                        _upcomingStreams.value = cachedOverview?.upcomingStreams.orEmpty()
+                    cachedOverview?.let { cache ->
+                        if (loadRecentVideos) {
+                            recentFollowedVideos.value = cache.recentVideos
+                            _recentVideosResolved.value = true
+                        }
+                        if (loadUpcomingStreams) {
+                            _upcomingStreams.value = cache.upcomingStreams
+                            _upcomingStreamsResolved.value = true
+                        }
                     }
                 }
                 coroutineScope {
                     val recentVideos = async {
-                        if (shouldLoadRecentVideos) {
+                        if (loadRecentVideos) {
                             loadRecentFollowedVideos()
                         } else null
                     }
                     val followedChannels = async {
-                        if (shouldLoadUpcomingStreams) {
+                        if (loadUpcomingStreams) {
                             loadFollowedChannels()
                         } else null
                     }
                     val loadedRecentVideos = recentVideos.await()
-                    val loadedUpcomingStreams = if (shouldLoadUpcomingStreams) {
+                    val loadedUpcomingStreams = if (loadUpcomingStreams) {
                         followedChannels.await()?.let { loadUpcomingStreams(it, _upcomingStreams.value) }
                     } else null
                     if (isCurrentOverviewRequest(generation, requestAccountId)) {
-                        loadedRecentVideos?.let { recentFollowedVideos.value = it }
-                        loadedUpcomingStreams?.let { _upcomingStreams.value = it }
+                        loadedRecentVideos?.let {
+                            recentFollowedVideos.value = it
+                            _recentVideosResolved.value = true
+                        }
+                        loadedUpcomingStreams?.let {
+                            _upcomingStreams.value = it
+                            _upcomingStreamsResolved.value = true
+                        }
                         if (loadedRecentVideos != null || loadedUpcomingStreams != null) {
                             tryNetworkRequest {
                                 metadataCache.writeFollowingOverview(
@@ -215,6 +268,8 @@ class FollowingOverviewViewModel(
                 if (isCurrentOverviewRequest(generation, requestAccountId)) {
                     _recentVideosLoading.value = false
                     _upcomingStreamsLoading.value = false
+                    if (loadRecentVideos) _recentVideosResolved.value = true
+                    if (loadUpcomingStreams) _upcomingStreamsResolved.value = true
                 }
             }
         }
@@ -228,6 +283,8 @@ class FollowingOverviewViewModel(
         _upcomingStreams.value = emptyList()
         _recentVideosLoading.value = false
         _upcomingStreamsLoading.value = false
+        _recentVideosResolved.value = false
+        _upcomingStreamsResolved.value = false
     }
 
     private fun isCurrentOverviewRequest(generation: Long, requestAccountId: String?): Boolean {
@@ -601,19 +658,23 @@ class FollowingOverviewViewModel(
             } finally {
                 if (isCurrentRecommendationRequest(generation, requestAccountId)) {
                     _recommendationsLoading.value = false
+                    _recommendationsResolved.value = true
                 }
             }
         }
     }
 
-    private fun cancelRecommendations() {
+    private fun cancelRecommendations(clearData: Boolean) {
         recommendationsGeneration++
         recommendationsJob?.cancel()
         recommendationsJob = null
-        _recommendedStreams.value = emptyList()
-        _recommendationSource.value = RecommendationSource.UNAVAILABLE
-        _recommendationAuthMode.value = RecommendationAuthMode.ANONYMOUS
         _recommendationsLoading.value = false
+        if (clearData) {
+            _recommendedStreams.value = emptyList()
+            _recommendationSource.value = RecommendationSource.UNAVAILABLE
+            _recommendationAuthMode.value = RecommendationAuthMode.ANONYMOUS
+            _recommendationsResolved.value = false
+        }
     }
 
     private fun isCurrentRecommendationRequest(generation: Long, requestAccountId: String?): Boolean {
@@ -672,10 +733,13 @@ class FollowingOverviewViewModel(
         private const val RECENT_VOD_CHANNEL_LIMIT = 30
         private const val RECENT_VODS_PER_CHANNEL = 3
         private const val RECENT_VOD_REQUEST_CONCURRENCY = 6
+        private const val RECOMMENDATIONS_TTL_MS = 5 * 60_000L
+        private const val RECENT_VIDEOS_TTL_MS = 5 * 60_000L
         private const val FOLLOWED_CHANNEL_LIMIT = 100
         private const val UPCOMING_REQUEST_CONCURRENCY = 6
         private const val UPCOMING_SEGMENTS_PER_CHANNEL = 3
         private const val UPCOMING_STREAM_LIMIT = 20
+        private const val UPCOMING_STREAMS_TTL_MS = 15 * 60_000L
 
         val FollowingOverviewViewModelFactory = viewModelFactory {
             initializer {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/overview/GameShelfAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/overview/GameShelfAdapter.kt
@@ -13,13 +13,18 @@ import coil3.request.target
 import com.github.andreyasadchy.xtra.R
 import com.github.andreyasadchy.xtra.databinding.ItemGameShelfBinding
 import com.github.andreyasadchy.xtra.model.ui.Game
-import com.github.andreyasadchy.xtra.util.C
+import com.github.andreyasadchy.xtra.ui.common.FeedImageRequestBag
+import com.github.andreyasadchy.xtra.ui.common.FeedImageRequestOwner
+import com.github.andreyasadchy.xtra.ui.common.FeedUiPreferencesStore
+import com.github.andreyasadchy.xtra.ui.common.restoreDecodedMemoryImage
+import com.github.andreyasadchy.xtra.ui.common.StreamThumbnailIdleScheduler
 import com.github.andreyasadchy.xtra.util.TwitchApiHelper
-import com.github.andreyasadchy.xtra.util.prefs
 
 class GameShelfAdapter(
     private val onGameClick: (Game) -> Unit,
 ) : ListAdapter<Game, GameShelfAdapter.ViewHolder>(DIFF_CALLBACK) {
+
+    private val imageLoadScheduler = StreamThumbnailIdleScheduler()
 
     init {
         setHasStableIds(true)
@@ -35,7 +40,14 @@ class GameShelfAdapter(
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
         (holder.itemView.parent as? RecyclerView)?.let { ShelfCardSizing.apply(holder.itemView, it) }
+        holder.beginImageBind(getItem(position))
         holder.bind(getItem(position))
+    }
+
+    override fun onViewRecycled(holder: ViewHolder) {
+        imageLoadScheduler.clear(holder)
+        holder.cancelImageWork()
+        super.onViewRecycled(holder)
     }
 
     private val layoutChangeListener = View.OnLayoutChangeListener { view, left, _, right, _, oldLeft, _, oldRight, _ ->
@@ -51,24 +63,55 @@ class GameShelfAdapter(
 
     override fun onAttachedToRecyclerView(recyclerView: RecyclerView) {
         super.onAttachedToRecyclerView(recyclerView)
+        imageLoadScheduler.attachTo(recyclerView)
         recyclerView.addOnLayoutChangeListener(layoutChangeListener)
         recyclerView.post { applyCardSizing(recyclerView) }
     }
 
     override fun onDetachedFromRecyclerView(recyclerView: RecyclerView) {
+        imageLoadScheduler.detach()
         recyclerView.removeOnLayoutChangeListener(layoutChangeListener)
         super.onDetachedFromRecyclerView(recyclerView)
     }
 
     inner class ViewHolder(
         private val binding: ItemGameShelfBinding,
-    ) : RecyclerView.ViewHolder(binding.root) {
+    ) : RecyclerView.ViewHolder(binding.root), FeedImageRequestOwner {
+
+        private val imageRequests = FeedImageRequestBag()
+        private var boundGameId: String? = null
+        private var boundGame: Game? = null
+
+        init {
+            binding.root.setOnClickListener { boundGame?.let(onGameClick) }
+        }
+
+        fun beginImageBind(game: Game) {
+            imageLoadScheduler.clear(this)
+            imageRequests.cancel()
+            boundGameId = game.id
+        }
+
+        override fun cancelImageRequests() {
+            imageRequests.cancel()
+        }
+
+        override fun pauseImageRequests() {
+            imageRequests.cancel(preserveRegistrations = true)
+        }
+
+        fun cancelImageWork() {
+            cancelImageRequests()
+            boundGameId = null
+            boundGame = null
+        }
 
         fun bind(game: Game) {
             val context = binding.root.context
-            binding.root.setOnClickListener { onGameClick(game) }
+            boundGame = game
             binding.gameName.text = game.name.orEmpty()
             binding.gameName.visibility = if (game.name.isNullOrBlank()) View.GONE else View.VISIBLE
+            val uiPreferences = FeedUiPreferencesStore.current(context)
             val viewerCount = game.viewerCount
             binding.viewers.text = viewerCount?.let {
                 context.resources.getQuantityString(
@@ -76,7 +119,7 @@ class GameShelfAdapter(
                     it,
                     TwitchApiHelper.formatCount(
                         it,
-                        context.prefs().getBoolean(C.UI_TRUNCATE_VIEW_COUNT, true),
+                        uiPreferences.truncateViewCount,
                     ),
                 )
             }.orEmpty()
@@ -86,15 +129,29 @@ class GameShelfAdapter(
             if (imageUrl.isNullOrBlank()) {
                 binding.gameImage.visibility = View.INVISIBLE
                 binding.gameImage.setImageDrawable(null)
+                binding.gameImage.tag = null
             } else {
                 binding.gameImage.visibility = View.VISIBLE
-                context.imageLoader.enqueue(
-                    ImageRequest.Builder(context)
-                        .data(imageUrl)
-                        .crossfade(true)
-                        .target(binding.gameImage)
-                        .build(),
-                )
+                val imageKey = "xtra:game-boxart:${game.id}|$imageUrl"
+                if (binding.gameImage.tag != imageKey) {
+                    binding.gameImage.setImageDrawable(null)
+                    binding.gameImage.tag = imageKey
+                }
+                restoreDecodedMemoryImage(imageKey, binding.gameImage)
+                imageLoadScheduler.runOrDefer(this@ViewHolder, binding.gameImage) {
+                    if (!binding.root.isAttachedToWindow || boundGameId != game.id) return@runOrDefer
+                    imageRequests.replace(
+                        binding.gameImage,
+                        context.imageLoader.enqueue(
+                            ImageRequest.Builder(context)
+                                .data(imageUrl)
+                                .memoryCacheKey(imageKey)
+                                .crossfade(false)
+                                .target(binding.gameImage)
+                                .build(),
+                        ),
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/overview/StreamShelfAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/overview/StreamShelfAdapter.kt
@@ -13,8 +13,18 @@ import com.github.andreyasadchy.xtra.databinding.ItemStreamShelfBinding
 import com.github.andreyasadchy.xtra.model.ui.Stream
 import com.github.andreyasadchy.xtra.ui.common.loadStreamProfileImage
 import com.github.andreyasadchy.xtra.ui.common.loadStreamThumbnail
+import com.github.andreyasadchy.xtra.ui.common.prepareStreamProfileImage
+import com.github.andreyasadchy.xtra.ui.common.prepareStreamThumbnailImage
+import com.github.andreyasadchy.xtra.ui.common.restoreWarmStreamThumbnail
+import com.github.andreyasadchy.xtra.ui.common.FeedImageRequestBag
+import com.github.andreyasadchy.xtra.ui.common.FeedImageRequestOwner
+import com.github.andreyasadchy.xtra.ui.common.FeedUiPreferencesStore
+import com.github.andreyasadchy.xtra.ui.common.StreamThumbnailIdleScheduler
+import com.github.andreyasadchy.xtra.ui.common.thumbnailIdentity
 import com.github.andreyasadchy.xtra.ui.common.streamContentsSame
 import com.github.andreyasadchy.xtra.ui.common.streamIdentity
+import com.github.andreyasadchy.xtra.ui.common.streamThumbnailOnlyChanged
+import com.github.andreyasadchy.xtra.ui.common.StreamThumbnailChangedPayload
 import com.github.andreyasadchy.xtra.util.C
 import com.github.andreyasadchy.xtra.util.TwitchApiHelper
 import com.github.andreyasadchy.xtra.util.prefs
@@ -24,6 +34,8 @@ import kotlin.time.Instant
 class StreamShelfAdapter(
     private val onStreamClick: (Stream) -> Unit,
 ) : ListAdapter<Stream, StreamShelfAdapter.ViewHolder>(DIFF_CALLBACK) {
+
+    private val thumbnailLoadScheduler = StreamThumbnailIdleScheduler()
 
     init {
         setHasStableIds(true)
@@ -39,13 +51,25 @@ class StreamShelfAdapter(
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
         (holder.itemView.parent as? RecyclerView)?.let { ShelfCardSizing.apply(holder.itemView, it) }
+        holder.beginImageBind(getItem(position))
         holder.bind(getItem(position))
+    }
+
+    override fun onBindViewHolder(holder: ViewHolder, position: Int, payloads: MutableList<Any>) {
+        if (payloads.isNotEmpty() && payloads.all { it === StreamThumbnailChangedPayload }) {
+            holder.beginImageBind(getItem(position))
+            holder.bindThumbnail(getItem(position))
+        } else {
+            super.onBindViewHolder(holder, position, payloads)
+        }
     }
 
     override fun onViewRecycled(holder: ViewHolder) {
         (holder.itemView.context.applicationContext as XtraApp).xtraModule.streamPreviewCoordinator
             .detachSurface(holder.previewSurface)
         holder.boundPreviewIdentity = null
+        thumbnailLoadScheduler.clear(holder)
+        holder.cancelImageWork()
         super.onViewRecycled(holder)
     }
 
@@ -62,23 +86,80 @@ class StreamShelfAdapter(
 
     override fun onAttachedToRecyclerView(recyclerView: RecyclerView) {
         super.onAttachedToRecyclerView(recyclerView)
+        thumbnailLoadScheduler.attachTo(recyclerView)
         recyclerView.addOnLayoutChangeListener(layoutChangeListener)
         recyclerView.post { applyCardSizing(recyclerView) }
     }
 
     override fun onDetachedFromRecyclerView(recyclerView: RecyclerView) {
+        thumbnailLoadScheduler.detach()
         recyclerView.removeOnLayoutChangeListener(layoutChangeListener)
         super.onDetachedFromRecyclerView(recyclerView)
     }
 
     inner class ViewHolder(
         private val binding: ItemStreamShelfBinding,
-    ) : RecyclerView.ViewHolder(binding.root) {
+    ) : RecyclerView.ViewHolder(binding.root), FeedImageRequestOwner {
         val previewSurface get() = binding.previewHost
         var boundPreviewIdentity: String? = null
+        private val imageRequests = FeedImageRequestBag()
+        private var boundImageIdentity: String? = null
+        private var boundThumbnailKey: String? = null
+        private var boundStream: Stream? = null
+
+        init {
+            binding.root.setOnClickListener { boundStream?.let(onStreamClick) }
+        }
+
+        fun beginImageBind(stream: Stream?) {
+            thumbnailLoadScheduler.clear(this)
+            imageRequests.cancel()
+            boundImageIdentity = stream?.streamIdentity()
+            boundThumbnailKey = null
+        }
+
+        override fun cancelImageRequests() {
+            imageRequests.cancel()
+        }
+
+        override fun pauseImageRequests() {
+            imageRequests.cancel(preserveRegistrations = true)
+        }
+
+        fun cancelImageWork() {
+            cancelImageRequests()
+            boundImageIdentity = null
+            boundThumbnailKey = null
+            boundStream = null
+        }
+
+        fun bindThumbnail(stream: Stream?) {
+            val item = stream ?: return
+            prepareStreamThumbnailImage(binding.thumbnail, item)
+            restoreWarmStreamThumbnail(item, binding.thumbnail)
+            val key = "${item.thumbnailIdentity()}|generation=${item.thumbnailGeneration}"
+            boundThumbnailKey = key
+            thumbnailLoadScheduler.runOrDefer(this@ViewHolder, binding.thumbnail) {
+                if (!binding.root.isAttachedToWindow ||
+                    boundImageIdentity != item.streamIdentity() ||
+                    boundThumbnailKey != key
+                ) return@runOrDefer
+                loadStreamThumbnail(
+                    context = binding.root.context,
+                    imageView = binding.thumbnail,
+                    stream = item,
+                    scheduleFreshRequest = { freshRequest ->
+                        thumbnailLoadScheduler.runOrDefer(this@ViewHolder, binding.thumbnail, freshRequest)
+                    },
+                )
+                    ?.let { imageRequests.replace(binding.thumbnail, it) }
+            }
+        }
 
         fun bind(stream: Stream) {
             val context = binding.root.context
+            val uiPreferences = FeedUiPreferencesStore.current(context)
+            boundStream = stream
             val nextPreviewIdentity = stream.streamIdentity()
             if (boundPreviewIdentity != nextPreviewIdentity) {
                 (context.applicationContext as XtraApp).xtraModule.streamPreviewCoordinator
@@ -86,9 +167,7 @@ class StreamShelfAdapter(
                 boundPreviewIdentity = nextPreviewIdentity
             }
             with(binding) {
-                root.setOnClickListener { onStreamClick(stream) }
-
-                loadStreamThumbnail(context, thumbnail, stream)
+                bindThumbnail(stream)
                 thumbnail.contentDescription = stream.title?.takeIf { it.isNotBlank() }
                     ?: context.getString(R.string.live)
 
@@ -99,13 +178,13 @@ class StreamShelfAdapter(
                         count,
                         TwitchApiHelper.formatCount(
                             count,
-                            context.prefs().getBoolean(C.UI_TRUNCATE_VIEW_COUNT, true),
+                            uiPreferences.truncateViewCount,
                         ),
                     )
                 }.orEmpty()
                 viewers.visibility = if (viewers.text.isNullOrBlank()) android.view.View.GONE else android.view.View.VISIBLE
 
-                val uptimeText = if (context.prefs().getBoolean(C.UI_UPTIME, true)) {
+                val uptimeText = if (uiPreferences.showUptime) {
                     stream.createdAt?.let { value ->
                         Instant.parseOrNull(value)?.let { createdAt ->
                             val uptime = Clock.System.now() - createdAt
@@ -123,7 +202,7 @@ class StreamShelfAdapter(
                 category.text = stream.gameName?.trim().orEmpty()
                 category.visibility = if (category.text.isNullOrBlank()) android.view.View.GONE else android.view.View.VISIBLE
 
-                val tags = if (context.prefs().getBoolean(C.UI_TAGS, true)) stream.tags.orEmpty().take(2) else emptyList()
+                val tags = if (uiPreferences.showTags) stream.tags.orEmpty().take(2) else emptyList()
                 tagOne.text = tags.getOrNull(0).orEmpty()
                 tagOne.visibility = if (tags.size > 0) android.view.View.VISIBLE else android.view.View.GONE
                 tagTwo.text = tags.getOrNull(1).orEmpty()
@@ -131,7 +210,14 @@ class StreamShelfAdapter(
 
                 if (stream.channelImage != null) {
                     avatar.visibility = android.view.View.VISIBLE
-                    loadStreamProfileImage(context, avatar, stream)
+                    prepareStreamProfileImage(avatar, stream)
+                    thumbnailLoadScheduler.runOrDefer(this@ViewHolder, avatar) {
+                        if (binding.root.isAttachedToWindow && boundImageIdentity == stream.streamIdentity()) {
+                            loadStreamProfileImage(context, avatar, stream)?.let {
+                                imageRequests.replace(binding.avatar, it)
+                            }
+                        }
+                    }
                 } else {
                     avatar.visibility = android.view.View.INVISIBLE
                     avatar.setImageDrawable(null)
@@ -148,6 +234,9 @@ class StreamShelfAdapter(
 
             override fun areContentsTheSame(oldItem: Stream, newItem: Stream): Boolean =
                 streamContentsSame(oldItem, newItem)
+
+            override fun getChangePayload(oldItem: Stream, newItem: Stream): Any? =
+                if (streamThumbnailOnlyChanged(oldItem, newItem)) StreamThumbnailChangedPayload else null
         }
     }
 }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/overview/UpcomingStreamShelfAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/overview/UpcomingStreamShelfAdapter.kt
@@ -17,11 +17,17 @@ import coil3.transform.CircleCropTransformation
 import com.github.andreyasadchy.xtra.R
 import com.github.andreyasadchy.xtra.databinding.ItemUpcomingStreamShelfBinding
 import com.github.andreyasadchy.xtra.model.ui.UpcomingStream
+import com.github.andreyasadchy.xtra.ui.common.FeedImageRequestBag
+import com.github.andreyasadchy.xtra.ui.common.FeedImageRequestOwner
+import com.github.andreyasadchy.xtra.ui.common.StreamThumbnailIdleScheduler
+import com.github.andreyasadchy.xtra.ui.common.restoreDecodedMemoryImage
 import com.github.andreyasadchy.xtra.util.TwitchApiHelper
 
 class UpcomingStreamShelfAdapter(
     private val onUpcomingClick: (UpcomingStream) -> Unit,
 ) : ListAdapter<UpcomingStream, UpcomingStreamShelfAdapter.ViewHolder>(DIFF_CALLBACK) {
+
+    private val imageLoadScheduler = StreamThumbnailIdleScheduler()
 
     init {
         setHasStableIds(true)
@@ -35,24 +41,84 @@ class UpcomingStreamShelfAdapter(
     }
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        holder.beginImageBind(getItem(position))
         holder.bind(getItem(position), showPreview = position == 0)
+    }
+
+    override fun onViewRecycled(holder: ViewHolder) {
+        imageLoadScheduler.clear(holder)
+        holder.cancelImageWork()
+        super.onViewRecycled(holder)
+    }
+
+    override fun onAttachedToRecyclerView(recyclerView: RecyclerView) {
+        super.onAttachedToRecyclerView(recyclerView)
+        imageLoadScheduler.attachTo(recyclerView)
+    }
+
+    override fun onDetachedFromRecyclerView(recyclerView: RecyclerView) {
+        imageLoadScheduler.detach()
+        super.onDetachedFromRecyclerView(recyclerView)
     }
 
     inner class ViewHolder(
         private val binding: ItemUpcomingStreamShelfBinding,
-    ) : RecyclerView.ViewHolder(binding.root) {
+    ) : RecyclerView.ViewHolder(binding.root), FeedImageRequestOwner {
+        private val imageRequests = FeedImageRequestBag()
+        private var boundItemId: String? = null
+        private var boundItem: UpcomingStream? = null
+
+        init {
+            binding.root.setOnClickListener { boundItem?.let(onUpcomingClick) }
+        }
+
+        fun beginImageBind(item: UpcomingStream) {
+            imageLoadScheduler.clear(this)
+            imageRequests.cancel()
+            boundItemId = item.id
+        }
+
+        override fun cancelImageRequests() {
+            imageRequests.cancel()
+        }
+
+        override fun pauseImageRequests() {
+            imageRequests.cancel(preserveRegistrations = true)
+        }
+
+        fun cancelImageWork() {
+            cancelImageRequests()
+            boundItemId = null
+            boundItem = null
+        }
+
         fun bind(item: UpcomingStream, showPreview: Boolean) {
             val context = binding.root.context
-            binding.root.setOnClickListener { onUpcomingClick(item) }
+            boundItem = item
             val avatarUrl = item.channelImageURL?.let(TwitchApiHelper::getProfileImage)
-            context.imageLoader.enqueue(ImageRequest.Builder(context).apply {
-                data(avatarUrl)
-                diskCachePolicy(CachePolicy.ENABLED)
-                transformations(CircleCropTransformation())
-                crossfade(true)
-                target(binding.avatar)
-            }.build())
             binding.avatar.visibility = if (avatarUrl.isNullOrBlank()) View.INVISIBLE else View.VISIBLE
+            if (avatarUrl.isNullOrBlank()) {
+                binding.avatar.setImageDrawable(null)
+                binding.avatar.tag = null
+            } else {
+                val avatarKey = "xtra:upcoming-avatar:${item.id}|$avatarUrl"
+                if (binding.avatar.tag != avatarKey) {
+                    binding.avatar.setImageDrawable(null)
+                    binding.avatar.tag = avatarKey
+                }
+                restoreDecodedMemoryImage(avatarKey, binding.avatar)
+                imageLoadScheduler.runOrDefer(this@ViewHolder, binding.avatar) {
+                    if (!binding.root.isAttachedToWindow || boundItemId != item.id) return@runOrDefer
+                    imageRequests.replace(binding.avatar, context.imageLoader.enqueue(ImageRequest.Builder(context).apply {
+                        data(avatarUrl)
+                        memoryCacheKey(avatarKey)
+                        diskCachePolicy(CachePolicy.ENABLED)
+                        transformations(CircleCropTransformation())
+                        crossfade(false)
+                        target(binding.avatar)
+                    }.build()))
+                }
+            }
             binding.channel.text = item.channelName ?: item.channelLogin.orEmpty()
             binding.channel.visibility = if (binding.channel.text.isNullOrBlank()) View.GONE else View.VISIBLE
             binding.title.text = item.title?.takeIf(String::isNotBlank)
@@ -64,14 +130,26 @@ class UpcomingStreamShelfAdapter(
 
             val previewUrl = item.previewImageURL?.takeIf { showPreview && it.isNotBlank() }
             binding.previewHost.visibility = if (previewUrl == null) View.GONE else View.VISIBLE
-            binding.previewImage.setImageDrawable(null)
             if (previewUrl != null) {
-                context.imageLoader.enqueue(ImageRequest.Builder(context).apply {
-                    data(previewUrl)
-                    diskCachePolicy(CachePolicy.ENABLED)
-                    crossfade(true)
-                    target(binding.previewImage)
-                }.build())
+                val previewKey = "xtra:upcoming-preview:${item.id}|$previewUrl"
+                if (binding.previewImage.tag != previewKey) {
+                    binding.previewImage.setImageDrawable(null)
+                    binding.previewImage.tag = previewKey
+                }
+                restoreDecodedMemoryImage(previewKey, binding.previewImage)
+                imageLoadScheduler.runOrDefer(this@ViewHolder, binding.previewImage) {
+                    if (!binding.root.isAttachedToWindow || boundItemId != item.id) return@runOrDefer
+                    imageRequests.replace(binding.previewImage, context.imageLoader.enqueue(ImageRequest.Builder(context).apply {
+                        data(previewUrl)
+                        memoryCacheKey(previewKey)
+                        diskCachePolicy(CachePolicy.ENABLED)
+                        crossfade(false)
+                        target(binding.previewImage)
+                    }.build()))
+                }
+            } else if (binding.previewImage.tag != null) {
+                binding.previewImage.setImageDrawable(null)
+                binding.previewImage.tag = null
             }
         }
     }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/overview/VideoShelfAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/overview/VideoShelfAdapter.kt
@@ -18,11 +18,17 @@ import com.github.andreyasadchy.xtra.R
 import com.github.andreyasadchy.xtra.XtraApp
 import com.github.andreyasadchy.xtra.databinding.ItemVideoShelfBinding
 import com.github.andreyasadchy.xtra.model.VideoHistory
+import com.github.andreyasadchy.xtra.ui.common.FeedImageRequestBag
+import com.github.andreyasadchy.xtra.ui.common.FeedImageRequestOwner
+import com.github.andreyasadchy.xtra.ui.common.StreamThumbnailIdleScheduler
+import com.github.andreyasadchy.xtra.ui.common.restoreDecodedMemoryImage
 import com.github.andreyasadchy.xtra.util.TwitchApiHelper
 
 class VideoShelfAdapter(
     private val onVideoClick: (VideoHistory) -> Unit,
 ) : ListAdapter<VideoHistory, VideoShelfAdapter.ViewHolder>(DIFF_CALLBACK) {
+
+    private val imageLoadScheduler = StreamThumbnailIdleScheduler()
 
     init {
         setHasStableIds(true)
@@ -38,11 +44,14 @@ class VideoShelfAdapter(
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
         (holder.itemView.parent as? RecyclerView)?.let { ShelfCardSizing.apply(holder.itemView, it) }
+        holder.beginImageBind(getItem(position))
         holder.bind(getItem(position))
     }
 
     override fun onViewRecycled(holder: ViewHolder) {
         holder.detachPreview()
+        imageLoadScheduler.clear(holder)
+        holder.cancelImageWork()
         super.onViewRecycled(holder)
     }
 
@@ -55,37 +64,78 @@ class VideoShelfAdapter(
 
     override fun onAttachedToRecyclerView(recyclerView: RecyclerView) {
         super.onAttachedToRecyclerView(recyclerView)
+        imageLoadScheduler.attachTo(recyclerView)
         recyclerView.addOnLayoutChangeListener(layoutChangeListener)
     }
 
     override fun onDetachedFromRecyclerView(recyclerView: RecyclerView) {
+        imageLoadScheduler.detach()
         recyclerView.removeOnLayoutChangeListener(layoutChangeListener)
         super.onDetachedFromRecyclerView(recyclerView)
     }
 
     inner class ViewHolder(
         private val binding: ItemVideoShelfBinding,
-    ) : RecyclerView.ViewHolder(binding.root) {
+    ) : RecyclerView.ViewHolder(binding.root), FeedImageRequestOwner {
         val previewSurface get() = binding.previewHost
         private var boundPreviewIdentity: String? = null
+        private val imageRequests = FeedImageRequestBag()
+        private var boundImageIdentity: String? = null
+        private var boundItem: VideoHistory? = null
+
+        init {
+            binding.root.setOnClickListener { boundItem?.let(onVideoClick) }
+        }
 
         private val streamPreviewCoordinator
             get() = (binding.root.context.applicationContext as XtraApp).xtraModule.streamPreviewCoordinator
 
+        fun beginImageBind(item: VideoHistory) {
+            imageLoadScheduler.clear(this)
+            imageRequests.cancel()
+            boundImageIdentity = "vod:${item.id}"
+        }
+
+        override fun cancelImageRequests() {
+            imageRequests.cancel()
+        }
+
+        override fun pauseImageRequests() {
+            imageRequests.cancel(preserveRegistrations = true)
+        }
+
+        fun cancelImageWork() {
+            cancelImageRequests()
+            boundImageIdentity = null
+            boundItem = null
+        }
+
         fun bind(item: VideoHistory) {
             val context = binding.root.context
+            boundItem = item
             val nextPreviewIdentity = "vod:${item.id}"
             if (boundPreviewIdentity != nextPreviewIdentity) {
                 streamPreviewCoordinator.detachSurface(previewSurface)
                 boundPreviewIdentity = nextPreviewIdentity
             }
-            binding.root.setOnClickListener { onVideoClick(item) }
-            context.imageLoader.enqueue(ImageRequest.Builder(context).apply {
-                data(item.thumbnailURL?.let(TwitchApiHelper::getVideoThumbnail))
-                diskCachePolicy(CachePolicy.ENABLED)
-                crossfade(true)
-                target(binding.thumbnail)
-            }.build())
+            val identity = "vod:${item.id}"
+            val thumbnailUrl = item.thumbnailURL?.let(TwitchApiHelper::getVideoThumbnail)
+            val thumbnailKey = "xtra:vod-thumbnail:$identity|$thumbnailUrl"
+            if (binding.thumbnail.tag != thumbnailKey) {
+                binding.thumbnail.setImageDrawable(null)
+                binding.thumbnail.tag = thumbnailKey
+            }
+            restoreDecodedMemoryImage(thumbnailKey, binding.thumbnail)
+            imageLoadScheduler.runOrDefer(this@ViewHolder, binding.thumbnail) {
+                if (!binding.root.isAttachedToWindow || boundImageIdentity != identity) return@runOrDefer
+                imageRequests.replace(binding.thumbnail, context.imageLoader.enqueue(ImageRequest.Builder(context).apply {
+                    data(thumbnailUrl)
+                    memoryCacheKey(thumbnailKey)
+                    diskCachePolicy(CachePolicy.ENABLED)
+                    crossfade(false)
+                    target(binding.thumbnail)
+                }.build()))
+            }
             binding.title.text = item.title.orEmpty()
             binding.channel.text = item.channelName.orEmpty()
             binding.category.text = item.gameName.orEmpty()
@@ -97,13 +147,28 @@ class VideoShelfAdapter(
             binding.progress.visibility = if (progress != null) View.VISIBLE else View.GONE
             binding.progress.scaleX = progress?.coerceIn(0f, 1f) ?: 0f
             val avatarUrl = item.channelImageURL?.let(TwitchApiHelper::getProfileImage)
-            context.imageLoader.enqueue(ImageRequest.Builder(context).apply {
-                data(avatarUrl)
-                diskCachePolicy(CachePolicy.ENABLED)
-                transformations(CircleCropTransformation())
-                target(binding.avatar)
-            }.build())
             binding.avatar.visibility = if (avatarUrl.isNullOrBlank()) View.INVISIBLE else View.VISIBLE
+            if (avatarUrl.isNullOrBlank()) {
+                binding.avatar.setImageDrawable(null)
+                binding.avatar.tag = null
+            } else {
+                val avatarKey = "xtra:vod-avatar:$identity|$avatarUrl|round=true"
+                if (binding.avatar.tag != avatarKey) {
+                    binding.avatar.setImageDrawable(null)
+                    binding.avatar.tag = avatarKey
+                }
+                restoreDecodedMemoryImage(avatarKey, binding.avatar)
+                imageLoadScheduler.runOrDefer(this@ViewHolder, binding.avatar) {
+                    if (!binding.root.isAttachedToWindow || boundImageIdentity != identity) return@runOrDefer
+                    imageRequests.replace(binding.avatar, context.imageLoader.enqueue(ImageRequest.Builder(context).apply {
+                        data(avatarUrl)
+                        memoryCacheKey(avatarKey)
+                        diskCachePolicy(CachePolicy.ENABLED)
+                        transformations(CircleCropTransformation())
+                        target(binding.avatar)
+                    }.build()))
+                }
+            }
         }
 
         fun detachPreview() {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/streams/FollowedStreamsFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/streams/FollowedStreamsFragment.kt
@@ -21,6 +21,7 @@ import com.github.andreyasadchy.xtra.XtraApp
 import com.github.andreyasadchy.xtra.databinding.CommonRecyclerViewLayoutBinding
 import com.github.andreyasadchy.xtra.model.ui.Stream
 import com.github.andreyasadchy.xtra.ui.common.PagedListFragment
+import com.github.andreyasadchy.xtra.ui.common.PagerScrollStateAware
 import com.github.andreyasadchy.xtra.ui.common.Scrollable
 import com.github.andreyasadchy.xtra.ui.common.StreamFeedScreenController
 import com.github.andreyasadchy.xtra.ui.common.StreamPreloadViewportController
@@ -33,7 +34,7 @@ import com.github.andreyasadchy.xtra.util.prefs
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 
-class FollowedStreamsFragment : PagedListFragment(), Scrollable {
+class FollowedStreamsFragment : PagedListFragment(), Scrollable, PagerScrollStateAware {
 
     override val initializeWithoutNetwork = true
 
@@ -105,6 +106,12 @@ class FollowedStreamsFragment : PagedListFragment(), Scrollable {
     override fun onNetworkRestored() {
         viewModel.syncCurrentAccount()
         viewModel.refreshCurrent(RefreshReason.NETWORK_RESTORED, force = true)
+    }
+
+    override fun onPagerScrollStateChanged(scrolling: Boolean) {
+        if (::streamPreloadViewportController.isInitialized) {
+            streamPreloadViewportController.onParentScrollStateChanged(scrolling)
+        }
     }
 
     override fun onResume() {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/streams/StreamsShelfPagingAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/streams/StreamsShelfPagingAdapter.kt
@@ -16,14 +16,21 @@ import com.github.andreyasadchy.xtra.model.ui.Stream
 import com.github.andreyasadchy.xtra.ui.channel.ChannelPagerFragmentDirections
 import com.github.andreyasadchy.xtra.ui.common.loadStreamProfileImage
 import com.github.andreyasadchy.xtra.ui.common.loadStreamThumbnail
+import com.github.andreyasadchy.xtra.ui.common.prepareStreamProfileImage
+import com.github.andreyasadchy.xtra.ui.common.prepareStreamThumbnailImage
+import com.github.andreyasadchy.xtra.ui.common.restoreWarmStreamThumbnail
+import com.github.andreyasadchy.xtra.ui.common.FeedImageRequestBag
+import com.github.andreyasadchy.xtra.ui.common.FeedImageRequestOwner
+import com.github.andreyasadchy.xtra.ui.common.StreamThumbnailIdleScheduler
+import com.github.andreyasadchy.xtra.ui.common.thumbnailIdentity
 import com.github.andreyasadchy.xtra.ui.common.streamContentsSame
 import com.github.andreyasadchy.xtra.ui.common.streamIdentity
+import com.github.andreyasadchy.xtra.ui.common.streamThumbnailOnlyChanged
+import com.github.andreyasadchy.xtra.ui.common.StreamThumbnailChangedPayload
 import com.github.andreyasadchy.xtra.ui.game.GamePagerFragmentDirections
 import com.github.andreyasadchy.xtra.ui.main.MainActivity
 import com.github.andreyasadchy.xtra.ui.multiview.MultiviewFragment
-import com.github.andreyasadchy.xtra.util.C
 import com.github.andreyasadchy.xtra.util.TwitchApiHelper
-import com.github.andreyasadchy.xtra.util.prefs
 import kotlin.time.Clock
 import kotlin.time.Instant
 
@@ -32,29 +39,118 @@ class StreamsShelfPagingAdapter(
     private val selectTag: (String) -> Unit,
 ) : PagingDataAdapter<Stream, StreamsShelfPagingAdapter.ViewHolder>(DIFF_CALLBACK) {
 
+    private val thumbnailLoadScheduler = StreamThumbnailIdleScheduler()
+
+    override fun onAttachedToRecyclerView(recyclerView: RecyclerView) {
+        super.onAttachedToRecyclerView(recyclerView)
+        thumbnailLoadScheduler.attachTo(recyclerView)
+    }
+
+    override fun onDetachedFromRecyclerView(recyclerView: RecyclerView) {
+        thumbnailLoadScheduler.detach()
+        super.onDetachedFromRecyclerView(recyclerView)
+    }
+
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
         return ViewHolder(ItemStreamShelfBinding.inflate(LayoutInflater.from(parent.context), parent, false))
     }
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        holder.beginImageBind(getItem(position))
         holder.bind(getItem(position))
+    }
+
+    override fun onBindViewHolder(holder: ViewHolder, position: Int, payloads: MutableList<Any>) {
+        if (payloads.isNotEmpty() && payloads.all { it === StreamThumbnailChangedPayload }) {
+            holder.beginImageBind(getItem(position))
+            holder.bindThumbnail(getItem(position))
+        } else {
+            super.onBindViewHolder(holder, position, payloads)
+        }
     }
 
     override fun onViewRecycled(holder: ViewHolder) {
         (fragment.requireContext().applicationContext as XtraApp).xtraModule.streamPreviewCoordinator
             .detachSurface(holder.previewSurface)
         holder.boundPreviewIdentity = null
+        thumbnailLoadScheduler.clear(holder)
+        holder.cancelImageWork()
         super.onViewRecycled(holder)
     }
 
     inner class ViewHolder(
         private val binding: ItemStreamShelfBinding,
-    ) : RecyclerView.ViewHolder(binding.root) {
+    ) : RecyclerView.ViewHolder(binding.root), FeedImageRequestOwner {
         val previewSurface get() = binding.previewHost
         var boundPreviewIdentity: String? = null
+        private val imageRequests = FeedImageRequestBag()
+        private var boundImageIdentity: String? = null
+        private var boundThumbnailKey: String? = null
+        private var boundStream: Stream? = null
+        private var boundTags: List<String> = emptyList()
+
+        init {
+            binding.root.setOnClickListener {
+                boundStream?.let { (fragment.activity as? MainActivity)?.startStream(it) }
+            }
+            binding.avatar.setOnClickListener { boundStream?.let(::openChannel) }
+            binding.channel.setOnClickListener { boundStream?.let(::openChannel) }
+            binding.category.setOnClickListener { boundStream?.let(::openGame) }
+            binding.multiview.setOnClickListener { boundStream?.let(::openMultiview) }
+            binding.tagOne.setOnClickListener { boundTags.getOrNull(0)?.let(selectTag) }
+            binding.tagTwo.setOnClickListener { boundTags.getOrNull(1)?.let(selectTag) }
+        }
+
+        fun beginImageBind(item: Stream?) {
+            thumbnailLoadScheduler.clear(this)
+            imageRequests.cancel()
+            boundImageIdentity = item?.streamIdentity()
+            boundThumbnailKey = null
+        }
+
+        override fun cancelImageRequests() {
+            imageRequests.cancel()
+        }
+
+        override fun pauseImageRequests() {
+            imageRequests.cancel(preserveRegistrations = true)
+        }
+
+        fun cancelImageWork() {
+            cancelImageRequests()
+            boundImageIdentity = null
+            boundThumbnailKey = null
+            boundStream = null
+            boundTags = emptyList()
+        }
+
+        fun bindThumbnail(item: Stream?) {
+            val stream = item ?: return
+            prepareStreamThumbnailImage(binding.thumbnail, stream)
+            restoreWarmStreamThumbnail(stream, binding.thumbnail)
+            val key = "${stream.thumbnailIdentity()}|generation=${stream.thumbnailGeneration}"
+            boundThumbnailKey = key
+            thumbnailLoadScheduler.runOrDefer(this@ViewHolder, binding.thumbnail) {
+                if (!binding.root.isAttachedToWindow ||
+                    boundImageIdentity != stream.streamIdentity() ||
+                    boundThumbnailKey != key
+                ) return@runOrDefer
+                loadStreamThumbnail(
+                    context = binding.root.context,
+                    imageView = binding.thumbnail,
+                    stream = stream,
+                    scheduleFreshRequest = { freshRequest ->
+                        thumbnailLoadScheduler.runOrDefer(this@ViewHolder, binding.thumbnail, freshRequest)
+                    },
+                )
+                    ?.let { imageRequests.replace(binding.thumbnail, it) }
+            }
+        }
 
         fun bind(item: Stream?) {
             val context = fragment.requireContext()
+            val uiPreferences = com.github.andreyasadchy.xtra.ui.common.FeedUiPreferencesStore.current(context)
+            boundStream = item
             val nextPreviewIdentity = item?.streamIdentity()
             if (boundPreviewIdentity != nextPreviewIdentity) {
                 (context.applicationContext as XtraApp).xtraModule.streamPreviewCoordinator
@@ -67,8 +163,7 @@ class StreamsShelfPagingAdapter(
                     return
                 }
 
-                root.setOnClickListener { (fragment.activity as? MainActivity)?.startStream(item) }
-                loadStreamThumbnail(context, thumbnail, item)
+                bindThumbnail(item)
                 thumbnail.contentDescription = item.title?.takeIf { it.isNotBlank() }
                     ?: context.getString(R.string.live)
                 liveBadge.visibility = View.VISIBLE
@@ -80,13 +175,13 @@ class StreamsShelfPagingAdapter(
                         count,
                         TwitchApiHelper.formatCount(
                             count,
-                            context.prefs().getBoolean(C.UI_TRUNCATE_VIEW_COUNT, true),
+                            uiPreferences.truncateViewCount,
                         ),
                     )
                 }.orEmpty()
                 viewers.visibility = if (viewers.text.isNullOrBlank()) View.GONE else View.VISIBLE
 
-                val uptimeText = if (context.prefs().getBoolean(C.UI_UPTIME, true)) {
+                val uptimeText = if (uiPreferences.showUptime) {
                     item.createdAt?.let { value ->
                         Instant.parseOrNull(value)?.let { createdAt ->
                             val uptime = Clock.System.now() - createdAt
@@ -102,7 +197,7 @@ class StreamsShelfPagingAdapter(
                 if (item.channelName != null) {
                     channel.visibility = View.VISIBLE
                     channel.text = if (item.channelLogin != null && !item.channelLogin.equals(item.channelName, true)) {
-                        when (context.prefs().getString(C.UI_NAME_DISPLAY, "0")) {
+                        when (uiPreferences.nameDisplay) {
                             "0" -> "${item.channelName}(${item.channelLogin})"
                             "1" -> item.channelName
                             else -> item.channelLogin
@@ -117,66 +212,67 @@ class StreamsShelfPagingAdapter(
                 category.text = item.gameName?.trim().orEmpty()
                 category.visibility = if (category.text.isNullOrBlank()) View.GONE else View.VISIBLE
 
-                val channelListener = View.OnClickListener {
-                    fragment.findNavController().navigate(
-                        ChannelPagerFragmentDirections.actionGlobalChannelPagerFragment(
-                            channelId = item.channelId,
-                            channelLogin = item.channelLogin,
-                            channelName = item.channelName,
-                            channelImage = item.channelImage,
-                            streamId = item.id,
-                        )
-                    )
-                }
                 if (item.channelImage != null) {
                     avatar.visibility = View.VISIBLE
-                    loadStreamProfileImage(context, avatar, item)
-                    avatar.setOnClickListener(channelListener)
+                    prepareStreamProfileImage(avatar, item)
+                    thumbnailLoadScheduler.runOrDefer(this@ViewHolder, avatar) {
+                        if (binding.root.isAttachedToWindow && boundImageIdentity == item.streamIdentity()) {
+                            loadStreamProfileImage(context, avatar, item)?.let {
+                                imageRequests.replace(binding.avatar, it)
+                            }
+                        }
+                    }
                 } else {
                     avatar.visibility = View.INVISIBLE
                     avatar.setImageDrawable(null)
                     avatar.tag = null
-                    avatar.setOnClickListener(null)
                 }
-                channel.setOnClickListener(channelListener)
-
-                category.setOnClickListener(if (item.gameName.isNullOrBlank()) null else View.OnClickListener {
-                    fragment.findNavController().navigate(
-                        GamePagerFragmentDirections.actionGlobalGamePagerFragment(
-                            gameId = item.gameId,
-                            gameSlug = item.gameSlug,
-                            gameName = item.gameName,
-                        )
-                    )
-                })
 
                 multiview.visibility = if (item.channelLogin.isNullOrBlank()) View.GONE else View.VISIBLE
-                multiview.setOnClickListener {
-                    (fragment.activity as? MainActivity)?.let { activity ->
-                        if (activity.playerFragment != null) activity.closePlayer()
-                    }
-                    fragment.findNavController().navigate(R.id.multiviewFragment, MultiviewFragment.arguments(item))
-                }
 
-                val tags = if (context.prefs().getBoolean(C.UI_TAGS, true)) item.tags.orEmpty().take(2) else emptyList()
+                val tags = if (uiPreferences.showTags) item.tags.orEmpty().take(2) else emptyList()
+                boundTags = tags
                 tagOne.text = tags.getOrNull(0).orEmpty()
                 tagOne.visibility = if (tags.isNotEmpty()) View.VISIBLE else View.GONE
-                tagOne.setOnClickListener(tags.getOrNull(0)?.let { tag -> View.OnClickListener { selectTag(tag) } })
                 tagTwo.text = tags.getOrNull(1).orEmpty()
                 tagTwo.visibility = if (tags.size > 1) View.VISIBLE else View.GONE
-                tagTwo.setOnClickListener(tags.getOrNull(1)?.let { tag -> View.OnClickListener { selectTag(tag) } })
             }
+        }
+
+        private fun openChannel(stream: Stream) {
+            fragment.findNavController().navigate(
+                ChannelPagerFragmentDirections.actionGlobalChannelPagerFragment(
+                    channelId = stream.channelId,
+                    channelLogin = stream.channelLogin,
+                    channelName = stream.channelName,
+                    channelImage = stream.channelImage,
+                    streamId = stream.id,
+                )
+            )
+        }
+
+        private fun openGame(stream: Stream) {
+            if (stream.gameName.isNullOrBlank()) return
+            fragment.findNavController().navigate(
+                GamePagerFragmentDirections.actionGlobalGamePagerFragment(
+                    gameId = stream.gameId,
+                    gameSlug = stream.gameSlug,
+                    gameName = stream.gameName,
+                )
+            )
+        }
+
+        private fun openMultiview(stream: Stream) {
+            (fragment.activity as? MainActivity)?.let { activity ->
+                if (activity.playerFragment != null) activity.closePlayer()
+            }
+            fragment.findNavController().navigate(R.id.multiviewFragment, MultiviewFragment.arguments(stream))
         }
 
         private fun reset() {
             with(binding) {
-                root.setOnClickListener(null)
-                avatar.setOnClickListener(null)
-                channel.setOnClickListener(null)
-                category.setOnClickListener(null)
-                multiview.setOnClickListener(null)
-                tagOne.setOnClickListener(null)
-                tagTwo.setOnClickListener(null)
+                boundStream = null
+                boundTags = emptyList()
                 avatar.visibility = View.INVISIBLE
                 avatar.setImageDrawable(null)
                 avatar.tag = null
@@ -209,6 +305,9 @@ class StreamsShelfPagingAdapter(
 
             override fun areContentsTheSame(oldItem: Stream, newItem: Stream): Boolean =
                 streamContentsSame(oldItem, newItem)
+
+            override fun getChangePayload(oldItem: Stream, newItem: Stream): Any? =
+                if (streamThumbnailOnlyChanged(oldItem, newItem)) StreamThumbnailChangedPayload else null
         }
     }
 }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/videos/FollowedVideosFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/videos/FollowedVideosFragment.kt
@@ -23,6 +23,7 @@ import com.github.andreyasadchy.xtra.model.ui.ChannelSort
 import com.github.andreyasadchy.xtra.model.ui.Video
 import com.github.andreyasadchy.xtra.ui.common.FragmentHost
 import com.github.andreyasadchy.xtra.ui.common.PagedListFragment
+import com.github.andreyasadchy.xtra.ui.common.PagerScrollStateAware
 import com.github.andreyasadchy.xtra.ui.common.Scrollable
 import com.github.andreyasadchy.xtra.ui.common.StreamPreloadViewportController
 import com.github.andreyasadchy.xtra.ui.common.StreamPreviewCandidate
@@ -37,7 +38,7 @@ import com.github.andreyasadchy.xtra.util.prefs
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 
-class FollowedVideosFragment : PagedListFragment(), Scrollable, Sortable, VideosSortDialog.OnFilter {
+class FollowedVideosFragment : PagedListFragment(), Scrollable, Sortable, PagerScrollStateAware, VideosSortDialog.OnFilter {
 
     private var _binding: CommonRecyclerViewLayoutBinding? = null
     private val binding get() = _binding!!
@@ -206,6 +207,12 @@ class FollowedVideosFragment : PagedListFragment(), Scrollable, Sortable, Videos
 
     override fun onNetworkRestored() {
         pagingAdapter.retry()
+    }
+
+    override fun onPagerScrollStateChanged(scrolling: Boolean) {
+        if (::videoPreviewViewportController.isInitialized) {
+            videoPreviewViewportController.onParentScrollStateChanged(scrolling)
+        }
     }
 
     override fun onResume() {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/game/GamePagerFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/game/GamePagerFragment.kt
@@ -42,6 +42,7 @@ import com.github.andreyasadchy.xtra.ui.common.BaseNetworkFragment
 import com.github.andreyasadchy.xtra.ui.common.FragmentHost
 import com.github.andreyasadchy.xtra.ui.common.Scrollable
 import com.github.andreyasadchy.xtra.ui.common.Sortable
+import com.github.andreyasadchy.xtra.ui.common.dispatchPagerScrollState
 import com.github.andreyasadchy.xtra.ui.game.GamePagerViewModel.Companion.GamePagerViewModelFactory
 import com.github.andreyasadchy.xtra.ui.games.GamesFragmentDirections
 import com.github.andreyasadchy.xtra.ui.login.TwitchWebLoginActivity
@@ -50,10 +51,10 @@ import com.github.andreyasadchy.xtra.ui.search.SearchPagerFragmentDirections
 import com.github.andreyasadchy.xtra.ui.settings.SettingsActivity
 import com.github.andreyasadchy.xtra.ui.settings.setTabCustomizationLongPress
 import com.github.andreyasadchy.xtra.util.C
+import com.github.andreyasadchy.xtra.util.configureForSmoothPaging
 import com.github.andreyasadchy.xtra.util.TwitchApiHelper
 import com.github.andreyasadchy.xtra.util.getAlertDialogBuilder
 import com.github.andreyasadchy.xtra.util.prefs
-import com.github.andreyasadchy.xtra.util.reduceDragSensitivity
 import com.github.andreyasadchy.xtra.util.tokenPrefs
 import com.google.android.material.appbar.CollapsingToolbarLayout
 import com.google.android.material.color.MaterialColors
@@ -253,6 +254,10 @@ class GamePagerFragment : BaseNetworkFragment(), Scrollable, FragmentHost {
             val adapter = GamePagerAdapter(this@GamePagerFragment, tabs)
             viewPager.adapter = adapter
             viewPager.registerOnPageChangeCallback(object : ViewPager2.OnPageChangeCallback() {
+                override fun onPageScrollStateChanged(state: Int) {
+                    dispatchPagerScrollState(state != ViewPager2.SCROLL_STATE_IDLE)
+                }
+
                 override fun onPageSelected(position: Int) {
                     viewPager.doOnLayout {
                         childFragmentManager.findFragmentByTag("f${position}")?.let { fragment ->
@@ -285,8 +290,7 @@ class GamePagerFragment : BaseNetworkFragment(), Scrollable, FragmentHost {
                 )
                 firstLaunch = false
             }
-            viewPager.offscreenPageLimit = adapter.itemCount
-            viewPager.reduceDragSensitivity()
+            viewPager.configureForSmoothPaging()
             TabLayoutMediator(tabLayout, viewPager) { tab, position ->
                 tab.text = when (tabs.getOrNull(position)) {
                     "0" -> getString(R.string.videos)
@@ -461,6 +465,7 @@ class GamePagerFragment : BaseNetworkFragment(), Scrollable, FragmentHost {
     }
 
     override fun onDestroyView() {
+        dispatchPagerScrollState(false)
         super.onDestroyView()
         _binding = null
     }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/game/videos/GameVideosFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/game/videos/GameVideosFragment.kt
@@ -24,6 +24,7 @@ import com.github.andreyasadchy.xtra.model.ui.GameSort
 import com.github.andreyasadchy.xtra.model.ui.Video
 import com.github.andreyasadchy.xtra.ui.common.FragmentHost
 import com.github.andreyasadchy.xtra.ui.common.PagedListFragment
+import com.github.andreyasadchy.xtra.ui.common.PagerScrollStateAware
 import com.github.andreyasadchy.xtra.ui.common.Scrollable
 import com.github.andreyasadchy.xtra.ui.common.Sortable
 import com.github.andreyasadchy.xtra.ui.common.StreamPreloadViewportController
@@ -39,7 +40,7 @@ import com.github.andreyasadchy.xtra.util.prefs
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 
-class GameVideosFragment : PagedListFragment(), Scrollable, Sortable, VideosSortDialog.OnFilter {
+class GameVideosFragment : PagedListFragment(), Scrollable, Sortable, PagerScrollStateAware, VideosSortDialog.OnFilter {
 
     private var _binding: CommonRecyclerViewLayoutBinding? = null
     private val binding get() = _binding!!
@@ -273,6 +274,12 @@ class GameVideosFragment : PagedListFragment(), Scrollable, Sortable, VideosSort
 
     override fun onNetworkRestored() {
         pagingAdapter.retry()
+    }
+
+    override fun onPagerScrollStateChanged(scrolling: Boolean) {
+        if (::videoPreviewViewportController.isInitialized) {
+            videoPreviewViewportController.onParentScrollStateChanged(scrolling)
+        }
     }
 
     override fun onResume() {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/main/KeepStateFragmentNavigator.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/main/KeepStateFragmentNavigator.kt
@@ -1,0 +1,378 @@
+package com.github.andreyasadchy.xtra.ui.main
+
+import android.content.Context
+import android.os.Bundle
+import android.util.Log
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentManager
+import androidx.fragment.app.FragmentTransaction
+import androidx.lifecycle.Lifecycle
+import androidx.navigation.NavBackStackEntry
+import androidx.navigation.NavOptions
+import androidx.navigation.Navigator
+import androidx.navigation.fragment.FragmentNavigator
+import com.github.andreyasadchy.xtra.R
+
+/**
+ * Fragment navigator used by the main screen.
+ *
+ * The stock navigator replaces the host's fragment on every destination change. That is a poor fit
+ * for the six long-lived bottom tabs: replacing a tab destroys its entire view hierarchy and makes
+ * the next click synchronously rebuild nested pagers and shelves. Keep those fragments attached and
+ * switch them with hide/show instead. Detail destinations are removed when navigation moves past
+ * them so a long browsing session does not retain every detail view; the parent tab remains alive.
+ */
+@Navigator.Name("fragment")
+class KeepStateFragmentNavigator(
+    private val appContext: Context,
+    private val fragmentManager: FragmentManager,
+    private val hostContainerId: Int,
+) : FragmentNavigator(appContext, fragmentManager, hostContainerId) {
+
+    var onNavigationTransactionCommitted: ((destinationId: Int?) -> Unit)? = null
+
+    private val entryFragments = mutableMapOf<String, Fragment>()
+    private val pendingFragments = mutableMapOf<String, Fragment>()
+    private val preservedFragments = mutableMapOf<Int, Fragment>()
+    private val lastUsedTabAt = mutableMapOf<Int, Long>()
+    private val destinationByTag = mutableMapOf<String, Int>()
+    private var usageSequence = 0L
+    private var hiddenTabTrimPending = false
+
+    private val tabDestinationIds = setOf(
+        R.id.rootGamesFragment,
+        R.id.rootDiscoverFragment,
+        R.id.rootTopFragment,
+        R.id.followPagerFragment,
+        R.id.savedPagerFragment,
+        R.id.statisticsFragment,
+    )
+
+    override fun navigate(
+        entries: List<NavBackStackEntry>,
+        navOptions: NavOptions?,
+        navigatorExtras: Navigator.Extras?,
+    ) {
+        if (fragmentManager.isStateSaved || entries.isEmpty()) {
+            if (fragmentManager.isStateSaved) {
+                Log.i(TAG, "Ignoring navigate() because FragmentManager has already saved state")
+            }
+            return
+        }
+
+        val currentEntry = state.backStack.value.lastOrNull()
+        var outgoing = currentEntry?.let(::findFragment)
+            ?: fragmentManager.primaryNavigationFragment
+        val transaction = fragmentManager.beginTransaction().setReorderingAllowed(true)
+        val outgoingDestinationId = currentEntry?.destination?.id
+        var transactionOutgoingDestinationId = outgoingDestinationId
+        val createdInThisNavigation = mutableSetOf<Fragment>()
+
+        entries.forEach { entry ->
+            val destinationId = entry.destination.id
+            val fragment = findFragment(entry) ?: createFragment(entry).also {
+                registerNewFragment(entry, it)
+                createdInThisNavigation += it
+            }
+
+            if (outgoing != null && outgoing !== fragment) {
+                if (transactionOutgoingDestinationId != null && isTabDestination(transactionOutgoingDestinationId)) {
+                    transaction.hide(outgoing)
+                    transaction.setMaxLifecycle(outgoing, Lifecycle.State.CREATED)
+                } else if (outgoing !in createdInThisNavigation) {
+                    transaction.remove(outgoing)
+                    forget(outgoing)
+                }
+            }
+
+            if (fragment.isAdded || (fragment !in createdInThisNavigation && isPending(fragment))) {
+                transaction.show(fragment)
+            } else {
+                transaction.add(hostContainerId, fragment, fragment.tag ?: entry.id)
+            }
+
+            outgoing = fragment
+            transactionOutgoingDestinationId = destinationId
+        }
+
+        val incoming = requireNotNull(outgoing)
+        val incomingDestinationId = entries.last().destination.id
+        evictLeastRecentlyUsedTabIfNeeded(
+            transaction = transaction,
+            incomingDestinationId = incomingDestinationId,
+            outgoing = outgoing,
+        )
+        if (shouldAnimate(outgoingDestinationId, incomingDestinationId, navOptions)) {
+            transaction.setCustomAnimations(
+                navOptions?.enterAnim ?: 0,
+                navOptions?.exitAnim ?: 0,
+                navOptions?.popEnterAnim ?: 0,
+                navOptions?.popExitAnim ?: 0,
+            )
+        }
+        transaction.setPrimaryNavigationFragment(incoming)
+        transaction.setMaxLifecycle(incoming, Lifecycle.State.RESUMED)
+
+        val entriesToComplete = entries.toList()
+        transaction.runOnCommit {
+            entriesToComplete.forEach { entry ->
+                pendingFragments.remove(entry.id)
+                state.markTransitionComplete(entry)
+            }
+            onNavigationTransactionCommitted?.invoke(incomingDestinationId)
+        }
+        transaction.commit()
+
+        entries.forEach { entry ->
+            state.pushWithTransition(entry)
+        }
+    }
+
+    override fun onLaunchSingleTop(backStackEntry: NavBackStackEntry) {
+        if (fragmentManager.isStateSaved) {
+            Log.i(TAG, "Ignoring onLaunchSingleTop() because FragmentManager has already saved state")
+            return
+        }
+
+        val currentEntry = state.backStack.value.lastOrNull()
+        val currentFragment = currentEntry?.let(::findFragment)
+        if (currentFragment != null &&
+            currentEntry.destination.id == backStackEntry.destination.id &&
+            isTabDestination(backStackEntry.destination.id)
+        ) {
+            entryFragments[backStackEntry.id] = currentFragment
+            destinationByTag[backStackEntry.id] = backStackEntry.destination.id
+            if (isTabDestination(backStackEntry.destination.id)) {
+                preservedFragments[backStackEntry.destination.id] = currentFragment
+                markTabUsed(backStackEntry.destination.id)
+            }
+            state.onLaunchSingleTop(backStackEntry)
+            return
+        }
+
+        // This is only a fallback for callers that use launchSingleTop outside the bottom bar. The
+        // stock implementation remains the safest behavior when there is no reusable fragment.
+        super.onLaunchSingleTop(backStackEntry)
+    }
+
+    override fun popBackStack(popUpTo: NavBackStackEntry, savedState: Boolean) {
+        if (fragmentManager.isStateSaved) {
+            Log.i(TAG, "Ignoring popBackStack() because FragmentManager has already saved state")
+            return
+        }
+
+        val backStack = state.backStack.value
+        val popUpToIndex = backStack.indexOf(popUpTo)
+        if (popUpToIndex < 0) {
+            Log.w(TAG, "Ignoring popBackStack() for an entry not in the navigator back stack")
+            return
+        }
+
+        val poppedEntries = backStack.subList(popUpToIndex, backStack.size).toList()
+        val incomingEntry = backStack.getOrNull(popUpToIndex - 1)
+        val transaction = fragmentManager.beginTransaction().setReorderingAllowed(true)
+
+        poppedEntries.asReversed().forEach { entry ->
+            val fragment = findFragment(entry) ?: return@forEach
+            if (savedState && isTabDestination(entry.destination.id)) {
+                transaction.hide(fragment)
+                transaction.setMaxLifecycle(fragment, Lifecycle.State.CREATED)
+            } else {
+                transaction.remove(fragment)
+                forget(fragment)
+                if (isTabDestination(entry.destination.id)) {
+                    preservedFragments.remove(entry.destination.id)
+                    lastUsedTabAt.remove(entry.destination.id)
+                }
+            }
+        }
+
+        incomingEntry?.let { entry ->
+            val existingFragment = findFragment(entry)
+            val fragment = existingFragment ?: createFragment(entry).also { registerNewFragment(entry, it) }
+            if (fragment.isAdded || (existingFragment != null && isPending(fragment))) {
+                transaction.show(fragment)
+            } else {
+                transaction.add(hostContainerId, fragment, fragment.tag ?: entry.id)
+            }
+            transaction.setMaxLifecycle(fragment, Lifecycle.State.RESUMED)
+            transaction.setPrimaryNavigationFragment(fragment)
+        }
+
+        transaction.runOnCommit {
+            poppedEntries.forEach { entry ->
+                pendingFragments.remove(entry.id)
+                state.markTransitionComplete(entry)
+            }
+            incomingEntry?.let {
+                pendingFragments.remove(it.id)
+                state.markTransitionComplete(it)
+            }
+            onNavigationTransactionCommitted?.invoke(incomingEntry?.destination?.id)
+        }
+        transaction.commit()
+        state.popWithTransition(popUpTo, savedState)
+    }
+
+    override fun onSaveState(): Bundle? {
+        val state = super.onSaveState() ?: Bundle()
+        val tags = ArrayList<String>()
+        val destinationIds = ArrayList<Int>()
+        destinationByTag.forEach { (tag, destinationId) ->
+            if (fragmentManager.findFragmentByTag(tag) != null) {
+                tags += tag
+                destinationIds += destinationId
+            }
+        }
+        state.putStringArrayList(KEY_DESTINATION_TAGS, tags)
+        state.putIntegerArrayList(KEY_DESTINATION_IDS, destinationIds)
+        return state
+    }
+
+    override fun onRestoreState(savedState: Bundle) {
+        super.onRestoreState(savedState)
+        val tags = savedState.getStringArrayList(KEY_DESTINATION_TAGS).orEmpty()
+        val destinationIds = savedState.getIntegerArrayList(KEY_DESTINATION_IDS).orEmpty()
+        tags.zip(destinationIds).forEach { (tag, destinationId) ->
+            destinationByTag[tag] = destinationId
+        }
+    }
+
+    private fun createFragment(entry: NavBackStackEntry): Fragment {
+        val destination = entry.destination as Destination
+        var className = destination.className
+        if (className.startsWith('.')) {
+            className = appContext.packageName + className
+        }
+        return instantiateFragment(appContext, fragmentManager, className, entry.arguments).apply {
+            arguments = entry.arguments
+        }
+    }
+
+    private fun registerNewFragment(entry: NavBackStackEntry, fragment: Fragment) {
+        pendingFragments[entry.id] = fragment
+        entryFragments[entry.id] = fragment
+        destinationByTag[entry.id] = entry.destination.id
+        if (isTabDestination(entry.destination.id)) {
+            preservedFragments[entry.destination.id] = fragment
+            markTabUsed(entry.destination.id)
+        }
+    }
+
+    private fun isPending(fragment: Fragment): Boolean = pendingFragments.values.any { it === fragment }
+
+    private fun forget(fragment: Fragment) {
+        entryFragments.filterValues { it === fragment }.keys.forEach(entryFragments::remove)
+        pendingFragments.filterValues { it === fragment }.keys.forEach(pendingFragments::remove)
+        fragment.tag?.let(destinationByTag::remove)
+    }
+
+    private fun findFragment(entry: NavBackStackEntry): Fragment? {
+        entryFragments[entry.id]?.let { fragment ->
+            if (isTabDestination(entry.destination.id)) markTabUsed(entry.destination.id)
+            return fragment
+        }
+        fragmentManager.findFragmentByTag(entry.id)?.let { fragment ->
+            remember(entry, fragment)
+            return fragment
+        }
+        if (isTabDestination(entry.destination.id)) {
+            preservedFragments[entry.destination.id]?.let { fragment ->
+                remember(entry, fragment)
+                return fragment
+            }
+            destinationByTag.entries.firstOrNull { it.value == entry.destination.id }
+                ?.key
+                ?.let(fragmentManager::findFragmentByTag)
+                ?.let { fragment ->
+                    remember(entry, fragment)
+                    return fragment
+                }
+        }
+        return null
+    }
+
+    private fun remember(entry: NavBackStackEntry, fragment: Fragment) {
+        entryFragments[entry.id] = fragment
+        destinationByTag[fragment.tag ?: entry.id] = entry.destination.id
+        if (isTabDestination(entry.destination.id)) {
+            preservedFragments[entry.destination.id] = fragment
+            markTabUsed(entry.destination.id)
+        }
+    }
+
+    private fun markTabUsed(destinationId: Int) {
+        usageSequence++
+        lastUsedTabAt[destinationId] = usageSequence
+    }
+
+    private fun evictLeastRecentlyUsedTabIfNeeded(
+        transaction: FragmentTransaction,
+        incomingDestinationId: Int,
+        outgoing: Fragment?,
+    ) {
+        if (!isTabDestination(incomingDestinationId) ||
+            preservedFragments.size <= MAX_PRESERVED_TABS
+        ) {
+            return
+        }
+
+        val candidate = preservedFragments.entries
+            .asSequence()
+            .filter { (destinationId, fragment) ->
+                destinationId != incomingDestinationId &&
+                    fragment !== outgoing &&
+                    fragment.isAdded &&
+                    fragment.isHidden &&
+                    fragment.lifecycle.currentState == Lifecycle.State.CREATED &&
+                    !isPending(fragment)
+            }
+            .minByOrNull { (destinationId, _) -> lastUsedTabAt[destinationId] ?: Long.MIN_VALUE }
+            ?: return
+
+        transaction.remove(candidate.value)
+        preservedFragments.remove(candidate.key)
+        lastUsedTabAt.remove(candidate.key)
+        forget(candidate.value)
+    }
+
+    /** Drop hidden root views when Android reports process memory pressure. */
+    fun trimHiddenTabs() {
+        if (fragmentManager.isStateSaved || hiddenTabTrimPending) return
+        val hiddenTabs = preservedFragments.entries.filter { (_, fragment) ->
+            fragment.isAdded && fragment.isHidden && fragment.lifecycle.currentState == Lifecycle.State.CREATED
+        }
+        if (hiddenTabs.isEmpty()) return
+
+        hiddenTabTrimPending = true
+        val transaction = fragmentManager.beginTransaction().setReorderingAllowed(true)
+        hiddenTabs.forEach { (destinationId, fragment) ->
+            transaction.remove(fragment)
+            preservedFragments.remove(destinationId)
+            lastUsedTabAt.remove(destinationId)
+            forget(fragment)
+        }
+        transaction.runOnCommit { hiddenTabTrimPending = false }
+        transaction.commit()
+    }
+
+    private fun isTabDestination(destinationId: Int): Boolean = destinationId in tabDestinationIds
+
+    private fun shouldAnimate(
+        outgoingDestinationId: Int?,
+        incomingDestinationId: Int,
+        navOptions: NavOptions?,
+    ): Boolean {
+        if (navOptions == null) return false
+        return !(outgoingDestinationId != null &&
+            isTabDestination(outgoingDestinationId) &&
+            isTabDestination(incomingDestinationId))
+    }
+
+    private companion object {
+        const val TAG = "KeepStateNavigator"
+        const val KEY_DESTINATION_TAGS = "xtra:destinationTags"
+        const val KEY_DESTINATION_IDS = "xtra:destinationIds"
+        const val MAX_PRESERVED_TABS = 3
+    }
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/main/MainActivity.kt
@@ -5,6 +5,7 @@ import android.app.ActivityOptions
 import android.app.PictureInPictureParams
 import android.app.admin.DevicePolicyManager
 import android.content.BroadcastReceiver
+import android.content.ComponentCallbacks2
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
@@ -89,6 +90,7 @@ import com.github.andreyasadchy.xtra.util.C
 import com.github.andreyasadchy.xtra.util.SettingsUpdateIndicator
 import com.github.andreyasadchy.xtra.util.SettingsMigration
 import com.github.andreyasadchy.xtra.util.TwitchApiHelper
+import com.github.andreyasadchy.xtra.util.UiInteractionGovernor
 import com.github.andreyasadchy.xtra.util.updater.UpdateRelease
 import com.github.andreyasadchy.xtra.util.updater.UpdateReleaseHistory
 import com.github.andreyasadchy.xtra.util.updater.UpdateCheckScheduler
@@ -143,6 +145,12 @@ class MainActivity : AppCompatActivity() {
     private var updateNotificationPermissionLauncher: ActivityResultLauncher<String>? = null
     private var fragmentLifecycleCallbacks: FragmentManager.FragmentLifecycleCallbacks? = null
     private var startupTasksReady = false
+    private var pendingBottomNavigationItemId: Int? = null
+    private var bottomNavigationTransactionInFlight = false
+    private var bottomNavigationDestinationInFlight: Int? = null
+    private var bottomNavigationDrainPosted = false
+    private val bottomNavigationInteractionSource = Any()
+    private var keepStateNavigator: KeepStateFragmentNavigator? = null
 
     //Lifecycle methods
 
@@ -431,7 +439,10 @@ class MainActivity : AppCompatActivity() {
                 repeatOnLifecycle(Lifecycle.State.STARTED) {
                     viewModel.playbackStates.collectLatest { states ->
                         val savedState = states.firstOrNull()
-                        if (savedState != null) {
+                        // This flow is only for restoring a player after process/activity
+                        // recreation. A user-initiated start can overlap a pending database
+                        // read; never replace that player with a second restored fragment.
+                        if (savedState != null && !viewModel.isPlayerOpened && playerFragment == null) {
                             (playerFragment as? Media3PlayerFragment)?.close() ?: (playerFragment as? PlayerFragment)?.close()
                             val fragment = when (prefs.getString(C.PLAYER, C.EXOPLAYER)) {
                                 C.MEDIA_PLAYER -> MediaPlayerFragment()
@@ -446,6 +457,7 @@ class MainActivity : AppCompatActivity() {
                             (application as XtraApp).xtraModule.streamFeedRefreshCoordinator.playbackEntered(
                                 isLive = savedState.type == BasePlaybackService.STREAM,
                             )
+                            (application as XtraApp).xtraModule.streamPreviewCoordinator.onFullscreenPlaybackStarted()
                             startPlayer(fragment)
                         }
                     }
@@ -810,7 +822,17 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
+    override fun onTrimMemory(level: Int) {
+        super.onTrimMemory(level)
+        if (level >= ComponentCallbacks2.TRIM_MEMORY_RUNNING_LOW) {
+            keepStateNavigator?.trimHiddenTabs()
+        }
+    }
+
     override fun onDestroy() {
+        UiInteractionGovernor.setInteracting(bottomNavigationInteractionSource, false)
+        keepStateNavigator?.onNavigationTransactionCommitted = null
+        keepStateNavigator = null
         networkSnackbar?.dismiss()
         networkSnackbar = null
         updateNotificationSnackbar?.dismiss()
@@ -1193,9 +1215,18 @@ class MainActivity : AppCompatActivity() {
 
     private fun startPlayer(fragment: Fragment) {
         playerFragment = fragment
-        supportFragmentManager.beginTransaction()
-            .replace(R.id.playerContainer, fragment).commit()
         viewModel.isPlayerOpened = true
+        val transaction = supportFragmentManager.beginTransaction()
+            .setReorderingAllowed(true)
+            .replace(R.id.playerContainer, fragment)
+        if (supportFragmentManager.findFragmentById(R.id.playerContainer) != null) {
+            // A player can be minimized when the next stream is selected. Commit the replacement
+            // synchronously so the transformed old player cannot draw one more frame over the
+            // new player's handoff cover.
+            transaction.commitNow()
+        } else {
+            transaction.commit()
+        }
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S &&
             packageManager.hasSystemFeature(PackageManager.FEATURE_PICTURE_IN_PICTURE) &&
             prefs.getBoolean(C.PLAYER_PICTURE_IN_PICTURE, true)
@@ -1226,11 +1257,13 @@ class MainActivity : AppCompatActivity() {
     }
 
     fun onPlayerEnteredPlayback(isLive: Boolean = true, channelLogin: String? = null) {
+        viewModel.isPlayerOpened = true
         (application as XtraApp).xtraModule.streamFeedRefreshCoordinator.playbackEntered(isLive)
         (application as XtraApp).xtraModule.streamPreviewCoordinator.onFullscreenPlaybackStarted(channelLogin)
     }
 
     fun onPlayerChangedPlayback(isLive: Boolean) {
+        viewModel.isPlayerOpened = true
         (application as XtraApp).xtraModule.streamFeedRefreshCoordinator.playbackChanged(isLive)
         (application as XtraApp).xtraModule.streamPreviewCoordinator.onFullscreenPlaybackStarted()
     }
@@ -1331,6 +1364,7 @@ class MainActivity : AppCompatActivity() {
 
     private fun initNavigation() {
         navController = (supportFragmentManager.findFragmentById(R.id.navHostFragment) as NavHostFragment).navController
+        navController.setOnBackPressedDispatcher(onBackPressedDispatcher)
         val tabList = prefs.getString(C.UI_NAVIGATION_TAB_LIST, null).let { tabPref ->
             val defaultTabs = C.DEFAULT_NAVIGATION_TAB_LIST.split(',')
             if (tabPref != null) {
@@ -1355,6 +1389,23 @@ class MainActivity : AppCompatActivity() {
                 defaultItem == "5" -> it.setStartDestination(R.id.statisticsFragment)
             }
         }, null)
+        keepStateNavigator = navController.navigatorProvider
+            .getNavigator<androidx.navigation.fragment.FragmentNavigator>("fragment")
+            .let { it as? KeepStateFragmentNavigator }
+            ?.also { navigator ->
+                navigator.onNavigationTransactionCommitted = { destinationId ->
+                    binding.navBar.post {
+                        if (bottomNavigationTransactionInFlight &&
+                            destinationId == bottomNavigationDestinationInFlight
+                        ) {
+                            UiInteractionGovernor.setInteracting(bottomNavigationInteractionSource, false)
+                            bottomNavigationTransactionInFlight = false
+                            bottomNavigationDestinationInFlight = null
+                            drainBottomNavigation()
+                        }
+                    }
+                }
+            }
         binding.navBar.apply {
             if (tabList.any { it.split(':')[2] != "0" }) {
                 tabList.forEach {
@@ -1392,16 +1443,47 @@ class MainActivity : AppCompatActivity() {
                 }
             }
             setOnItemSelectedListener {
-                NavigationUI.onNavDestinationSelected(it, navController)
+                pendingBottomNavigationItemId = it.itemId
+                drainBottomNavigation()
                 return@setOnItemSelectedListener true
             }
             setOnItemReselectedListener {
+                if (bottomNavigationTransactionInFlight) return@setOnItemReselectedListener
                 if (!navController.popBackStack(it.itemId, false)) {
-                    val currentFragment = supportFragmentManager.findFragmentById(R.id.navHostFragment)?.childFragmentManager?.fragments?.getOrNull(0)
-                    if (currentFragment is Scrollable) {
+                    val currentFragment = (supportFragmentManager.findFragmentById(R.id.navHostFragment) as? NavHostFragment)
+                        ?.childFragmentManager
+                        ?.primaryNavigationFragment
+                    if (currentFragment is Scrollable && currentFragment.isResumed && currentFragment.view != null) {
                         currentFragment.scrollToTop()
                     }
                 }
+            }
+        }
+    }
+
+    private fun drainBottomNavigation() {
+        if (bottomNavigationDrainPosted) return
+        bottomNavigationDrainPosted = true
+        binding.navBar.post {
+            bottomNavigationDrainPosted = false
+            if (isFinishing || isDestroyed || bottomNavigationTransactionInFlight) return@post
+
+            val itemId = pendingBottomNavigationItemId ?: return@post
+            if (navController.currentDestination?.id == itemId) {
+                pendingBottomNavigationItemId = null
+                return@post
+            }
+
+            val item = binding.navBar.menu.findItem(itemId) ?: return@post
+            pendingBottomNavigationItemId = null
+            bottomNavigationTransactionInFlight = true
+            bottomNavigationDestinationInFlight = itemId
+            UiInteractionGovernor.setInteracting(bottomNavigationInteractionSource, true)
+            if (!NavigationUI.onNavDestinationSelected(item, navController)) {
+                bottomNavigationTransactionInFlight = false
+                bottomNavigationDestinationInFlight = null
+                UiInteractionGovernor.setInteracting(bottomNavigationInteractionSource, false)
+                drainBottomNavigation()
             }
         }
     }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/main/MainNavHostFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/main/MainNavHostFragment.kt
@@ -1,0 +1,15 @@
+package com.github.andreyasadchy.xtra.ui.main
+
+import androidx.navigation.Navigator
+import androidx.navigation.fragment.FragmentNavigator
+import androidx.navigation.fragment.NavHostFragment
+
+/** Nav host that keeps the main tab fragment views attached between tab switches. */
+@Suppress("DEPRECATION", "OVERRIDE_DEPRECATION")
+class MainNavHostFragment : NavHostFragment() {
+
+    @Suppress("DEPRECATION")
+    override fun createFragmentNavigator(): Navigator<out FragmentNavigator.Destination> {
+        return KeepStateFragmentNavigator(requireContext(), childFragmentManager, id)
+    }
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/multiview/CombinedChatFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/multiview/CombinedChatFragment.kt
@@ -391,7 +391,6 @@ private class CombinedChatAdapter(
         channelId: String?,
         private val identity: String,
     ) {
-        private val singleMessage = mutableListOf<ChatMessage>()
         private val adapter: ChatAdapter
 
         init {
@@ -403,7 +402,7 @@ private class CombinedChatAdapter(
                 isLightTheme = getBoolean(0, false)
             }
             adapter = ChatAdapter(
-                messages = singleMessage,
+                initialMessages = emptyList(),
                 localTwitchEmotes = session.localTwitchEmotes,
                 thirdPartyEmotes = session.thirdPartyEmotes,
                 globalBadges = session.globalBadges,
@@ -432,7 +431,6 @@ private class CombinedChatAdapter(
                 showPersonalEmotes = preferences.getBoolean(C.CHAT_SHOW_PERSONAL_EMOTES, true),
                 showSystemMessageEmotes = preferences.getBoolean(C.CHAT_SYSTEM_MESSAGE_EMOTES, true),
                 chatUrl = null,
-                getEmoteBytes = session::getEmoteBytes,
                 fragment = fragment,
                 backgroundColor = MaterialColors.getColor(fragment.requireView(), com.google.android.material.R.attr.colorSurface),
                 dialogBackgroundColor = MaterialColors.getColor(fragment.requireView(), com.google.android.material.R.attr.colorSurfaceContainerLow),
@@ -473,9 +471,7 @@ private class CombinedChatAdapter(
         }
 
         fun bind(textView: TextView, message: ChatMessage) {
-            synchronized(singleMessage) {
-                if (singleMessage.isEmpty()) singleMessage += message else singleMessage[0] = message
-            }
+            adapter.setDirectMessage(message)
             adapter.onBindViewHolder(adapter.ViewHolder(textView), 0)
         }
 

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/multiview/chat/CombinedChatViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/multiview/chat/CombinedChatViewModel.kt
@@ -92,34 +92,17 @@ class CombinedChatViewModel(
     }
 
     private fun observe(session: ChannelSession) {
-        // ChatViewModel.onMessage waits for this collector. Keep the work off Main,
-        // but subscribe before startLive can deliver the first message.
+        // Keep combined-chat mutation handling off Main, but subscribe before startLive
+        // so the channel's ordered mutation stream is consumed from its first event.
         session.jobs += viewModelScope.launch(Dispatchers.Default, start = CoroutineStart.UNDISPATCHED) {
-            session.viewModel.newMessage.collect { result ->
-                if (result.third > 0) {
-                    session.viewModel.trimMessageOverflow()
-                }
-                append(session, result.first)
-            }
-        }
-        session.jobs += viewModelScope.launch(Dispatchers.Default, start = CoroutineStart.UNDISPATCHED) {
-            session.viewModel.addMessages.collect { result ->
-                prependHistory(session, result.first)
-            }
-        }
-        session.jobs += viewModelScope.launch {
-            session.viewModel.removeMessages.collect {
-                synchronized(messages) {
-                    var remaining = it
-                    val iterator = messages.listIterator()
-                    while (iterator.hasNext() && remaining > 0) {
-                        if (iterator.next().identity == session.identity) {
-                            iterator.remove()
-                            remaining--
-                        }
+            session.viewModel.chatMutations.collect { mutation ->
+                when (mutation) {
+                    is ChatViewModel.ChatMutation.Append -> {
+                        append(session, mutation.messages, mutation.trimCount)
                     }
+                    is ChatViewModel.ChatMutation.Prepend -> prependHistory(session, mutation.messages)
+                    is ChatViewModel.ChatMutation.Clear -> removeSessionMessages(session, Int.MAX_VALUE)
                 }
-                _updates.tryEmit(Unit)
             }
         }
         session.jobs += viewModelScope.launch {
@@ -193,10 +176,22 @@ class CombinedChatViewModel(
         session.networkActive = true
     }
 
-    private fun append(session: ChannelSession, message: ChatMessage) {
+    private fun append(session: ChannelSession, incoming: List<ChatMessage>, trimCount: Int) {
+        if (incoming.isEmpty() && trimCount <= 0) return
         synchronized(messages) {
-            if (message.id != null && messages.any { it.identity == session.identity && it.message.id == message.id }) return
-            messages += CombinedChatMessage(session.identity, displayName(session.stream), message, sequence++)
+            var remaining = trimCount
+            val iterator = messages.listIterator()
+            while (iterator.hasNext() && remaining > 0) {
+                if (iterator.next().identity == session.identity) {
+                    iterator.remove()
+                    remaining--
+                }
+            }
+            incoming.forEach { message ->
+                if (message.id == null || messages.none { it.identity == session.identity && it.message.id == message.id }) {
+                    messages += CombinedChatMessage(session.identity, displayName(session.stream), message, sequence++)
+                }
+            }
             while (messages.size > MAX_MESSAGES) messages.removeAt(0)
         }
         _updates.tryEmit(Unit)
@@ -211,6 +206,21 @@ class CombinedChatViewModel(
             }
             messages.sortWith(compareBy<CombinedChatMessage> { it.message.timestamp ?: Long.MAX_VALUE }.thenBy { it.sequence })
             while (messages.size > MAX_MESSAGES) messages.removeAt(0)
+        }
+        _updates.tryEmit(Unit)
+    }
+
+    private fun removeSessionMessages(session: ChannelSession, count: Int) {
+        if (count <= 0) return
+        synchronized(messages) {
+            var remaining = count
+            val iterator = messages.listIterator()
+            while (iterator.hasNext() && remaining > 0) {
+                if (iterator.next().identity == session.identity) {
+                    iterator.remove()
+                    remaining--
+                }
+            }
         }
         _updates.tryEmit(Unit)
     }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/ExoPlayerFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/ExoPlayerFragment.kt
@@ -13,6 +13,7 @@ import android.os.IBinder
 import android.text.format.DateUtils
 import android.util.Log
 import android.view.View
+import android.widget.FrameLayout
 import android.widget.HorizontalScrollView
 import android.widget.TextView
 import android.widget.Toast
@@ -68,6 +69,7 @@ class ExoPlayerFragment : PlayerFragment() {
     private var liveSurfaceRestoreListener: Player.Listener? = null
     private var liveSurfaceRestoreTimeout: Runnable? = null
     private var clipEditorCoverTimeout: Runnable? = null
+    private var videoOutputCover: View? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -79,6 +81,19 @@ class ExoPlayerFragment : PlayerFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        val outputCover = View(requireContext()).apply {
+            layoutParams = FrameLayout.LayoutParams(
+                FrameLayout.LayoutParams.MATCH_PARENT,
+                FrameLayout.LayoutParams.MATCH_PARENT,
+            )
+            setBackgroundColor(Color.BLACK)
+            importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_NO
+        }
+        videoOutputCover = outputCover
+        // Keep the SurfaceView renderer for lower composition overhead. The cover is a normal
+        // view above it and remains visible until the player confirms a new decoded frame.
+        binding.aspectRatioFrameLayout.addView(outputCover)
+        binding.playerSurface.visibility = View.GONE
         childFragmentManager.setFragmentResultListener(
             ClipEditorDialogFragment.RESULT_KEY,
             viewLifecycleOwner,
@@ -235,10 +250,14 @@ class ExoPlayerFragment : PlayerFragment() {
             override fun onTrackSelectionParametersChanged(parameters: TrackSelectionParameters) {
                 if (isClipEditorVisible()) return
                 if (parameters.disabledTrackTypes.contains(androidx.media3.common.C.TRACK_TYPE_VIDEO)) {
-                    binding.playerSurface.visibility = View.GONE
+                    setVideoOutputVisible(false)
                 } else {
-                    binding.playerSurface.visibility = View.VISIBLE
+                    setVideoOutputVisible(true)
                 }
+            }
+
+            override fun onRenderedFirstFrame() {
+                hideVideoOutputCover()
             }
         }
         val serviceListener = object : ExoPlayerService.Listener {
@@ -356,13 +375,20 @@ class ExoPlayerFragment : PlayerFragment() {
                                 if (player == null) {
                                     false
                                 } else {
-                                    binding.playerSurface.visibility = View.VISIBLE
+                                    showVideoOutputCover()
+                                    setVideoOutputVisible(true)
                                     player.setVideoSurfaceView(binding.playerSurface)
                                     true
                                 }
                             }
                             if (!restored) {
-                                connectedService.player?.setVideoSurfaceView(binding.playerSurface)
+                                showVideoOutputCover()
+                                connectedService.player?.let { player ->
+                                    if (!player.trackSelectionParameters.disabledTrackTypes.contains(androidx.media3.common.C.TRACK_TYPE_VIDEO)) {
+                                        setVideoOutputVisible(true)
+                                        player.setVideoSurfaceView(binding.playerSurface)
+                                    }
+                                }
                             }
                         } else {
                             pauseLiveClipPlayback()
@@ -564,7 +590,7 @@ class ExoPlayerFragment : PlayerFragment() {
         livePlayer?.playWhenReady = false
         livePlayer?.pause()
         clipDebug("live player paused")
-        binding.playerSurface.visibility = View.GONE
+        setVideoOutputVisible(false)
         clipDebug("live surface hidden parentVisible=${binding.playerSurface.visibility == View.VISIBLE}")
         livePlayer?.clearVideoSurfaceView(binding.playerSurface)
         clipDebug("live surface cleared parentVisible=${binding.playerSurface.visibility == View.VISIBLE}")
@@ -661,7 +687,8 @@ class ExoPlayerFragment : PlayerFragment() {
         liveSurfaceRestoreListener = firstFrameListener
         livePlayer.addListener(firstFrameListener)
         binding.playerLayout.visibility = View.VISIBLE
-        binding.playerSurface.visibility = View.VISIBLE
+        showVideoOutputCover()
+        setVideoOutputVisible(true)
         clipDebug("live surface reattach")
         livePlayer.setVideoSurfaceView(binding.playerSurface)
         if (resumePlayback) {
@@ -847,7 +874,7 @@ class ExoPlayerFragment : PlayerFragment() {
                 if (view != null && !isInPIPMode) {
                     playbackService?.player?.clearVideoSurfaceView(binding.playerSurface)
                     if (videoDetachedForBackground) {
-                        binding.playerSurface.visibility = View.GONE
+                        setVideoOutputVisible(false)
                     }
                 }
             }
@@ -885,6 +912,20 @@ class ExoPlayerFragment : PlayerFragment() {
         super.onDestroyView()
     }
 
+    private fun setVideoOutputVisible(visible: Boolean) {
+        binding.playerSurface.visibility = if (visible) View.VISIBLE else View.GONE
+        if (!visible) {
+            showVideoOutputCover()
+        }
+    }
+
+    private fun showVideoOutputCover() {
+        videoOutputCover?.visibility = View.VISIBLE
+    }
+
+    private fun hideVideoOutputCover() {
+        videoOutputCover?.visibility = View.GONE
+    }
     override fun onDestroy() {
         playbackService?.cancelLiveClipPreparation()
         super.onDestroy()

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/saved/SavedMediaFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/saved/SavedMediaFragment.kt
@@ -12,7 +12,6 @@ import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.updateLayoutParams
 import androidx.fragment.app.Fragment
-import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.ui.AppBarConfiguration
@@ -21,6 +20,8 @@ import androidx.recyclerview.widget.RecyclerView
 import com.github.andreyasadchy.xtra.R
 import com.github.andreyasadchy.xtra.databinding.FragmentMediaBinding
 import com.github.andreyasadchy.xtra.ui.common.FragmentHost
+import com.github.andreyasadchy.xtra.ui.common.FragmentTabSwitcher
+import com.github.andreyasadchy.xtra.ui.common.RecyclerViewLiftTargetConnector
 import com.github.andreyasadchy.xtra.ui.common.Scrollable
 import com.github.andreyasadchy.xtra.ui.common.Sortable
 import com.github.andreyasadchy.xtra.ui.login.TwitchWebLoginActivity
@@ -49,6 +50,8 @@ class SavedMediaFragment : Fragment(), Scrollable, FragmentHost {
     private var fileResultLauncher: ActivityResultLauncher<Intent>? = null
 
     private var previousItem = -1
+    private var tabSwitcher: FragmentTabSwitcher? = null
+    private var liftTargetConnector: RecyclerViewLiftTargetConnector? = null
 
     override val currentFragment: Fragment?
         get() = childFragmentManager.findFragmentById(R.id.fragmentContainer)
@@ -91,6 +94,13 @@ class SavedMediaFragment : Fragment(), Scrollable, FragmentHost {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        liftTargetConnector = RecyclerViewLiftTargetConnector(binding.appBar)
+        tabSwitcher = FragmentTabSwitcher(childFragmentManager, R.id.fragmentContainer) { fragment ->
+            fragment.view?.findViewById<RecyclerView>(R.id.recyclerView)?.let { liftTargetConnector?.connect(it) }
+            if (fragment is Sortable) fragment.setupSortBar(binding.sortBar) else binding.sortBar.root.visibility = View.GONE
+            binding.toolbar.menu.findItem(R.id.importFolders).isVisible = fragment is DownloadsFragment
+            binding.toolbar.menu.findItem(R.id.importFiles).isVisible = fragment is DownloadsFragment
+        }
         with(binding) {
             val activity = requireActivity() as MainActivity
             val isLoggedIn = !TwitchApiHelper.getGQLHeaders(requireContext(), true)[C.HEADER_TOKEN].isNullOrBlank() ||
@@ -178,20 +188,19 @@ class SavedMediaFragment : Fragment(), Scrollable, FragmentHost {
                 }.toTypedArray().ifEmpty { arrayOf(getString(R.string.bookmarks)) })
                 setOnItemClickListener { _, _, position, _ ->
                     if (position != previousItem) {
-                        childFragmentManager.beginTransaction().replace(R.id.fragmentContainer, onSpinnerItemSelected(tabs, position)).commit()
-                        previousItem = position
+                        showTab(tabs, position)
                     }
                 }
                 if (previousItem == -1) {
                     val defaultItem = tabList.find { it.split(':')[1] != "0" }?.split(':')[0] ?: "1"
                     val position = tabs.indexOf(defaultItem).takeIf { it != -1 } ?: tabs.indexOf("1").takeIf { it != -1 } ?: 0
-                    childFragmentManager.beginTransaction().replace(R.id.fragmentContainer, onSpinnerItemSelected(tabs, position)).commit()
-                    previousItem = position
+                    showTab(tabs, position)
                 }
                 if (previousItem <= tabs.lastIndex) {
                     setText(adapter.getItem(previousItem).toString(), false)
                 }
             }
+            /* Legacy per-view listener wiring replaced by FragmentTabSwitcher.
             childFragmentManager.registerFragmentLifecycleCallbacks(object : FragmentManager.FragmentLifecycleCallbacks() {
                 override fun onFragmentViewCreated(fm: FragmentManager, f: Fragment, v: View, savedInstanceState: Bundle?) {
                     f.view?.findViewById<RecyclerView>(R.id.recyclerView)?.let {
@@ -214,7 +223,7 @@ class SavedMediaFragment : Fragment(), Scrollable, FragmentHost {
                     toolbar.menu.findItem(R.id.importFolders).isVisible = f is DownloadsFragment
                     toolbar.menu.findItem(R.id.importFiles).isVisible = f is DownloadsFragment
                 }
-            }, false)
+            }, false) */
             ViewCompat.setOnApplyWindowInsetsListener(view) { _, windowInsets ->
                 val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout())
                 toolbar.updateLayoutParams<ViewGroup.MarginLayoutParams> {
@@ -235,6 +244,12 @@ class SavedMediaFragment : Fragment(), Scrollable, FragmentHost {
         }
     }
 
+    private fun showTab(tabs: List<String>, position: Int) {
+        if (position !in tabs.indices) return
+        previousItem = position
+        tabSwitcher?.show("media_$position") { onSpinnerItemSelected(tabs, position) }
+    }
+
     override fun onSaveInstanceState(outState: Bundle) {
         outState.putInt("previousItem", previousItem)
         super.onSaveInstanceState(outState)
@@ -246,6 +261,9 @@ class SavedMediaFragment : Fragment(), Scrollable, FragmentHost {
     }
 
     override fun onDestroyView() {
+        liftTargetConnector?.disconnect()
+        liftTargetConnector = null
+        tabSwitcher = null
         super.onDestroyView()
         _binding = null
     }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/saved/SavedPagerFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/saved/SavedPagerFragment.kt
@@ -22,8 +22,10 @@ import androidx.viewpager2.widget.ViewPager2
 import com.github.andreyasadchy.xtra.R
 import com.github.andreyasadchy.xtra.databinding.FragmentMediaPagerBinding
 import com.github.andreyasadchy.xtra.ui.common.FragmentHost
+import com.github.andreyasadchy.xtra.ui.common.RecyclerViewLiftTargetConnector
 import com.github.andreyasadchy.xtra.ui.common.Scrollable
 import com.github.andreyasadchy.xtra.ui.common.Sortable
+import com.github.andreyasadchy.xtra.ui.common.dispatchPagerScrollState
 import com.github.andreyasadchy.xtra.ui.login.TwitchWebLoginActivity
 import com.github.andreyasadchy.xtra.ui.main.MainActivity
 import com.github.andreyasadchy.xtra.ui.saved.SavedPagerViewModel.Companion.SavedPagerViewModelFactory
@@ -32,10 +34,10 @@ import com.github.andreyasadchy.xtra.ui.search.SearchPagerFragmentDirections
 import com.github.andreyasadchy.xtra.ui.settings.SettingsActivity
 import com.github.andreyasadchy.xtra.ui.settings.setTabCustomizationLongPress
 import com.github.andreyasadchy.xtra.util.C
+import com.github.andreyasadchy.xtra.util.configureForSmoothPaging
 import com.github.andreyasadchy.xtra.util.TwitchApiHelper
 import com.github.andreyasadchy.xtra.util.getAlertDialogBuilder
 import com.github.andreyasadchy.xtra.util.prefs
-import com.github.andreyasadchy.xtra.util.reduceDragSensitivity
 import com.github.andreyasadchy.xtra.util.tokenPrefs
 import com.google.android.material.tabs.TabLayout
 import com.google.android.material.tabs.TabLayoutMediator
@@ -46,6 +48,7 @@ class SavedPagerFragment : Fragment(), Scrollable, FragmentHost {
     private val binding get() = _binding!!
     private val viewModel: SavedPagerViewModel by viewModels { SavedPagerViewModelFactory }
     private var firstLaunch = true
+    private var liftTargetConnector: RecyclerViewLiftTargetConnector? = null
     private var folderResultLauncher: ActivityResultLauncher<Intent>? = null
     private var fileResultLauncher: ActivityResultLauncher<Intent>? = null
 
@@ -90,6 +93,7 @@ class SavedPagerFragment : Fragment(), Scrollable, FragmentHost {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        liftTargetConnector = RecyclerViewLiftTargetConnector(binding.appBar)
         with(binding) {
             val activity = requireActivity() as MainActivity
             val isLoggedIn = !TwitchApiHelper.getGQLHeaders(requireContext(), true)[C.HEADER_TOKEN].isNullOrBlank() ||
@@ -171,20 +175,15 @@ class SavedPagerFragment : Fragment(), Scrollable, FragmentHost {
             val adapter = SavedPagerAdapter(this@SavedPagerFragment, tabs)
             viewPager.adapter = adapter
             viewPager.registerOnPageChangeCallback(object : ViewPager2.OnPageChangeCallback() {
+                override fun onPageScrollStateChanged(state: Int) {
+                    dispatchPagerScrollState(state != ViewPager2.SCROLL_STATE_IDLE)
+                }
+
                 override fun onPageSelected(position: Int) {
                     viewPager.doOnLayout {
                         childFragmentManager.findFragmentByTag("f${position}")?.let { fragment ->
                             fragment.view?.findViewById<RecyclerView>(R.id.recyclerView)?.let {
-                                appBar.setLiftOnScrollTargetView(it)
-                                it.addOnScrollListener(object : RecyclerView.OnScrollListener() {
-                                    override fun onScrolled(recyclerView: RecyclerView, dx: Int, dy: Int) {
-                                        super.onScrolled(recyclerView, dx, dy)
-                                        appBar.isLifted = recyclerView.canScrollVertically(-1)
-                                    }
-                                })
-                                it.addOnLayoutChangeListener { _, _, _, _, _, _, _, _, _ ->
-                                    appBar.isLifted = it.canScrollVertically(-1)
-                                }
+                                liftTargetConnector?.connect(it)
                             }
                             if (fragment is Sortable) {
                                 fragment.setupSortBar(sortBar)
@@ -205,8 +204,7 @@ class SavedPagerFragment : Fragment(), Scrollable, FragmentHost {
                 )
                 firstLaunch = false
             }
-            viewPager.offscreenPageLimit = adapter.itemCount
-            viewPager.reduceDragSensitivity()
+            viewPager.configureForSmoothPaging()
             TabLayoutMediator(tabLayout, viewPager) { tab, position ->
                 tab.text = when (tabs.getOrNull(position)) {
                     "0" -> getString(R.string.bookmarks)
@@ -233,6 +231,9 @@ class SavedPagerFragment : Fragment(), Scrollable, FragmentHost {
     }
 
     override fun onDestroyView() {
+        dispatchPagerScrollState(false)
+        liftTargetConnector?.disconnect()
+        liftTargetConnector = null
         super.onDestroyView()
         _binding = null
     }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/saved/bookmarks/BookmarksAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/saved/bookmarks/BookmarksAdapter.kt
@@ -24,6 +24,11 @@ import com.github.andreyasadchy.xtra.model.ui.Bookmark
 import com.github.andreyasadchy.xtra.model.ui.BookmarkIgnoredUser
 import com.github.andreyasadchy.xtra.model.ui.Video
 import com.github.andreyasadchy.xtra.ui.channel.ChannelPagerFragmentDirections
+import com.github.andreyasadchy.xtra.ui.common.FeedImageRequestBag
+import com.github.andreyasadchy.xtra.ui.common.FeedImageRequestOwner
+import com.github.andreyasadchy.xtra.ui.common.FeedUiPreferencesStore
+import com.github.andreyasadchy.xtra.ui.common.StreamThumbnailIdleScheduler
+import com.github.andreyasadchy.xtra.ui.common.restoreDecodedMemoryImage
 import com.github.andreyasadchy.xtra.ui.common.thumbnailState
 import com.github.andreyasadchy.xtra.ui.game.GamePagerFragmentDirections
 import com.github.andreyasadchy.xtra.ui.main.MainActivity
@@ -47,9 +52,21 @@ class BookmarksAdapter(
             oldItem.id == newItem.id
 
         override fun areContentsTheSame(oldItem: Bookmark, newItem: Bookmark): Boolean =
-            oldItem.title == newItem.title &&
+                    oldItem.title == newItem.title &&
                     oldItem.duration == newItem.duration
     }) {
+
+    private val imageLoadScheduler = StreamThumbnailIdleScheduler()
+
+    override fun onAttachedToRecyclerView(recyclerView: RecyclerView) {
+        super.onAttachedToRecyclerView(recyclerView)
+        imageLoadScheduler.attachTo(recyclerView)
+    }
+
+    override fun onDetachedFromRecyclerView(recyclerView: RecyclerView) {
+        imageLoadScheduler.detach()
+        super.onDetachedFromRecyclerView(recyclerView)
+    }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): PagingViewHolder {
         val binding = FragmentVideosListItemBinding.inflate(LayoutInflater.from(parent.context), parent, false)
@@ -57,7 +74,14 @@ class BookmarksAdapter(
     }
 
     override fun onBindViewHolder(holder: PagingViewHolder, position: Int) {
+        holder.beginImageBind(getItem(position))
         holder.bind(getItem(position))
+    }
+
+    override fun onViewRecycled(holder: PagingViewHolder) {
+        imageLoadScheduler.clear(holder)
+        holder.cancelImageWork()
+        super.onViewRecycled(holder)
     }
 
     private var positions: List<VideoPosition>? = null
@@ -81,11 +105,34 @@ class BookmarksAdapter(
     inner class PagingViewHolder(
         private val binding: FragmentVideosListItemBinding,
         private val fragment: Fragment,
-    ) : RecyclerView.ViewHolder(binding.root) {
+    ) : RecyclerView.ViewHolder(binding.root), FeedImageRequestOwner {
+        private val imageRequests = FeedImageRequestBag()
+        private var boundBookmarkId: Int? = null
+
+        fun beginImageBind(item: Bookmark?) {
+            imageLoadScheduler.clear(this)
+            imageRequests.cancel()
+            boundBookmarkId = item?.id
+        }
+
+        override fun cancelImageRequests() {
+            imageRequests.cancel()
+        }
+
+        override fun pauseImageRequests() {
+            imageRequests.cancel(preserveRegistrations = true)
+        }
+
+        fun cancelImageWork() {
+            cancelImageRequests()
+            boundBookmarkId = null
+        }
+
         fun bind(item: Bookmark?) {
             with(binding) {
                 if (item != null) {
                     val context = fragment.requireContext()
+                    val uiPreferences = FeedUiPreferencesStore.current(context)
                     val channelListener: (View) -> Unit = {
                         fragment.findNavController().navigate(
                             ChannelPagerFragmentDirections.actionGlobalChannelPagerFragment(
@@ -138,15 +185,28 @@ class BookmarksAdapter(
                         deleteVideo(item)
                         true
                     }
-                    fragment.requireContext().imageLoader.enqueue(
-                        ImageRequest.Builder(fragment.requireContext()).apply {
-                            data(item.thumbnail)
-                            diskCachePolicy(CachePolicy.DISABLED)
-                            crossfade(true)
-                            target(thumbnail)
-                            thumbnailState()
-                        }.build()
-                    )
+                    val thumbnailKey = "xtra:bookmark-thumbnail:${item.id}|${item.thumbnail}"
+                    if (thumbnail.tag != thumbnailKey) {
+                        thumbnail.setImageDrawable(null)
+                        thumbnail.tag = thumbnailKey
+                    }
+                    restoreDecodedMemoryImage(thumbnailKey, thumbnail)
+                    imageLoadScheduler.runOrDefer(this@PagingViewHolder, thumbnail) {
+                        if (!root.isAttachedToWindow || boundBookmarkId != item.id) return@runOrDefer
+                        imageRequests.replace(
+                            thumbnail,
+                            context.imageLoader.enqueue(
+                                ImageRequest.Builder(context).apply {
+                                    data(item.thumbnail)
+                                    memoryCacheKey(thumbnailKey)
+                                    diskCachePolicy(CachePolicy.ENABLED)
+                                    crossfade(false)
+                                    target(thumbnail)
+                                    thumbnailState()
+                                }.build()
+                            ),
+                        )
+                    }
                     if (item.createdAt != null) {
                         val text = Instant.parseOrNull(item.createdAt)?.toEpochMilliseconds()?.takeIf { ms -> ms > 0 }?.let {
                             TwitchApiHelper.formatDate(context, it)
@@ -207,17 +267,30 @@ class BookmarksAdapter(
                         userImage.contentDescription = item.userName?.let {
                             context.getString(R.string.player_open_channel, it)
                         }
-                        fragment.requireContext().imageLoader.enqueue(
-                            ImageRequest.Builder(fragment.requireContext()).apply {
-                                data(item.userLogo)
-                                diskCachePolicy(CachePolicy.ENABLED)
-                                if (context.prefs().getBoolean(C.UI_ROUND_USER_IMAGE, true)) {
-                                    transformations(CircleCropTransformation())
-                                }
-                                crossfade(true)
-                                target(userImage)
-                            }.build()
-                        )
+                        val profileKey = "xtra:bookmark-avatar:${item.id}|${item.userLogo}|round=${uiPreferences.roundUserImage}"
+                        if (userImage.tag != profileKey) {
+                            userImage.setImageDrawable(null)
+                            userImage.tag = profileKey
+                        }
+                        restoreDecodedMemoryImage(profileKey, userImage)
+                        imageLoadScheduler.runOrDefer(this@PagingViewHolder, userImage) {
+                            if (!root.isAttachedToWindow || boundBookmarkId != item.id) return@runOrDefer
+                            imageRequests.replace(
+                                userImage,
+                                context.imageLoader.enqueue(
+                                    ImageRequest.Builder(context).apply {
+                                        data(item.userLogo)
+                                        memoryCacheKey(profileKey)
+                                        diskCachePolicy(CachePolicy.ENABLED)
+                                        if (uiPreferences.roundUserImage) {
+                                            transformations(CircleCropTransformation())
+                                        }
+                                        crossfade(false)
+                                        target(userImage)
+                                    }.build()
+                                ),
+                            )
+                        }
                         userImage.setOnClickListener(channelListener)
                     } else {
                         userImage.visibility = View.GONE

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/search/SearchPagerFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/search/SearchPagerFragment.kt
@@ -27,15 +27,17 @@ import com.github.andreyasadchy.xtra.databinding.FragmentSearchBinding
 import com.github.andreyasadchy.xtra.ui.channel.ChannelPagerFragmentDirections
 import com.github.andreyasadchy.xtra.ui.common.BaseNetworkFragment
 import com.github.andreyasadchy.xtra.ui.common.FragmentHost
+import com.github.andreyasadchy.xtra.ui.common.RecyclerViewLiftTargetConnector
 import com.github.andreyasadchy.xtra.ui.common.Sortable
+import com.github.andreyasadchy.xtra.ui.common.dispatchPagerScrollState
 import com.github.andreyasadchy.xtra.ui.main.MainActivity
 import com.github.andreyasadchy.xtra.ui.search.SearchPagerViewModel.Companion.SearchPagerViewModelFactory
 import com.github.andreyasadchy.xtra.ui.settings.setTabCustomizationLongPress
 import com.github.andreyasadchy.xtra.util.C
+import com.github.andreyasadchy.xtra.util.configureForSmoothPaging
 import com.github.andreyasadchy.xtra.util.TwitchApiHelper
 import com.github.andreyasadchy.xtra.util.getAlertDialogBuilder
 import com.github.andreyasadchy.xtra.util.prefs
-import com.github.andreyasadchy.xtra.util.reduceDragSensitivity
 import com.google.android.material.tabs.TabLayout
 import com.google.android.material.tabs.TabLayoutMediator
 import kotlinx.coroutines.Job
@@ -50,6 +52,7 @@ class SearchPagerFragment : BaseNetworkFragment(), FragmentHost {
     private val binding get() = _binding!!
     private val viewModel: SearchPagerViewModel by viewModels { SearchPagerViewModelFactory }
     private var firstLaunch = true
+    private var liftTargetConnector: RecyclerViewLiftTargetConnector? = null
 
     override val currentFragment: Fragment?
         get() = childFragmentManager.findFragmentByTag("f${binding.viewPager.currentItem}")
@@ -66,6 +69,7 @@ class SearchPagerFragment : BaseNetworkFragment(), FragmentHost {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        liftTargetConnector = RecyclerViewLiftTargetConnector(binding.appBar)
         with(binding) {
             val tabList = requireContext().prefs().getString(C.UI_SEARCH_TABS, null).let { tabPref ->
                 val defaultTabs = C.DEFAULT_SEARCH_TABS.split(',')
@@ -102,21 +106,16 @@ class SearchPagerFragment : BaseNetworkFragment(), FragmentHost {
             val adapter = SearchPagerAdapter(this@SearchPagerFragment, tabs)
             viewPager.adapter = adapter
             viewPager.registerOnPageChangeCallback(object : ViewPager2.OnPageChangeCallback() {
+                override fun onPageScrollStateChanged(state: Int) {
+                    dispatchPagerScrollState(state != ViewPager2.SCROLL_STATE_IDLE)
+                }
+
                 override fun onPageSelected(position: Int) {
                     (currentFragment as? Searchable)?.search(binding.searchView.query.toString())
                     viewPager.doOnLayout {
                         childFragmentManager.findFragmentByTag("f${position}")?.let { fragment ->
                             fragment.view?.findViewById<RecyclerView>(R.id.recyclerView)?.let {
-                                appBar.setLiftOnScrollTargetView(it)
-                                it.addOnScrollListener(object : RecyclerView.OnScrollListener() {
-                                    override fun onScrolled(recyclerView: RecyclerView, dx: Int, dy: Int) {
-                                        super.onScrolled(recyclerView, dx, dy)
-                                        appBar.isLifted = recyclerView.canScrollVertically(-1)
-                                    }
-                                })
-                                it.addOnLayoutChangeListener { _, _, _, _, _, _, _, _, _ ->
-                                    appBar.isLifted = it.canScrollVertically(-1)
-                                }
+                                liftTargetConnector?.connect(it)
                             }
                             if (fragment is Sortable) {
                                 fragment.setupSortBar(sortBar)
@@ -135,8 +134,7 @@ class SearchPagerFragment : BaseNetworkFragment(), FragmentHost {
                 )
                 firstLaunch = false
             }
-            viewPager.offscreenPageLimit = adapter.itemCount
-            viewPager.reduceDragSensitivity()
+            viewPager.configureForSmoothPaging()
             TabLayoutMediator(tabLayout, viewPager) { tab, position ->
                 tab.text = when (tabs.getOrNull(position)) {
                     "0" -> getString(R.string.videos)
@@ -269,6 +267,9 @@ class SearchPagerFragment : BaseNetworkFragment(), FragmentHost {
     }
 
     override fun onDestroyView() {
+        dispatchPagerScrollState(false)
+        liftTargetConnector?.disconnect()
+        liftTargetConnector = null
         super.onDestroyView()
         _binding = null
     }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/search/channels/ChannelSearchFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/search/channels/ChannelSearchFragment.kt
@@ -91,8 +91,8 @@ class ChannelSearchFragment : PagedListFragment(), Searchable {
     }
 
     override fun search(query: String) {
-        viewModel.setQuery(query)
-        if (requireContext().prefs().getBoolean(C.UI_STORE_RECENT_SEARCHES, true)) {
+        val changed = viewModel.setQuery(query)
+        if (changed && query.isNotBlank() && requireContext().prefs().getBoolean(C.UI_STORE_RECENT_SEARCHES, true)) {
             viewModel.saveRecentSearch(query)
         }
     }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/search/channels/ChannelSearchViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/search/channels/ChannelSearchViewModel.kt
@@ -51,10 +51,10 @@ class ChannelSearchViewModel(
         }.flow
     }.cachedIn(viewModelScope)
 
-    fun setQuery(newQuery: String) {
-        if (_query.value != newQuery) {
-            _query.value = newQuery
-        }
+    fun setQuery(newQuery: String): Boolean {
+        if (_query.value == newQuery) return false
+        _query.value = newQuery
+        return true
     }
 
     fun saveRecentSearch(query: String) {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/search/games/GameSearchFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/search/games/GameSearchFragment.kt
@@ -100,8 +100,8 @@ class GameSearchFragment : PagedListFragment(), Searchable {
     }
 
     override fun search(query: String) {
-        viewModel.setQuery(query)
-        if (requireContext().prefs().getBoolean(C.UI_STORE_RECENT_SEARCHES, true)) {
+        val changed = viewModel.setQuery(query)
+        if (changed && query.isNotBlank() && requireContext().prefs().getBoolean(C.UI_STORE_RECENT_SEARCHES, true)) {
             viewModel.saveRecentSearch(query)
         }
     }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/search/games/GameSearchViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/search/games/GameSearchViewModel.kt
@@ -51,10 +51,10 @@ class GameSearchViewModel(
         }.flow
     }.cachedIn(viewModelScope)
 
-    fun setQuery(newQuery: String) {
-        if (_query.value != newQuery) {
-            _query.value = newQuery
-        }
+    fun setQuery(newQuery: String): Boolean {
+        if (_query.value == newQuery) return false
+        _query.value = newQuery
+        return true
     }
 
     fun saveRecentSearch(query: String) {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/search/streams/StreamSearchFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/search/streams/StreamSearchFragment.kt
@@ -111,8 +111,8 @@ class StreamSearchFragment : PagedListFragment(), Searchable {
     }
 
     override fun search(query: String) {
-        viewModel.setQuery(query)
-        if (requireContext().prefs().getBoolean(C.UI_STORE_RECENT_SEARCHES, true)) {
+        val changed = viewModel.setQuery(query)
+        if (changed && query.isNotBlank() && requireContext().prefs().getBoolean(C.UI_STORE_RECENT_SEARCHES, true)) {
             viewModel.saveRecentSearch(query)
         }
     }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/search/streams/StreamSearchViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/search/streams/StreamSearchViewModel.kt
@@ -55,10 +55,10 @@ class StreamSearchViewModel(
         }.flow
     }.cachedIn(viewModelScope)
 
-    fun setQuery(newQuery: String) {
-        if (_query.value != newQuery) {
-            _query.value = newQuery
-        }
+    fun setQuery(newQuery: String): Boolean {
+        if (_query.value == newQuery) return false
+        _query.value = newQuery
+        return true
     }
 
     fun saveRecentSearch(query: String) {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/search/videos/VideoSearchFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/search/videos/VideoSearchFragment.kt
@@ -19,6 +19,7 @@ import com.github.andreyasadchy.xtra.R
 import com.github.andreyasadchy.xtra.databinding.CommonRecyclerViewLayoutBinding
 import com.github.andreyasadchy.xtra.model.ui.Video
 import com.github.andreyasadchy.xtra.ui.common.PagedListFragment
+import com.github.andreyasadchy.xtra.ui.common.PagerScrollStateAware
 import com.github.andreyasadchy.xtra.ui.common.StreamPreloadViewportController
 import com.github.andreyasadchy.xtra.ui.common.StreamPreviewCandidate
 import com.github.andreyasadchy.xtra.ui.common.VideosAdapter
@@ -33,7 +34,7 @@ import com.github.andreyasadchy.xtra.util.prefs
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 
-class VideoSearchFragment : PagedListFragment(), Searchable {
+class VideoSearchFragment : PagedListFragment(), PagerScrollStateAware, Searchable {
 
     private var _binding: CommonRecyclerViewLayoutBinding? = null
     private val binding get() = _binding!!
@@ -161,14 +162,20 @@ class VideoSearchFragment : PagedListFragment(), Searchable {
     }
 
     override fun search(query: String) {
-        viewModel.setQuery(query)
-        if (requireContext().prefs().getBoolean(C.UI_STORE_RECENT_SEARCHES, true)) {
+        val changed = viewModel.setQuery(query)
+        if (changed && query.isNotBlank() && requireContext().prefs().getBoolean(C.UI_STORE_RECENT_SEARCHES, true)) {
             viewModel.saveRecentSearch(query)
         }
     }
 
     override fun onNetworkRestored() {
         pagingAdapter.retry()
+    }
+
+    override fun onPagerScrollStateChanged(scrolling: Boolean) {
+        if (::videoPreviewViewportController.isInitialized) {
+            videoPreviewViewportController.onParentScrollStateChanged(scrolling)
+        }
     }
 
     override fun onResume() {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/search/videos/VideoSearchViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/search/videos/VideoSearchViewModel.kt
@@ -74,10 +74,10 @@ class VideoSearchViewModel(
         }.flow
     }.cachedIn(viewModelScope)
 
-    fun setQuery(newQuery: String) {
-        if (_query.value != newQuery) {
-            _query.value = newQuery
-        }
+    fun setQuery(newQuery: String): Boolean {
+        if (_query.value == newQuery) return false
+        _query.value = newQuery
+        return true
     }
 
     fun saveRecentSearch(query: String) {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/top/TopStreamsFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/top/TopStreamsFragment.kt
@@ -28,6 +28,7 @@ import com.github.andreyasadchy.xtra.model.ui.GameSort
 import com.github.andreyasadchy.xtra.model.ui.SavedFilter
 import com.github.andreyasadchy.xtra.model.ui.Stream
 import com.github.andreyasadchy.xtra.ui.common.PagedListFragment
+import com.github.andreyasadchy.xtra.ui.common.PagerScrollStateAware
 import com.github.andreyasadchy.xtra.ui.common.Scrollable
 import com.github.andreyasadchy.xtra.ui.common.StreamsAdapter
 import com.github.andreyasadchy.xtra.ui.common.StreamsCompactAdapter
@@ -52,7 +53,7 @@ import com.github.andreyasadchy.xtra.repository.streamfeed.RefreshReason
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 
-class TopStreamsFragment : PagedListFragment(), Scrollable, StreamsSortDialog.OnFilter {
+class TopStreamsFragment : PagedListFragment(), Scrollable, PagerScrollStateAware, StreamsSortDialog.OnFilter {
 
     override val initializeWithoutNetwork = true
 
@@ -340,6 +341,12 @@ class TopStreamsFragment : PagedListFragment(), Scrollable, StreamsSortDialog.On
 
     override fun onNetworkRestored() {
         viewModel.refreshCurrent(RefreshReason.NETWORK_RESTORED, force = true)
+    }
+
+    override fun onPagerScrollStateChanged(scrolling: Boolean) {
+        if (::streamPreloadViewportController.isInitialized) {
+            streamPreloadViewportController.onParentScrollStateChanged(scrolling)
+        }
     }
 
     override fun onResume() {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/view/CenteredImageSpan.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/view/CenteredImageSpan.kt
@@ -7,10 +7,14 @@ import android.graphics.drawable.Drawable
 import android.text.style.ImageSpan
 
 
-class CenteredImageSpan(drawable: Drawable) : ImageSpan(drawable) {
+class CenteredImageSpan(initialDrawable: Drawable) : ImageSpan(initialDrawable) {
+
+    var imageDrawable: Drawable = initialDrawable
+
+    override fun getDrawable(): Drawable = imageDrawable
 
     override fun getSize(paint: Paint, text: CharSequence, start: Int, end: Int, fontMetricsInt: FontMetricsInt?): Int {
-        val drawable = drawable
+        val drawable = imageDrawable
         val rect = drawable.bounds
         if (fontMetricsInt != null) {
             val fmPaint = paint.fontMetricsInt
@@ -26,7 +30,7 @@ class CenteredImageSpan(drawable: Drawable) : ImageSpan(drawable) {
     }
 
     override fun draw(canvas: Canvas, text: CharSequence, start: Int, end: Int, x: Float, top: Int, y: Int, bottom: Int, paint: Paint) {
-        val drawable = drawable
+        val drawable = imageDrawable
         canvas.save()
         val fmPaint = paint.fontMetricsInt
         val fontHeight = fmPaint.descent - fmPaint.ascent

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/UiInteractionGovernor.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/UiInteractionGovernor.kt
@@ -1,0 +1,101 @@
+package com.github.andreyasadchy.xtra.util
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import java.util.Collections
+import java.util.IdentityHashMap
+import java.util.concurrent.CopyOnWriteArrayList
+
+/**
+ * Process-local QoS signal for work that competes with touch, scrolling, and
+ * pager transitions. Sources are identity-based because several independent
+ * RecyclerViews can be active in one screen.
+ */
+object UiInteractionGovernor {
+    private const val IDLE_SETTLE_MS = 150L
+
+    private val activeSources = Collections.newSetFromMap(IdentityHashMap<Any, Boolean>())
+    private val idleListeners = CopyOnWriteArrayList<() -> Unit>()
+    private val interactionStartListeners = CopyOnWriteArrayList<() -> Unit>()
+    private val _isInteracting = MutableStateFlow(false)
+    private val imageBudgetLock = Any()
+    private var imageBudgetFrame = Long.MIN_VALUE
+    private var imageStartsThisFrame = 0
+
+    val isInteracting: StateFlow<Boolean> = _isInteracting.asStateFlow()
+
+    fun setInteracting(source: Any, interacting: Boolean) {
+        val becameIdle: Boolean
+        val becameInteracting: Boolean
+        synchronized(activeSources) {
+            if (interacting) activeSources.add(source) else activeSources.remove(source)
+            val next = activeSources.isNotEmpty()
+            becameIdle = _isInteracting.value && !next
+            becameInteracting = !_isInteracting.value && next
+            if (_isInteracting.value == next) return
+            _isInteracting.value = next
+        }
+        if (becameInteracting) interactionStartListeners.forEach { it() }
+        if (becameIdle) idleListeners.forEach { it() }
+    }
+
+    fun addIdleListener(listener: () -> Unit) {
+        idleListeners += listener
+    }
+
+    fun removeIdleListener(listener: () -> Unit) {
+        idleListeners -= listener
+    }
+
+    fun addInteractionStartListener(listener: () -> Unit) {
+        interactionStartListeners += listener
+    }
+
+    fun removeInteractionStartListener(listener: () -> Unit) {
+        interactionStartListeners -= listener
+    }
+
+    fun runWhenIdle(scope: CoroutineScope, block: suspend () -> Unit): Job = scope.launch {
+        awaitIdle()
+        block()
+    }
+
+    /**
+     * Reserves one optional visible-image start for the current display frame.
+     * All feed adapters share this budget, including nested Overview shelves.
+     */
+    fun tryAcquireVisibleImageStart(frameTimeNanos: Long? = null): Boolean {
+        // Callers draining work from postOnAnimation pass Choreographer's
+        // actual frame timestamp. Immediate binds use a lightweight fallback
+        // until the next display callback rather than installing a perpetual
+        // Choreographer observer.
+        val frame = frameTimeNanos ?: (System.nanoTime() / FRAME_NANOS)
+        synchronized(imageBudgetLock) {
+            if (imageBudgetFrame != frame) {
+                imageBudgetFrame = frame
+                imageStartsThisFrame = 0
+            }
+            if (imageStartsThisFrame >= VISIBLE_IMAGE_STARTS_PER_FRAME) return false
+            imageStartsThisFrame++
+            return true
+        }
+    }
+
+    suspend fun awaitIdle() {
+        while (true) {
+            isInteracting.filter { !it }.first()
+            delay(IDLE_SETTLE_MS)
+            if (!isInteracting.value) return
+        }
+    }
+
+    private const val FRAME_NANOS = 16_666_667L
+    private const val VISIBLE_IMAGE_STARTS_PER_FRAME = 2
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/ViewExtensions.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/ViewExtensions.kt
@@ -30,3 +30,14 @@ fun ViewPager2.reduceDragSensitivity() {
     } catch (e: Exception) {
     }
 }
+
+/** Keeps tab paging lightweight and leaves expensive child work to the visible page. */
+fun ViewPager2.configureForSmoothPaging() {
+    offscreenPageLimit = 1
+    (getChildAt(0) as? RecyclerView)?.apply {
+        itemAnimator = null
+        overScrollMode = View.OVER_SCROLL_NEVER
+        setHasFixedSize(true)
+    }
+    reduceDragSensitivity()
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/chat/ChatAdapterUtils.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/chat/ChatAdapterUtils.kt
@@ -1,12 +1,17 @@
 package com.github.andreyasadchy.xtra.util.chat
 
 import android.content.Context
+import android.content.ContentResolver
 import android.graphics.Color
 import android.graphics.Typeface
 import android.graphics.drawable.Animatable
 import android.graphics.drawable.ColorDrawable
 import android.graphics.drawable.Drawable
 import android.graphics.drawable.LayerDrawable
+import android.os.ParcelFileDescriptor
+import android.system.ErrnoException
+import android.system.Os
+import android.system.OsConstants
 import android.text.SpannableStringBuilder
 import android.text.Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
 import android.text.TextPaint
@@ -16,8 +21,10 @@ import android.text.style.StyleSpan
 import android.text.style.URLSpan
 import android.util.Patterns
 import android.view.View
+import android.net.Uri
 import androidx.core.graphics.ColorUtils
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
 import coil3.asDrawable
 import coil3.imageLoader
 import coil3.network.NetworkHeaders
@@ -46,11 +53,81 @@ import com.github.andreyasadchy.xtra.ui.view.NamePaintImageSpan
 import com.github.andreyasadchy.xtra.ui.view.NamePaintSpan
 import com.github.andreyasadchy.xtra.util.TwitchApiHelper
 import java.text.NumberFormat
+import java.io.File
+import java.io.IOException
+import java.io.RandomAccessFile
+import android.util.Base64
+import coil3.request.Disposable
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import java.util.Random
 import kotlin.math.floor
 import kotlin.math.pow
 
 object ChatAdapterUtils {
+
+    private data class LocalEmoteKey(val source: String, val offset: Long, val length: Int)
+
+    private const val LOCAL_EMOTE_CACHE_MAX_BYTES = 8 * 1024 * 1024
+    private val localEmoteCache = LinkedHashMap<LocalEmoteKey, ByteArray>(32, 0.75f, true)
+    private var localEmoteCacheBytes = 0
+
+    class ChatCatalogIndexes private constructor(
+        val twitchEmotesById: Map<String, TwitchEmote>,
+        val thirdPartyEmotesByName: Map<String, Emote>,
+        val personalEmotesBySet: Map<String, Map<String, Emote>>,
+        val globalBadgesByKey: Map<String, TwitchBadge>,
+        val channelBadgesByKey: Map<String, TwitchBadge>,
+        val stvUsersById: Map<String, STVUser>,
+        val stvBadgesById: Map<String, STVBadge>,
+        val namePaintsById: Map<String, NamePaint>,
+        val cheersByName: Map<String, List<CheerEmote>>,
+    ) {
+        companion object {
+            fun create(
+                localTwitchEmotes: List<TwitchEmote>,
+                thirdPartyEmotes: List<Emote>,
+                globalBadges: List<TwitchBadge>,
+                channelBadges: List<TwitchBadge>,
+                stvUsers: List<STVUser>,
+                stvBadges: List<STVBadge>,
+                namePaints: List<NamePaint>,
+                personalEmoteSets: Map<String, List<Emote>>,
+                cheerEmotes: List<CheerEmote>,
+            ) = ChatCatalogIndexes(
+                twitchEmotesById = localTwitchEmotes.mapNotNull { it.id?.let { id -> id to it } }.toMap(),
+                thirdPartyEmotesByName = thirdPartyEmotes.mapNotNull { it.name?.let { name -> name to it } }.toMap(),
+                personalEmotesBySet = personalEmoteSets.mapValues { (_, emotes) ->
+                    emotes.mapNotNull { it.name?.let { name -> name to it } }.toMap()
+                },
+                globalBadgesByKey = globalBadges.associateBy(::badgeKey),
+                channelBadgesByKey = channelBadges.associateBy(::badgeKey),
+                stvUsersById = stvUsers.associateBy { it.userId },
+                stvBadgesById = stvBadges.associateBy { it.id },
+                namePaintsById = namePaints.mapNotNull { it.id?.let { id -> id to it } }.toMap(),
+                cheersByName = cheerEmotes.groupBy { it.name.lowercase() },
+            )
+
+            private fun badgeKey(badge: TwitchBadge) = "${badge.setId}:${badge.version}"
+        }
+    }
+
+    class ImageRequestBag {
+        private val disposables = mutableListOf<Disposable>()
+        private val jobs = mutableListOf<Job>()
+        private val clearers = mutableListOf<() -> Unit>()
+        fun add(disposable: Disposable) { disposables += disposable }
+        fun add(job: Job) { jobs += job }
+        fun addClearer(clear: () -> Unit) { clearers += clear }
+        fun cancel() {
+            disposables.forEach(Disposable::dispose)
+            jobs.forEach(Job::cancel)
+            clearers.forEach { it() }
+            disposables.clear(); jobs.clear(); clearers.clear()
+        }
+    }
 
     private val twitchColors = intArrayOf(-65536, -16776961, -16744448, -5103070, -32944, -6632142, -47872, -13726889, -2448096, -2987746, -10510688, -14774017, -38476, -7722014, -16711809)
     private const val RED_HUE_DEGREES = 0f
@@ -107,7 +184,8 @@ object ChatAdapterUtils {
         return description
     }
 
-    fun prepareChatMessage(chatMessage: ChatMessage, context: Context, itemView: View, enableTimestamps: Boolean, timestampFormat: String?, firstMsgVisibility: Int, firstChatMsg: String, redeemedChatMsg: String, redeemedNoMsg: String, rewardChatMsg: String, replyMessage: String, imageClick: ((String?, String?, String?, Boolean?, Int?, Boolean?, String?) -> Unit)?, useRandomColors: Boolean, random: Random, useReadableColors: Boolean, isLightTheme: Boolean, nameDisplay: String?, useBoldNames: Boolean, showNamePaints: Boolean, namePaints: List<NamePaint>, showBadges: Boolean, showSTVBadges: Boolean, stvBadges: List<STVBadge>, showPersonalEmotes: Boolean, personalEmoteSets: Map<String, List<Emote>>, stvUsers: List<STVUser>, enableOverlayEmotes: Boolean, showSystemMessageEmotes: Boolean, loggedInUser: String?, chatUrl: String?, getEmoteBytes: ((String, Pair<Long, Int>) -> ByteArray?)?, userColors: HashMap<String, Int>, savedColors: HashMap<String, Int>, translateAllMessages: Boolean, translateMessage: (ChatMessage, String?) -> Unit, showLanguageDownloadDialog: (ChatMessage, String) -> Unit, hideErrors: Boolean, localTwitchEmotes: List<TwitchEmote>, thirdPartyEmotes: List<Emote>, globalBadges: List<TwitchBadge>, channelBadges: List<TwitchBadge>, cheerEmotes: List<CheerEmote>, savedLocalTwitchEmotes: MutableMap<String, ByteArray>, savedLocalBadges: MutableMap<String, ByteArray>, savedLocalCheerEmotes: MutableMap<String, ByteArray>, savedLocalEmotes: MutableMap<String, ByteArray>): MessageResult {
+    fun prepareChatMessage(chatMessage: ChatMessage, context: Context, itemView: View?, enableTimestamps: Boolean, timestampFormat: String?, firstMsgVisibility: Int, firstChatMsg: String, redeemedChatMsg: String, redeemedNoMsg: String, rewardChatMsg: String, replyMessage: String, imageClick: ((String?, String?, String?, Boolean?, Int?, Boolean?, String?) -> Unit)?, useRandomColors: Boolean, random: Random, useReadableColors: Boolean, isLightTheme: Boolean, nameDisplay: String?, useBoldNames: Boolean, showNamePaints: Boolean, namePaints: List<NamePaint>, showBadges: Boolean, showSTVBadges: Boolean, stvBadges: List<STVBadge>, showPersonalEmotes: Boolean, personalEmoteSets: Map<String, List<Emote>>, stvUsers: List<STVUser>, enableOverlayEmotes: Boolean, showSystemMessageEmotes: Boolean, loggedInUser: String?, chatUrl: String?, userColors: HashMap<String, Int>, savedColors: HashMap<String, Int>, translateAllMessages: Boolean, translateMessage: (ChatMessage, String?) -> Unit, showLanguageDownloadDialog: (ChatMessage, String) -> Unit, hideErrors: Boolean, localTwitchEmotes: List<TwitchEmote>, thirdPartyEmotes: List<Emote>, globalBadges: List<TwitchBadge>, channelBadges: List<TwitchBadge>, cheerEmotes: List<CheerEmote>, savedLocalTwitchEmotes: MutableMap<String, ByteArray>, savedLocalBadges: MutableMap<String, ByteArray>, savedLocalCheerEmotes: MutableMap<String, ByteArray>, savedLocalEmotes: MutableMap<String, ByteArray>, catalogIndexes: ChatCatalogIndexes? = null, includeAccessibilityDescription: Boolean = false): MessageResult {
+        val indexes = catalogIndexes ?: ChatCatalogIndexes.create(localTwitchEmotes, thirdPartyEmotes, globalBadges, channelBadges, stvUsers, stvBadges, namePaints, personalEmoteSets, cheerEmotes)
         val builder = SpannableStringBuilder()
         val images = ArrayList<Image>()
         var imagePaint: NamePaint? = null
@@ -115,6 +193,7 @@ object ChatAdapterUtils {
         var userNameStartIndex: Int? = null
         var wasMentioned = false
         var translated = false
+        var backgroundResource = 0
         var builderIndex = 0
         val badgeVisibility = chatBadgeVisibility(showBadges, showSTVBadges, showNamePaints, showPersonalEmotes)
         when {
@@ -136,10 +215,10 @@ object ChatAdapterUtils {
                 if (message != null) {
                     builder.append(message)
                     builder.setSpan(ForegroundColorSpan(getSavedColor("#999999", savedColors, useReadableColors, isLightTheme)), builderIndex, builderIndex + message.length, SPAN_EXCLUSIVE_EXCLUSIVE)
-                    prepareEmotes(chatMessage, message, builder, builderIndex, images, null, useReadableColors, isLightTheme, enableOverlayEmotes, useBoldNames, loggedInUser, chatUrl, getEmoteBytes, savedColors, localTwitchEmotes, showPersonalEmotes, personalEmoteSets, null, thirdPartyEmotes, cheerEmotes, savedLocalTwitchEmotes, savedLocalCheerEmotes, savedLocalEmotes)
+                    prepareEmotes(chatMessage, message, builder, builderIndex, images, null, useReadableColors, isLightTheme, enableOverlayEmotes, useBoldNames, loggedInUser, chatUrl, savedColors, localTwitchEmotes, showPersonalEmotes, personalEmoteSets, null, thirdPartyEmotes, cheerEmotes, savedLocalTwitchEmotes, savedLocalCheerEmotes, savedLocalEmotes, indexes)
                     builderIndex = builder.length
                 }
-                itemView.setBackgroundResource(0)
+                backgroundResource = 0
             }
             chatMessage.message.isNullOrBlank() && (chatMessage.systemMsg != null || chatMessage.reward?.title != null) -> {
                 if (chatMessage.timestamp != null && enableTimestamps) {
@@ -154,7 +233,7 @@ object ChatAdapterUtils {
                     builder.append(chatMessage.systemMsg)
                     builder.setSpan(ForegroundColorSpan(getSavedColor("#999999", savedColors, useReadableColors, isLightTheme)), builderIndex, builderIndex + chatMessage.systemMsg.length, SPAN_EXCLUSIVE_EXCLUSIVE)
                     if (showSystemMessageEmotes) {
-                        prepareEmotes(chatMessage, chatMessage.systemMsg, builder, builderIndex, images, imageClick, useReadableColors, isLightTheme, enableOverlayEmotes, useBoldNames, loggedInUser, chatUrl, getEmoteBytes, savedColors, localTwitchEmotes, showPersonalEmotes, personalEmoteSets, null, thirdPartyEmotes, cheerEmotes, savedLocalTwitchEmotes, savedLocalCheerEmotes, savedLocalEmotes)
+                        prepareEmotes(chatMessage, chatMessage.systemMsg, builder, builderIndex, images, imageClick, useReadableColors, isLightTheme, enableOverlayEmotes, useBoldNames, loggedInUser, chatUrl, savedColors, localTwitchEmotes, showPersonalEmotes, personalEmoteSets, null, thirdPartyEmotes, cheerEmotes, savedLocalTwitchEmotes, savedLocalCheerEmotes, savedLocalEmotes, indexes)
                     }
                     builderIndex = builder.length
                     if (chatMessage.translatedMessage != null) {
@@ -181,7 +260,7 @@ object ChatAdapterUtils {
                         builder.append("$string ")
                         builder.setSpan(ForegroundColorSpan(getSavedColor("#999999", savedColors, useReadableColors, isLightTheme)), builderIndex, builderIndex + string.length, SPAN_EXCLUSIVE_EXCLUSIVE)
                         if (showSystemMessageEmotes) {
-                            prepareEmotes(chatMessage, string, builder, builderIndex, images, imageClick, useReadableColors, isLightTheme, enableOverlayEmotes, useBoldNames, loggedInUser, chatUrl, getEmoteBytes, savedColors, localTwitchEmotes, showPersonalEmotes, personalEmoteSets, null, thirdPartyEmotes, cheerEmotes, savedLocalTwitchEmotes, savedLocalCheerEmotes, savedLocalEmotes)
+                            prepareEmotes(chatMessage, string, builder, builderIndex, images, imageClick, useReadableColors, isLightTheme, enableOverlayEmotes, useBoldNames, loggedInUser, chatUrl, savedColors, localTwitchEmotes, showPersonalEmotes, personalEmoteSets, null, thirdPartyEmotes, cheerEmotes, savedLocalTwitchEmotes, savedLocalCheerEmotes, savedLocalEmotes, indexes)
                         }
                         builderIndex = builder.length
                         builder.append(". ")
@@ -203,7 +282,7 @@ object ChatAdapterUtils {
                         }
                     }
                 }
-                itemView.setBackgroundResource(0)
+                backgroundResource = 0
             }
             else -> {
                 if (chatMessage.systemMsg != null) {
@@ -260,10 +339,10 @@ object ChatAdapterUtils {
                 if (badgeVisibility.showTwitchBadges) {
                     chatMessage.badges?.forEach { chatBadge ->
                         val badge = synchronized(channelBadges) {
-                            channelBadges.find { it.setId == chatBadge.setId && it.version == chatBadge.version }
+                            indexes.channelBadgesByKey["${chatBadge.setId}:${chatBadge.version}"]
                         } ?:
                         synchronized(globalBadges) {
-                            globalBadges.find { it.setId == chatBadge.setId && it.version == chatBadge.version }
+                            indexes.globalBadgesByKey["${chatBadge.setId}:${chatBadge.version}"]
                         }
                         if (badge != null) {
                             hasBadge = true
@@ -279,7 +358,9 @@ object ChatAdapterUtils {
                                 }, builderIndex, builderIndex + 1, SPAN_EXCLUSIVE_EXCLUSIVE)
                             }
                             images.add(Image(
-                                localData = badge.localData?.let { getLocalEmoteData(badge.setId + badge.version, it, savedLocalBadges, chatUrl, getEmoteBytes) },
+                                localData = badge.localData?.let { getLocalEmoteData(badge.setId + badge.version, it, savedLocalBadges, chatUrl)?.first },
+                                localDataUrl = badge.localData?.let { getLocalEmoteData(badge.setId + badge.version, it, savedLocalBadges, chatUrl)?.second },
+                                localDataRange = badge.localData?.let { getLocalEmoteData(badge.setId + badge.version, it, savedLocalBadges, chatUrl)?.third },
                                 url1x = badge.url1x,
                                 url2x = badge.url2x,
                                 url3x = badge.url3x,
@@ -293,13 +374,13 @@ object ChatAdapterUtils {
                 }
                 val stvUser = if (badgeVisibility.loadStvUser && !chatMessage.userId.isNullOrBlank()) {
                     synchronized(stvUsers) {
-                        stvUsers.find { it.userId == chatMessage.userId }
+                        indexes.stvUsersById[chatMessage.userId]
                     }
                 } else null
                 if (badgeVisibility.showStvBadges && !chatMessage.userId.isNullOrBlank()) {
                     val badge = stvUser?.badgeId?.let { badgeId ->
                         synchronized(stvBadges) {
-                            stvBadges.find { it.id == badgeId }
+                            indexes.stvBadgesById[badgeId]
                         }
                     }
                     if (badge != null) {
@@ -336,16 +417,18 @@ object ChatAdapterUtils {
                 val color = if (chatMessage.color != null) {
                     getSavedColor(chatMessage.color, savedColors, useReadableColors, isLightTheme)
                 } else {
-                    userColors[chatMessage.userName] ?: if (useRandomColors) {
-                        twitchColors[random.nextInt(twitchColors.size)]
-                    } else {
-                        -10066329
-                    }.let { newColor ->
-                        if (useReadableColors) {
-                            adaptUsernameColor(newColor, isLightTheme)
+                    synchronized(userColors) {
+                        userColors[chatMessage.userName] ?: if (useRandomColors) {
+                            twitchColors[random.nextInt(twitchColors.size)]
                         } else {
-                            newColor
-                        }.also { if (chatMessage.userName != null) userColors[chatMessage.userName] = it }
+                            -10066329
+                        }.let { newColor ->
+                            if (useReadableColors) {
+                                adaptUsernameColor(newColor, isLightTheme)
+                            } else {
+                                newColor
+                            }.also { if (chatMessage.userName != null) userColors[chatMessage.userName] = it }
+                        }
                     }
                 }
                 if (!chatMessage.userName.isNullOrBlank()) {
@@ -366,7 +449,7 @@ object ChatAdapterUtils {
                     if (showNamePaints && !chatMessage.userId.isNullOrBlank()) {
                         stvUser?.paintId?.let { paintId ->
                             synchronized(namePaints) {
-                                namePaints.find { it.id == paintId }
+                                indexes.namePaintsById[paintId]
                             }
                         }?.let { paint ->
                             when (paint.type) {
@@ -411,7 +494,7 @@ object ChatAdapterUtils {
                     if (chatMessage.isAction) {
                         builder.setSpan(ForegroundColorSpan(color), builderIndex, builderIndex + chatMessage.message.length, SPAN_EXCLUSIVE_EXCLUSIVE)
                     }
-                    val result = prepareEmotes(chatMessage, chatMessage.message, builder, builderIndex, images, imageClick, useReadableColors, isLightTheme, enableOverlayEmotes, useBoldNames, loggedInUser, chatUrl, getEmoteBytes, savedColors, localTwitchEmotes, showPersonalEmotes, personalEmoteSets, stvUser, thirdPartyEmotes, cheerEmotes, savedLocalTwitchEmotes, savedLocalCheerEmotes, savedLocalEmotes)
+                    val result = prepareEmotes(chatMessage, chatMessage.message, builder, builderIndex, images, imageClick, useReadableColors, isLightTheme, enableOverlayEmotes, useBoldNames, loggedInUser, chatUrl, savedColors, localTwitchEmotes, showPersonalEmotes, personalEmoteSets, stvUser, thirdPartyEmotes, cheerEmotes, savedLocalTwitchEmotes, savedLocalCheerEmotes, savedLocalEmotes, indexes)
                     wasMentioned = result
                     builderIndex = builder.length
                 }
@@ -424,16 +507,28 @@ object ChatAdapterUtils {
                         translateMessage(chatMessage, null)
                     }
                 }
-                when {
-                    chatMessage.isFirst && firstMsgVisibility < 2 -> itemView.setBackgroundResource(R.color.chatMessageFirst)
-                    chatMessage.reward?.id != null && firstMsgVisibility < 2 -> itemView.setBackgroundResource(R.color.chatMessageReward)
-                    chatMessage.systemMsg != null || chatMessage.msgId != null -> itemView.setBackgroundResource(R.color.chatMessageNotice)
-                    wasMentioned -> itemView.setBackgroundResource(R.color.chatMessageMention)
-                    else -> itemView.setBackgroundResource(0)
+                backgroundResource = when {
+                    chatMessage.isFirst && firstMsgVisibility < 2 -> R.color.chatMessageFirst
+                    chatMessage.reward?.id != null && firstMsgVisibility < 2 -> R.color.chatMessageReward
+                    chatMessage.systemMsg != null || chatMessage.msgId != null -> R.color.chatMessageNotice
+                    wasMentioned -> R.color.chatMessageMention
+                    else -> 0
                 }
             }
         }
-        return MessageResult(builder, images, imagePaint, userName, userNameStartIndex, translated)
+        itemView?.setBackgroundResource(backgroundResource)
+        return MessageResult(
+            builder = builder,
+            images = images,
+            imagePaint = imagePaint,
+            userName = userName,
+            userNameStartIndex = userNameStartIndex,
+            translated = translated,
+            backgroundResource = backgroundResource,
+            accessibilityDescription = if (includeAccessibilityDescription) {
+                accessibilityDescription(context, chatMessage, nameDisplay, builder)
+            } else null,
+        )
     }
 
     class MessageResult(
@@ -443,7 +538,21 @@ object ChatAdapterUtils {
         val userName: String?,
         val userNameStartIndex: Int?,
         val translated: Boolean,
-    )
+        val backgroundResource: Int,
+        val accessibilityDescription: String? = null,
+    ) {
+        /** Keep the parsed spans but give each holder its own mutable builder and image list. */
+        fun copyForBind() = MessageResult(
+            builder = SpannableStringBuilder(builder),
+            images = ArrayList(images),
+            imagePaint = imagePaint,
+            userName = userName,
+            userNameStartIndex = userNameStartIndex,
+            translated = translated,
+            backgroundResource = backgroundResource,
+            accessibilityDescription = accessibilityDescription,
+        )
+    }
 
     fun addTranslation(chatMessage: ChatMessage, builder: SpannableStringBuilder, startIndex: Int, savedColors: HashMap<String, Int>, useReadableColors: Boolean, isLightTheme: Boolean, showLanguageDownloadDialog: (ChatMessage, String) -> Unit, hideErrors: Boolean): Int {
         var builderIndex = startIndex
@@ -466,13 +575,23 @@ object ChatAdapterUtils {
         return builderIndex
     }
 
+    fun installImagePlaceholders(builder: SpannableStringBuilder, images: List<Image>, emoteSize: Int, badgeSize: Int, inlineIconSize: Int) {
+        images.forEach { image ->
+            val size = imageSizeForKind(image.kind, emoteSize, badgeSize, inlineIconSize)
+            val placeholder = ColorDrawable(Color.TRANSPARENT).apply { setBounds(0, 0, size, size) }
+            builder.setSpan(CenteredImageSpan(placeholder), image.start, image.end, SPAN_EXCLUSIVE_EXCLUSIVE)
+        }
+    }
+
     private fun getSavedColor(color: String, savedColors: HashMap<String, Int>, useReadableColors: Boolean, isLightTheme: Boolean): Int {
-        return savedColors[color] ?: Color.parseColor(color).let { newColor ->
-            if (useReadableColors) {
-                adaptUsernameColor(newColor, isLightTheme)
-            } else {
-                newColor
-            }.also { savedColors[color] = it }
+        return synchronized(savedColors) {
+            savedColors[color] ?: Color.parseColor(color).let { newColor ->
+                if (useReadableColors) {
+                    adaptUsernameColor(newColor, isLightTheme)
+                } else {
+                    newColor
+                }.also { savedColors[color] = it }
+            }
         }
     }
 
@@ -498,7 +617,7 @@ object ChatAdapterUtils {
         return ColorUtils.HSLToColor(colorArray)
     }
 
-    private fun prepareEmotes(chatMessage: ChatMessage, message: String, builder: SpannableStringBuilder, startIndex: Int, images: ArrayList<Image>, imageClick: ((String?, String?, String?, Boolean?, Int?, Boolean?, String?) -> Unit)?, useReadableColors: Boolean, isLightTheme: Boolean, enableOverlayEmotes: Boolean, useBoldNames: Boolean, loggedInUser: String?, chatUrl: String?, getEmoteBytes: ((String, Pair<Long, Int>) -> ByteArray?)?, savedColors: HashMap<String, Int>, localTwitchEmotes: List<TwitchEmote>, showPersonalEmotes: Boolean, personalEmoteSets: Map<String, List<Emote>>, stvUser: STVUser?, thirdPartyEmotes: List<Emote>, cheerEmotes: List<CheerEmote>, savedLocalTwitchEmotes: MutableMap<String, ByteArray>, savedLocalCheerEmotes: MutableMap<String, ByteArray>, savedLocalEmotes: MutableMap<String, ByteArray>): Boolean {
+    private fun prepareEmotes(chatMessage: ChatMessage, message: String, builder: SpannableStringBuilder, startIndex: Int, images: ArrayList<Image>, imageClick: ((String?, String?, String?, Boolean?, Int?, Boolean?, String?) -> Unit)?, useReadableColors: Boolean, isLightTheme: Boolean, enableOverlayEmotes: Boolean, useBoldNames: Boolean, loggedInUser: String?, chatUrl: String?, savedColors: HashMap<String, Int>, localTwitchEmotes: List<TwitchEmote>, showPersonalEmotes: Boolean, personalEmoteSets: Map<String, List<Emote>>, stvUser: STVUser?, thirdPartyEmotes: List<Emote>, cheerEmotes: List<CheerEmote>, savedLocalTwitchEmotes: MutableMap<String, ByteArray>, savedLocalCheerEmotes: MutableMap<String, ByteArray>, savedLocalEmotes: MutableMap<String, ByteArray>, catalogIndexes: ChatCatalogIndexes): Boolean {
         var wasMentioned = false
         try {
             var builderIndex = startIndex
@@ -511,7 +630,7 @@ object ChatAdapterUtils {
                 } else {
                     it.end + realBegin - it.begin
                 }
-                localTwitchEmotes.find { emote -> emote.id == it.id }?.let { emote ->
+                catalogIndexes.twitchEmotesById[it.id]?.let { emote ->
                     TwitchEmote(
                         id = emote.id,
                         name = emote.name,
@@ -526,11 +645,7 @@ object ChatAdapterUtils {
                 } ?: TwitchEmote(id = it.id, begin = realBegin, end = realEnd)
             }?.sortedBy { it.begin }?.toMutableList()
             val personalEmotes = if (showPersonalEmotes) {
-                stvUser?.emoteSetId?.let { setId ->
-                    synchronized(personalEmoteSets) {
-                        personalEmoteSets.entries.find { it.key == setId }?.value
-                    }
-                }
+                stvUser?.emoteSetId?.let(catalogIndexes.personalEmotesBySet::get)
             } else null
             for (value in split) {
                 if (chatMessage.bits != null) {
@@ -538,7 +653,7 @@ object ChatAdapterUtils {
                     val bitsName = value.substringBeforeLast(bitsCount)
                     if (bitsCount.isNotEmpty()) {
                         val emote = synchronized(cheerEmotes) {
-                            cheerEmotes.findLast { it.name.equals(bitsName, true) && it.minBits <= bitsCount.toInt() }
+                            catalogIndexes.cheersByName[bitsName.lowercase()]?.lastOrNull { it.minBits <= bitsCount.toInt() }
                         }
                         if (emote != null) {
                             builder.replace(builderIndex, builderIndex + bitsName.length, ".")
@@ -553,7 +668,9 @@ object ChatAdapterUtils {
                                 }, builderIndex, builderIndex + 1, SPAN_EXCLUSIVE_EXCLUSIVE)
                             }
                             images.add(Image(
-                                localData = emote.localData?.let { getLocalEmoteData(emote.name + emote.minBits, it, savedLocalCheerEmotes, chatUrl, getEmoteBytes) },
+                                localData = emote.localData?.let { getLocalEmoteData(emote.name + emote.minBits, it, savedLocalCheerEmotes, chatUrl)?.first },
+                                localDataUrl = emote.localData?.let { getLocalEmoteData(emote.name + emote.minBits, it, savedLocalCheerEmotes, chatUrl)?.second },
+                                localDataRange = emote.localData?.let { getLocalEmoteData(emote.name + emote.minBits, it, savedLocalCheerEmotes, chatUrl)?.third },
                                 url1x = emote.url1x,
                                 url2x = emote.url2x,
                                 url3x = emote.url3x,
@@ -581,16 +698,15 @@ object ChatAdapterUtils {
                         }
                     }
                 }
-                val emote = personalEmotes?.find {
-                    it.name == value
-                } ?: synchronized(thirdPartyEmotes) {
-                    thirdPartyEmotes.find { it.name == value }
-                }
+                val emote = personalEmotes?.get(value)
+                    ?: catalogIndexes.thirdPartyEmotesByName[value]
                 if (emote != null) {
                     if (emote.isOverlayEmote && enableOverlayEmotes && previousImage != null) {
                         builder.replace(builderIndex - 1, builderIndex + value.length, "")
                         val image = Image(
-                            localData = emote.localData?.let { getLocalEmoteData(emote.name!!, it, savedLocalEmotes, chatUrl, getEmoteBytes) },
+                            localData = emote.localData?.let { getLocalEmoteData(emote.name!!, it, savedLocalEmotes, chatUrl)?.first },
+                            localDataUrl = emote.localData?.let { getLocalEmoteData(emote.name!!, it, savedLocalEmotes, chatUrl)?.second },
+                            localDataRange = emote.localData?.let { getLocalEmoteData(emote.name!!, it, savedLocalEmotes, chatUrl)?.third },
                             url1x = emote.url1x,
                             url2x = emote.url2x,
                             url3x = emote.url3x,
@@ -625,7 +741,9 @@ object ChatAdapterUtils {
                             }, builderIndex, builderIndex + 1, SPAN_EXCLUSIVE_EXCLUSIVE)
                         }
                         val image = Image(
-                            localData = emote.localData?.let { getLocalEmoteData(emote.name!!, it, savedLocalEmotes, chatUrl, getEmoteBytes) },
+                            localData = emote.localData?.let { getLocalEmoteData(emote.name!!, it, savedLocalEmotes, chatUrl)?.first },
+                            localDataUrl = emote.localData?.let { getLocalEmoteData(emote.name!!, it, savedLocalEmotes, chatUrl)?.second },
+                            localDataRange = emote.localData?.let { getLocalEmoteData(emote.name!!, it, savedLocalEmotes, chatUrl)?.third },
                             url1x = emote.url1x,
                             url2x = emote.url2x,
                             url3x = emote.url3x,
@@ -665,7 +783,7 @@ object ChatAdapterUtils {
                     twitchEmotes.remove(twitchEmote)
                     builder.replace(builderIndex, builderIndex + value.length, ".")
                     builder.setSpan(ForegroundColorSpan(Color.TRANSPARENT), builderIndex, builderIndex + 1, SPAN_EXCLUSIVE_EXCLUSIVE)
-                    val emote = localTwitchEmotes.find { emote -> emote.id == twitchEmote.id }?.let { emote ->
+                    val emote = catalogIndexes.twitchEmotesById[twitchEmote.id]?.let { emote ->
                         TwitchEmote(
                             id = emote.id,
                             name = emote.name,
@@ -688,7 +806,9 @@ object ChatAdapterUtils {
                         }, builderIndex, builderIndex + 1, SPAN_EXCLUSIVE_EXCLUSIVE)
                     }
                     val image = Image(
-                        localData = emote.localData?.let { getLocalEmoteData(emote.id!!, it, savedLocalTwitchEmotes, chatUrl, getEmoteBytes) },
+                        localData = emote.localData?.let { getLocalEmoteData(emote.id!!, it, savedLocalTwitchEmotes, chatUrl)?.first },
+                        localDataUrl = emote.localData?.let { getLocalEmoteData(emote.id!!, it, savedLocalTwitchEmotes, chatUrl)?.second },
+                        localDataRange = emote.localData?.let { getLocalEmoteData(emote.id!!, it, savedLocalTwitchEmotes, chatUrl)?.third },
                         url1x = emote.url1x,
                         url2x = emote.url2x,
                         url3x = emote.url3x,
@@ -738,30 +858,51 @@ object ChatAdapterUtils {
         return wasMentioned
     }
 
-    private fun getLocalEmoteData(name: String, data: Pair<Long, Int>, savedLocalEmotes: MutableMap<String, ByteArray>, chatUrl: String?, getEmoteBytes: ((String, Pair<Long, Int>) -> ByteArray?)?): ByteArray? {
-        return savedLocalEmotes[name] ?: chatUrl?.let { url ->
-            getEmoteBytes?.let { get ->
-                get(url, data)?.also {
-                    if (savedLocalEmotes.size >= 100) {
-                        savedLocalEmotes.remove(savedLocalEmotes.keys.first())
-                    }
-                    savedLocalEmotes[name] = it
-                }
+    private fun getLocalEmoteData(name: String, data: Pair<Long, Int>, savedLocalEmotes: MutableMap<String, ByteArray>, chatUrl: String?): Triple<ByteArray?, String?, Pair<Long, Int>?>? {
+        synchronized(savedLocalEmotes) {
+            savedLocalEmotes[name]?.let { return Triple(it, null, null) }
+        }
+        return chatUrl?.let { Triple(null, it, data) }
+    }
+
+    private fun getCachedLocalEmote(source: String, range: Pair<Long, Int>): ByteArray? = synchronized(localEmoteCache) {
+        localEmoteCache[LocalEmoteKey(source, range.first, range.second)]
+    }
+
+    private fun cacheLocalEmote(source: String, range: Pair<Long, Int>, bytes: ByteArray) {
+        if (bytes.size > LOCAL_EMOTE_CACHE_MAX_BYTES) return
+        synchronized(localEmoteCache) {
+            val key = LocalEmoteKey(source, range.first, range.second)
+            localEmoteCache.remove(key)?.let { localEmoteCacheBytes -= it.size }
+            localEmoteCache[key] = bytes
+            localEmoteCacheBytes += bytes.size
+            while (localEmoteCacheBytes > LOCAL_EMOTE_CACHE_MAX_BYTES) {
+                val iterator = localEmoteCache.entries.iterator()
+                if (!iterator.hasNext()) break
+                localEmoteCacheBytes -= iterator.next().value.size
+                iterator.remove()
             }
         }
     }
 
-    fun loadImages(fragment: Fragment, itemView: View, bind: (SpannableStringBuilder) -> Unit, images: List<Image>, imagePaint: NamePaint?, userName: String?, userNameStartIndex: Int?, backgroundColor: Int, imageLibrary: String?, builder: SpannableStringBuilder, translated: Boolean, emoteSize: Int, badgeSize: Int, inlineIconSize: Int, emoteQuality: String, animateGifs: Boolean, enableOverlayEmotes: Boolean, chatMessage: ChatMessage, savedColors: HashMap<String, Int>, useReadableColors: Boolean, isLightTheme: Boolean, showLanguageDownloadDialog: (ChatMessage, String) -> Unit, hideErrors: Boolean) {
+    fun loadImages(fragment: Fragment, itemView: View, bind: (SpannableStringBuilder) -> Unit, images: List<Image>, imagePaint: NamePaint?, userName: String?, userNameStartIndex: Int?, backgroundColor: Int, imageLibrary: String?, builder: SpannableStringBuilder, translated: Boolean, emoteSize: Int, badgeSize: Int, inlineIconSize: Int, emoteQuality: String, animateGifs: Boolean, enableOverlayEmotes: Boolean, chatMessage: ChatMessage, savedColors: HashMap<String, Int>, useReadableColors: Boolean, isLightTheme: Boolean, showLanguageDownloadDialog: (ChatMessage, String) -> Unit, hideErrors: Boolean, isCurrent: () -> Boolean = { true }, shouldAnimate: () -> Boolean = { true }, requestBag: ImageRequestBag? = null, shouldLoad: () -> Boolean = { true }, onLoadDeferred: () -> Unit = {}) {
+        // During a fling the placeholder layout is sufficient. Deferring every request, including
+        // static badges and name paints, prevents decode/cache work from competing with scrolling.
+        if (!shouldLoad()) {
+            if (imagePaint != null || images.isNotEmpty()) onLoadDeferred()
+            return
+        }
         if (imagePaint != null) {
             if (imageLibrary == "0") {
-                fragment.requireContext().imageLoader.enqueue(
+                val disposable = fragment.requireContext().imageLoader.enqueue(
                     ImageRequest.Builder(fragment.requireContext()).apply {
                         data(imagePaint.imageUrl)
                         httpHeaders(NetworkHeaders.Builder().apply {
                             add("User-Agent", "Xtra/" + BuildConfig.VERSION_NAME)
                         }.build())
                         target(
-                            onSuccess = {
+                            onSuccess = imagePaintLoaded@{
+                                if (!isCurrent()) return@imagePaintLoaded
                                 (it.asDrawable(fragment.resources)).let { result ->
                                     if (result is Animatable && animateGifs) {
                                         result.callback = object : Drawable.Callback {
@@ -777,7 +918,7 @@ object ChatAdapterUtils {
                                                 itemView.postDelayed(what, `when`)
                                             }
                                         }
-                                        (result as Animatable).start()
+                                        if (shouldAnimate()) (result as Animatable).start()
                                     }
                                     try {
                                         builder.setSpan(
@@ -803,56 +944,62 @@ object ChatAdapterUtils {
                         )
                     }.build()
                 )
+                requestBag?.add(disposable)
             } else {
-                Glide.with(fragment)
+                val requestManager = Glide.with(fragment)
+                val target = object : CustomTarget<Drawable>() {
+                    override fun onResourceReady(resource: Drawable, transition: Transition<in Drawable>?) {
+                        if (!isCurrent()) return
+                        if (resource is Animatable && animateGifs) {
+                            resource.callback = object : Drawable.Callback {
+                                override fun unscheduleDrawable(who: Drawable, what: Runnable) {
+                                    itemView.removeCallbacks(what)
+                                }
+
+                                override fun invalidateDrawable(who: Drawable) {
+                                    itemView.invalidate()
+                                }
+
+                                override fun scheduleDrawable(who: Drawable, what: Runnable, `when`: Long) {
+                                    itemView.postDelayed(what, `when`)
+                                }
+                            }
+                            if (shouldAnimate()) (resource as Animatable).start()
+                        }
+                        try {
+                            builder.setSpan(
+                                NamePaintImageSpan(
+                                    userName!!,
+                                    imagePaint.shadows,
+                                    (itemView.background as? ColorDrawable)?.color,
+                                    backgroundColor,
+                                    resource
+                                ),
+                                userNameStartIndex!!,
+                                userNameStartIndex + userName.length,
+                                SPAN_EXCLUSIVE_EXCLUSIVE
+                            )
+                        } catch (e: IndexOutOfBoundsException) {
+                        }
+                        if (!translated && chatMessage.translatedMessage != null) {
+                            addTranslation(chatMessage, builder, builder.length, savedColors, useReadableColors, isLightTheme, showLanguageDownloadDialog, hideErrors)
+                        }
+                        bind(builder)
+                    }
+
+                    override fun onLoadCleared(placeholder: Drawable?) {
+                    }
+                }
+                requestManager
                     .load(GlideUrl(imagePaint.imageUrl) { mapOf("User-Agent" to "Xtra/" + BuildConfig.VERSION_NAME) })
                     .diskCacheStrategy(DiskCacheStrategy.DATA)
-                    .into(object : CustomTarget<Drawable>() {
-                        override fun onResourceReady(resource: Drawable, transition: Transition<in Drawable>?) {
-                            if (resource is Animatable && animateGifs) {
-                                resource.callback = object : Drawable.Callback {
-                                    override fun unscheduleDrawable(who: Drawable, what: Runnable) {
-                                        itemView.removeCallbacks(what)
-                                    }
-
-                                    override fun invalidateDrawable(who: Drawable) {
-                                        itemView.invalidate()
-                                    }
-
-                                    override fun scheduleDrawable(who: Drawable, what: Runnable, `when`: Long) {
-                                        itemView.postDelayed(what, `when`)
-                                    }
-                                }
-                                (resource as Animatable).start()
-                            }
-                            try {
-                                builder.setSpan(
-                                    NamePaintImageSpan(
-                                        userName!!,
-                                        imagePaint.shadows,
-                                        (itemView.background as? ColorDrawable)?.color,
-                                        backgroundColor,
-                                        resource
-                                    ),
-                                    userNameStartIndex!!,
-                                    userNameStartIndex + userName.length,
-                                    SPAN_EXCLUSIVE_EXCLUSIVE
-                                )
-                            } catch (e: IndexOutOfBoundsException) {
-                            }
-                            if (!translated && chatMessage.translatedMessage != null) {
-                                addTranslation(chatMessage, builder, builder.length, savedColors, useReadableColors, isLightTheme, showLanguageDownloadDialog, hideErrors)
-                            }
-                            bind(builder)
-                        }
-
-                        override fun onLoadCleared(placeholder: Drawable?) {
-                        }
-                    })
+                    .into(target)
+                requestBag?.addClearer { requestManager.clear(target) }
             }
         }
         images.forEach { image ->
-            loadImage(imageLibrary, fragment, image, emoteQuality) { result ->
+            loadImage(imageLibrary, fragment, image, emoteQuality, requestBag) imageLoaded@{ result ->
+                if (!isCurrent()) return@imageLoaded
                 val imageSize = imageSizeForKind(image.kind, emoteSize, badgeSize, inlineIconSize)
                 val widthRatio = result.intrinsicWidth.toFloat() / result.intrinsicHeight.toFloat()
                 val size = if (widthRatio == 1f) {
@@ -875,24 +1022,26 @@ object ChatAdapterUtils {
                             itemView.postDelayed(what, `when`)
                         }
                     }
-                    (result as Animatable).start()
+                    if (shouldAnimate()) (result as Animatable).start()
                 }
                 if (image.overlayEmote != null) {
                     val drawables = arrayOf(result)
-                    nextOverlayEmote(imageLibrary, fragment, drawables, image.overlayEmote!!, image, itemView, bind, builder, translated, emoteSize, emoteQuality, animateGifs, enableOverlayEmotes, chatMessage, savedColors, useReadableColors, isLightTheme, showLanguageDownloadDialog, hideErrors)
+                    nextOverlayEmote(imageLibrary, fragment, drawables, image.overlayEmote!!, image, itemView, bind, builder, translated, emoteSize, emoteQuality, animateGifs, enableOverlayEmotes, chatMessage, savedColors, useReadableColors, isLightTheme, showLanguageDownloadDialog, hideErrors, isCurrent, shouldAnimate, requestBag, shouldLoad, onLoadDeferred)
                 } else {
-                    builder.setSpan(CenteredImageSpan(result), image.start, image.end, SPAN_EXCLUSIVE_EXCLUSIVE)
-                    if (!translated && chatMessage.translatedMessage != null) {
-                        addTranslation(chatMessage, builder, builder.length, savedColors, useReadableColors, isLightTheme, showLanguageDownloadDialog, hideErrors)
-                    }
-                    bind(builder)
+                    builder.getSpans(image.start, image.end, CenteredImageSpan::class.java).firstOrNull()?.imageDrawable = result
+                    itemView.invalidate()
                 }
             }
         }
     }
 
-    private fun nextOverlayEmote(imageLibrary: String?, fragment: Fragment, drawables: Array<Drawable>, image: Image, bottomImage: Image, itemView: View, bind: (SpannableStringBuilder) -> Unit, builder: SpannableStringBuilder, translated: Boolean, emoteSize: Int, emoteQuality: String, animateGifs: Boolean, enableOverlayEmotes: Boolean, chatMessage: ChatMessage, savedColors: HashMap<String, Int>, useReadableColors: Boolean, isLightTheme: Boolean, showLanguageDownloadDialog: (ChatMessage, String) -> Unit, hideErrors: Boolean) {
-        loadImage(imageLibrary, fragment, image, emoteQuality) { result ->
+    private fun nextOverlayEmote(imageLibrary: String?, fragment: Fragment, drawables: Array<Drawable>, image: Image, bottomImage: Image, itemView: View, bind: (SpannableStringBuilder) -> Unit, builder: SpannableStringBuilder, translated: Boolean, emoteSize: Int, emoteQuality: String, animateGifs: Boolean, enableOverlayEmotes: Boolean, chatMessage: ChatMessage, savedColors: HashMap<String, Int>, useReadableColors: Boolean, isLightTheme: Boolean, showLanguageDownloadDialog: (ChatMessage, String) -> Unit, hideErrors: Boolean, isCurrent: () -> Boolean, shouldAnimate: () -> Boolean, requestBag: ImageRequestBag?, shouldLoad: () -> Boolean, onLoadDeferred: () -> Unit) {
+        if (!shouldLoad()) {
+            onLoadDeferred()
+            return
+        }
+        loadImage(imageLibrary, fragment, image, emoteQuality, requestBag) overlayLoaded@{ result ->
+            if (!isCurrent()) return@overlayLoaded
             val widthRatio = result.intrinsicWidth.toFloat() / result.intrinsicHeight.toFloat()
             val size = if (widthRatio == 1f) {
                 emoteSize to emoteSize
@@ -914,35 +1063,98 @@ object ChatAdapterUtils {
                         itemView.postDelayed(what, `when`)
                     }
                 }
-                (result as Animatable).start()
+                if (shouldAnimate()) (result as Animatable).start()
             }
             val array = drawables.plus(result)
             if (image.overlayEmote != null) {
-                nextOverlayEmote(imageLibrary, fragment, array, image.overlayEmote!!, bottomImage, itemView, bind, builder, translated, emoteSize, emoteQuality, animateGifs, enableOverlayEmotes, chatMessage, savedColors, useReadableColors, isLightTheme, showLanguageDownloadDialog, hideErrors)
+                nextOverlayEmote(imageLibrary, fragment, array, image.overlayEmote!!, bottomImage, itemView, bind, builder, translated, emoteSize, emoteQuality, animateGifs, enableOverlayEmotes, chatMessage, savedColors, useReadableColors, isLightTheme, showLanguageDownloadDialog, hideErrors, isCurrent, shouldAnimate, requestBag, shouldLoad, onLoadDeferred)
             } else {
                 val layer = LayerDrawable(array)
                 val width = array.maxOf { it.bounds.right }
                 val height = array.maxOf { it.bounds.bottom }
                 layer.setBounds(0, 0, width, height)
-                builder.setSpan(CenteredImageSpan(layer), bottomImage.start, bottomImage.end, SPAN_EXCLUSIVE_EXCLUSIVE)
-                if (!translated && chatMessage.translatedMessage != null) {
-                    addTranslation(chatMessage, builder, builder.length, savedColors, useReadableColors, isLightTheme, showLanguageDownloadDialog, hideErrors)
-                }
-                bind(builder)
+                builder.getSpans(bottomImage.start, bottomImage.end, CenteredImageSpan::class.java).firstOrNull()?.imageDrawable = layer
+                itemView.invalidate()
             }
         }
     }
 
-    private fun loadImage(imageLibrary: String?, fragment: Fragment, image: Image, emoteQuality: String, onLoaded: (Drawable) -> Unit) {
+    private fun loadImage(imageLibrary: String?, fragment: Fragment, image: Image, emoteQuality: String, requestBag: ImageRequestBag?, onLoaded: (Drawable) -> Unit) {
+        if (image.localData == null && image.localDataUrl != null && image.localDataRange != null) {
+            val context = fragment.requireContext()
+            val range = image.localDataRange
+            getCachedLocalEmote(image.localDataUrl, range)?.let { bytes ->
+                loadImage(imageLibrary, fragment, image.withLocalData(bytes), emoteQuality, requestBag, onLoaded)
+                return
+            }
+            val job = fragment.viewLifecycleOwner.lifecycleScope.launch(Dispatchers.IO) {
+                val bytes = readLocalEmote(context, image.localDataUrl, range)
+                cacheLocalEmote(image.localDataUrl, range, bytes)
+                withContext(Dispatchers.Main.immediate) { loadImage(imageLibrary, fragment, image.withLocalData(bytes), emoteQuality, requestBag, onLoaded) }
+            }
+            requestBag?.add(job)
+            return
+        }
         if (imageLibrary == "0" || (imageLibrary == "1" && !image.format.equals("webp", true))) {
-            loadCoil(fragment, image, emoteQuality, onLoaded)
+            loadCoil(fragment, image, emoteQuality, requestBag, onLoaded)
         } else {
-            loadGlide(fragment, image, emoteQuality, onLoaded)
+            loadGlide(fragment, image, emoteQuality, requestBag, onLoaded)
         }
     }
 
-    private fun loadCoil(fragment: Fragment, image: Image, emoteQuality: String, onLoaded: (Drawable) -> Unit) {
-        fragment.requireContext().imageLoader.enqueue(
+    private fun readLocalEmote(context: Context, url: String, range: Pair<Long, Int>): ByteArray {
+        val encoded = ByteArray(range.second)
+        val uri = Uri.parse(url)
+        if (uri.scheme == ContentResolver.SCHEME_CONTENT) {
+            val descriptor = context.contentResolver.openFileDescriptor(uri, "r")
+            if (descriptor != null) {
+                try {
+                    Os.lseek(descriptor.fileDescriptor, range.first, OsConstants.SEEK_SET)
+                    ParcelFileDescriptor.AutoCloseInputStream(descriptor).use { input ->
+                        input.readFully(encoded)
+                    }
+                    return Base64.decode(encoded, Base64.NO_WRAP or Base64.NO_PADDING)
+                } catch (_: ErrnoException) {
+                    descriptor.close()
+                } catch (_: IOException) {
+                    descriptor.close()
+                }
+            }
+            val stream = context.contentResolver.openInputStream(uri)
+                ?: error("Unable to open local emote source")
+            stream.use { input ->
+                input.skipFully(range.first)
+                input.readFully(encoded)
+            }
+        } else {
+            RandomAccessFile(File(url), "r").use { file ->
+                file.seek(range.first)
+                file.readFully(encoded)
+            }
+        }
+        return Base64.decode(encoded, Base64.NO_WRAP or Base64.NO_PADDING)
+    }
+
+    private fun java.io.InputStream.skipFully(byteCount: Long) {
+        var skipped = 0L
+        while (skipped < byteCount) {
+            val count = skip(byteCount - skipped)
+            if (count <= 0) error("Unexpected end of local emote data")
+            skipped += count
+        }
+    }
+
+    private fun java.io.InputStream.readFully(buffer: ByteArray) {
+        var read = 0
+        while (read < buffer.size) {
+            val count = read(buffer, read, buffer.size - read)
+            if (count < 0) error("Unexpected end of local emote data")
+            read += count
+        }
+    }
+
+    private fun loadCoil(fragment: Fragment, image: Image, emoteQuality: String, requestBag: ImageRequestBag?, onLoaded: (Drawable) -> Unit) {
+        val disposable = fragment.requireContext().imageLoader.enqueue(
             ImageRequest.Builder(fragment.requireContext()).apply {
                 data(image.localData ?: when (emoteQuality) {
                     "4" -> image.url4x ?: image.url3x ?: image.url2x ?: image.url1x
@@ -950,6 +1162,11 @@ object ChatAdapterUtils {
                     "2" -> image.url2x ?: image.url1x
                     else -> image.url1x
                 })
+                image.localDataUrl?.let { source ->
+                    image.localDataRange?.let { range ->
+                        memoryCacheKey("xtra:chat-local-emote:$source:${range.first}:${range.second}:$emoteQuality")
+                    }
+                }
                 diskCachePolicy(CachePolicy.ENABLED)
                 if (image.thirdParty) {
                     httpHeaders(NetworkHeaders.Builder().apply {
@@ -963,10 +1180,16 @@ object ChatAdapterUtils {
                 )
             }.build()
         )
+        requestBag?.add(disposable)
     }
 
-    private fun loadGlide(fragment: Fragment, image: Image, emoteQuality: String, onLoaded: (Drawable) -> Unit) {
-        Glide.with(fragment)
+    private fun loadGlide(fragment: Fragment, image: Image, emoteQuality: String, requestBag: ImageRequestBag?, onLoaded: (Drawable) -> Unit) {
+        val requestManager = Glide.with(fragment)
+        val target = object : CustomTarget<Drawable>() {
+            override fun onResourceReady(resource: Drawable, transition: Transition<in Drawable>?) { onLoaded(resource) }
+            override fun onLoadCleared(placeholder: Drawable?) {}
+        }
+        requestManager
             .load(image.localData ?: when (emoteQuality) {
                 "4" -> image.url4x ?: image.url3x ?: image.url2x ?: image.url1x
                 "3" -> image.url3x ?: image.url2x ?: image.url1x
@@ -978,13 +1201,7 @@ object ChatAdapterUtils {
                 } else it
             })
             .diskCacheStrategy(DiskCacheStrategy.DATA)
-            .into(object : CustomTarget<Drawable>() {
-                override fun onResourceReady(resource: Drawable, transition: Transition<in Drawable>?) {
-                    onLoaded(resource)
-                }
-
-                override fun onLoadCleared(placeholder: Drawable?) {
-                }
-            })
+            .into(target)
+        requestBag?.addClearer { requestManager.clear(target) }
     }
 }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -8,7 +8,7 @@
 
     <androidx.fragment.app.FragmentContainerView
         android:id="@+id/navHostFragment"
-        android:name="androidx.navigation.fragment.NavHostFragment"
+        android:name="com.github.andreyasadchy.xtra.ui.main.MainNavHostFragment"
         android:layout_width="match_parent"
         android:layout_height="0dp"
         app:defaultNavHost="true"

--- a/app/src/main/res/layout/chat_list_item.xml
+++ b/app/src/main/res/layout/chat_list_item.xml
@@ -2,7 +2,6 @@
 <TextView xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:autoLink="web"
     android:clickable="true"
     android:focusable="true"
     android:linksClickable="true"

--- a/app/src/main/res/layout/common_recycler_view_layout.xml
+++ b/app/src/main/res/layout/common_recycler_view_layout.xml
@@ -22,14 +22,15 @@
     <com.github.andreyasadchy.xtra.ui.view.CustomSwipeRefreshLayout
         android:id="@+id/swipeRefresh"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="0dp"
         android:enabled="false"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintTop_toTopOf="parent">
 
         <com.github.andreyasadchy.xtra.ui.view.GridRecyclerView
             android:id="@+id/recyclerView"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
+            android:layout_height="match_parent"
             android:clipToPadding="false"
             tools:listitem="@layout/fragment_downloads_list_item" />
 

--- a/app/src/main/res/layout/fragment_chat.xml
+++ b/app/src/main/res/layout/fragment_chat.xml
@@ -15,8 +15,7 @@
         <FrameLayout
             android:layout_width="match_parent"
             android:layout_height="0dp"
-            android:layout_weight="1"
-            android:animateLayoutChanges="true">
+            android:layout_weight="1">
 
             <androidx.recyclerview.widget.RecyclerView
                 android:id="@+id/recyclerView"

--- a/app/src/main/res/values/ids.xml
+++ b/app/src/main/res/values/ids.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <item name="twitch_inbox_refresh_job" type="id" />
+    <item name="stream_thumbnail_request_key" type="id" />
+    <item name="stream_profile_request_key" type="id" />
 </resources>

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/common/ThumbnailImageRequestTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/common/ThumbnailImageRequestTest.kt
@@ -13,7 +13,7 @@ import org.junit.Test
 class ThumbnailImageRequestTest {
 
     @Test
-    fun previewBucketsUseOneStableDiskEntryButFreshNetworkUrls() {
+    fun previewBucketsReuseDecodedMemoryAndDiskEntriesButFreshNetworkUrls() {
         val stream = Stream(
             channelId = "channel-42",
             thumbnailURL = "https://static-cdn.jtvnw.net/previews/{width}x{height}.jpg",
@@ -23,7 +23,7 @@ class ThumbnailImageRequestTest {
         val second = streamThumbnailRequestPlan(stream, bucket = 11L)
 
         assertEquals(first!!.diskCacheKey, second!!.diskCacheKey)
-        assertNotEquals(first.memoryCacheKey, second.memoryCacheKey)
+        assertEquals(first.memoryCacheKey, second.memoryCacheKey)
         assertNotEquals(first.networkUrl, second.networkUrl)
         assertFalse(first.diskCacheKey.contains("https://"))
     }
@@ -158,7 +158,7 @@ class ThumbnailImageRequestTest {
     }
 
     @Test
-    fun refreshGenerationMakesIdenticalStreamMetadataChangedForDiffUtil() {
+    fun refreshGenerationDoesNotMakeIdenticalStreamMetadataChangedForDiffUtil() {
         val oldItem = Stream(
             id = "broadcast-1",
             channelId = "channel-42",
@@ -175,7 +175,7 @@ class ThumbnailImageRequestTest {
         )
 
         assertEquals(oldItem.streamIdentity(), newItem.streamIdentity())
-        org.junit.Assert.assertFalse(streamContentsSame(oldItem, newItem))
+        org.junit.Assert.assertTrue(streamContentsSame(oldItem, newItem))
     }
 
     @Test


### PR DESCRIPTION
Improves the parts of Xtra that were stalling while browsing: chat rows no longer do replay-file work during binds, image work is canceled when rows leave screen, hidden tabs stop updating, and stream transitions no longer expose a stale miniature preview before the next video frame.