### PR TITLE
Fix intermittent video rendering corruption

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/PreviewTargetGeneration.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/PreviewTargetGeneration.kt
@@ -1,0 +1,16 @@
+package com.github.andreyasadchy.xtra.ui.common
+
+import java.util.WeakHashMap
+
+/** Invalidates async preview binds when their RecyclerView target is recycled. */
+internal class PreviewTargetGeneration<T : Any> {
+    private val generations = WeakHashMap<T, Long>()
+
+    fun capture(target: T): Long = generations[target] ?: 0L
+
+    fun invalidate(target: T) {
+        generations[target] = capture(target) + 1L
+    }
+
+    fun isCurrent(target: T, generation: Long): Boolean = capture(target) == generation
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/StreamPreviewCoordinator.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/StreamPreviewCoordinator.kt
@@ -93,6 +93,7 @@ class StreamPreviewCoordinator(
     private val activePreviews = linkedMapOf<String, ActivePreview>()
     private var sharedPreviewPlayer: ExoPlayer? = null
     private var sharedPreviewView: PlayerView? = null
+    private val previewTargetGenerations = PreviewTargetGeneration<FrameLayout>()
     private val previewLifecycle = StreamPreviewLifecycle()
     private val pendingStarts = mutableMapOf<String, Job>()
     private val dwellStarts = mutableMapOf<String, Long>()
@@ -172,7 +173,11 @@ class StreamPreviewCoordinator(
     }
 
     fun detachViewport(viewportKey: String) {
-        viewports.remove(viewportKey)
+        val viewport = viewports.remove(viewportKey)
+        viewport?.candidates
+            ?.map { it.surface }
+            ?.distinct()
+            ?.forEach(::detachSurface)
         scheduleSelection()
     }
 
@@ -236,8 +241,8 @@ class StreamPreviewCoordinator(
         // reconciliation while the full-screen player is being added, producing a small stale
         // video over the new player's opaque handoff cover. Releasing every preview also avoids
         // decoding and composing muted browsing video while the user is watching the stream.
-        hideViewportSurfaces()
         stopPreview()
+        hideViewportSurfaces()
     }
 
     fun onFullscreenPlaybackFirstFrame(channelLogin: String?) {
@@ -264,6 +269,13 @@ class StreamPreviewCoordinator(
 
     /** Unbinds only the view. The player remains reusable during the offscreen grace period. */
     fun detachSurface(surface: FrameLayout) {
+        previewTargetGenerations.invalidate(surface)
+        viewports.entries.forEach { (key, viewport) ->
+            val remainingCandidates = viewport.candidates.filterNot { it.surface === surface }
+            if (remainingCandidates.size != viewport.candidates.size) {
+                viewports[key] = viewport.copy(candidates = remainingCandidates)
+            }
+        }
         val active = activePreviews.values.firstOrNull { it.surface === surface }
         active?.let {
             detachPreviewSurface(it)
@@ -454,6 +466,8 @@ class StreamPreviewCoordinator(
         ) return
 
         val candidate = bestCandidatesByIdentity(currentCandidates())[identity] ?: return
+        val target = candidate.surface
+        val targetGeneration = previewTargetGenerations.capture(target)
         if (candidate.visibleFraction < StreamPreviewSelectionPolicy.START_VISIBLE_FRACTION) return
         if (isScrolling(candidate)) {
             dwellStarts.remove(identity)
@@ -464,7 +478,9 @@ class StreamPreviewCoordinator(
         } else {
             urlCoordinator.resolveVodForPreview(candidate.videoId)
         } ?: return
+        if (!previewTargetGenerations.isCurrent(target, targetGeneration)) return
         val latestCandidate = bestCandidatesByIdentity(currentCandidates())[identity] ?: return
+        if (latestCandidate.surface !== target) return
         if (latestCandidate.visibleFraction < StreamPreviewSelectionPolicy.START_VISIBLE_FRACTION) return
         if (isScrolling(latestCandidate)) {
             dwellStarts.remove(identity)
@@ -572,6 +588,7 @@ class StreamPreviewCoordinator(
         if (activePreviews[active.identity]?.player !== active.player) return
         active.firstFrameRendered = true
         revealPreviewSurface(active.playerView, active.surface)
+        logVideoSurfaceBinding("preview_first_frame", active.player, active.playerView, active.playerView.player)
         if (BuildConfig.DEBUG) Log.d("StreamPreview", "first_frame identity=${active.identity}")
     }
 
@@ -608,7 +625,7 @@ class StreamPreviewCoordinator(
         if (active.playerView.parent !== candidate.surface) {
             candidate.surface.addView(active.playerView)
         }
-        active.playerView.player = active.player
+        attachPreviewPlayer(active)
         active.playerView.alpha = if (active.firstFrameRendered) 1f else 0f
         active.playerView.visibility = View.VISIBLE
         candidate.surface.alpha = 1f
@@ -721,40 +738,54 @@ class StreamPreviewCoordinator(
     }
 
     private fun releaseSharedPreviewPlayer() {
+        sharedPreviewView?.let { view ->
+            if (view.player != null) {
+                logVideoSurfaceBinding("preview_detach", sharedPreviewPlayer, view, view.player)
+                view.player = null
+            }
+            (view.parent as? ViewGroup)?.removeView(view)
+        }
         sharedPreviewPlayer?.let { player ->
             runCatching { player.removeListener(sharedPreviewPlayerListener) }
             runCatching { player.stop() }
             runCatching { player.release() }
-        }
-        sharedPreviewView?.let { view ->
-            (view.parent as? ViewGroup)?.removeView(view)
-            view.player = null
         }
         sharedPreviewView = null
         sharedPreviewPlayer = null
     }
 
     private fun detachPreviewSurface(active: ActivePreview) {
+        if (active.playerView.player != null) {
+            logVideoSurfaceBinding("preview_detach", active.player, active.playerView, active.playerView.player)
+            active.playerView.player = null
+        }
         active.surface?.let { surface ->
             surface.removeView(active.playerView)
             surface.alpha = 0f
             surface.visibility = View.GONE
         }
-        active.playerView.player = null
         active.playerView.alpha = 0f
         active.playerView.visibility = View.GONE
         active.surface = null
     }
 
     private fun suspendPreviewSurface(active: ActivePreview) {
-        active.surface?.let { surface ->
-            surface.removeView(active.playerView)
-            surface.alpha = 0f
-            surface.visibility = View.GONE
+        detachPreviewSurface(active)
+    }
+
+    private fun attachPreviewPlayer(active: ActivePreview) {
+        if (active.playerView.player !== active.player) {
+            logVideoSurfaceBinding("preview_attach", active.player, active.playerView, active.playerView.player)
+            active.playerView.player = active.player
         }
-        active.playerView.player = null
-        active.playerView.alpha = 0f
-        active.playerView.visibility = View.GONE
+        if (BuildConfig.DEBUG) {
+            val attachedTargets = activePreviews.values.count {
+                it.player === active.player && it.playerView.player === active.player
+            }
+            check(attachedTargets <= 1) {
+                "Player ${active.player.identityId()} is attached to $attachedTargets preview PlayerViews"
+            }
+        }
     }
 
     private fun normalize(login: String?): String? =

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/StreamPreviewCoordinator.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/StreamPreviewCoordinator.kt
@@ -284,9 +284,7 @@ class StreamPreviewCoordinator(
             lifecycleReconciler.reconcile(now, additionalDeadlines = failedUntil.values)
         }
         if (active == null) {
-            surface.removeAllViews()
-            surface.alpha = 0f
-            surface.visibility = View.GONE
+            clearPreviewSurface(surface)
         }
     }
 
@@ -695,11 +693,21 @@ class StreamPreviewCoordinator(
             .flatMap { it.candidates }
             .map { it.surface }
             .distinct()
-            .forEach { surface ->
-                surface.removeAllViews()
-                surface.alpha = 0f
-                surface.visibility = View.GONE
+            .forEach(::clearPreviewSurface)
+    }
+
+    private fun clearPreviewSurface(surface: FrameLayout) {
+        previewTargetGenerations.invalidate(surface)
+        for (index in surface.childCount - 1 downTo 0) {
+            val child = surface.getChildAt(index)
+            if (child is PlayerView && child.player != null) {
+                logVideoSurfaceBinding("preview_detach", child.player, child, child.player)
+                child.player = null
             }
+            surface.removeViewAt(index)
+        }
+        surface.alpha = 0f
+        surface.visibility = View.GONE
     }
 
     private fun stopActivePreviews() {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/VideoSurfaceDebug.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/VideoSurfaceDebug.kt
@@ -1,0 +1,26 @@
+package com.github.andreyasadchy.xtra.ui.common
+
+import android.util.Log
+import android.view.View
+import androidx.media3.common.Player
+import com.github.andreyasadchy.xtra.BuildConfig
+
+internal fun Any?.identityId(): String =
+    if (this == null) "null" else System.identityHashCode(this).toString(16)
+
+internal fun logVideoSurfaceBinding(
+    action: String,
+    player: Player?,
+    target: View?,
+    targetPlayer: Player? = null,
+) {
+    if (!BuildConfig.DEBUG) return
+
+    Log.d(
+        "VideoSurface",
+        "$action player=${player.identityId()} target=${target.identityId()} " +
+            "target.player=${targetPlayer.identityId()} " +
+            "attached=${target?.isAttachedToWindow} visible=${target?.visibility} " +
+            "size=${target?.width}x${target?.height} xy=${target?.x},${target?.y}",
+    )
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/multiview/playback/MultiviewPlaybackCoordinator.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/multiview/playback/MultiviewPlaybackCoordinator.kt
@@ -36,6 +36,7 @@ import com.github.andreyasadchy.xtra.player.lowlatency.CronetDataSource
 import com.github.andreyasadchy.xtra.player.lowlatency.HttpEngineDataSource
 import com.github.andreyasadchy.xtra.player.lowlatency.OkHttpDataSource
 import com.github.andreyasadchy.xtra.ui.player.ExoPlayerService
+import com.github.andreyasadchy.xtra.ui.common.logVideoSurfaceBinding
 import com.github.andreyasadchy.xtra.ui.player.TwitchAdController
 import com.github.andreyasadchy.xtra.util.C
 import com.github.andreyasadchy.xtra.util.NetworkUtils.proxyCandidates
@@ -128,8 +129,14 @@ class MultiviewPlaybackCoordinator(
     fun attach(identity: String, playerView: PlayerView) {
         slots[identity]?.let { slot ->
             if (slot.attachedView !== playerView) {
-                slot.attachedView?.player = null
+                slot.attachedView?.let { oldView ->
+                    logVideoSurfaceBinding("multiview_detach", slot.player, oldView, oldView.player)
+                    oldView.player = null
+                }
                 slot.attachedView = playerView
+            }
+            if (playerView.player !== slot.player) {
+                logVideoSurfaceBinding("multiview_attach", slot.player, playerView, playerView.player)
                 playerView.player = slot.player
             }
         }
@@ -137,6 +144,7 @@ class MultiviewPlaybackCoordinator(
 
     fun detach(identity: String, playerView: PlayerView) {
         slots[identity]?.takeIf { it.attachedView === playerView }?.let { slot ->
+            logVideoSurfaceBinding("multiview_detach", slot.player, playerView, playerView.player)
             playerView.player = null
             slot.attachedView = null
         }
@@ -170,7 +178,7 @@ class MultiviewPlaybackCoordinator(
         backgroundPlayback = false
         slots.values.forEach { slot ->
             restoreBackgroundVideo(slot)
-            slot.attachedView?.player = slot.player
+            slot.attachedView?.let { attach(slot.identity, it) }
             slot.player.playWhenReady = shouldPlayWhenReady(slot)
         }
         maintainBackgroundPlaybackService()
@@ -942,7 +950,12 @@ class MultiviewPlaybackCoordinator(
                 .setTrackTypeDisabled(androidx.media3.common.C.TRACK_TYPE_VIDEO, true)
                 .build()
         }
-        slot.attachedView?.player = null
+        slot.attachedView?.let { view ->
+            if (view.player === slot.player) {
+                logVideoSurfaceBinding("multiview_detach", slot.player, view, view.player)
+                view.player = null
+            }
+        }
     }
 
     @androidx.media3.common.util.UnstableApi
@@ -1225,7 +1238,12 @@ class MultiviewPlaybackCoordinator(
             stableRecoveryJob?.cancel()
             adAvoidanceJob?.cancel()
             primaryRestoreJob?.cancel()
-            attachedView?.player = null
+            attachedView?.let { view ->
+                if (view.player === player) {
+                    logVideoSurfaceBinding("multiview_detach", player, view, view.player)
+                    view.player = null
+                }
+            }
             attachedView = null
             player.release()
         }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/ExoPlayerFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/ExoPlayerFragment.kt
@@ -13,6 +13,7 @@ import android.os.IBinder
 import android.text.format.DateUtils
 import android.util.Log
 import android.view.View
+import android.view.TextureView
 import android.widget.FrameLayout
 import android.widget.HorizontalScrollView
 import android.widget.TextView
@@ -39,6 +40,7 @@ import com.github.andreyasadchy.xtra.BuildConfig
 import com.github.andreyasadchy.xtra.R
 import com.github.andreyasadchy.xtra.model.VideoQuality
 import com.github.andreyasadchy.xtra.ui.game.GamePagerFragmentDirections
+import com.github.andreyasadchy.xtra.ui.common.logVideoSurfaceBinding
 import com.github.andreyasadchy.xtra.ui.main.MainActivity
 import com.github.andreyasadchy.xtra.ui.player.clip.ClipEditorDialogFragment
 import com.github.andreyasadchy.xtra.ui.player.clip.ClipEditorRestorationState
@@ -70,6 +72,10 @@ class ExoPlayerFragment : PlayerFragment() {
     private var liveSurfaceRestoreTimeout: Runnable? = null
     private var clipEditorCoverTimeout: Runnable? = null
     private var videoOutputCover: View? = null
+    private val videoOutputOwner = VideoOutputOwner<Player, TextureView>(
+        attachTarget = { currentPlayer, target -> currentPlayer.setVideoTextureView(target) },
+        detachTarget = { currentPlayer, target -> currentPlayer.clearVideoTextureView(target) },
+    )
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -90,10 +96,11 @@ class ExoPlayerFragment : PlayerFragment() {
             importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_NO
         }
         videoOutputCover = outputCover
-        // Keep the SurfaceView renderer for lower composition overhead. The cover is a normal
+        // Keep the TextureView renderer in the moving player layout. The cover is a normal
         // view above it and remains visible until the player confirms a new decoded frame.
         binding.aspectRatioFrameLayout.addView(outputCover)
         binding.playerSurface.visibility = View.GONE
+        binding.playerTextureView.visibility = View.VISIBLE
         childFragmentManager.setFragmentResultListener(
             ClipEditorDialogFragment.RESULT_KEY,
             viewLifecycleOwner,
@@ -257,6 +264,7 @@ class ExoPlayerFragment : PlayerFragment() {
             }
 
             override fun onRenderedFirstFrame() {
+                logVideoSurfaceBinding("first_frame", playbackService?.player, binding.playerTextureView)
                 hideVideoOutputCover()
             }
         }
@@ -377,7 +385,7 @@ class ExoPlayerFragment : PlayerFragment() {
                                 } else {
                                     showVideoOutputCover()
                                     setVideoOutputVisible(true)
-                                    player.setVideoSurfaceView(binding.playerSurface)
+                                    attachVideoOutput(player)
                                     true
                                 }
                             }
@@ -386,7 +394,7 @@ class ExoPlayerFragment : PlayerFragment() {
                                 connectedService.player?.let { player ->
                                     if (!player.trackSelectionParameters.disabledTrackTypes.contains(androidx.media3.common.C.TRACK_TYPE_VIDEO)) {
                                         setVideoOutputVisible(true)
-                                        player.setVideoSurfaceView(binding.playerSurface)
+                                        attachVideoOutput(player)
                                     }
                                 }
                             }
@@ -591,9 +599,9 @@ class ExoPlayerFragment : PlayerFragment() {
         livePlayer?.pause()
         clipDebug("live player paused")
         setVideoOutputVisible(false)
-        clipDebug("live surface hidden parentVisible=${binding.playerSurface.visibility == View.VISIBLE}")
-        livePlayer?.clearVideoSurfaceView(binding.playerSurface)
-        clipDebug("live surface cleared parentVisible=${binding.playerSurface.visibility == View.VISIBLE}")
+        clipDebug("live surface hidden parentVisible=${binding.playerTextureView.visibility == View.VISIBLE}")
+        detachVideoOutput(livePlayer)
+        clipDebug("live surface cleared parentVisible=${binding.playerTextureView.visibility == View.VISIBLE}")
         binding.playerLayout.visibility = View.GONE
     }
 
@@ -681,6 +689,7 @@ class ExoPlayerFragment : PlayerFragment() {
         val resumePlayback = livePlaybackBeforeClipEditor == true
         val firstFrameListener = object : Player.Listener {
             override fun onRenderedFirstFrame() {
+                logVideoSurfaceBinding("first_frame", livePlayer, binding.playerTextureView)
                 finishLiveSurfaceRestore(livePlayer)
             }
         }
@@ -690,7 +699,7 @@ class ExoPlayerFragment : PlayerFragment() {
         showVideoOutputCover()
         setVideoOutputVisible(true)
         clipDebug("live surface reattach")
-        livePlayer.setVideoSurfaceView(binding.playerSurface)
+        attachVideoOutput(livePlayer)
         if (resumePlayback) {
             livePlayer.seekToDefaultPosition()
             livePlayer.playWhenReady = true
@@ -708,6 +717,7 @@ class ExoPlayerFragment : PlayerFragment() {
         liveSurfaceRestoreListener?.let(livePlayer::removeListener)
         liveSurfaceRestoreListener = null
         livePlaybackBeforeClipEditor = null
+        detachVideoOutput(livePlayer)
         binding.clipEditorTransitionCover.visibility = View.GONE
         clipDebug("live first frame/timeout cover hidden")
     }
@@ -835,6 +845,7 @@ class ExoPlayerFragment : PlayerFragment() {
     }
 
     override fun close(deleteStates: Boolean) {
+        detachVideoOutput()
         playbackService?.cancelLiveClipPreparation()
         liveClipDirectoryPath?.let { playbackService?.releaseLiveClip(it) }
         liveClipDirectoryPath = null
@@ -872,7 +883,7 @@ class ExoPlayerFragment : PlayerFragment() {
             } else {
                 val videoDetachedForBackground = playbackService?.stop(isInPIPMode) == true
                 if (view != null && !isInPIPMode) {
-                    playbackService?.player?.clearVideoSurfaceView(binding.playerSurface)
+                    detachVideoOutput(playbackService?.player)
                     if (videoDetachedForBackground) {
                         setVideoOutputVisible(false)
                     }
@@ -896,6 +907,7 @@ class ExoPlayerFragment : PlayerFragment() {
     }
 
     override fun onDestroyView() {
+        detachVideoOutput()
         clipDebug("parent editor view destroyed")
         serviceSetupJob?.cancel()
         serviceSetupJob = null
@@ -912,8 +924,21 @@ class ExoPlayerFragment : PlayerFragment() {
         super.onDestroyView()
     }
 
+    private fun attachVideoOutput(currentPlayer: Player) {
+        videoOutputOwner.attach(currentPlayer, binding.playerTextureView)
+        logVideoSurfaceBinding("attach", currentPlayer, binding.playerTextureView)
+    }
+
+    private fun detachVideoOutput(currentPlayer: Player? = videoOutputOwner.attachedPlayer()) {
+        if (currentPlayer == null) return
+        if (videoOutputOwner.attachedPlayer() === currentPlayer) {
+            logVideoSurfaceBinding("detach", currentPlayer, binding.playerTextureView)
+            videoOutputOwner.clear()
+        }
+    }
+
     private fun setVideoOutputVisible(visible: Boolean) {
-        binding.playerSurface.visibility = if (visible) View.VISIBLE else View.GONE
+        binding.playerTextureView.visibility = if (visible) View.VISIBLE else View.GONE
         if (!visible) {
             showVideoOutputCover()
         }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/ExoPlayerFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/ExoPlayerFragment.kt
@@ -717,7 +717,6 @@ class ExoPlayerFragment : PlayerFragment() {
         liveSurfaceRestoreListener?.let(livePlayer::removeListener)
         liveSurfaceRestoreListener = null
         livePlaybackBeforeClipEditor = null
-        detachVideoOutput(livePlayer)
         binding.clipEditorTransitionCover.visibility = View.GONE
         clipDebug("live first frame/timeout cover hidden")
     }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/Media3Fragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/Media3Fragment.kt
@@ -13,6 +13,7 @@ import android.util.Log
 import android.view.View
 import android.widget.HorizontalScrollView
 import android.widget.TextView
+import android.view.TextureView
 import androidx.annotation.OptIn
 import androidx.core.content.ContextCompat
 import androidx.core.content.edit
@@ -42,6 +43,7 @@ import com.github.andreyasadchy.xtra.model.ui.Stream
 import com.github.andreyasadchy.xtra.model.ui.Video
 import com.github.andreyasadchy.xtra.ui.download.DownloadDialog
 import com.github.andreyasadchy.xtra.ui.main.MainActivity
+import com.github.andreyasadchy.xtra.ui.common.logVideoSurfaceBinding
 import com.github.andreyasadchy.xtra.util.C
 import com.github.andreyasadchy.xtra.util.PlayerControlLayout
 import com.github.andreyasadchy.xtra.util.getAlertDialogBuilder
@@ -78,6 +80,10 @@ class Media3Fragment : Media3PlayerFragment() {
     private var adAvoidanceJob: Job? = null
     private var primaryStreamRestoreJob: Job? = null
     private val updateProgressAction = Runnable { if (view != null) updateProgress() }
+    private val videoOutputOwner = VideoOutputOwner<Player, TextureView>(
+        attachTarget = { currentPlayer, target -> currentPlayer.setVideoTextureView(target) },
+        detachTarget = { currentPlayer, target -> currentPlayer.clearVideoTextureView(target) },
+    )
 
     override fun onViewingMetadataChanged(title: String?, gameId: String?, gameName: String?) {
         if (videoType != STREAM) return
@@ -462,14 +468,18 @@ class Media3Fragment : Media3PlayerFragment() {
                         }
                     }
                 }
+
+                override fun onRenderedFirstFrame() {
+                    logVideoSurfaceBinding("first_frame", controller, binding.playerTextureView)
+                }
             }
             val restored = viewModel.videoOutputState.restoreIfNeeded {
-                binding.playerSurface.visibility = View.VISIBLE
-                controller.setVideoSurfaceView(binding.playerSurface)
+                binding.playerTextureView.visibility = View.VISIBLE
+                attachVideoOutput(controller)
                 true
             }
             if (!restored) {
-                controller.setVideoSurfaceView(binding.playerSurface)
+                attachVideoOutput(controller)
             }
             controller.addListener(listener)
             playerListener = listener
@@ -594,7 +604,7 @@ class Media3Fragment : Media3PlayerFragment() {
                     player.trackSelectionParameters = player.trackSelectionParameters.buildUpon().apply {
                         setTrackTypeDisabled(androidx.media3.common.C.TRACK_TYPE_VIDEO, true)
                     }.build()
-                    binding.playerSurface.visibility = View.GONE
+                    binding.playerTextureView.visibility = View.GONE
                 }
                 player.volume = 0f
             }
@@ -610,7 +620,7 @@ class Media3Fragment : Media3PlayerFragment() {
                     player.trackSelectionParameters = player.trackSelectionParameters.buildUpon().apply {
                         setTrackTypeDisabled(androidx.media3.common.C.TRACK_TYPE_VIDEO, false)
                     }.build()
-                    binding.playerSurface.visibility = View.VISIBLE
+                    binding.playerTextureView.visibility = View.VISIBLE
                 }
                 player.volume = requireContext().prefs().getInt(C.PLAYER_VOLUME, 100) / 100f
             }
@@ -784,7 +794,7 @@ class Media3Fragment : Media3PlayerFragment() {
             player.trackSelectionParameters = player.trackSelectionParameters.buildUpon().apply {
                 setTrackTypeDisabled(androidx.media3.common.C.TRACK_TYPE_VIDEO, false)
             }.build()
-            binding.playerSurface.visibility = View.VISIBLE
+            binding.playerTextureView.visibility = View.VISIBLE
             player.sendCustomCommand(
                 SessionCommand(
                     PlaybackService.START_VIDEO, Bundle().apply {
@@ -811,12 +821,12 @@ class Media3Fragment : Media3PlayerFragment() {
                 player.trackSelectionParameters = player.trackSelectionParameters.buildUpon().apply {
                     setTrackTypeDisabled(androidx.media3.common.C.TRACK_TYPE_VIDEO, true)
                 }.build()
-                binding.playerSurface.visibility = View.GONE
+                binding.playerTextureView.visibility = View.GONE
             } else {
                 player.trackSelectionParameters = player.trackSelectionParameters.buildUpon().apply {
                     setTrackTypeDisabled(androidx.media3.common.C.TRACK_TYPE_VIDEO, false)
                 }.build()
-                binding.playerSurface.visibility = View.VISIBLE
+                binding.playerTextureView.visibility = View.VISIBLE
             }
             player.sendCustomCommand(
                 SessionCommand(
@@ -843,12 +853,12 @@ class Media3Fragment : Media3PlayerFragment() {
                 player.trackSelectionParameters = player.trackSelectionParameters.buildUpon().apply {
                     setTrackTypeDisabled(androidx.media3.common.C.TRACK_TYPE_VIDEO, true)
                 }.build()
-                binding.playerSurface.visibility = View.GONE
+                binding.playerTextureView.visibility = View.GONE
             } else {
                 player.trackSelectionParameters = player.trackSelectionParameters.buildUpon().apply {
                     setTrackTypeDisabled(androidx.media3.common.C.TRACK_TYPE_VIDEO, false)
                 }.build()
-                binding.playerSurface.visibility = View.VISIBLE
+                binding.playerTextureView.visibility = View.VISIBLE
             }
             player.sendCustomCommand(
                 SessionCommand(
@@ -1052,7 +1062,7 @@ class Media3Fragment : Media3PlayerFragment() {
                                 setTrackTypeDisabled(androidx.media3.common.C.TRACK_TYPE_VIDEO, false)
                                 clearOverridesOfType(androidx.media3.common.C.TRACK_TYPE_VIDEO)
                             }.build()
-                            binding.playerSurface.visibility = View.VISIBLE
+                            binding.playerTextureView.visibility = View.VISIBLE
                         }
                         AUDIO_ONLY_QUALITY -> {
                             if (viewModel.usingProxy) {
@@ -1068,7 +1078,7 @@ class Media3Fragment : Media3PlayerFragment() {
                             player.trackSelectionParameters = player.trackSelectionParameters.buildUpon().apply {
                                 setTrackTypeDisabled(androidx.media3.common.C.TRACK_TYPE_VIDEO, true)
                             }.build()
-                            binding.playerSurface.visibility = View.GONE
+                            binding.playerTextureView.visibility = View.GONE
                             quality.url?.let {
                                 val position = player.currentPosition
                                 if (viewModel.qualities?.find { it.name == AUTO_QUALITY } != null) {
@@ -1105,7 +1115,7 @@ class Media3Fragment : Media3PlayerFragment() {
                                 } ?: player.prepare()
                                 player.trackSelectionParameters = player.trackSelectionParameters.buildUpon().apply {
                                     setTrackTypeDisabled(androidx.media3.common.C.TRACK_TYPE_VIDEO, false)
-                                    binding.playerSurface.visibility = View.VISIBLE
+                                    binding.playerTextureView.visibility = View.VISIBLE
                                     if (!player.currentTracks.isEmpty) {
                                         player.currentTracks.groups.find { it.type == androidx.media3.common.C.TRACK_TYPE_VIDEO }?.let { trackGroup ->
                                             val selectedQuality = quality.name?.split("p")
@@ -1150,7 +1160,7 @@ class Media3Fragment : Media3PlayerFragment() {
                                 player.trackSelectionParameters = player.trackSelectionParameters.buildUpon().apply {
                                     setTrackTypeDisabled(androidx.media3.common.C.TRACK_TYPE_VIDEO, false)
                                 }.build()
-                                binding.playerSurface.visibility = View.VISIBLE
+                                binding.playerTextureView.visibility = View.VISIBLE
                             }
                         }
                     }
@@ -1188,7 +1198,7 @@ class Media3Fragment : Media3PlayerFragment() {
                             player.trackSelectionParameters = player.trackSelectionParameters.buildUpon().apply {
                                 setTrackTypeDisabled(androidx.media3.common.C.TRACK_TYPE_VIDEO, true)
                             }.build()
-                            binding.playerSurface.visibility = View.GONE
+                            binding.playerTextureView.visibility = View.GONE
                         }
                     }
                 }
@@ -1264,7 +1274,7 @@ class Media3Fragment : Media3PlayerFragment() {
         adAvoidanceJob?.cancel()
         adAvoidanceJob = null
         if (view != null) {
-            controller?.clearVideoSurfaceView(binding.playerSurface)
+            detachVideoOutput()
         }
         playerListener?.let { controller?.removeListener(it) }
         playerListener = null
@@ -1297,7 +1307,7 @@ class Media3Fragment : Media3PlayerFragment() {
                     if (!isInPIPMode && player.playWhenReady && viewModel.quality?.name != AUDIO_ONLY_QUALITY) {
                         if (player.currentMediaItem != null) {
                             viewModel.videoOutputState.markDetachedForBackground()
-                            binding.playerSurface.visibility = View.GONE
+                            binding.playerTextureView.visibility = View.GONE
                         }
                     }
                 } else {
@@ -1341,6 +1351,22 @@ class Media3Fragment : Media3PlayerFragment() {
         // ExoPlayer keeps the media timeline and retries loading as connectivity returns.
         // Stopping here discards that state and makes a temporary network loss look like a
         // user stop, especially when the fragment is about to be backgrounded.
+    }
+
+    override fun onDestroyView() {
+        detachVideoOutput()
+        super.onDestroyView()
+    }
+
+    private fun attachVideoOutput(currentPlayer: Player) {
+        videoOutputOwner.attach(currentPlayer, binding.playerTextureView)
+        logVideoSurfaceBinding("attach", currentPlayer, binding.playerTextureView)
+    }
+
+    private fun detachVideoOutput() {
+        val currentPlayer = videoOutputOwner.attachedPlayer() ?: return
+        logVideoSurfaceBinding("detach", currentPlayer, binding.playerTextureView)
+        videoOutputOwner.clear()
     }
 
     companion object {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/Media3PlayerFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/Media3PlayerFragment.kt
@@ -191,6 +191,8 @@ abstract class Media3PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFr
     @SuppressLint("ClickableViewAccessibility")
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        binding.playerSurface.visibility = View.GONE
+        binding.playerTextureView.visibility = View.VISIBLE
         with(binding) {
             val ignoreCutouts = requireContext().prefs().getBoolean(C.UI_DRAW_BEHIND_CUTOUTS, false)
             val cornerPadding = requireContext().prefs().getBoolean(C.PLAYER_ROUNDED_CORNER_PADDING, false)

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/MediaPlayerFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/MediaPlayerFragment.kt
@@ -36,6 +36,8 @@ class MediaPlayerFragment : PlayerFragment() {
 
     override fun onStart() {
         super.onStart()
+        binding.playerSurface.visibility = View.VISIBLE
+        binding.playerTextureView.visibility = View.GONE
         val listener = object : MediaPlayerService.PlayerListener {
             override fun onPrepared(player: MediaPlayer) {
                 clearPlayerError()

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/VideoOutputOwner.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/VideoOutputOwner.kt
@@ -1,0 +1,52 @@
+package com.github.andreyasadchy.xtra.ui.player
+
+/**
+ * Owns one player's video target and transfers it deterministically.
+ *
+ * The callbacks are deliberately supplied by the caller so this state machine
+ * can be tested without constructing Android video views.
+ */
+internal class VideoOutputOwner<Player : Any, Target : Any>(
+    private val attachTarget: (Player, Target) -> Unit,
+    private val detachTarget: (Player, Target) -> Unit,
+) {
+    private var binding: Binding<Player, Target>? = null
+
+    fun attach(player: Player, target: Target) {
+        val current = binding
+        if (current?.player === player && current.target === target) return
+
+        binding = null
+        current?.let { detachTarget(it.player, it.target) }
+
+        val next = Binding(player, target)
+        binding = next
+        try {
+            attachTarget(player, target)
+        } catch (error: Throwable) {
+            if (binding === next) binding = null
+            throw error
+        }
+    }
+
+    fun detach(player: Player, target: Target) {
+        val current = binding ?: return
+        if (current.player !== player || current.target !== target) return
+
+        binding = null
+        detachTarget(current.player, current.target)
+    }
+
+    fun clear() {
+        val current = binding ?: return
+        binding = null
+        detachTarget(current.player, current.target)
+    }
+
+    internal fun attachedPlayer(): Player? = binding?.player
+
+    private data class Binding<Player : Any, Target : Any>(
+        val player: Player,
+        val target: Target,
+    )
+}

--- a/app/src/main/res/layout/fragment_player.xml
+++ b/app/src/main/res/layout/fragment_player.xml
@@ -26,7 +26,14 @@
                 <SurfaceView
                     android:id="@+id/playerSurface"
                     android:layout_width="match_parent"
-                    android:layout_height="match_parent" />
+                    android:layout_height="match_parent"
+                    android:visibility="gone" />
+
+                <TextureView
+                    android:id="@+id/playerTextureView"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:visibility="gone" />
 
             </androidx.media3.ui.AspectRatioFrameLayout>
 

--- a/app/src/main/res/layout/multiview_slot.xml
+++ b/app/src/main/res/layout/multiview_slot.xml
@@ -16,7 +16,9 @@
         android:keepScreenOn="true"
         android:visibility="visible"
         app:resize_mode="fit"
+        app:keep_content_on_player_reset="false"
         app:show_buffering="never"
+        app:surface_type="texture_view"
         app:use_controller="false" />
 
     <View

--- a/app/src/main/res/layout/multiview_slot.xml
+++ b/app/src/main/res/layout/multiview_slot.xml
@@ -18,7 +18,6 @@
         app:resize_mode="fit"
         app:keep_content_on_player_reset="false"
         app:show_buffering="never"
-        app:surface_type="texture_view"
         app:use_controller="false" />
 
     <View

--- a/app/src/main/res/layout/view_stream_preview.xml
+++ b/app/src/main/res/layout/view_stream_preview.xml
@@ -3,5 +3,6 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    app:keep_content_on_player_reset="false"
     app:surface_type="texture_view"
     app:use_controller="false" />

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/common/PreviewTargetGenerationTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/common/PreviewTargetGenerationTest.kt
@@ -1,0 +1,20 @@
+package com.github.andreyasadchy.xtra.ui.common
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PreviewTargetGenerationTest {
+    @Test
+    fun recyclingTargetInvalidatesAnInFlightPreviewBind() {
+        val target = Any()
+        val generations = PreviewTargetGeneration<Any>()
+        val bindGeneration = generations.capture(target)
+
+        generations.invalidate(target)
+
+        assertFalse(generations.isCurrent(target, bindGeneration))
+        val reboundGeneration = generations.capture(target)
+        assertTrue(generations.isCurrent(target, reboundGeneration))
+    }
+}

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/player/VideoOutputOwnerTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/player/VideoOutputOwnerTest.kt
@@ -1,0 +1,42 @@
+package com.github.andreyasadchy.xtra.ui.player
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class VideoOutputOwnerTest {
+    @Test
+    fun switchingTargetsLeavesOnlyTheNewestTargetOwned() {
+        val player = Any()
+        val mainTarget = Any()
+        val secondaryTarget = Any()
+        val attached = mutableListOf<Pair<Any, Any>>()
+        val detached = mutableListOf<Pair<Any, Any>>()
+        val owner = VideoOutputOwner<Any, Any>(
+            attachTarget = { currentPlayer, target -> attached += currentPlayer to target },
+            detachTarget = { currentPlayer, target -> detached += currentPlayer to target },
+        )
+
+        owner.attach(player, mainTarget)
+        owner.attach(player, secondaryTarget)
+        assertEquals(listOf(player to mainTarget), detached)
+        assertEquals(listOf(player to mainTarget, player to secondaryTarget), attached)
+
+        owner.attach(player, mainTarget)
+        assertEquals(
+            listOf(player to mainTarget, player to secondaryTarget),
+            detached,
+        )
+        assertEquals(
+            listOf(player to mainTarget, player to secondaryTarget, player to mainTarget),
+            attached,
+        )
+
+        owner.clear()
+        assertEquals(
+            listOf(player to mainTarget, player to secondaryTarget, player to mainTarget),
+            detached,
+        )
+        assertTrue(owner.attachedPlayer() == null)
+    }
+}


### PR DESCRIPTION
Fix render-target lifetime hazards in the main player and stream previews. Main dynamic playback uses TextureView with deterministic ownership handoffs; recycled preview targets invalidate pending binds and clear PlayerView ownership before removal. Multiview keeps its original SurfaceView rendering. Includes DEBUG diagnostics and focused ownership/recycling tests. These are code-inspection hazards consistent with the reported corruption; physical-device reproduction is still required to identify which hazard produced a given occurrence.