### PR TITLE
Prevent partial chat rows and warm feed images

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -114,6 +114,7 @@ jobs:
       run: bash .github/scripts/test-release-lookup.sh
 
     - name: Build with Gradle
+      id: build
       env:
         TWITCH_PUBLIC_CLIENT_ID: ${{ vars.TWITCH_PUBLIC_CLIENT_ID }}
       shell: bash
@@ -130,8 +131,21 @@ jobs:
         # Release and perf share almost all sources. Build them in separate
         # Gradle invocations so Kotlin does not compile both variants at the
         # same time and exhaust the GitHub runner heap.
-        ./gradlew --no-daemon :app:assembleRelease "${build_args[@]}"
-        ./gradlew --no-daemon :app:assemblePerf "${build_args[@]}"
+        # AGP's incremental universal-APK splitter can fail transiently after
+        # a packaging worker is interrupted. Avoid reusing a partial
+        # configuration-cache/package state and retry the complete variant
+        # once; real compilation failures still fail the job.
+        build_variant() {
+          local task="$1"
+          if ./gradlew --no-daemon --no-configuration-cache "$task" "${build_args[@]}"; then
+            return 0
+          fi
+          echo "${task} failed; retrying once after stopping Gradle daemons" >&2
+          ./gradlew --stop || true
+          ./gradlew --no-daemon --no-configuration-cache "$task" "${build_args[@]}"
+        }
+        build_variant :app:assembleRelease
+        build_variant :app:assemblePerf
 
     - name: Inspect release APK
       if: always()
@@ -151,6 +165,7 @@ jobs:
           sed -n '1,20p'
 
     - name: Verify release metadata against APK
+      id: verify-release-apk
       env:
         VERSION_NAME: ${{ steps.version.outputs.name }}
         VERSION_CODE: ${{ steps.version.outputs.code }}
@@ -232,7 +247,11 @@ jobs:
         fi
 
     - name: Upload a Build Artifact
