### PR TITLE
Fix prediction betting for multiple outcomes

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChannelPointsDialog.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChannelPointsDialog.kt
@@ -723,6 +723,10 @@ class ChannelPointsDialog : DialogFragment() {
         val outcomes = prediction.outcomes.orEmpty()
         val betStateMatches = predictionBetState.predictionId == prediction.id
         val selectedOutcomeId = predictionBetState.outcomeId.takeIf { betStateMatches }
+        val confirmedViewerAmount = predictionBetState.amount
+            .takeIf { betStateMatches }
+            ?.takeIf { it > 0 }
+        val confirmedOutcomeId = selectedOutcomeId.takeIf { confirmedViewerAmount != null }
         val betInFlight = betStateMatches && predictionBetState.inFlight
         val predictionBetError = predictionBetState.error.takeIf { betStateMatches }
         val totalPoints = outcomes.mapNotNull { it.totalPoints }.sum().takeIf { it > 0 }
@@ -768,8 +772,8 @@ class ChannelPointsDialog : DialogFragment() {
                 winner = PredictionState.isFinal(prediction) && prediction.winningOutcomeId == outcome.id,
                 tie = status == "RESOLVED" && prediction.winningOutcomeId.isNullOrBlank() &&
                     totalPoints != null && outcome.totalPoints == outcomes.mapNotNull { it.totalPoints }.maxOrNull(),
-                viewerSelected = selectedOutcomeId == outcome.id,
-                viewerAmount = predictionBetState.amount.takeIf { betStateMatches && selectedOutcomeId == outcome.id },
+                viewerSelected = confirmedOutcomeId == outcome.id,
+                viewerAmount = confirmedViewerAmount.takeIf { confirmedOutcomeId == outcome.id },
             )
         }
 
