### PR TITLE
Fix active poll choice rendering

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChannelPointsDialog.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChannelPointsDialog.kt
@@ -592,6 +592,7 @@ class ChannelPointsDialog : DialogFragment() {
         binding.pollChoices.removeAllViews()
         if (poll == null) return
 
+        val pollId = poll.id
         val status = poll.status.orEmpty().uppercase()
         val isActive = activePoll != null && PollState.isActive(poll)
         binding.pollCardTitle.text = getString(
@@ -620,17 +621,18 @@ class ChannelPointsDialog : DialogFragment() {
             poll.startedAt?.let { add(getString(R.string.channel_points_poll_started, TwitchApiHelper.formatDate(requireContext(), it))) }
             poll.endedAt?.let { add(getString(R.string.channel_points_poll_ended, TwitchApiHelper.formatDate(requireContext(), it))) }
             poll.durationSeconds?.let { add(getString(R.string.channel_points_poll_duration, android.text.format.DateUtils.formatElapsedTime(it.toLong()))) }
-            pollVoteState.error?.takeIf { pollVoteState.pollId == poll.id }?.let {
+            pollVoteState.error?.takeIf { pollId != null && pollVoteState.pollId == pollId }?.let {
                 add(getString(R.string.channel_points_poll_vote_error, it))
             }
         }
         binding.pollCardStatus.text = details.joinToString(" · ")
         val maxVotes = poll.choices.orEmpty().mapNotNull { it.totalVotes }.maxOrNull()
         val winners = poll.choices.orEmpty().filter { maxVotes != null && it.totalVotes == maxVotes }
-        val voteStateMatches = pollVoteState.pollId == poll.id
+        val voteStateMatches = pollId != null && pollVoteState.pollId == pollId
         val canVote = isActive && listener.canVotePoll() && voteStateMatches &&
                 pollVoteState.pendingChoiceId == null && pollVoteState.selectedChoiceId == null
         poll.choices.orEmpty().forEachIndexed { index, choice ->
+            val choiceId = choice.id
             val percent = if (totalVotes > 0) {
                 (((choice.totalVotes ?: 0).toLong() * 100.0) / totalVotes).roundToInt()
             } else 0
@@ -641,9 +643,9 @@ class ChannelPointsDialog : DialogFragment() {
                 choice.bitsVotes?.let { add("${numberFormat.format(it)} bits") }
             }.joinToString(" · ")
             val choiceText = "$prefix$percent% · $voteDetails · ${choice.title}"
-            val selected = voteStateMatches && pollVoteState.selectedChoiceId == choice.id
-            val pending = voteStateMatches && pollVoteState.pendingChoiceId == choice.id
-            val showButton = isActive && choice.id != null &&
+            val selected = voteStateMatches && choiceId != null && pollVoteState.selectedChoiceId == choiceId
+            val pending = voteStateMatches && choiceId != null && pollVoteState.pendingChoiceId == choiceId
+            val showButton = isActive && choiceId != null &&
                     (canVote || selected || pending || (voteStateMatches && pollVoteState.inFlight))
             if (showButton) {
                 binding.pollChoices.addView(
@@ -665,7 +667,9 @@ class ChannelPointsDialog : DialogFragment() {
                             )
                         }
                         setOnClickListener {
-                            listener.votePoll(choice.id)
+                            if (canVote && !selected && !pending) {
+                                choiceId?.let { listener.votePoll(it) }
+                            }
                         }
                         layoutParams = LinearLayout.LayoutParams(
                             LinearLayout.LayoutParams.MATCH_PARENT,

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/chat/PollState.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/chat/PollState.kt
@@ -85,10 +85,38 @@ object PollState {
     private fun mergeChoices(current: List<Poll.PollChoice>?, incoming: List<Poll.PollChoice>?): List<Poll.PollChoice>? {
         if (current.isNullOrEmpty()) return incoming
         if (incoming.isNullOrEmpty()) return current
-        val currentByKey = current.associateBy { it.id ?: it.title }
+
+        val currentById = current.mapNotNull { choice ->
+            choice.id
+                ?.takeIf { it.isNotBlank() }
+                ?.let { it to choice }
+        }.toMap()
+        val currentByUniqueTitle = current
+            .mapNotNull { choice ->
+                choice.title
+                    ?.takeIf { it.isNotBlank() }
+                    ?.let { it to choice }
+            }
+            .groupBy(
+                keySelector = { it.first },
+                valueTransform = { it.second },
+            )
+            .mapNotNull { (title, choices) ->
+                choices.singleOrNull()?.let { title to it }
+            }
+            .toMap()
+
         return incoming.map { choice ->
-            val previous = currentByKey[choice.id ?: choice.title]
+            val incomingId = choice.id?.takeIf { it.isNotBlank() }
+            val previous = if (incomingId != null) {
+                currentById[incomingId]
+            } else {
+                choice.title
+                    ?.takeIf { it.isNotBlank() }
+                    ?.let(currentByUniqueTitle::get)
+            }
             if (previous == null) choice else choice.copy(
+                id = incomingId ?: previous.id,
                 totalVotes = max(previous.totalVotes, choice.totalVotes),
                 channelPointsVotes = max(previous.channelPointsVotes, choice.channelPointsVotes),
                 bitsVotes = max(previous.bitsVotes, choice.bitsVotes),

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/chat/PubSubUtils.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/chat/PubSubUtils.kt
@@ -226,32 +226,48 @@ object PubSubUtils {
             effectiveEndsAt ?: observedAt
         } else null
 
-        val choicesList = buildList {
-            poll.optJSONArray("choices")?.let { choices ->
-                for (index in 0 until choices.length()) {
-                    val choice = choices.optJSONObject(index) ?: continue
-                    val title = choice.optionalString("title") ?: continue
-                    val nestedVotes = choice.opt("votes") as? JSONObject
-                    val votes = choice.optionalInt("votes")
-                        ?: nestedVotes?.optionalInt("total")
-                        ?: choice.optionalInt("total_votes")
-                    val channelPointsVotes = choice.optionalInt("channel_points_votes")
-                        ?: nestedVotes?.optionalInt("channel_points_votes")
-                        ?: nestedVotes?.optionalInt("channel_points")
-                    val bitsVotes = choice.optionalInt("bits_votes")
-                        ?: nestedVotes?.optionalInt("bits_votes")
-                        ?: nestedVotes?.optionalInt("bits")
-                    add(
-                        Poll.PollChoice(
-                            id = choice.optionalString("id"),
-                            title = title,
-                            totalVotes = votes,
-                            channelPointsVotes = channelPointsVotes,
-                            bitsVotes = bitsVotes,
-                        ),
-                    )
+        val rawChoices = mutableListOf<Pair<String?, JSONObject>>()
+        poll.optJSONArray("choices")?.let { choices ->
+            for (index in 0 until choices.length()) {
+                val choice = choices.optJSONObject(index) ?: continue
+                rawChoices.add(null to choice)
+            }
+        }
+        if (rawChoices.isEmpty()) {
+            poll.optJSONObject("choices")?.let { choices ->
+                val keys = choices.keys()
+                while (keys.hasNext()) {
+                    val key = keys.next()
+                    val choice = choices.optJSONObject(key) ?: continue
+                    rawChoices.add(key to choice)
                 }
             }
+        }
+
+        val choicesList = rawChoices.mapNotNull { (fallbackId, choice) ->
+            val title = choice.optionalString("title")
+                ?: return@mapNotNull null
+            val nestedVotes = choice.opt("votes") as? JSONObject
+            val votes = choice.optionalInt("votes")
+                ?: nestedVotes?.optionalInt("total")
+                ?: choice.optionalInt("total_votes")
+            val channelPointsVotes = choice.optionalInt("channel_points_votes")
+                ?: choice.optionalInt("channelPointsVotes")
+                ?: nestedVotes?.optionalInt("channel_points_votes")
+                ?: nestedVotes?.optionalInt("channel_points")
+            val bitsVotes = choice.optionalInt("bits_votes")
+                ?: choice.optionalInt("bitsVotes")
+                ?: nestedVotes?.optionalInt("bits_votes")
+                ?: nestedVotes?.optionalInt("bits")
+            Poll.PollChoice(
+                id = listOf("id", "choice_id", "choiceId", "choiceID")
+                    .firstNotNullOfOrNull { choice.optionalString(it) }
+                    ?: fallbackId?.takeIf { it.isNotBlank() },
+                title = title,
+                totalVotes = votes,
+                channelPointsVotes = channelPointsVotes,
+                bitsVotes = bitsVotes,
+            )
         }
 
         val channelPointsVoting = poll.optJSONObject("channel_points_voting")

--- a/app/src/test/java/com/github/andreyasadchy/xtra/util/chat/PollStateTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/util/chat/PollStateTest.kt
@@ -1,6 +1,7 @@
 package com.github.andreyasadchy.xtra.util.chat
 
 import com.github.andreyasadchy.xtra.model.chat.Poll
+import com.github.andreyasadchy.xtra.model.chat.PollVoteState
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -32,6 +33,102 @@ class PollStateTest {
         assertEquals(2, poll?.choices?.single()?.channelPointsVotes)
         assertTrue(poll?.startedAt != null)
         assertTrue(poll?.endsAt != null)
+    }
+
+    @Test
+    fun preservesChoiceIdAliasesAndMapKeys() {
+        val eventSub = PubSubUtils.onPollUpdate(
+            JSONObject(
+                """{"id":"p1","title":"Pick","choices":[{"id":"choice-a","title":"A","votes":10,"bits_votes":0,"channel_points_votes":0}]}""",
+            ),
+        )
+        val alternate = PubSubUtils.onPollUpdate(
+            JSONObject(
+                """{"id":"p2","title":"Pick","choices":[{"choice_id":"choice-b","title":"B","total_votes":20}]}""",
+            ),
+        )
+        val mapped = PubSubUtils.onPollUpdate(
+            JSONObject(
+                """{"id":"p3","title":"Pick","choices":{"choice-c":{"title":"C","votes":30}}}""",
+            ),
+        )
+
+        assertEquals("choice-a", eventSub?.choices?.single()?.id)
+        assertEquals("choice-b", alternate?.choices?.single()?.id)
+        assertEquals("choice-c", mapped?.choices?.single()?.id)
+    }
+
+    @Test
+    fun skipsChoicesWithoutTitles() {
+        val poll = PubSubUtils.onPollUpdate(
+            JSONObject("""{"id":"p1","title":"Pick","choices":[{"id":"choice-a","votes":10}]}"""),
+        )
+
+        assertEquals(0, poll?.choices?.size)
+    }
+
+    @Test
+    fun missingChoiceIdDoesNotMatchMissingSelectedChoiceId() {
+        val pollId: String? = "p1"
+        val choiceId: String? = null
+        val voteState = PollVoteState(pollId = pollId)
+        val voteStateMatches = pollId != null && voteState.pollId == pollId
+        val selected = voteStateMatches && choiceId != null && voteState.selectedChoiceId == choiceId
+
+        assertFalse(selected)
+    }
+
+    @Test
+    fun progressWithoutChoiceIdsPreservesKnownChoiceIds() {
+        val initial = Poll(
+            id = "p1",
+            title = "Pick",
+            status = "ACTIVE",
+            choices = listOf(
+                Poll.PollChoice("choice-a", "A", 10),
+                Poll.PollChoice("choice-b", "B", 20),
+            ),
+            totalVotes = 30,
+            remainingMilliseconds = null,
+            observedAt = 100L,
+        )
+        val progress = Poll(
+            id = "p1",
+            title = "Pick",
+            status = "ACTIVE",
+            choices = listOf(
+                Poll.PollChoice(null, "A", 11),
+                Poll.PollChoice(null, "B", 22),
+            ),
+            totalVotes = 33,
+            remainingMilliseconds = null,
+            observedAt = 200L,
+        )
+
+        val merged = requireNotNull(PollState.merge(initial, progress))
+
+        assertEquals("choice-a", merged.choices?.get(0)?.id)
+        assertEquals("choice-b", merged.choices?.get(1)?.id)
+        assertEquals(11, merged.choices?.get(0)?.totalVotes)
+        assertEquals(22, merged.choices?.get(1)?.totalVotes)
+        assertEquals(33, merged.totalVotes)
+    }
+
+    @Test
+    fun ambiguousChoiceTitleDoesNotInventAnId() {
+        val initial = poll("p1", "ACTIVE", 100L, 30).copy(
+            choices = listOf(
+                Poll.PollChoice("choice-a", "Same", 10),
+                Poll.PollChoice("choice-b", "Same", 20),
+            ),
+        )
+        val progress = poll("p1", "ACTIVE", 200L, 31).copy(
+            choices = listOf(Poll.PollChoice(null, "Same", 31)),
+        )
+
+        val merged = requireNotNull(PollState.merge(initial, progress))
+
+        assertNull(merged.choices?.single()?.id)
     }
 
     @Test


### PR DESCRIPTION
Active poll choices now retain their Twitch IDs and render as clickable buttons when voting is allowed. Partial progress snapshots preserve known choice IDs through unique-title matching; ambiguous titles remain unresolved. ID-less choices stay read-only, and null vote state no longer marks every choice selected.