-      if: always() && (github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch')
+      if: >-
+        success() &&
+        steps.build.outcome == 'success' &&
+        steps.verify-release-apk.outcome == 'success' &&
+        (github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch')
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: apk

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/ChannelCardPresentation.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/ChannelCardPresentation.kt
@@ -5,9 +5,7 @@ import android.util.LruCache
 import com.github.andreyasadchy.xtra.R
 import com.github.andreyasadchy.xtra.model.ui.User
 import com.github.andreyasadchy.xtra.util.TwitchApiHelper
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlin.time.Instant
@@ -32,9 +30,7 @@ internal data class ChannelCardPresentationKey(
 /** Keeps timestamp and display-name work off the RecyclerView bind path. */
 internal object ChannelCardPresentationCache {
     private const val MAX_ENTRIES = 512
-    private val scope = CoroutineScope(
-        SupervisorJob() + Dispatchers.Default.limitedParallelism(2),
-    )
+    private val scope = FeedPresentationDispatcher.scope
     private val lock = Any()
     private val cache = object : LruCache<ChannelCardPresentationKey, ChannelCardPresentation>(MAX_ENTRIES) {}
     private val pending = HashMap<ChannelCardPresentationKey, MutableList<(ChannelCardPresentation) -> Unit>>()

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/ClipsAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/ClipsAdapter.kt
@@ -154,8 +154,8 @@ class ClipsAdapter(
                         thumbnail.setImageDrawable(null)
                         thumbnail.tag = thumbnailKey
                     }
-                    restoreDecodedMemoryImage(thumbnailKey, thumbnail)
-                    imageLoadScheduler.runOrDefer(this@PagingViewHolder, thumbnail) {
+                    val thumbnailRestored = restoreDecodedMemoryImage(thumbnailKey, thumbnail)
+                    if (!thumbnailRestored) imageLoadScheduler.runOrDefer(this@PagingViewHolder, thumbnail) {
                         if (!root.isAttachedToWindow || boundClipId != clipId) return@runOrDefer
                         imageRequests.replace(
                             thumbnail,
@@ -206,8 +206,8 @@ class ClipsAdapter(
                                 userImage.setImageDrawable(null)
                                 userImage.tag = profileKey
                             }
-                            restoreDecodedMemoryImage(profileKey, userImage)
-                            imageLoadScheduler.runOrDefer(this@PagingViewHolder, userImage) {
+                            val profileRestored = restoreDecodedMemoryImage(profileKey, userImage)
+                            if (!profileRestored) imageLoadScheduler.runOrDefer(this@PagingViewHolder, userImage) {
                                 if (!root.isAttachedToWindow || boundClipId != clipId) return@runOrDefer
                                 imageRequests.replace(
                                     userImage,

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/GamesAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/GamesAdapter.kt
@@ -142,8 +142,8 @@ class GamesAdapter(
                             gameImage.setImageDrawable(null)
                             gameImage.tag = imageKey
                         }
-                        restoreDecodedMemoryImage(imageKey, gameImage)
-                        imageLoadScheduler.runOrDefer(this@PagingViewHolder, binding.gameImage) {
+                        val restored = restoreDecodedMemoryImage(imageKey, gameImage)
+                        if (!restored) imageLoadScheduler.runOrDefer(this@PagingViewHolder, binding.gameImage) {
                             if (!binding.root.isAttachedToWindow || boundGameId != gameId) return@runOrDefer
                             imageRequests.replace(
                                 binding.gameImage,

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/StreamCardPresentation.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/StreamCardPresentation.kt
@@ -114,25 +114,11 @@ internal object StreamCardPresentationCache {
         context: Context,
         streams: List<Stream>,
         preferences: FeedUiPreferences,
-        callback: (() -> Unit)? = null,
     ) {
         val visibleWindow = streams.take(PREWARM_LIMIT)
-        if (visibleWindow.isEmpty()) {
-            callback?.invoke()
-            return
-        }
-        if (callback == null) {
-            visibleWindow.forEach { stream -> request(context, stream, preferences) }
-        } else {
-            val remaining = java.util.concurrent.atomic.AtomicInteger(visibleWindow.size)
-            visibleWindow.forEach { stream ->
-                request(context, stream, preferences) {
-                    if (remaining.decrementAndGet() == 0) callback()
-                } ?: run {
-                    if (remaining.decrementAndGet() == 0) callback()
-                }
-            }
-        }
+        // Prewarming only populates the process-local cache. It must not hop
+        // back to the main thread or cause a second bind for every card.
+        visibleWindow.forEach { stream -> request(context, stream, preferences) }
     }
 
     private fun build(

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/StreamsAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/StreamsAdapter.kt
@@ -194,8 +194,8 @@ class StreamsAdapter(
                             context.getString(R.string.player_open_channel, it)
                         }
                         prepareStreamProfileImage(userImage, item)
-                        restoreWarmStreamProfileImage(context, userImage, item)
-                        thumbnailLoadScheduler.runOrDefer(this@PagingViewHolder, binding.userImage) {
+                        val profileRestored = restoreWarmStreamProfileImage(context, userImage, item)
+                        if (!profileRestored) thumbnailLoadScheduler.runOrDefer(this@PagingViewHolder, binding.userImage) {
                             if (binding.root.isAttachedToWindow && boundImageIdentity == item.streamIdentity()) {
                                 loadStreamProfileImage(context, userImage, item)?.let {
                                     imageRequests.replace(binding.userImage, it)

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/StreamsCompactAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/StreamsCompactAdapter.kt
@@ -65,7 +65,7 @@ class StreamsCompactAdapter(
                     context = context,
                     streams = snapshot().items.filterNotNull(),
                     preferences = preferences,
-                ) {}
+                )
             }
         }
     }
@@ -206,8 +206,8 @@ class StreamsCompactAdapter(
                             context.getString(R.string.player_open_channel, it)
                         }
                         prepareStreamProfileImage(userImage, item)
-                        restoreWarmStreamProfileImage(context, userImage, item)
-                        thumbnailLoadScheduler.runOrDefer(this@PagingViewHolder, binding.userImage) {
+                        val profileRestored = restoreWarmStreamProfileImage(context, userImage, item)
+                        if (!profileRestored) thumbnailLoadScheduler.runOrDefer(this@PagingViewHolder, binding.userImage) {
                             if (binding.root.isAttachedToWindow && boundImageIdentity == item.streamIdentity()) {
                                 loadStreamProfileImage(context, userImage, item)?.let {
                                     imageRequests.replace(binding.userImage, it)

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/ThumbnailImageRequest.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/ThumbnailImageRequest.kt
@@ -479,15 +479,9 @@ internal fun restoreDecodedMemoryImage(
         ?.image
         ?: return false
 
-    // Generic feed holders use cacheKey as their normal ImageView tag.
-    // If the correct decoded image is already represented by this holder,
-    // avoid reassigning the drawable. The Coil memory-cache hit is what proves
-    // the image successfully exists; drawable != null by itself is NOT proof.
-    if (imageView.tag != cacheKey || imageView.drawable == null) {
-        imageView.setImageDrawable(
-            cachedImage.asDrawable(imageView.resources)
-        )
-    }
+    imageView.setImageDrawable(
+        cachedImage.asDrawable(imageView.resources)
+    )
 
     if (BuildConfig.DEBUG) {
         Log.d(

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/ThumbnailImageRequest.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/ThumbnailImageRequest.kt
@@ -470,14 +470,31 @@ private fun restoreWarmStreamThumbnail(cacheKey: String, imageView: ImageView): 
  * The small ConstantState cache above remains a fallback for images Coil has
  * already evicted from its decoded cache.
  */
-internal fun restoreDecodedMemoryImage(cacheKey: String, imageView: ImageView): Boolean {
-    if (imageView.drawable != null) return false
+internal fun restoreDecodedMemoryImage(
+    cacheKey: String,
+    imageView: ImageView,
+): Boolean {
+    // Most generic feed holders use their image cache key as the ImageView
+    // tag. If this holder already has the correct drawable, there is
+    // literally nothing to do.
+    if (imageView.tag == cacheKey && imageView.drawable != null) {
+        return true
+    }
+
     val cachedImage = imageView.context.imageLoader.memoryCache
         ?.get(MemoryCache.Key(cacheKey))
         ?.image
         ?: return false
+
     imageView.setImageDrawable(cachedImage.asDrawable(imageView.resources))
-    if (BuildConfig.DEBUG) Log.d("StreamThumbnail", "memory_restore keyHash=${cacheKey.hashCode().toString(16)}")
+
+    if (BuildConfig.DEBUG) {
+        Log.d(
+            "StreamThumbnail",
+            "memory_restore keyHash=${cacheKey.hashCode().toString(16)}",
+        )
+    }
+
     return true
 }
 
@@ -718,7 +735,19 @@ internal fun restoreWarmStreamProfileImage(
 ): Boolean {
     val url = stream.channelImage ?: return false
     val preferences = FeedUiPreferencesStore.current(context)
+
     val requestKey = "${stream.streamIdentity()}|$url|round=${preferences.roundUserImage}"
+
+    // Stream profile ImageViews use streamIdentity() as their normal tag
+    // rather than requestKey, so check both identity and stored request key.
+    if (
+        imageView.tag == stream.streamIdentity() &&
+        imageView.getTag(R.id.stream_profile_request_key) == requestKey &&
+        imageView.drawable != null
+    ) {
+        return true
+    }
+
     return restoreDecodedMemoryImage(requestKey, imageView)
 }
 

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/ThumbnailImageRequest.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/ThumbnailImageRequest.kt
@@ -474,19 +474,20 @@ internal fun restoreDecodedMemoryImage(
     cacheKey: String,
     imageView: ImageView,
 ): Boolean {
-    // Most generic feed holders use their image cache key as the ImageView
-    // tag. If this holder already has the correct drawable, there is
-    // literally nothing to do.
-    if (imageView.tag == cacheKey && imageView.drawable != null) {
-        return true
-    }
-
     val cachedImage = imageView.context.imageLoader.memoryCache
         ?.get(MemoryCache.Key(cacheKey))
         ?.image
         ?: return false
 
-    imageView.setImageDrawable(cachedImage.asDrawable(imageView.resources))
+    // Generic feed holders use cacheKey as their normal ImageView tag.
+    // If the correct decoded image is already represented by this holder,
+    // avoid reassigning the drawable. The Coil memory-cache hit is what proves
+    // the image successfully exists; drawable != null by itself is NOT proof.
+    if (imageView.tag != cacheKey || imageView.drawable == null) {
+        imageView.setImageDrawable(
+            cachedImage.asDrawable(imageView.resources)
+        )
+    }
 
     if (BuildConfig.DEBUG) {
         Log.d(
@@ -736,19 +737,32 @@ internal fun restoreWarmStreamProfileImage(
     val url = stream.channelImage ?: return false
     val preferences = FeedUiPreferencesStore.current(context)
 
-    val requestKey = "${stream.streamIdentity()}|$url|round=${preferences.roundUserImage}"
+    val identity = stream.streamIdentity()
+    val requestKey =
+        "$identity|$url|round=${preferences.roundUserImage}"
 
-    // Stream profile ImageViews use streamIdentity() as their normal tag
-    // rather than requestKey, so check both identity and stored request key.
+    // Already displaying the exact successfully satisfied profile request.
     if (
-        imageView.tag == stream.streamIdentity() &&
+        imageView.tag == identity &&
         imageView.getTag(R.id.stream_profile_request_key) == requestKey &&
         imageView.drawable != null
     ) {
         return true
     }
 
-    return restoreDecodedMemoryImage(requestKey, imageView)
+    if (!restoreDecodedMemoryImage(requestKey, imageView)) {
+        return false
+    }
+
+    // This decoded-memory hit satisfies exactly the same request that
+    // loadStreamProfileImage() would mark before starting Coil.
+    // Record it so subsequent binds become a true zero-work fast path.
+    imageView.setTag(
+        R.id.stream_profile_request_key,
+        requestKey,
+    )
+
+    return true
 }
 
 internal fun loadStreamThumbnail(

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/VideoHistoryCardPresentation.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/VideoHistoryCardPresentation.kt
@@ -4,9 +4,7 @@ import android.text.format.DateUtils
 import android.util.LruCache
 import com.github.andreyasadchy.xtra.model.VideoHistory
 import com.github.andreyasadchy.xtra.util.TwitchApiHelper
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
@@ -29,9 +27,7 @@ internal object VideoHistoryCardPresentationCache {
     private const val MAX_ENTRIES = 256
     private const val PREWARM_LIMIT = 32
 
-    private val scope = CoroutineScope(
-        SupervisorJob() + Dispatchers.Default.limitedParallelism(2),
-    )
+    private val scope = FeedPresentationDispatcher.scope
     private val lock = Any()
     private val cache = object : LruCache<VideoHistoryCardPresentationKey, VideoHistoryCardPresentation>(MAX_ENTRIES) {}
     private val pending = HashMap<VideoHistoryCardPresentationKey, MutableList<(VideoHistoryCardPresentation) -> Unit>>()
@@ -47,21 +43,21 @@ internal object VideoHistoryCardPresentationCache {
         synchronized(lock) { cache.get(key(item)) }
 
     fun prewarm(items: List<VideoHistory>) {
-        items.take(PREWARM_LIMIT).forEach { item -> request(item) {} }
+        items.take(PREWARM_LIMIT).forEach { item -> request(item) }
     }
 
     fun request(
         item: VideoHistory,
-        callback: (VideoHistoryCardPresentation) -> Unit,
+        callback: ((VideoHistoryCardPresentation) -> Unit)? = null,
     ): VideoHistoryCardPresentation? {
         val key = key(item)
         synchronized(lock) {
             cache.get(key)?.let { return it }
             pending[key]?.let {
-                it += callback
+                callback?.let(it::add)
                 return null
             }
-            pending[key] = mutableListOf(callback)
+            pending[key] = callback?.let(::mutableListOf) ?: mutableListOf()
         }
         scope.launch {
             val presentation = build(item, key)
@@ -69,8 +65,10 @@ internal object VideoHistoryCardPresentationCache {
                 cache.put(key, presentation)
                 pending.remove(key).orEmpty()
             }
-            withContext(Dispatchers.Main.immediate) {
-                callbacks.forEach { it(presentation) }
+            if (callbacks.isNotEmpty()) {
+                withContext(Dispatchers.Main.immediate) {
+                    callbacks.forEach { it(presentation) }
+                }
             }
         }
         return null

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/VideosAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/VideosAdapter.kt
@@ -179,8 +179,8 @@ class VideosAdapter(
                 binding.thumbnail.setImageDrawable(null)
                 binding.thumbnail.tag = thumbnailKey
             }
-            restoreDecodedMemoryImage(thumbnailKey, binding.thumbnail)
-            imageLoadScheduler.runOrDefer(this@PagingViewHolder, binding.thumbnail) {
+            val thumbnailRestored = restoreDecodedMemoryImage(thumbnailKey, binding.thumbnail)
+            if (!thumbnailRestored) imageLoadScheduler.runOrDefer(this@PagingViewHolder, binding.thumbnail) {
                 if (!binding.root.isAttachedToWindow || boundImageIdentity != identity) return@runOrDefer
                 imageRequests.replace(
                     binding.thumbnail,
@@ -210,8 +210,8 @@ class VideosAdapter(
                 binding.userImage.setImageDrawable(null)
                 binding.userImage.tag = profileKey
             }
-            restoreDecodedMemoryImage(profileKey, binding.userImage)
-            imageLoadScheduler.runOrDefer(this@PagingViewHolder, binding.userImage) {
+            val profileRestored = restoreDecodedMemoryImage(profileKey, binding.userImage)
+            if (!profileRestored) imageLoadScheduler.runOrDefer(this@PagingViewHolder, binding.userImage) {
                 if (!binding.root.isAttachedToWindow || boundImageIdentity != identity) return@runOrDefer
                 imageRequests.replace(
                     binding.userImage,

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/channels/FollowedChannelsAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/channels/FollowedChannelsAdapter.kt
@@ -137,8 +137,8 @@ class FollowedChannelsAdapter(
                             userImage.setImageDrawable(null)
                             userImage.tag = imageKey
                         }
-                        restoreDecodedMemoryImage(imageKey, userImage)
-                        imageLoadScheduler.runOrDefer(this@PagingViewHolder, userImage) {
+                        val restored = restoreDecodedMemoryImage(imageKey, userImage)
+                        if (!restored) imageLoadScheduler.runOrDefer(this@PagingViewHolder, userImage) {
                             if (!binding.root.isAttachedToWindow || boundUserId != userId) return@runOrDefer
                             imageRequests.replace(
                                 userImage,

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/games/FollowedGamesAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/games/FollowedGamesAdapter.kt
@@ -125,13 +125,13 @@ class FollowedGamesAdapter(
                     if (item.boxArt != null) {
                         gameImage.visibility = View.VISIBLE
                         val gameId = item.id
-                        val imageKey = "game:$gameId|${item.boxArt}"
+                        val imageKey = "xtra:game-boxart:$gameId|${item.boxArt}"
                         if (gameImage.tag != imageKey) {
                             gameImage.setImageDrawable(null)
                             gameImage.tag = imageKey
                         }
-                        restoreDecodedMemoryImage(imageKey, gameImage)
-                        imageLoadScheduler.runOrDefer(this@PagingViewHolder, gameImage) {
+                        val restored = restoreDecodedMemoryImage(imageKey, gameImage)
+                        if (!restored) imageLoadScheduler.runOrDefer(this@PagingViewHolder, gameImage) {
                             if (!binding.root.isAttachedToWindow || boundGameId != gameId) return@runOrDefer
                             imageRequests.replace(
                                 gameImage,

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/overview/FeaturedStreamShelfAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/overview/FeaturedStreamShelfAdapter.kt
@@ -294,8 +294,8 @@ class FeaturedStreamShelfAdapter(
                 if (stream.channelImage != null) {
                     avatar.visibility = View.VISIBLE
                     prepareStreamProfileImage(avatar, stream)
-                    restoreWarmStreamProfileImage(context, avatar, stream)
-                    thumbnailLoadScheduler.runOrDefer(this@ViewHolder, avatar) {
+                    val profileRestored = restoreWarmStreamProfileImage(context, avatar, stream)
+                    if (!profileRestored) thumbnailLoadScheduler.runOrDefer(this@ViewHolder, avatar) {
                         if (binding.root.isAttachedToWindow && boundImageIdentity == stream.streamIdentity()) {
                             loadStreamProfileImage(context, avatar, stream)?.let {
                                 imageRequests.replace(binding.avatar, it)

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/overview/GameShelfAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/overview/GameShelfAdapter.kt
@@ -132,8 +132,8 @@ class GameShelfAdapter(
                     binding.gameImage.setImageDrawable(null)
                     binding.gameImage.tag = imageKey
                 }
-                restoreDecodedMemoryImage(imageKey, binding.gameImage)
-                imageLoadScheduler.runOrDefer(this@ViewHolder, binding.gameImage) {
+                val restored = restoreDecodedMemoryImage(imageKey, binding.gameImage)
+                if (!restored) imageLoadScheduler.runOrDefer(this@ViewHolder, binding.gameImage) {
                     if (!binding.root.isAttachedToWindow || boundGameId != game.id) return@runOrDefer
                     imageRequests.replace(
                         binding.gameImage,

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/overview/StreamShelfAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/overview/StreamShelfAdapter.kt
@@ -198,8 +198,8 @@ class StreamShelfAdapter(
                 if (stream.channelImage != null) {
                     avatar.visibility = android.view.View.VISIBLE
                     prepareStreamProfileImage(avatar, stream)
-                    restoreWarmStreamProfileImage(context, avatar, stream)
-                    thumbnailLoadScheduler.runOrDefer(this@ViewHolder, avatar) {
+                    val profileRestored = restoreWarmStreamProfileImage(context, avatar, stream)
+                    if (!profileRestored) thumbnailLoadScheduler.runOrDefer(this@ViewHolder, avatar) {
                         if (binding.root.isAttachedToWindow && boundImageIdentity == stream.streamIdentity()) {
                             loadStreamProfileImage(context, avatar, stream)?.let {
                                 imageRequests.replace(binding.avatar, it)

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/overview/UpcomingStreamShelfAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/overview/UpcomingStreamShelfAdapter.kt
@@ -106,8 +106,8 @@ class UpcomingStreamShelfAdapter(
                     binding.avatar.setImageDrawable(null)
                     binding.avatar.tag = avatarKey
                 }
-                restoreDecodedMemoryImage(avatarKey, binding.avatar)
-                imageLoadScheduler.runOrDefer(this@ViewHolder, binding.avatar) {
+                val avatarRestored = restoreDecodedMemoryImage(avatarKey, binding.avatar)
+                if (!avatarRestored) imageLoadScheduler.runOrDefer(this@ViewHolder, binding.avatar) {
                     if (!binding.root.isAttachedToWindow || boundItemId != item.id) return@runOrDefer
                     imageRequests.replace(binding.avatar, context.imageLoader.enqueue(ImageRequest.Builder(context).apply {
                         data(avatarUrl)
@@ -136,8 +136,8 @@ class UpcomingStreamShelfAdapter(
                     binding.previewImage.setImageDrawable(null)
                     binding.previewImage.tag = previewKey
                 }
-                restoreDecodedMemoryImage(previewKey, binding.previewImage)
-                imageLoadScheduler.runOrDefer(this@ViewHolder, binding.previewImage) {
+                val previewRestored = restoreDecodedMemoryImage(previewKey, binding.previewImage)
+                if (!previewRestored) imageLoadScheduler.runOrDefer(this@ViewHolder, binding.previewImage) {
                     if (!binding.root.isAttachedToWindow || boundItemId != item.id) return@runOrDefer
                     imageRequests.replace(binding.previewImage, context.imageLoader.enqueue(ImageRequest.Builder(context).apply {
                         data(previewUrl)

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/overview/VideoShelfAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/overview/VideoShelfAdapter.kt
@@ -131,8 +131,8 @@ class VideoShelfAdapter(
                 binding.thumbnail.setImageDrawable(null)
                 binding.thumbnail.tag = thumbnailKey
             }
-            restoreDecodedMemoryImage(thumbnailKey, binding.thumbnail)
-            imageLoadScheduler.runOrDefer(this@ViewHolder, binding.thumbnail) {
+            val thumbnailRestored = restoreDecodedMemoryImage(thumbnailKey, binding.thumbnail)
+            if (!thumbnailRestored) imageLoadScheduler.runOrDefer(this@ViewHolder, binding.thumbnail) {
                 if (!binding.root.isAttachedToWindow || boundImageIdentity != identity) return@runOrDefer
                 imageRequests.replace(binding.thumbnail, context.imageLoader.enqueue(ImageRequest.Builder(context).apply {
                     data(thumbnailUrl)
@@ -163,8 +163,8 @@ class VideoShelfAdapter(
                     binding.avatar.setImageDrawable(null)
                     binding.avatar.tag = avatarKey
                 }
-                restoreDecodedMemoryImage(avatarKey, binding.avatar)
-                imageLoadScheduler.runOrDefer(this@ViewHolder, binding.avatar) {
+                val avatarRestored = restoreDecodedMemoryImage(avatarKey, binding.avatar)
+                if (!avatarRestored) imageLoadScheduler.runOrDefer(this@ViewHolder, binding.avatar) {
                     if (!binding.root.isAttachedToWindow || boundImageIdentity != identity) return@runOrDefer
                     imageRequests.replace(binding.avatar, context.imageLoader.enqueue(ImageRequest.Builder(context).apply {
                         data(avatarUrl)


### PR DESCRIPTION
Reduces redundant feed image work by reusing decoded Coil memory hits and skipping duplicate idle image requests. Consolidates presentation-cache worker usage and removes unnecessary prewarm callbacks. Keeps chat rendering behavior aligned with the known-good master implementation. Also hardens release CI packaging retry and artifact validation.