@@ -781,9 +785,9 @@ class ChannelPointsDialog : DialogFragment() {
         val hint = when {
             predictionBetError != null -> predictionBetError
             betInFlight -> getString(R.string.channel_points_prediction_bet_pending)
-            selectedOutcomeId != null -> getString(
+            confirmedOutcomeId != null -> getString(
                 R.string.channel_points_prediction_bet_selected,
-                numberFormat.format(predictionBetState.amount ?: 0),
+                numberFormat.format(confirmedViewerAmount),
             )
             isBettingOpen && !canBetAvailable -> getString(R.string.channel_points_prediction_bet_login)
             isBettingOpen && !wagerablePrediction -> getString(R.string.channel_points_prediction_bet_unavailable)
@@ -807,6 +811,7 @@ class ChannelPointsDialog : DialogFragment() {
             renderPredictionBetChoices(
                 prediction = prediction,
                 enabled = !betInFlight,
+                confirmedAmount = confirmedViewerAmount ?: 0,
             )
             for (i in 0 until binding.predictionBetChoices.childCount) {
                 val button = binding.predictionBetChoices.getChildAt(i) as? MaterialButton ?: continue
@@ -815,6 +820,9 @@ class ChannelPointsDialog : DialogFragment() {
                     selectedOutcomeId = selectedOutcomeId,
                     candidateOutcomeId = candidateOutcomeId,
                     inFlight = betInFlight,
+                    confirmedAmount = confirmedViewerAmount ?: 0,
+                    minimumPoints = MIN_PREDICTION_POINTS,
+                    maximumPoints = MAX_PREDICTION_POINTS,
                 )
             }
         } else {
@@ -822,7 +830,11 @@ class ChannelPointsDialog : DialogFragment() {
         }
     }
 
-    private fun renderPredictionBetChoices(prediction: Prediction, enabled: Boolean) {
+    private fun renderPredictionBetChoices(
+        prediction: Prediction,
+        enabled: Boolean,
+        confirmedAmount: Int,
+    ) {
         val container = binding.predictionBetChoices
         container.removeAllViews()
         val outcomes = prediction.outcomes.orEmpty()
@@ -839,7 +851,11 @@ class ChannelPointsDialog : DialogFragment() {
                 isEnabled = enabled
                 stylePredictionButton(this, buttonColor)
                 setOnClickListener {
-                    placePredictionBet(binding.predictionBetAmount, outcomeId)
+                    placePredictionBet(
+                        input = binding.predictionBetAmount,
+                        outcomeId = outcomeId,
+                        confirmedAmount = confirmedAmount,
+                    )
                 }
                 layoutParams = LinearLayout.LayoutParams(
                     LinearLayout.LayoutParams.MATCH_PARENT,
@@ -1008,16 +1024,36 @@ class ChannelPointsDialog : DialogFragment() {
         button.ellipsize = android.text.TextUtils.TruncateAt.END
     }
 
-    private fun placePredictionBet(input: EditText, outcomeId: String?) {
+    private fun placePredictionBet(
+        input: EditText,
+        outcomeId: String?,
+        confirmedAmount: Int,
+    ) {
         val points = input.text.toString().toIntOrNull()
         val balance = listener.channelPointsFlow().value?.balance
+        val remaining = PredictionBetPolicy.remainingPoints(
+            previousAmount = confirmedAmount,
+            maximumPoints = MAX_PREDICTION_POINTS,
+        )
         when {
             outcomeId.isNullOrBlank() -> input.error = getString(R.string.channel_points_prediction_bet_unavailable)
-            points == null || points !in MIN_PREDICTION_POINTS..MAX_PREDICTION_POINTS -> input.error = getString(
-                R.string.channel_points_prediction_bet_range,
-                MIN_PREDICTION_POINTS,
-                MAX_PREDICTION_POINTS,
-            )
+            points == null || !PredictionBetPolicy.canAddPoints(
+                previousAmount = confirmedAmount,
+                additionalPoints = points,
+                minimumPoints = MIN_PREDICTION_POINTS,
+                maximumPoints = MAX_PREDICTION_POINTS,
+            ) -> input.error = if (remaining < MIN_PREDICTION_POINTS) {
+                getString(
+                    R.string.channel_points_prediction_bet_limit,
+                    NumberFormat.getInstance().format(remaining),
+                )
+            } else {
+                getString(
+                    R.string.channel_points_prediction_bet_range,
+                    MIN_PREDICTION_POINTS,
+                    remaining,
+                )
+            }
             balance != null && points > balance -> input.error = getString(
                 R.string.channel_points_prediction_bet_balance,
                 NumberFormat.getInstance().format(balance),

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChannelPointsDialog.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChannelPointsDialog.kt
@@ -50,6 +50,7 @@ import com.github.andreyasadchy.xtra.util.TwitchApiHelper
 import com.github.andreyasadchy.xtra.util.getAlertDialogBuilder
 import com.github.andreyasadchy.xtra.util.prefs
 import com.github.andreyasadchy.xtra.util.chat.PollState
+import com.github.andreyasadchy.xtra.util.chat.PredictionBetPolicy
 import com.github.andreyasadchy.xtra.util.chat.PredictionState
 import com.google.android.material.card.MaterialCardView
 import com.google.android.material.button.MaterialButton
@@ -749,8 +750,9 @@ class ChannelPointsDialog : DialogFragment() {
         }.joinToString(" · ")
         binding.predictionCardMeta.isVisible = binding.predictionCardMeta.text.isNotBlank()
 
-        val twoOutcomePrediction = outcomes.size == 2 && outcomes.all { !it.id.isNullOrBlank() }
-        binding.predictionOutcomes.orientation = if (twoOutcomePrediction) {
+        val compactPredictionLayout = outcomes.size == 2
+        val wagerablePrediction = PredictionBetPolicy.isPredictionWagerable(outcomes.map { it.id })
+        binding.predictionOutcomes.orientation = if (compactPredictionLayout) {
             LinearLayout.HORIZONTAL
         } else {
             LinearLayout.VERTICAL
@@ -771,7 +773,8 @@ class ChannelPointsDialog : DialogFragment() {
             )
         }
 
-        val canBet = isBettingOpen && twoOutcomePrediction && listener.canBetPrediction()
+        val canBetAvailable = listener.canBetPrediction()
+        val canBet = isBettingOpen && wagerablePrediction && canBetAvailable
         if (binding.predictionBetRow.isVisible != canBet) {
             binding.predictionBetRow.isVisible = canBet
         }
@@ -782,8 +785,8 @@ class ChannelPointsDialog : DialogFragment() {
                 R.string.channel_points_prediction_bet_selected,
                 numberFormat.format(predictionBetState.amount ?: 0),
             )
-            isBettingOpen && !listener.canBetPrediction() -> getString(R.string.channel_points_prediction_bet_login)
-            isBettingOpen && !twoOutcomePrediction -> getString(R.string.channel_points_prediction_bet_unavailable)
+            isBettingOpen && !canBetAvailable -> getString(R.string.channel_points_prediction_bet_login)
+            isBettingOpen && !wagerablePrediction -> getString(R.string.channel_points_prediction_bet_unavailable)
             isBettingOpen && channelPoints != null && channelPoints.balance < MIN_PREDICTION_POINTS -> getString(
                 R.string.channel_points_prediction_bet_balance,
                 numberFormat.format(channelPoints.balance),
@@ -801,18 +804,51 @@ class ChannelPointsDialog : DialogFragment() {
                 }
                 setSelectAllOnFocus(true)
             }
-            binding.predictionBetLeft.text = outcomes[0].title
-            binding.predictionBetRight.text = outcomes[1].title
-            stylePredictionButton(binding.predictionBetLeft, BLUE_PREDICTION_COLOR)
-            stylePredictionButton(binding.predictionBetRight, PINK_PREDICTION_COLOR)
-            binding.predictionBetLeft.isEnabled = !betInFlight && selectedOutcomeId == null
-            binding.predictionBetRight.isEnabled = !betInFlight && selectedOutcomeId == null
-            binding.predictionBetLeft.setOnClickListener {
-                placePredictionBet(binding.predictionBetAmount, outcomes[0].id)
+            renderPredictionBetChoices(
+                prediction = prediction,
+                enabled = !betInFlight,
+            )
+            for (i in 0 until binding.predictionBetChoices.childCount) {
+                val button = binding.predictionBetChoices.getChildAt(i) as? MaterialButton ?: continue
+                val candidateOutcomeId = button.tag as? String
+                button.isEnabled = PredictionBetPolicy.canBetOutcome(
+                    selectedOutcomeId = selectedOutcomeId,
+                    candidateOutcomeId = candidateOutcomeId,
+                    inFlight = betInFlight,
+                )
             }
-            binding.predictionBetRight.setOnClickListener {
-                placePredictionBet(binding.predictionBetAmount, outcomes[1].id)
+        } else {
+            binding.predictionBetChoices.removeAllViews()
+        }
+    }
+
+    private fun renderPredictionBetChoices(prediction: Prediction, enabled: Boolean) {
+        val container = binding.predictionBetChoices
+        container.removeAllViews()
+        val outcomes = prediction.outcomes.orEmpty()
+        outcomes.forEach { outcome ->
+            val outcomeId = outcome.id ?: return@forEach
+            val buttonColor = when {
+                outcome.color.equals("PINK", true) -> PINK_PREDICTION_COLOR
+                outcome.color.equals("BLUE", true) -> BLUE_PREDICTION_COLOR
+                else -> BLUE_PREDICTION_COLOR
             }
+            val button = MaterialButton(requireContext()).apply {
+                text = outcome.title
+                tag = outcomeId
+                isEnabled = enabled
+                stylePredictionButton(this, buttonColor)
+                setOnClickListener {
+                    placePredictionBet(binding.predictionBetAmount, outcomeId)
+                }
+                layoutParams = LinearLayout.LayoutParams(
+                    LinearLayout.LayoutParams.MATCH_PARENT,
+                    LinearLayout.LayoutParams.WRAP_CONTENT,
+                ).apply {
+                    bottomMargin = dp(4)
+                }
+            }
+            container.addView(button)
         }
     }
 

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatViewModel.kt
@@ -4051,6 +4051,10 @@ class ChatViewModel(
             samePrediction && !it.isNullOrBlank()
         }
         val previousAmount = previous.amount.takeIf { samePrediction } ?: 0
+        val remainingPredictionPoints = PredictionBetPolicy.remainingPoints(
+            previousAmount = previousAmount,
+            maximumPoints = MAX_PREDICTION_POINTS,
+        )
         if ((samePrediction && previous.inFlight) ||
             (previousOutcomeId != null && previousOutcomeId != outcomeId) ||
             !canBetPrediction() ||
@@ -4058,7 +4062,10 @@ class ChatViewModel(
             outcomeId.isBlank() ||
             current.outcomes.orEmpty().none { it.id == outcomeId }
         ) return
-        if (points !in MIN_PREDICTION_POINTS..MAX_PREDICTION_POINTS || (balance != null && points > balance)) return
+        if (points < MIN_PREDICTION_POINTS ||
+            points > remainingPredictionPoints ||
+            (balance != null && points > balance)
+        ) return
 
         val networkLibrary = applicationContext.prefs().getString(C.NETWORK_LIBRARY, C.OKHTTP)
         val headers = TwitchApiHelper.getGQLHeaders(applicationContext, true)

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatViewModel.kt
@@ -79,6 +79,7 @@ import com.github.andreyasadchy.xtra.util.chat.GqlPredictionSnapshot
 import com.github.andreyasadchy.xtra.util.chat.HermesWebSocket
 import com.github.andreyasadchy.xtra.util.chat.PollCache
 import com.github.andreyasadchy.xtra.util.chat.PollState
+import com.github.andreyasadchy.xtra.util.chat.PredictionBetPolicy
 import com.github.andreyasadchy.xtra.util.chat.PredictionCache
 import com.github.andreyasadchy.xtra.util.chat.PredictionState
 import com.github.andreyasadchy.xtra.util.chat.PredictionStateStore
@@ -4045,8 +4046,13 @@ class ChatViewModel(
         val userId = applicationContext.tokenPrefs().getString(C.USER_ID, null)
         val balance = channelPoints.value?.balance
         val previous = _predictionBetState.value
-        if ((previous.predictionId == predictionId &&
-                    (previous.inFlight || !previous.outcomeId.isNullOrBlank())) ||
+        val samePrediction = previous.predictionId == predictionId
+        val previousOutcomeId = previous.outcomeId.takeIf {
+            samePrediction && !it.isNullOrBlank()
+        }
+        val previousAmount = previous.amount.takeIf { samePrediction } ?: 0
+        if ((samePrediction && previous.inFlight) ||
+            (previousOutcomeId != null && previousOutcomeId != outcomeId) ||
             !canBetPrediction() ||
             predictionId.isNullOrBlank() ||
             outcomeId.isBlank() ||
@@ -4059,8 +4065,9 @@ class ChatViewModel(
         _predictionBetState.value = PredictionBetState(
             predictionId = predictionId,
             outcomeId = outcomeId,
-            amount = points,
+            amount = previousAmount.takeIf { it > 0 },
             inFlight = true,
+            error = null,
         )
         predictionBetJob = viewModelScope.launch(Dispatchers.IO) {
             try {
@@ -4081,6 +4088,7 @@ class ChatViewModel(
                         response.data.hasError() == false
                 if (activeChannelLogin == channelLogin && _predictionBetState.value.predictionId == predictionId) {
                     _predictionBetState.value = if (success) {
+                        val totalAmount = PredictionBetPolicy.totalAfterAdditionalBet(previousAmount, points)
                         activeChannelId?.let { channelId ->
                             userId?.takeIf { it.isNotBlank() }?.let { currentUserId ->
                                 ViewerParticipationCache.savePredictionBet(
@@ -4088,7 +4096,7 @@ class ChatViewModel(
                                     channelId = channelId,
                                     predictionId = predictionId,
                                     outcomeId = outcomeId,
-                                    amount = points,
+                                    amount = totalAmount,
                                     userId = currentUserId,
                                     broadcastId = streamId,
                                 )
@@ -4097,12 +4105,13 @@ class ChatViewModel(
                         PredictionBetState(
                             predictionId = predictionId,
                             outcomeId = outcomeId,
-                            amount = points,
+                            amount = totalAmount,
                         )
                     } else {
-                        _predictionBetState.value.copy(
-                            outcomeId = null,
-                            amount = null,
+                        PredictionBetState(
+                            predictionId = predictionId,
+                            outcomeId = previousOutcomeId,
+                            amount = previousAmount.takeIf { it > 0 },
                             inFlight = false,
                             error = errorMessage ?: "Twitch rejected the prediction",
                         )
@@ -4134,9 +4143,10 @@ class ChatViewModel(
             } catch (e: Exception) {
                 if (activeChannelLogin == channelLogin && _predictionBetState.value.predictionId == predictionId) {
                     val message = e.message ?: "Prediction request failed"
-                    _predictionBetState.value = _predictionBetState.value.copy(
-                        outcomeId = null,
-                        amount = null,
+                    _predictionBetState.value = PredictionBetState(
+                        predictionId = predictionId,
+                        outcomeId = previousOutcomeId,
+                        amount = previousAmount.takeIf { it > 0 },
                         inFlight = false,
                         error = message,
                     )

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/chat/PredictionBetPolicy.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/chat/PredictionBetPolicy.kt
@@ -4,13 +4,32 @@ internal object PredictionBetPolicy {
     fun isPredictionWagerable(outcomeIds: List<String?>): Boolean =
         outcomeIds.size in 2..10 && outcomeIds.all { !it.isNullOrBlank() }
 
+    fun remainingPoints(
+        previousAmount: Int?,
+        maximumPoints: Int,
+    ): Int = (maximumPoints - (previousAmount ?: 0)).coerceAtLeast(0)
+
+    fun canAddPoints(
+        previousAmount: Int?,
+        additionalPoints: Int,
+        minimumPoints: Int,
+        maximumPoints: Int,
+    ): Boolean {
+        val remaining = remainingPoints(previousAmount, maximumPoints)
+        return additionalPoints >= minimumPoints && additionalPoints <= remaining
+    }
+
     fun canBetOutcome(
         selectedOutcomeId: String?,
         candidateOutcomeId: String?,
         inFlight: Boolean,
+        confirmedAmount: Int,
+        minimumPoints: Int,
+        maximumPoints: Int,
     ): Boolean =
         !inFlight &&
             !candidateOutcomeId.isNullOrBlank() &&
+            remainingPoints(confirmedAmount, maximumPoints) >= minimumPoints &&
             (
                 selectedOutcomeId.isNullOrBlank() ||
                     selectedOutcomeId == candidateOutcomeId

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/chat/PredictionBetPolicy.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/chat/PredictionBetPolicy.kt
@@ -1,0 +1,23 @@
+package com.github.andreyasadchy.xtra.util.chat
+
+internal object PredictionBetPolicy {
+    fun isPredictionWagerable(outcomeIds: List<String?>): Boolean =
+        outcomeIds.size in 2..10 && outcomeIds.all { !it.isNullOrBlank() }
+
+    fun canBetOutcome(
+        selectedOutcomeId: String?,
+        candidateOutcomeId: String?,
+        inFlight: Boolean,
+    ): Boolean =
+        !inFlight &&
+            !candidateOutcomeId.isNullOrBlank() &&
+            (
+                selectedOutcomeId.isNullOrBlank() ||
+                    selectedOutcomeId == candidateOutcomeId
+                )
+
+    fun totalAfterAdditionalBet(
+        previousAmount: Int?,
+        additionalPoints: Int,
+    ): Int = (previousAmount ?: 0) + additionalPoints
+}

--- a/app/src/main/res/layout/dialog_channel_points.xml
+++ b/app/src/main/res/layout/dialog_channel_points.xml
@@ -124,18 +124,9 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="8dp"
-                    android:gravity="center_vertical"
-                    android:orientation="horizontal"
+                    android:gravity="center_horizontal"
+                    android:orientation="vertical"
                     android:visibility="gone">
-
-                    <com.google.android.material.button.MaterialButton
-                        android:id="@+id/predictionBetLeft"
-                        android:layout_width="0dp"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:maxLines="2"
-                        android:textAllCaps="false"
-                        tools:text="Yes, he will win" />
 
                     <EditText
                         android:id="@+id/predictionBetAmount"
@@ -150,14 +141,11 @@
                         android:selectAllOnFocus="true"
                         android:textSize="16sp" />
 
-                    <com.google.android.material.button.MaterialButton
-                        android:id="@+id/predictionBetRight"
-                        android:layout_width="0dp"
+                    <LinearLayout
+                        android:id="@+id/predictionBetChoices"
+                        android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:maxLines="2"
-                        android:textAllCaps="false"
-                        tools:text="No, he will lose" />
+                        android:orientation="vertical" />
                 </LinearLayout>
 
                 <TextView

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -1421,4 +1421,5 @@
     <string name="viewer_list_empty">No viewers are currently listed.</string>
     <string name="player_lock_controls">Lock player controls</string>
     <string name="player_unlock_controls">Unlock player controls</string>
+    <string name="channel_points_prediction_bet_limit">يمكنك إضافة %s نقطة كحد أقصى</string>
 </resources>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -1444,4 +1444,5 @@
     <string name="viewer_list_empty">No viewers are currently listed.</string>
     <string name="player_lock_controls">Lock player controls</string>
     <string name="player_unlock_controls">Unlock player controls</string>
+    <string name="channel_points_prediction_bet_limit">Můžete přidat nejvýše %s bodů</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1421,4 +1421,5 @@
     <string name="viewer_list_empty">No viewers are currently listed.</string>
     <string name="player_lock_controls">Lock player controls</string>
     <string name="player_unlock_controls">Unlock player controls</string>
+    <string name="channel_points_prediction_bet_limit">Sie können höchstens %s Punkte hinzufügen</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1426,4 +1426,5 @@
     <string name="viewer_list_empty">No viewers are currently listed.</string>
     <string name="player_lock_controls">Lock player controls</string>
     <string name="player_unlock_controls">Unlock player controls</string>
+    <string name="channel_points_prediction_bet_limit">Puedes añadir como máximo %s puntos</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1421,4 +1421,5 @@
     <string name="viewer_list_empty">No viewers are currently listed.</string>
     <string name="player_lock_controls">Lock player controls</string>
     <string name="player_unlock_controls">Unlock player controls</string>
+    <string name="channel_points_prediction_bet_limit">Vous pouvez ajouter au maximum %s points</string>
 </resources>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -1421,4 +1421,5 @@
     <string name="viewer_list_empty">No viewers are currently listed.</string>
     <string name="player_lock_controls">Lock player controls</string>
     <string name="player_unlock_controls">Unlock player controls</string>
+    <string name="channel_points_prediction_bet_limit">Podes engadir como máximo %s puntos</string>
 </resources>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -1422,4 +1422,5 @@
     <string name="viewer_list_empty">No viewers are currently listed.</string>
     <string name="player_lock_controls">Lock player controls</string>
     <string name="player_unlock_controls">Unlock player controls</string>
+    <string name="channel_points_prediction_bet_limit">Anda dapat menambahkan paling banyak %s poin</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1421,4 +1421,5 @@
     <string name="viewer_list_empty">No viewers are currently listed.</string>
     <string name="player_lock_controls">Lock player controls</string>
     <string name="player_unlock_controls">Unlock player controls</string>
+    <string name="channel_points_prediction_bet_limit">Puoi aggiungere al massimo %s punti</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1421,4 +1421,5 @@
     <string name="viewer_list_empty">No viewers are currently listed.</string>
     <string name="player_lock_controls">Lock player controls</string>
     <string name="player_unlock_controls">Unlock player controls</string>
+    <string name="channel_points_prediction_bet_limit">追加できるポイントは最大%sです</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -1419,4 +1419,5 @@
     <string name="viewer_list_empty">No viewers are currently listed.</string>
     <string name="player_lock_controls">Lock player controls</string>
     <string name="player_unlock_controls">Unlock player controls</string>
+    <string name="channel_points_prediction_bet_limit">Możesz dodać maksymalnie %s punktów</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -1421,4 +1421,5 @@
     <string name="viewer_list_empty">No viewers are currently listed.</string>
     <string name="player_lock_controls">Lock player controls</string>
     <string name="player_unlock_controls">Unlock player controls</string>
+    <string name="channel_points_prediction_bet_limit">Você pode adicionar no máximo %s pontos</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1421,4 +1421,5 @@
     <string name="viewer_list_empty">No viewers are currently listed.</string>
     <string name="player_lock_controls">Lock player controls</string>
     <string name="player_unlock_controls">Unlock player controls</string>
+    <string name="channel_points_prediction_bet_limit">Можно добавить не более %s очков</string>
 </resources>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -1444,4 +1444,5 @@
     <string name="viewer_list_empty">No viewers are currently listed.</string>
     <string name="player_lock_controls">Lock player controls</string>
     <string name="player_unlock_controls">Unlock player controls</string>
+    <string name="channel_points_prediction_bet_limit">Môžete pridať najviac %s bodov</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -1422,4 +1422,5 @@
     <string name="viewer_list_empty">No viewers are currently listed.</string>
     <string name="player_lock_controls">Lock player controls</string>
     <string name="player_unlock_controls">Unlock player controls</string>
+    <string name="channel_points_prediction_bet_limit">En fazla %s puan ekleyebilirsiniz</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1421,4 +1421,5 @@
     <string name="viewer_list_empty">No viewers are currently listed.</string>
     <string name="player_lock_controls">Lock player controls</string>
     <string name="player_unlock_controls">Unlock player controls</string>
+    <string name="channel_points_prediction_bet_limit">最多可添加 %s 点</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -1421,4 +1421,5 @@
     <string name="viewer_list_empty">No viewers are currently listed.</string>
     <string name="player_lock_controls">Lock player controls</string>
     <string name="player_unlock_controls">Unlock player controls</string>
+    <string name="channel_points_prediction_bet_limit">最多可新增 %s 點</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -871,6 +871,7 @@
     <string name="channel_points_prediction_bet_login">Log in to place a prediction</string>
     <string name="channel_points_prediction_bet_unavailable">Betting is unavailable for this prediction</string>
     <string name="channel_points_prediction_bet_range">Enter between %1$d and %2$d points</string>
+    <string name="channel_points_prediction_bet_limit">You can add at most %s points</string>
     <string name="channel_points_prediction_bet_balance">You have %s points</string>
     <string name="channel_points_prediction_bet_pending">Submitting prediction…</string>
     <string name="channel_points_prediction_bet_selected">Your prediction: %s points</string>

--- a/app/src/test/java/com/github/andreyasadchy/xtra/util/chat/PredictionBetPolicyTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/util/chat/PredictionBetPolicyTest.kt
@@ -1,0 +1,76 @@
+package com.github.andreyasadchy.xtra.util.chat
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PredictionBetPolicyTest {
+    @Test
+    fun `2 through 10 outcomes are wagerable`() {
+        assertTrue(PredictionBetPolicy.isPredictionWagerable(listOf("a", "b")))
+        assertTrue(PredictionBetPolicy.isPredictionWagerable(listOf("a", "b", "c")))
+        assertTrue(PredictionBetPolicy.isPredictionWagerable(listOf("a", "b", "c", "d")))
+        assertTrue(
+            PredictionBetPolicy.isPredictionWagerable(
+                (1..10).map { "outcome-$it" },
+            ),
+        )
+    }
+
+    @Test
+    fun `invalid outcome sets are not wagerable`() {
+        assertFalse(PredictionBetPolicy.isPredictionWagerable(listOf("a")))
+        assertFalse(PredictionBetPolicy.isPredictionWagerable(listOf("a", null, "c")))
+        assertFalse(PredictionBetPolicy.isPredictionWagerable(listOf("a", "", "c")))
+        assertFalse(
+            PredictionBetPolicy.isPredictionWagerable(
+                (1..11).map { "outcome-$it" },
+            ),
+        )
+    }
+
+    @Test
+    fun `same selected outcome can receive more points`() {
+        assertTrue(
+            PredictionBetPolicy.canBetOutcome(
+                selectedOutcomeId = "c",
+                candidateOutcomeId = "c",
+                inFlight = false,
+            ),
+        )
+    }
+
+    @Test
+    fun `different outcome cannot be selected after first bet`() {
+        assertFalse(
+            PredictionBetPolicy.canBetOutcome(
+                selectedOutcomeId = "c",
+                candidateOutcomeId = "b",
+                inFlight = false,
+            ),
+        )
+    }
+
+    @Test
+    fun `nothing can be submitted while request is in flight`() {
+        assertFalse(
+            PredictionBetPolicy.canBetOutcome(
+                selectedOutcomeId = "c",
+                candidateOutcomeId = "c",
+                inFlight = true,
+            ),
+        )
+    }
+
+    @Test
+    fun `additional bets accumulate local confirmed total`() {
+        assertEquals(
+            350,
+            PredictionBetPolicy.totalAfterAdditionalBet(
+                previousAmount = 100,
+                additionalPoints = 250,
+            ),
+        )
+    }
+}

--- a/app/src/test/java/com/github/andreyasadchy/xtra/util/chat/PredictionBetPolicyTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/util/chat/PredictionBetPolicyTest.kt
@@ -37,6 +37,9 @@ class PredictionBetPolicyTest {
                 selectedOutcomeId = "c",
                 candidateOutcomeId = "c",
                 inFlight = false,
+                confirmedAmount = 0,
+                minimumPoints = 10,
+                maximumPoints = 250_000,
             ),
         )
     }
@@ -48,6 +51,9 @@ class PredictionBetPolicyTest {
                 selectedOutcomeId = "c",
                 candidateOutcomeId = "b",
                 inFlight = false,
+                confirmedAmount = 0,
+                minimumPoints = 10,
+                maximumPoints = 250_000,
             ),
         )
     }
@@ -59,6 +65,9 @@ class PredictionBetPolicyTest {
                 selectedOutcomeId = "c",
                 candidateOutcomeId = "c",
                 inFlight = true,
+                confirmedAmount = 0,
+                minimumPoints = 10,
+                maximumPoints = 250_000,
             ),
         )
     }
@@ -70,6 +79,91 @@ class PredictionBetPolicyTest {
             PredictionBetPolicy.totalAfterAdditionalBet(
                 previousAmount = 100,
                 additionalPoints = 250,
+            ),
+        )
+    }
+
+    @Test
+    fun `full maximum may be wagered initially`() {
+        assertTrue(
+            PredictionBetPolicy.canAddPoints(
+                previousAmount = 0,
+                additionalPoints = 250_000,
+                minimumPoints = 10,
+                maximumPoints = 250_000,
+            ),
+        )
+    }
+
+    @Test
+    fun `remaining maximum may be added`() {
+        assertTrue(
+            PredictionBetPolicy.canAddPoints(
+                previousAmount = 100_000,
+                additionalPoints = 150_000,
+                minimumPoints = 10,
+                maximumPoints = 250_000,
+            ),
+        )
+    }
+
+    @Test
+    fun `cumulative amount above maximum is rejected`() {
+        assertFalse(
+            PredictionBetPolicy.canAddPoints(
+                previousAmount = 100_000,
+                additionalPoints = 150_001,
+                minimumPoints = 10,
+                maximumPoints = 250_000,
+            ),
+        )
+    }
+
+    @Test
+    fun `last ten points may be added`() {
+        assertTrue(
+            PredictionBetPolicy.canAddPoints(
+                previousAmount = 249_990,
+                additionalPoints = 10,
+                minimumPoints = 10,
+                maximumPoints = 250_000,
+            ),
+        )
+    }
+
+    @Test
+    fun `less than minimum remaining cannot be added`() {
+        assertFalse(
+            PredictionBetPolicy.canAddPoints(
+                previousAmount = 249_991,
+                additionalPoints = 10,
+                minimumPoints = 10,
+                maximumPoints = 250_000,
+            ),
+        )
+    }
+
+    @Test
+    fun `remaining maximum is zero when previous amount is full`() {
+        assertEquals(
+            0,
+            PredictionBetPolicy.remainingPoints(
+                previousAmount = 250_000,
+                maximumPoints = 250_000,
+            ),
+        )
+    }
+
+    @Test
+    fun `exhausted prediction allowance disables every outcome`() {
+        assertFalse(
+            PredictionBetPolicy.canBetOutcome(
+                selectedOutcomeId = "c",
+                candidateOutcomeId = "c",
+                inFlight = false,
+                confirmedAmount = 250_000,
+                minimumPoints = 10,
+                maximumPoints = 250_000,
             ),
         )
     }


### PR DESCRIPTION
Prediction betting now supports all Twitch prediction choices and lets viewers add points to the same choice while it is open.