### PR TITLE
Fix Chat Identity badge artwork sizing

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/GraphQLChatIdentity.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/GraphQLChatIdentity.kt
@@ -33,19 +33,19 @@ internal const val CHAT_IDENTITY_QUERY = """
             setID
             version
             title
-            imageURL(size: NORMAL)
+            imageURL(size: QUADRUPLE)
           }
           availableBadges {
             setID
             version
             title
-            imageURL(size: NORMAL)
+            imageURL(size: QUADRUPLE)
           }
           displayBadges {
             setID
             version
             title
-            imageURL(size: NORMAL)
+            imageURL(size: QUADRUPLE)
           }
         }
       }
@@ -62,13 +62,13 @@ internal const val CHAT_IDENTITY_QUERY = """
           setID
           version
           title
-          imageURL(size: NORMAL)
+          imageURL(size: QUADRUPLE)
         }
         availableBadges {
           setID
           version
           title
-          imageURL(size: NORMAL)
+          imageURL(size: QUADRUPLE)
         }
       }
     }
@@ -82,7 +82,7 @@ internal const val CHAT_EARNED_BADGES_CHANNEL_DATA_QUERY = """
           setID
           version
           title
-          imageURL(size: NORMAL)
+          imageURL(size: QUADRUPLE)
         }
       }
     }

--- a/app/src/main/res/layout/fragment_chat.xml
+++ b/app/src/main/res/layout/fragment_chat.xml
@@ -196,8 +196,7 @@
                 android:contentDescription="@string/chat_identity"
                 android:minWidth="48dp"
                 android:minHeight="48dp"
-                android:padding="8dp"
-                android:scaleType="fitCenter"
+                android:padding="12dp"
                 android:src="@drawable/ic_chat_identity"
                 android:visibility="gone"
                 app:tint="?attr/colorControlNormal" />

--- a/app/src/main/res/layout/fragment_chat.xml
+++ b/app/src/main/res/layout/fragment_chat.xml
@@ -196,7 +196,8 @@
                 android:contentDescription="@string/chat_identity"
                 android:minWidth="48dp"
                 android:minHeight="48dp"
-                android:padding="12dp"
+                android:padding="8dp"
+                android:scaleType="fitCenter"
                 android:src="@drawable/ic_chat_identity"
                 android:visibility="gone"
                 app:tint="?attr/colorControlNormal" />

--- a/app/src/main/res/layout/item_chat_identity_badge.xml
+++ b/app/src/main/res/layout/item_chat_identity_badge.xml
@@ -8,12 +8,12 @@
     android:focusable="true"
     android:foreground="?android:selectableItemBackgroundBorderless"
     android:importantForAccessibility="yes"
-    android:padding="8dp">
+    android:padding="6dp">
 
     <ImageView
         android:id="@+id/chatIdentityBadgeImage"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:contentDescription="@null"
-        android:scaleType="centerInside" />
+        android:scaleType="fitCenter" />
 </FrameLayout>

--- a/app/src/main/res/layout/popup_chat_identity.xml
+++ b/app/src/main/res/layout/popup_chat_identity.xml
@@ -101,6 +101,7 @@
                     android:layout_height="24dp"
                     android:layout_marginEnd="6dp"
                     android:contentDescription="@null"
+                    android:scaleType="fitCenter"
                     android:visibility="gone" />
 
                 <TextView


### PR DESCRIPTION
Scale the existing Chat Identity badge artwork into its tiles and composer/preview bounds so Twitch badges are readable without changing identity behavior.