### PR TITLE
Fix duplicate live notifications

### DIFF
--- a/app/schemas/com.github.andreyasadchy.xtra.db.AppDatabase/51.json
+++ b/app/schemas/com.github.andreyasadchy.xtra.db.AppDatabase/51.json
@@ -1,0 +1,1894 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 51,
+    "identityHash": "3ddfbd1373044465dbcacbc3383eced6",
+    "entities": [
+      {
+        "tableName": "videos",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`url` TEXT, `source_url` TEXT, `source_start_position` INTEGER, `name` TEXT, `channel_id` TEXT, `channel_login` TEXT, `channel_name` TEXT, `channel_logo` TEXT, `thumbnail` TEXT, `gameId` TEXT, `gameSlug` TEXT, `gameName` TEXT, `duration` INTEGER, `upload_date` INTEGER, `download_date` INTEGER, `last_watch_position` INTEGER, `progress` INTEGER NOT NULL, `max_progress` INTEGER NOT NULL, `bytes` INTEGER NOT NULL, `downloadPath` TEXT, `fromTime` INTEGER, `toTime` INTEGER, `status` INTEGER NOT NULL, `type` TEXT, `videoId` TEXT, `videoCreatedAt` TEXT, `clipId` TEXT, `quality` TEXT, `downloadChat` INTEGER NOT NULL, `downloadChatEmotes` INTEGER NOT NULL, `chatProgress` INTEGER NOT NULL, `maxChatProgress` INTEGER NOT NULL, `chatBytes` INTEGER NOT NULL, `chatOffsetSeconds` INTEGER NOT NULL, `chatUrl` TEXT, `playlistToFile` INTEGER NOT NULL, `live` INTEGER NOT NULL, `lastSegmentUrl` TEXT, `liveCommentsArrayStarted` INTEGER NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceUrl",
+            "columnName": "source_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceStartPosition",
+            "columnName": "source_start_position",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channel_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelLogin",
+            "columnName": "channel_login",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelName",
+            "columnName": "channel_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelLogo",
+            "columnName": "channel_logo",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "thumbnail",
+            "columnName": "thumbnail",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "gameId",
+            "columnName": "gameId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "gameSlug",
+            "columnName": "gameSlug",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "gameName",
+            "columnName": "gameName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "uploadDate",
+            "columnName": "upload_date",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "downloadDate",
+            "columnName": "download_date",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastWatchPosition",
+            "columnName": "last_watch_position",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "progress",
+            "columnName": "progress",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxProgress",
+            "columnName": "max_progress",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bytes",
+            "columnName": "bytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadPath",
+            "columnName": "downloadPath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "fromTime",
+            "columnName": "fromTime",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "toTime",
+            "columnName": "toTime",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "videoId",
+            "columnName": "videoId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "videoCreatedAt",
+            "columnName": "videoCreatedAt",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "clipId",
+            "columnName": "clipId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "quality",
+            "columnName": "quality",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "downloadChat",
+            "columnName": "downloadChat",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadChatEmotes",
+            "columnName": "downloadChatEmotes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chatProgress",
+            "columnName": "chatProgress",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxChatProgress",
+            "columnName": "maxChatProgress",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chatBytes",
+            "columnName": "chatBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chatOffsetSeconds",
+            "columnName": "chatOffsetSeconds",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chatUrl",
+            "columnName": "chatUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "playlistToFile",
+            "columnName": "playlistToFile",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "live",
+            "columnName": "live",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSegmentUrl",
+            "columnName": "lastSegmentUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "liveCommentsArrayStarted",
+            "columnName": "liveCommentsArrayStarted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_videos_url",
+            "unique": false,
+            "columnNames": [
+              "url"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_videos_url` ON `${TABLE_NAME}` (`url`)"
+          },
+          {
+            "name": "index_videos_status",
+            "unique": false,
+            "columnNames": [
+              "status"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_videos_status` ON `${TABLE_NAME}` (`status`)"
+          },
+          {
+            "name": "index_videos_videoId",
+            "unique": false,
+            "columnNames": [
+              "videoId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_videos_videoId` ON `${TABLE_NAME}` (`videoId`)"
+          },
+          {
+            "name": "index_videos_channel_id",
+            "unique": false,
+            "columnNames": [
+              "channel_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_videos_channel_id` ON `${TABLE_NAME}` (`channel_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "recent_emotes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`name` TEXT NOT NULL, `used_at` INTEGER NOT NULL, PRIMARY KEY(`name`))",
+        "fields": [
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "usedAt",
+            "columnName": "used_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "name"
+          ]
+        }
+      },
+      {
+        "tableName": "favorite_emotes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`provider` TEXT NOT NULL, `emote_id` TEXT NOT NULL, `favorited_at` INTEGER NOT NULL, `sort_order` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`provider`, `emote_id`))",
+        "fields": [
+          {
+            "fieldPath": "provider",
+            "columnName": "provider",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "emoteId",
+            "columnName": "emote_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "favoritedAt",
+            "columnName": "favorited_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sort_order",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "provider",
+            "emote_id"
+          ]
+        }
+      },
+      {
+        "tableName": "video_positions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `position` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "video_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `position` INTEGER NOT NULL, `durationSeconds` INTEGER, `channelId` TEXT, `channelLogin` TEXT, `channelName` TEXT, `channelImageURL` TEXT, `title` TEXT, `thumbnailURL` TEXT, `gameId` TEXT, `gameSlug` TEXT, `gameName` TEXT, `createdAt` TEXT, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationSeconds",
+            "columnName": "durationSeconds",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channelId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelLogin",
+            "columnName": "channelLogin",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelName",
+            "columnName": "channelName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelImageURL",
+            "columnName": "channelImageURL",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "thumbnailURL",
+            "columnName": "thumbnailURL",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "gameId",
+            "columnName": "gameId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "gameSlug",
+            "columnName": "gameSlug",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "gameName",
+            "columnName": "gameName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_video_history_updatedAt",
+            "unique": false,
+            "columnNames": [
+              "updatedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_video_history_updatedAt` ON `${TABLE_NAME}` (`updatedAt`)"
+          },
+          {
+            "name": "index_video_history_channelId",
+            "unique": false,
+            "columnNames": [
+              "channelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_video_history_channelId` ON `${TABLE_NAME}` (`channelId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "local_follows",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`userId` TEXT, `userLogin` TEXT, `userName` TEXT, `channelLogo` TEXT, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userLogin",
+            "columnName": "userLogin",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userName",
+            "columnName": "userName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelLogo",
+            "columnName": "channelLogo",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "local_follows_games",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`gameId` TEXT, `gameSlug` TEXT, `gameName` TEXT, `boxArt` TEXT, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "gameId",
+            "columnName": "gameId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "gameSlug",
+            "columnName": "gameSlug",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "gameName",
+            "columnName": "gameName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "boxArt",
+            "columnName": "boxArt",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "bookmarks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`videoId` TEXT, `userId` TEXT, `userLogin` TEXT, `userName` TEXT, `userType` TEXT, `userBroadcasterType` TEXT, `userLogo` TEXT, `gameId` TEXT, `gameSlug` TEXT, `gameName` TEXT, `title` TEXT, `createdAt` TEXT, `thumbnail` TEXT, `type` TEXT, `duration` TEXT, `animatedPreviewURL` TEXT, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "videoId",
+            "columnName": "videoId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userLogin",
+            "columnName": "userLogin",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userName",
+            "columnName": "userName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userType",
+            "columnName": "userType",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userBroadcasterType",
+            "columnName": "userBroadcasterType",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userLogo",
+            "columnName": "userLogo",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "gameId",
+            "columnName": "gameId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "gameSlug",
+            "columnName": "gameSlug",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "gameName",
+            "columnName": "gameName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "thumbnail",
+            "columnName": "thumbnail",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "animatedPreviewURL",
+            "columnName": "animatedPreviewURL",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_bookmarks_videoId",
+            "unique": false,
+            "columnNames": [
+              "videoId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_bookmarks_videoId` ON `${TABLE_NAME}` (`videoId`)"
+          },
+          {
+            "name": "index_bookmarks_userId",
+            "unique": false,
+            "columnNames": [
+              "userId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_bookmarks_userId` ON `${TABLE_NAME}` (`userId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "vod_bookmark_ignored_users",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`user_id` TEXT NOT NULL, PRIMARY KEY(`user_id`))",
+        "fields": [
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "user_id"
+          ]
+        }
+      },
+      {
+        "tableName": "sort_channel",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `videoSort` TEXT, `videoType` TEXT, `clipPeriod` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "videoSort",
+            "columnName": "videoSort",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "videoType",
+            "columnName": "videoType",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "clipPeriod",
+            "columnName": "clipPeriod",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "sort_game",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `streamSort` TEXT, `streamTags` TEXT, `streamLanguages` TEXT, `videoSort` TEXT, `videoPeriod` TEXT, `videoType` TEXT, `videoLanguages` TEXT, `clipPeriod` TEXT, `clipLanguages` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "streamSort",
+            "columnName": "streamSort",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "streamTags",
+            "columnName": "streamTags",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "streamLanguages",
+            "columnName": "streamLanguages",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "videoSort",
+            "columnName": "videoSort",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "videoPeriod",
+            "columnName": "videoPeriod",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "videoType",
+            "columnName": "videoType",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "videoLanguages",
+            "columnName": "videoLanguages",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "clipPeriod",
+            "columnName": "clipPeriod",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "clipLanguages",
+            "columnName": "clipLanguages",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "shown_notifications",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `channelId` TEXT NOT NULL, `streamId` TEXT NOT NULL, `startedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channelId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "streamId",
+            "columnName": "streamId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startedAt",
+            "columnName": "startedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_shown_notifications_streamId",
+            "unique": true,
+            "columnNames": [
+              "streamId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_shown_notifications_streamId` ON `${TABLE_NAME}` (`streamId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "notifications",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`channelId` TEXT NOT NULL, PRIMARY KEY(`channelId`))",
+        "fields": [
+          {
+            "fieldPath": "channelId",
+            "columnName": "channelId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "channelId"
+          ]
+        }
+      },
+      {
+        "tableName": "notification_events",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`eventId` TEXT NOT NULL, `channelId` TEXT NOT NULL, `streamId` TEXT, `channelLogin` TEXT, `channelName` TEXT, `channelImageURL` TEXT, `gameName` TEXT, `title` TEXT, `thumbnailURL` TEXT, `createdAt` TEXT, `viewerCount` INTEGER, `startedAt` INTEGER NOT NULL, `queuedAt` INTEGER NOT NULL, PRIMARY KEY(`eventId`))",
+        "fields": [
+          {
+            "fieldPath": "eventId",
+            "columnName": "eventId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channelId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "streamId",
+            "columnName": "streamId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelLogin",
+            "columnName": "channelLogin",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelName",
+            "columnName": "channelName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelImageURL",
+            "columnName": "channelImageURL",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "gameName",
+            "columnName": "gameName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "thumbnailURL",
+            "columnName": "thumbnailURL",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "viewerCount",
+            "columnName": "viewerCount",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "startedAt",
+            "columnName": "startedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "queuedAt",
+            "columnName": "queuedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "eventId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_notification_events_channelId",
+            "unique": false,
+            "columnNames": [
+              "channelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_notification_events_channelId` ON `${TABLE_NAME}` (`channelId`)"
+          },
+          {
+            "name": "index_notification_events_queuedAt",
+            "unique": false,
+            "columnNames": [
+              "queuedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_notification_events_queuedAt` ON `${TABLE_NAME}` (`queuedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "translate_all_messages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`channelId` TEXT NOT NULL, PRIMARY KEY(`channelId`))",
+        "fields": [
+          {
+            "fieldPath": "channelId",
+            "columnName": "channelId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "channelId"
+          ]
+        }
+      },
+      {
+        "tableName": "filters",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`gameId` TEXT, `gameSlug` TEXT, `gameName` TEXT, `tags` TEXT, `languages` TEXT, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "gameId",
+            "columnName": "gameId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "gameSlug",
+            "columnName": "gameSlug",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "gameName",
+            "columnName": "gameName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "tags",
+            "columnName": "tags",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "languages",
+            "columnName": "languages",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "recent_search",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`query` TEXT NOT NULL, `type` TEXT NOT NULL, `lastSearched` INTEGER NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "query",
+            "columnName": "query",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSearched",
+            "columnName": "lastSearched",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_recent_search_type_lastSearched",
+            "unique": false,
+            "columnNames": [
+              "type",
+              "lastSearched"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_recent_search_type_lastSearched` ON `${TABLE_NAME}` (`type`, `lastSearched`)"
+          },
+          {
+            "name": "index_recent_search_query_type",
+            "unique": false,
+            "columnNames": [
+              "query",
+              "type"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_recent_search_query_type` ON `${TABLE_NAME}` (`query`, `type`)"
+          }
+        ]
+      },
+      {
+        "tableName": "playback_states",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`type` TEXT, `streamId` TEXT, `videoId` TEXT, `clipId` TEXT, `offlineVideoId` INTEGER, `channelId` TEXT, `channelLogin` TEXT, `channelName` TEXT, `channelImage` TEXT, `gameId` TEXT, `gameSlug` TEXT, `gameName` TEXT, `title` TEXT, `thumbnail` TEXT, `createdAt` TEXT, `viewerCount` INTEGER, `durationSeconds` INTEGER, `videoType` TEXT, `videoOffsetSeconds` INTEGER, `videoCreatedAt` TEXT, `videoAnimatedPreviewURL` TEXT, `videoUrl` TEXT, `position` INTEGER, `paused` INTEGER NOT NULL, `qualities` TEXT, `quality` TEXT, `previousQuality` TEXT, `restoreQuality` INTEGER NOT NULL, `playlistUrl` TEXT, `restorePlaylist` INTEGER NOT NULL, `useCustomProxy` INTEGER NOT NULL, `skipAccessToken` INTEGER NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "streamId",
+            "columnName": "streamId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "videoId",
+            "columnName": "videoId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "clipId",
+            "columnName": "clipId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "offlineVideoId",
+            "columnName": "offlineVideoId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channelId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelLogin",
+            "columnName": "channelLogin",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelName",
+            "columnName": "channelName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelImage",
+            "columnName": "channelImage",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "gameId",
+            "columnName": "gameId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "gameSlug",
+            "columnName": "gameSlug",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "gameName",
+            "columnName": "gameName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "thumbnail",
+            "columnName": "thumbnail",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "viewerCount",
+            "columnName": "viewerCount",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "durationSeconds",
+            "columnName": "durationSeconds",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "videoType",
+            "columnName": "videoType",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "videoOffsetSeconds",
+            "columnName": "videoOffsetSeconds",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "videoCreatedAt",
+            "columnName": "videoCreatedAt",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "videoAnimatedPreviewURL",
+            "columnName": "videoAnimatedPreviewURL",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "videoUrl",
+            "columnName": "videoUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "paused",
+            "columnName": "paused",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "qualities",
+            "columnName": "qualities",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "quality",
+            "columnName": "quality",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "previousQuality",
+            "columnName": "previousQuality",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "restoreQuality",
+            "columnName": "restoreQuality",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playlistUrl",
+            "columnName": "playlistUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "restorePlaylist",
+            "columnName": "restorePlaylist",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "useCustomProxy",
+            "columnName": "useCustomProxy",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "skipAccessToken",
+            "columnName": "skipAccessToken",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "viewing_sessions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `channel_id` TEXT NOT NULL, `channel_login` TEXT, `channel_name` TEXT, `channel_image` TEXT, `content_type` TEXT NOT NULL, `content_id` TEXT, `started_at` INTEGER NOT NULL, `ended_at` INTEGER NOT NULL, `watched_ms` INTEGER NOT NULL, `last_checkpoint_at` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channel_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "channelLogin",
+            "columnName": "channel_login",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelName",
+            "columnName": "channel_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelImage",
+            "columnName": "channel_image",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "contentType",
+            "columnName": "content_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contentId",
+            "columnName": "content_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "startedAt",
+            "columnName": "started_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endedAt",
+            "columnName": "ended_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "watchedMs",
+            "columnName": "watched_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastCheckpointAt",
+            "columnName": "last_checkpoint_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_viewing_sessions_started_at",
+            "unique": false,
+            "columnNames": [
+              "started_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_viewing_sessions_started_at` ON `${TABLE_NAME}` (`started_at`)"
+          },
+          {
+            "name": "index_viewing_sessions_channel_id_started_at",
+            "unique": false,
+            "columnNames": [
+              "channel_id",
+              "started_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_viewing_sessions_channel_id_started_at` ON `${TABLE_NAME}` (`channel_id`, `started_at`)"
+          }
+        ]
+      },
+      {
+        "tableName": "viewing_intervals",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `session_id` INTEGER NOT NULL, `channel_id` TEXT NOT NULL, `channel_login` TEXT, `channel_name` TEXT, `channel_image` TEXT, `category_id` TEXT, `category_name` TEXT, `category_image` TEXT, `content_type` TEXT NOT NULL, `content_id` TEXT, `stream_title` TEXT, `start_at` INTEGER NOT NULL, `end_at` INTEGER NOT NULL, `watched_ms` INTEGER NOT NULL, `last_checkpoint_at` INTEGER NOT NULL, FOREIGN KEY(`session_id`) REFERENCES `viewing_sessions`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "session_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channel_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "channelLogin",
+            "columnName": "channel_login",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelName",
+            "columnName": "channel_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelImage",
+            "columnName": "channel_image",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "categoryId",
+            "columnName": "category_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "categoryName",
+            "columnName": "category_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "categoryImage",
+            "columnName": "category_image",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "contentType",
+            "columnName": "content_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contentId",
+            "columnName": "content_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "streamTitle",
+            "columnName": "stream_title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "startAt",
+            "columnName": "start_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endAt",
+            "columnName": "end_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "watchedMs",
+            "columnName": "watched_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastCheckpointAt",
+            "columnName": "last_checkpoint_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_viewing_intervals_start_at",
+            "unique": false,
+            "columnNames": [
+              "start_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_viewing_intervals_start_at` ON `${TABLE_NAME}` (`start_at`)"
+          },
+          {
+            "name": "index_viewing_intervals_channel_id_start_at",
+            "unique": false,
+            "columnNames": [
+              "channel_id",
+              "start_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_viewing_intervals_channel_id_start_at` ON `${TABLE_NAME}` (`channel_id`, `start_at`)"
+          },
+          {
+            "name": "index_viewing_intervals_category_id_start_at",
+            "unique": false,
+            "columnNames": [
+              "category_id",
+              "start_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_viewing_intervals_category_id_start_at` ON `${TABLE_NAME}` (`category_id`, `start_at`)"
+          },
+          {
+            "name": "index_viewing_intervals_content_type_start_at",
+            "unique": false,
+            "columnNames": [
+              "content_type",
+              "start_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_viewing_intervals_content_type_start_at` ON `${TABLE_NAME}` (`content_type`, `start_at`)"
+          },
+          {
+            "name": "index_viewing_intervals_session_id",
+            "unique": false,
+            "columnNames": [
+              "session_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_viewing_intervals_session_id` ON `${TABLE_NAME}` (`session_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "viewing_sessions",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "session_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "stream_feed_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`feedKey` TEXT NOT NULL, `itemKey` TEXT NOT NULL, `position` INTEGER NOT NULL, `streamId` TEXT, `channelId` TEXT, `channelLogin` TEXT, `channelName` TEXT, `channelImageURL` TEXT, `gameId` TEXT, `gameSlug` TEXT, `gameName` TEXT, `title` TEXT, `thumbnailURL` TEXT, `createdAt` TEXT, `viewerCount` INTEGER, `tags` TEXT, `generation` INTEGER NOT NULL, PRIMARY KEY(`feedKey`, `itemKey`))",
+        "fields": [
+          {
+            "fieldPath": "feedKey",
+            "columnName": "feedKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemKey",
+            "columnName": "itemKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "streamId",
+            "columnName": "streamId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channelId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelLogin",
+            "columnName": "channelLogin",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelName",
+            "columnName": "channelName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelImageURL",
+            "columnName": "channelImageURL",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "gameId",
+            "columnName": "gameId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "gameSlug",
+            "columnName": "gameSlug",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "gameName",
+            "columnName": "gameName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "thumbnailURL",
+            "columnName": "thumbnailURL",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "viewerCount",
+            "columnName": "viewerCount",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "tags",
+            "columnName": "tags",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "generation",
+            "columnName": "generation",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "feedKey",
+            "itemKey"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_stream_feed_items_feedKey_position",
+            "unique": false,
+            "columnNames": [
+              "feedKey",
+              "position"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_stream_feed_items_feedKey_position` ON `${TABLE_NAME}` (`feedKey`, `position`)"
+          },
+          {
+            "name": "index_stream_feed_items_feedKey_channelId",
+            "unique": false,
+            "columnNames": [
+              "feedKey",
+              "channelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_stream_feed_items_feedKey_channelId` ON `${TABLE_NAME}` (`feedKey`, `channelId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "stream_feed_states",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`feedKey` TEXT NOT NULL, `nextCursor` TEXT, `lastSuccessAt` INTEGER, `lastAttemptAt` INTEGER, `lastAccessAt` INTEGER NOT NULL, `failureBackoffUntil` INTEGER, `rateLimitUntil` INTEGER, `nextCursorApi` TEXT, `activeGeneration` INTEGER NOT NULL, `staleTailRetainedAt` INTEGER, PRIMARY KEY(`feedKey`))",
+        "fields": [
+          {
+            "fieldPath": "feedKey",
+            "columnName": "feedKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nextCursor",
+            "columnName": "nextCursor",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastSuccessAt",
+            "columnName": "lastSuccessAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastAttemptAt",
+            "columnName": "lastAttemptAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastAccessAt",
+            "columnName": "lastAccessAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "failureBackoffUntil",
+            "columnName": "failureBackoffUntil",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "rateLimitUntil",
+            "columnName": "rateLimitUntil",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "nextCursorApi",
+            "columnName": "nextCursorApi",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "activeGeneration",
+            "columnName": "activeGeneration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "staleTailRetainedAt",
+            "columnName": "staleTailRetainedAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "feedKey"
+          ]
+        }
+      },
+      {
+        "tableName": "game_feed_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`feedKey` TEXT NOT NULL, `itemKey` TEXT NOT NULL, `position` INTEGER NOT NULL, `gameId` TEXT, `gameSlug` TEXT, `gameName` TEXT, `boxArtURL` TEXT, `viewerCount` INTEGER, `broadcasterCount` INTEGER, `tags` TEXT, `generation` INTEGER NOT NULL, PRIMARY KEY(`feedKey`, `itemKey`))",
+        "fields": [
+          {
+            "fieldPath": "feedKey",
+            "columnName": "feedKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemKey",
+            "columnName": "itemKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gameId",
+            "columnName": "gameId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "gameSlug",
+            "columnName": "gameSlug",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "gameName",
+            "columnName": "gameName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "boxArtURL",
+            "columnName": "boxArtURL",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "viewerCount",
+            "columnName": "viewerCount",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "broadcasterCount",
+            "columnName": "broadcasterCount",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "tags",
+            "columnName": "tags",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "generation",
+            "columnName": "generation",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "feedKey",
+            "itemKey"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_game_feed_items_feedKey_position",
+            "unique": false,
+            "columnNames": [
+              "feedKey",
+              "position"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_game_feed_items_feedKey_position` ON `${TABLE_NAME}` (`feedKey`, `position`)"
+          }
+        ]
+      },
+      {
+        "tableName": "game_feed_states",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`feedKey` TEXT NOT NULL, `nextCursor` TEXT, `lastSuccessAt` INTEGER, `lastAttemptAt` INTEGER, `lastAccessAt` INTEGER NOT NULL, `failureBackoffUntil` INTEGER, `rateLimitUntil` INTEGER, `nextCursorApi` TEXT, `activeGeneration` INTEGER NOT NULL, `staleTailRetainedAt` INTEGER, PRIMARY KEY(`feedKey`))",
+        "fields": [
+          {
+            "fieldPath": "feedKey",
+            "columnName": "feedKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nextCursor",
+            "columnName": "nextCursor",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastSuccessAt",
+            "columnName": "lastSuccessAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastAttemptAt",
+            "columnName": "lastAttemptAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastAccessAt",
+            "columnName": "lastAccessAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "failureBackoffUntil",
+            "columnName": "failureBackoffUntil",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "rateLimitUntil",
+            "columnName": "rateLimitUntil",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "nextCursorApi",
+            "columnName": "nextCursorApi",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "activeGeneration",
+            "columnName": "activeGeneration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "staleTailRetainedAt",
+            "columnName": "staleTailRetainedAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "feedKey"
+          ]
+        }
+      },
+      {
+        "tableName": "metadata_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`kind` TEXT NOT NULL, `cacheKey` TEXT NOT NULL, `payload` TEXT NOT NULL, `updatedAt` INTEGER NOT NULL, `lastAccessAt` INTEGER NOT NULL, PRIMARY KEY(`kind`, `cacheKey`))",
+        "fields": [
+          {
+            "fieldPath": "kind",
+            "columnName": "kind",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cacheKey",
+            "columnName": "cacheKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "payload",
+            "columnName": "payload",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAccessAt",
+            "columnName": "lastAccessAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "kind",
+            "cacheKey"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_metadata_cache_lastAccessAt",
+            "unique": false,
+            "columnNames": [
+              "lastAccessAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_metadata_cache_lastAccessAt` ON `${TABLE_NAME}` (`lastAccessAt`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '3ddfbd1373044465dbcacbc3383eced6')"
+    ]
+  }
+}

--- a/app/src/androidTest/java/com/github/andreyasadchy/xtra/db/AppDatabaseMigrationTest.kt
+++ b/app/src/androidTest/java/com/github/andreyasadchy/xtra/db/AppDatabaseMigrationTest.kt
@@ -136,6 +136,19 @@ class AppDatabaseMigrationTest {
         database.close()
     }
 
+    @Test
+    fun migrateVersion50ShownNotificationsPreservesLegacyRows() {
+        val name = "migration-v50-shown-notifications.db"
+        prepareVersion50ShownNotificationsDatabase(name)
+
+        val database = openMigratedDatabase(name)
+        val shown = database.shownNotifications().getAll().single()
+        assertEquals("A", shown.channelId)
+        assertEquals("legacy:A:1000", shown.streamId)
+        assertEquals(1000L, shown.startedAt)
+        database.close()
+    }
+
     private fun openMigratedDatabase(name: String): AppDatabase {
         return Room.databaseBuilder(context, AppDatabase::class.java, name)
             .addMigrations(
@@ -187,6 +200,7 @@ class AppDatabaseMigrationTest {
                     db.execSQL("CREATE INDEX IF NOT EXISTS index_notification_events_queuedAt ON notification_events(queuedAt)")
                 },
                 GameFeedMigrations.FROM_49,
+                NotificationMigrations.FROM_50,
             )
             .build()
             .also { it.openHelper.writableDatabase }
@@ -239,6 +253,18 @@ class AppDatabaseMigrationTest {
         sqlite.execSQL("DROP TABLE IF EXISTS game_feed_items")
         sqlite.execSQL("DROP TABLE IF EXISTS game_feed_states")
         sqlite.execSQL("PRAGMA user_version = 49")
+        database.close()
+    }
+
+    private fun prepareVersion50ShownNotificationsDatabase(name: String) {
+        context.deleteDatabase(name)
+        databaseNames += name
+        val database = Room.databaseBuilder(context, AppDatabase::class.java, name).build()
+        val sqlite = database.openHelper.writableDatabase
+        sqlite.execSQL("DROP TABLE shown_notifications")
+        sqlite.execSQL("CREATE TABLE shown_notifications (channelId TEXT NOT NULL, startedAt INTEGER NOT NULL, PRIMARY KEY (channelId))")
+        sqlite.execSQL("INSERT INTO shown_notifications (channelId, startedAt) VALUES ('A', 1000)")
+        sqlite.execSQL("PRAGMA user_version = 50")
         database.close()
     }
 

--- a/app/src/androidTest/java/com/github/andreyasadchy/xtra/db/ShownNotificationsDaoTest.kt
+++ b/app/src/androidTest/java/com/github/andreyasadchy/xtra/db/ShownNotificationsDaoTest.kt
@@ -1,0 +1,55 @@
+package com.github.andreyasadchy.xtra.db
+
+import androidx.room.Room
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.github.andreyasadchy.xtra.model.ShownNotification
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ShownNotificationsDaoTest {
+
+    private lateinit var database: AppDatabase
+
+    @Before
+    fun createDatabase() {
+        database = Room.inMemoryDatabaseBuilder(
+            InstrumentationRegistry.getInstrumentation().targetContext,
+            AppDatabase::class.java,
+        ).build()
+    }
+
+    @After
+    fun closeDatabase() {
+        database.close()
+    }
+
+    @Test
+    fun concurrentClaimsForTheSameStreamIdOnlyInsertOnce() = runBlocking {
+        val results = coroutineScope {
+            (1..2).map {
+                async(Dispatchers.Default) {
+                    database.shownNotifications().insert(
+                        ShownNotification(
+                            channelId = "A",
+                            streamId = "123",
+                            startedAt = 1L,
+                        )
+                    )
+                }
+            }.awaitAll()
+        }
+
+        assertEquals(1, results.count { it != -1L })
+        assertEquals(1, database.shownNotifications().getAll().size)
+    }
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/XtraModule.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/XtraModule.kt
@@ -14,6 +14,7 @@ import com.github.andreyasadchy.xtra.db.AppDatabase
 import com.github.andreyasadchy.xtra.db.MetadataCacheMigrations
 import com.github.andreyasadchy.xtra.db.StreamFeedMigrations
 import com.github.andreyasadchy.xtra.db.GameFeedMigrations
+import com.github.andreyasadchy.xtra.db.NotificationMigrations
 import com.github.andreyasadchy.xtra.db.ViewingStatsMigrations
 import com.github.andreyasadchy.xtra.repository.AuthRepository
 import com.github.andreyasadchy.xtra.repository.BookmarksRepository
@@ -522,6 +523,7 @@ class XtraModule(application: Application) {
                     db.execSQL("CREATE INDEX IF NOT EXISTS index_notification_events_queuedAt ON notification_events(queuedAt)")
                 },
                 GameFeedMigrations.FROM_49,
+                NotificationMigrations.FROM_50,
             )
         }.build()
 

--- a/app/src/main/java/com/github/andreyasadchy/xtra/db/AppDatabase.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/db/AppDatabase.kt
@@ -51,14 +51,14 @@ import com.github.andreyasadchy.xtra.model.ui.TranslatedChannel
         GameFeedState::class,
         MetadataCacheEntry::class,
     ],
-    version = 50,
+    version = 51,
     exportSchema = true
 )
 abstract class AppDatabase : RoomDatabase() {
 
     companion object {
-        const val VERSION = 50
-        const val IDENTITY_HASH = "1bfd4f2978b8169f4a5c4a6544030b07"
+        const val VERSION = 51
+        const val IDENTITY_HASH = "3ddfbd1373044465dbcacbc3383eced6"
     }
 
     abstract fun offlineVideos(): OfflineVideosDao

--- a/app/src/main/java/com/github/andreyasadchy/xtra/db/NotificationMigrations.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/db/NotificationMigrations.kt
@@ -1,0 +1,26 @@
+package com.github.andreyasadchy.xtra.db
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+object NotificationMigrations {
+
+    val FROM_50 = Migration(50, 51) { db: SupportSQLiteDatabase ->
+        db.execSQL(
+            "CREATE TABLE shown_notifications_new (" +
+                    "id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, " +
+                    "channelId TEXT NOT NULL, streamId TEXT NOT NULL, startedAt INTEGER NOT NULL)"
+        )
+        db.execSQL(
+            "INSERT INTO shown_notifications_new (channelId, streamId, startedAt) " +
+                    "SELECT channelId, 'legacy:' || channelId || ':' || startedAt, startedAt " +
+                    "FROM shown_notifications"
+        )
+        db.execSQL("DROP TABLE shown_notifications")
+        db.execSQL("ALTER TABLE shown_notifications_new RENAME TO shown_notifications")
+        db.execSQL(
+            "CREATE UNIQUE INDEX index_shown_notifications_streamId " +
+                    "ON shown_notifications(streamId)"
+        )
+    }
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/db/ShownNotificationsDao.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/db/ShownNotificationsDao.kt
@@ -13,10 +13,16 @@ interface ShownNotificationsDao {
     @Query("SELECT * FROM shown_notifications")
     fun getAll(): List<ShownNotification>
 
-    @Query("SELECT * FROM shown_notifications WHERE channelId = :channelId")
+    @Query("SELECT * FROM shown_notifications WHERE channelId = :channelId ORDER BY startedAt DESC LIMIT 1")
     fun getById(channelId: String): ShownNotification?
 
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    @Query("SELECT * FROM shown_notifications WHERE streamId = :streamId LIMIT 1")
+    fun getByStreamId(streamId: String): ShownNotification?
+
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    fun insert(item: ShownNotification): Long
+
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
     fun insertList(items: List<ShownNotification>)
 
     @Delete

--- a/app/src/main/java/com/github/andreyasadchy/xtra/model/NotificationEvent.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/model/NotificationEvent.kt
@@ -39,7 +39,7 @@ data class NotificationEvent(
         fun fromStream(stream: Stream, startedAt: Long): NotificationEvent? {
             val channelId = stream.channelId?.takeIf { it.isNotBlank() } ?: return null
             return NotificationEvent(
-                eventId = "$channelId:$startedAt",
+                eventId = "$channelId:${stream.id ?: startedAt}",
                 channelId = channelId,
                 streamId = stream.id,
                 channelLogin = stream.channelLogin,

--- a/app/src/main/java/com/github/andreyasadchy/xtra/model/ShownNotification.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/model/ShownNotification.kt
@@ -1,11 +1,28 @@
 package com.github.andreyasadchy.xtra.model
 
 import androidx.room.Entity
+import androidx.room.Index
 import androidx.room.PrimaryKey
 
-@Entity(tableName = "shown_notifications")
-class ShownNotification(
-    @PrimaryKey
-    val channelId: String,
-    val startedAt: Long,
+@Entity(
+    tableName = "shown_notifications",
+    indices = [Index(value = ["streamId"], unique = true)],
 )
+class ShownNotification(
+    @PrimaryKey(autoGenerate = true)
+    val id: Long = 0,
+    val channelId: String,
+    val streamId: String,
+    val startedAt: Long,
+) {
+    /** Compatibility for callers that mark the currently viewed stream without its Twitch ID. */
+    constructor(channelId: String, startedAt: Long) : this(
+        channelId = channelId,
+        streamId = legacyStreamId(channelId, startedAt),
+        startedAt = startedAt,
+    )
+
+    companion object {
+        fun legacyStreamId(channelId: String, startedAt: Long): String = "legacy:$channelId:$startedAt"
+    }
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/LiveNotificationDeduplicator.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/LiveNotificationDeduplicator.kt
@@ -1,0 +1,51 @@
+package com.github.andreyasadchy.xtra.repository
+
+import com.github.andreyasadchy.xtra.db.ShownNotificationsDao
+import com.github.andreyasadchy.xtra.model.ShownNotification
+import com.github.andreyasadchy.xtra.model.ui.Stream
+import kotlin.time.Instant
+
+/**
+ * Decides which live streams should become notifications and persists the decision.
+ *
+ * This deliberately sits between fetching and notification delivery so the decision can be
+ * exercised without constructing the Android service or Twitch clients.
+ */
+internal class LiveNotificationDeduplicator(
+    private val shownNotificationsDao: ShownNotificationsDao,
+) {
+
+    suspend fun processStreams(streams: List<Stream>): List<Stream> {
+        val liveStreams = streams.distinctBy { it.channelId ?: it.id }
+        return liveStreams.mapNotNull { stream ->
+            val channelId = stream.channelId?.takeIf { it.isNotBlank() } ?: return@mapNotNull null
+            // Live stream loaders reject incomplete payloads before this point. A Twitch stream
+            // ID is required because channel/start time cannot safely identify a broadcast.
+            val streamId = stream.id?.takeIf { it.isNotBlank() } ?: return@mapNotNull null
+            val startedAt = stream.startedAtMillis() ?: return@mapNotNull null
+            val inserted = shownNotificationsDao.insert(
+                ShownNotification(
+                    channelId = channelId,
+                    streamId = streamId,
+                    startedAt = startedAt,
+                )
+            )
+            if (inserted == -1L) {
+                return@mapNotNull null
+            }
+
+            // Databases upgraded from the old channel/start-time schema cannot recover Twitch's
+            // stream ID. Migrate an exact legacy match without generating a duplicate alert.
+            shownNotificationsDao.getByStreamId(ShownNotification.legacyStreamId(channelId, startedAt))?.let {
+                shownNotificationsDao.deleteList(listOf(it))
+                return@mapNotNull null
+            }
+            stream
+        }
+    }
+
+    private fun Stream.startedAtMillis(): Long? = createdAt
+        ?.takeIf { it.isNotBlank() }
+        ?.let { Instant.parseOrNull(it)?.toEpochMilliseconds() }
+        ?.takeIf { it > 0 }
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/NotificationsRepository.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/NotificationsRepository.kt
@@ -63,6 +63,8 @@ internal enum class NotificationUserSyncResult {
     PREFERENCE_TRANSIENT_FAILURE,
 }
 
+internal typealias LiveNotificationStreamsProvider = suspend () -> List<Stream>
+
 private data class GraphQlFollowedChannels(
     val followedIds: Set<String>,
     val preferenceEnabledIds: Set<String>,
@@ -84,7 +86,10 @@ class NotificationsRepository(
     private val notificationEventsDao: NotificationEventsDao,
     private val graphQLRepository: GraphQLRepository,
     private val helixRepository: HelixRepository,
+    private val liveNotificationStreamsProvider: LiveNotificationStreamsProvider? = null,
 ) {
+
+    private val liveNotificationDeduplicator = LiveNotificationDeduplicator(shownNotificationsDao)
 
     suspend fun getNewStreams(
         networkLibrary: String?,
@@ -107,7 +112,9 @@ class NotificationsRepository(
         ) {
             return@withContext emptyList()
         }
-        if (notificationIds.isNotEmpty()) {
+        if (liveNotificationStreamsProvider != null) {
+            list.addAll(liveNotificationStreamsProvider.invoke())
+        } else if (notificationIds.isNotEmpty()) {
             val localStreams = if (preferHelix && !helixHeaders[C.HEADER_TOKEN].isNullOrBlank()) {
                 try {
                     apiUsed = C.HELIX
@@ -140,7 +147,7 @@ class NotificationsRepository(
             }
             list.addAll(localStreams)
         }
-        if (includeFollowedStreams && !gqlHeaders[C.HEADER_TOKEN].isNullOrBlank()) {
+        if (liveNotificationStreamsProvider == null && includeFollowedStreams && !gqlHeaders[C.HEADER_TOKEN].isNullOrBlank()) {
             try {
                 if (apiUsed == "none") {
                     apiUsed = C.GQL
@@ -156,24 +163,7 @@ class NotificationsRepository(
                 }
             }
         }
-        val liveStreams = list.distinctBy { it.channelId ?: it.id }
-        val liveList = liveStreams.mapNotNull { stream ->
-            stream.channelId.takeUnless { it.isNullOrBlank() }?.let { channelId ->
-                stream.startedAtMillis()?.let { startedAt ->
-                    ShownNotification(channelId, startedAt)
-                }
-            }
-        }
-        val oldList = shownNotificationsDao.getAll()
-        oldList.filter { item -> liveList.find { it.channelId == item.channelId } == null }.let {
-            shownNotificationsDao.deleteList(it)
-        }
-        val oldByChannel = oldList.associateBy { it.channelId }
-        val newStreams = liveStreams.filter { stream ->
-            val channelId = stream.channelId ?: return@filter false
-            val startedAt = stream.startedAtMillis() ?: return@filter false
-            oldByChannel[channelId]?.startedAt?.let { it >= startedAt } != true
-        }
+        val newStreams = liveNotificationDeduplicator.processStreams(list)
         val notificationStreams = if (enqueueNotificationEvents) {
             enrichNewStreamsWithProfiles(
                 streams = newStreams,
@@ -188,7 +178,6 @@ class NotificationsRepository(
                 stream.startedAtMillis()?.let { NotificationEvent.fromStream(stream, it) }
             }.let(notificationEventsDao::insertList)
         }
-        shownNotificationsDao.insertList(liveList)
         onApiUsed?.invoke(apiUsed)
         notificationStreams
     }
@@ -364,21 +353,25 @@ class NotificationsRepository(
                 )
             items.mapNotNull { item ->
                 item?.node?.let {
+                    val stream = it.stream ?: return@let null
+                    val streamId = stream.id?.takeIf { id -> id.isNotBlank() } ?: return@let null
+                    val createdAt = stream.createdAt?.toString()?.takeIf { value -> value.isNotBlank() }
+                        ?: return@let null
                     if (it.self?.follower?.notificationSettings?.isEnabled == true) {
                         Stream(
-                            id = it.stream?.id,
+                            id = streamId,
                             channelId = it.id,
                             channelLogin = it.login,
                             channelName = it.displayName,
                             channelImageURL = it.profileImageURL,
-                            gameId = it.stream?.game?.id,
-                            gameSlug = it.stream?.game?.slug,
-                            gameName = it.stream?.game?.displayName,
-                            title = it.stream?.broadcaster?.broadcastSettings?.title,
-                            thumbnailURL = it.stream?.previewImageURL,
-                            createdAt = it.stream?.createdAt?.toString(),
-                            viewerCount = it.stream?.viewersCount,
-                            tags = it.stream?.freeformTags?.mapNotNull { tag -> tag.name },
+                            gameId = stream.game?.id,
+                            gameSlug = stream.game?.slug,
+                            gameName = stream.game?.displayName,
+                            title = stream.broadcaster?.broadcastSettings?.title,
+                            thumbnailURL = stream.previewImageURL,
+                            createdAt = createdAt,
+                            viewerCount = stream.viewersCount,
+                            tags = stream.freeformTags?.mapNotNull { tag -> tag.name },
                         )
                     } else null
                 }
@@ -415,7 +408,7 @@ class NotificationsRepository(
         }
         return items.mapNotNull { item ->
             item?.let {
-                if (it.stream?.viewersCount != null) {
+                if (it.stream?.viewersCount != null && !it.stream.id.isNullOrBlank()) {
                     Stream(
                         id = it.stream.id,
                         channelId = it.id,
@@ -472,7 +465,7 @@ class NotificationsRepository(
             }
         }
         return items.mapNotNull {
-            if (it.viewerCount != null) {
+            if (it.viewerCount != null && !it.id.isNullOrBlank() && !it.startedAt.isNullOrBlank()) {
                 Stream(
                     id = it.id,
                     channelId = it.channelId,

--- a/app/src/test/java/com/github/andreyasadchy/xtra/repository/LiveNotificationDeduplicatorTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/repository/LiveNotificationDeduplicatorTest.kt
@@ -1,0 +1,297 @@
+package com.github.andreyasadchy.xtra.repository
+
+import android.net.http.HttpEngine
+import com.github.andreyasadchy.xtra.db.NotificationEventsDao
+import com.github.andreyasadchy.xtra.db.NotificationUsersDao
+import com.github.andreyasadchy.xtra.db.ShownNotificationsDao
+import com.github.andreyasadchy.xtra.model.NotificationEvent
+import com.github.andreyasadchy.xtra.model.NotificationUser
+import com.github.andreyasadchy.xtra.model.ShownNotification
+import com.github.andreyasadchy.xtra.model.ui.Stream
+import com.github.andreyasadchy.xtra.util.C
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import okhttp3.OkHttpClient
+import org.chromium.net.CronetEngine
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+import java.io.IOException
+import java.util.concurrent.Executors
+import kotlin.time.Instant
+
+class LiveNotificationDeduplicatorTest {
+
+    @Test
+    fun sameBroadcastAcrossRepeatedChecks_isNotifiedOnce() = runBlocking {
+        val notifier = Notifier()
+        val subject = LiveNotificationDeduplicator(InMemoryShownNotifications())
+
+        repeat(10) {
+            notifier.notify(subject.processStreams(listOf(stream("A", "123", "2026-08-27T10:00:00Z"))))
+        }
+
+        assertEquals(1, notifier.count("A"))
+    }
+
+    @Test
+    fun sameBroadcastAfterTransientEmptyPoll_isNotifiedOnce() = runBlocking {
+        val notifier = Notifier()
+        val subject = LiveNotificationDeduplicator(InMemoryShownNotifications())
+
+        notifier.notify(subject.processStreams(listOf(stream("A", "123", "2026-08-27T10:00:00Z"))))
+        notifier.notify(subject.processStreams(emptyList()))
+        notifier.notify(subject.processStreams(listOf(stream("A", "123", "2026-08-27T10:00:00Z"))))
+
+        assertEquals(1, notifier.count("A"))
+    }
+
+    @Test
+    fun partialPollDoesNotResetTheOmittedBroadcaster() = runBlocking {
+        val notifier = Notifier()
+        val subject = LiveNotificationDeduplicator(InMemoryShownNotifications())
+
+        notifier.notify(subject.processStreams(listOf(
+            stream("A", "123", "2026-08-27T10:00:00Z"),
+            stream("B", "456", "2026-08-27T10:01:00Z"),
+        )))
+        notifier.notify(subject.processStreams(listOf(stream("B", "456", "2026-08-27T10:01:00Z"))))
+        notifier.notify(subject.processStreams(listOf(
+            stream("A", "123", "2026-08-27T10:00:00Z"),
+            stream("B", "456", "2026-08-27T10:01:00Z"),
+        )))
+
+        assertEquals(1, notifier.count("A"))
+        assertEquals(1, notifier.count("B"))
+    }
+
+    @Test
+    fun newStreamIdIsANewBroadcast() = runBlocking {
+        val notifier = Notifier()
+        val subject = LiveNotificationDeduplicator(InMemoryShownNotifications())
+
+        notifier.notify(subject.processStreams(listOf(stream("A", "123", "2026-08-27T10:00:00Z"))))
+        notifier.notify(subject.processStreams(listOf(stream("A", "999", "2026-08-27T11:00:00Z"))))
+
+        assertEquals(2, notifier.count("A"))
+    }
+
+    @Test
+    fun incompleteLivePayloadWithoutStreamIdIsIgnored() = runBlocking {
+        val subject = LiveNotificationDeduplicator(InMemoryShownNotifications())
+
+        assertTrue(subject.processStreams(listOf(stream("A", null, "2026-08-27T10:00:00Z"))).isEmpty())
+    }
+
+    @Test
+    fun concurrentChecksNotifyOnce() = runBlocking {
+        val notifier = Notifier()
+        val subject = LiveNotificationDeduplicator(InMemoryShownNotifications())
+
+        coroutineScope {
+            listOf(1, 2).map {
+                async(Dispatchers.Default) {
+                    subject.processStreams(listOf(stream("A", "123", "2026-08-27T10:00:00Z")))
+                }
+            }.awaitAll().forEach(notifier::notify)
+        }
+
+        assertEquals(1, notifier.count("A"))
+    }
+
+    @Test
+    fun sharedDatabaseStateSurvivesDeduplicatorRecreation() = runBlocking {
+        val notifier = Notifier()
+        val store = InMemoryShownNotifications()
+
+        notifier.notify(LiveNotificationDeduplicator(store).processStreams(listOf(stream("A", "123", "2026-08-27T10:00:00Z"))))
+        notifier.notify(LiveNotificationDeduplicator(store).processStreams(listOf(stream("A", "123", "2026-08-27T10:00:00Z"))))
+
+        assertEquals(1, notifier.count("A"))
+    }
+
+    @Test
+    fun failedPollPreservesClaimedBroadcast() = runBlocking {
+        var fetchResult = Result.success(listOf(stream("A", "123", "2026-08-27T10:00:00Z")))
+        val repository = repository(InMemoryShownNotifications()) { fetchResult.getOrThrow() }
+
+        val first = repository.getNewStreams(
+            networkLibrary = null,
+            gqlHeaders = mapOf(C.HEADER_TOKEN to "test-token"),
+            helixHeaders = emptyMap(),
+        )
+        assertEquals(listOf("123"), first.map { it.id })
+
+        fetchResult = Result.failure(IOException("timeout"))
+        try {
+            repository.getNewStreams(
+                networkLibrary = null,
+                gqlHeaders = mapOf(C.HEADER_TOKEN to "test-token"),
+                helixHeaders = emptyMap(),
+            )
+            fail("the failed Twitch fetch must propagate out of getNewStreams")
+        } catch (error: IOException) {
+            assertEquals("timeout", error.message)
+        }
+
+        fetchResult = Result.success(listOf(stream("A", "123", "2026-08-27T10:00:00Z")))
+        val afterRecovery = repository.getNewStreams(
+            networkLibrary = null,
+            gqlHeaders = mapOf(C.HEADER_TOKEN to "test-token"),
+            helixHeaders = emptyMap(),
+        )
+
+        assertTrue(afterRecovery.isEmpty())
+    }
+
+    @Test
+    fun migratedLegacyBroadcastIsNotNotifiedAgainWhenRealStreamIdAppears() = runBlocking {
+        val store = InMemoryShownNotifications()
+        val startedAt = Instant.parse("2026-08-27T10:00:00Z").toEpochMilliseconds()
+        val legacyStreamId = ShownNotification.legacyStreamId("A", startedAt)
+        store.insert(
+            ShownNotification(
+                channelId = "A",
+                streamId = legacyStreamId,
+                startedAt = startedAt,
+            )
+        )
+
+        val subject = LiveNotificationDeduplicator(store)
+
+        assertTrue(subject.processStreams(listOf(stream("A", "123", "2026-08-27T10:00:00Z"))).isEmpty())
+        assertEquals("123", store.getByStreamId("123")?.streamId)
+        assertNull(store.getByStreamId(legacyStreamId))
+        assertTrue(subject.processStreams(listOf(stream("A", "123", "2026-08-27T10:00:00Z"))).isEmpty())
+    }
+
+    @Test
+    fun separateBroadcastersAreDeduplicatedIndependently() = runBlocking {
+        val notifier = Notifier()
+        val subject = LiveNotificationDeduplicator(InMemoryShownNotifications())
+        val streams = listOf(
+            stream("A", "123", "2026-08-27T10:00:00Z"),
+            stream("B", "456", "2026-08-27T10:01:00Z"),
+        )
+
+        notifier.notify(subject.processStreams(streams))
+        notifier.notify(subject.processStreams(streams))
+
+        assertEquals(1, notifier.count("A"))
+        assertEquals(1, notifier.count("B"))
+    }
+
+    private fun stream(userId: String, streamId: String?, createdAt: String) = Stream(
+        id = streamId,
+        channelId = userId,
+        createdAt = createdAt,
+    )
+
+    private fun repository(
+        shownNotifications: ShownNotificationsDao,
+        provider: LiveNotificationStreamsProvider,
+    ) = NotificationsRepository(
+        shownNotificationsDao = shownNotifications,
+        notificationUsersDao = InMemoryNotificationUsers(),
+        notificationEventsDao = InMemoryNotificationEvents(),
+        graphQLRepository = emptyGraphQlRepository(),
+        helixRepository = emptyHelixRepository(),
+        liveNotificationStreamsProvider = provider,
+    )
+
+    private fun emptyGraphQlRepository() = GraphQLRepository(
+        httpEngine = lazyOf<HttpEngine?>(null),
+        cronetEngine = lazyOf<CronetEngine?>(null),
+        cronetExecutor = lazyOf(Executors.newSingleThreadExecutor()),
+        okHttpClient = lazyOf(OkHttpClient()),
+        json = Json.Default,
+    )
+
+    private fun emptyHelixRepository() = HelixRepository(
+        httpEngine = lazyOf<HttpEngine?>(null),
+        cronetEngine = lazyOf<CronetEngine?>(null),
+        cronetExecutor = lazyOf(Executors.newSingleThreadExecutor()),
+        okHttpClient = lazyOf(OkHttpClient()),
+        json = Json.Default,
+    )
+
+    private class Notifier {
+        private val notifications = mutableListOf<Stream>()
+
+        fun notify(streams: List<Stream>) {
+            notifications += streams
+        }
+
+        fun count(channelId: String): Int = notifications.count { it.channelId == channelId }
+    }
+
+    private class InMemoryNotificationUsers : NotificationUsersDao {
+        private val users = listOf(NotificationUser("A"))
+
+        override fun getAll(): List<NotificationUser> = users
+
+        override fun getById(id: String): NotificationUser? = users.firstOrNull { it.channelId == id }
+
+        override fun insert(item: NotificationUser) = Unit
+
+        override fun insertList(items: List<NotificationUser>) = Unit
+
+        override fun delete(item: NotificationUser) = Unit
+
+        override fun deleteAll() = Unit
+    }
+
+    private class InMemoryNotificationEvents : NotificationEventsDao {
+        override fun getAll(): List<NotificationEvent> = emptyList()
+
+        override fun insertList(items: List<NotificationEvent>) = Unit
+
+        override fun insert(item: NotificationEvent) = Unit
+
+        override fun delete(eventId: String) = Unit
+
+        override fun deleteForChannel(channelId: String) = Unit
+
+        override fun deleteAll() = Unit
+    }
+
+    private open class InMemoryShownNotifications : ShownNotificationsDao {
+        protected val items = mutableListOf<ShownNotification>()
+
+        override fun getAll(): List<ShownNotification> = items.toList()
+
+        override fun getById(channelId: String): ShownNotification? = items.firstOrNull { it.channelId == channelId }
+
+        override fun getByStreamId(streamId: String): ShownNotification? = items.firstOrNull { it.streamId == streamId }
+
+        @Synchronized
+        override fun insert(item: ShownNotification): Long {
+            if (items.any { it.streamId == item.streamId }) return -1L
+            val stored = ShownNotification(
+                id = (items.maxOfOrNull { it.id } ?: 0L) + 1L,
+                channelId = item.channelId,
+                streamId = item.streamId,
+                startedAt = item.startedAt,
+            )
+            items += stored
+            return stored.id
+        }
+
+        override fun insertList(items: List<ShownNotification>) {
+            items.forEach { item ->
+                insert(item)
+            }
+        }
+
+        override fun deleteList(items: List<ShownNotification>) {
+            this.items.removeAll(items.toSet())
+        }
+    }
+
+}


### PR DESCRIPTION
Persist Twitch broadcast IDs and atomically claim each live notification so transient poll gaps and overlapping checks cannot alert twice.