### PR TITLE
Fix live quality handoff on network changes

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/main/MainActivity.kt
@@ -132,6 +132,8 @@ class MainActivity : AppCompatActivity() {
     var playerFragment: Fragment? = null
         private set
     private var networkCallback: ConnectivityManager.NetworkCallback? = null
+    private var qualityNetworkCallback: ConnectivityManager.NetworkCallback? = null
+    private var lastPlaybackNetworkCellular: Boolean? = null
     private var pipActionReceiver: BroadcastReceiver? = null
     private lateinit var prefs: SharedPreferences
     var settingsResultLauncher: ActivityResultLauncher<Intent>? = null
@@ -414,6 +416,40 @@ class MainActivity : AppCompatActivity() {
             callback
         )
         networkCallback = callback
+        val qualityCallback = object : ConnectivityManager.NetworkCallback() {
+            override fun onCapabilitiesChanged(
+                network: Network,
+                networkCapabilities: NetworkCapabilities,
+            ) {
+                if (!networkCapabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) ||
+                    !networkCapabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
+                ) {
+                    return
+                }
+
+                val cellular =
+                    networkCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR)
+
+                lifecycleScope.launch {
+                    val previous = lastPlaybackNetworkCellular
+                    lastPlaybackNetworkCellular = cellular
+
+                    // First callback only establishes the baseline.
+                    // Only a real Wi-Fi/non-cellular <-> cellular transition
+                    // should reapply a playing stream's default.
+                    if (previous == null || previous == cellular) {
+                        return@launch
+                    }
+
+                    (playerFragment as? Media3PlayerFragment)
+                        ?.reapplyNetworkDefaultQuality(cellular)
+                        ?: (playerFragment as? PlayerFragment)
+                            ?.reapplyNetworkDefaultQuality(cellular)
+                }
+            }
+        }
+        connectivityManager.registerDefaultNetworkCallback(qualityCallback)
+        qualityNetworkCallback = qualityCallback
         val pipReceiver = object : BroadcastReceiver() {
             override fun onReceive(context: Context?, intent: Intent?) {
                 when (intent?.action) {
@@ -845,6 +881,11 @@ class MainActivity : AppCompatActivity() {
             val connectivityManager = getSystemService(CONNECTIVITY_SERVICE) as ConnectivityManager
             connectivityManager.unregisterNetworkCallback(it)
         }
+        qualityNetworkCallback?.let {
+            val connectivityManager = getSystemService(CONNECTIVITY_SERVICE) as ConnectivityManager
+            connectivityManager.unregisterNetworkCallback(it)
+        }
+        qualityNetworkCallback = null
         pipActionReceiver?.let { unregisterReceiver(it) }
         fragmentLifecycleCallbacks?.let {
             supportFragmentManager.unregisterFragmentLifecycleCallbacks(it)

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/BasePlaybackService.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/BasePlaybackService.kt
@@ -254,12 +254,16 @@ abstract class BasePlaybackService : LifecycleService() {
         val connectivityManager = getSystemService(CONNECTIVITY_SERVICE) as ConnectivityManager
         val networkCapabilities = connectivityManager.getNetworkCapabilities(connectivityManager.activeNetwork)
         val cellular = networkCapabilities?.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR) == true
+        quality = resolveDefaultQualityForNetwork(cellular)
+    }
+
+    fun resolveDefaultQualityForNetwork(cellular: Boolean): VideoQuality? {
         val defaultQuality = if (cellular) {
             prefs().getString(C.PLAYER_DEFAULT_CELLULAR_QUALITY, "saved")
         } else {
             prefs().getString(C.PLAYER_DEFAULT_QUALITY, "saved")
         }?.substringBefore(" ")
-        quality = when (defaultQuality) {
+        return when (defaultQuality) {
             "saved" -> {
                 val savedQuality = prefs().getString(C.PLAYER_QUALITY, "720p60")?.substringBefore(" ")
                 when (savedQuality) {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/ExoPlayerFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/ExoPlayerFragment.kt
@@ -825,8 +825,11 @@ class ExoPlayerFragment : PlayerFragment() {
         }
     }
 
-    override fun changeQuality(selectedQuality: VideoQuality?) {
-        playbackService?.changeQuality(selectedQuality)
+    override fun changeQuality(selectedQuality: VideoQuality?, persistSavedQuality: Boolean) {
+        playbackService?.changeQuality(
+            selectedQuality,
+            persistSavedQuality = persistSavedQuality,
+        )
     }
 
     override fun startAudioOnly() {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/ExoPlayerService.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/ExoPlayerService.kt
@@ -211,7 +211,11 @@ class ExoPlayerService : BasePlaybackService() {
                             toggleSubtitles(prefs().getBoolean(C.PLAYER_SUBTITLES_ENABLED, false))
                         }
                         if (qualities?.find { it.name == AUTO_QUALITY } != null && quality?.name != AUDIO_ONLY_QUALITY && !hidden) {
-                            changeQuality(quality, resetLiveClipGeneration = false)
+                            changeQuality(
+                                quality,
+                                resetLiveClipGeneration = false,
+                                persistSavedQuality = false,
+                            )
                         }
                     }
                 }
@@ -263,7 +267,7 @@ class ExoPlayerService : BasePlaybackService() {
                             setDefaultQuality()
                             serviceListener?.changePlayerMode()
                             if (quality?.name == AUDIO_ONLY_QUALITY) {
-                                changeQuality(quality)
+                                changeQuality(quality, persistSavedQuality = false)
                             }
                         }
                         if (reason == Player.TIMELINE_CHANGE_REASON_SOURCE_UPDATE) {
@@ -1604,7 +1608,11 @@ class ExoPlayerService : BasePlaybackService() {
         }
     }
 
-    fun changeQuality(selectedQuality: VideoQuality?, resetLiveClipGeneration: Boolean = true) {
+    fun changeQuality(
+        selectedQuality: VideoQuality?,
+        resetLiveClipGeneration: Boolean = true,
+        persistSavedQuality: Boolean = true,
+    ) {
         val qualityChanged = quality?.name != selectedQuality?.name || quality?.url != selectedQuality?.url
         if (type == STREAM && qualityChanged && resetLiveClipGeneration) {
             advanceLiveClipGeneration()
@@ -1717,11 +1725,13 @@ class ExoPlayerService : BasePlaybackService() {
                             }
                         }
                     }
-                    val connectivityManager = getSystemService(CONNECTIVITY_SERVICE) as ConnectivityManager
-                    val networkCapabilities = connectivityManager.getNetworkCapabilities(connectivityManager.activeNetwork)
-                    val cellular = networkCapabilities?.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR) == true
-                    if ((!cellular && prefs().getString(C.PLAYER_DEFAULT_QUALITY, "saved") == "saved") || (cellular && prefs().getString(C.PLAYER_DEFAULT_CELLULAR_QUALITY, "saved") == "saved")) {
-                        prefs().edit { putString(C.PLAYER_QUALITY, quality.name) }
+                    if (persistSavedQuality) {
+                        val connectivityManager = getSystemService(CONNECTIVITY_SERVICE) as ConnectivityManager
+                        val networkCapabilities = connectivityManager.getNetworkCapabilities(connectivityManager.activeNetwork)
+                        val cellular = networkCapabilities?.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR) == true
+                        if ((!cellular && prefs().getString(C.PLAYER_DEFAULT_QUALITY, "saved") == "saved") || (cellular && prefs().getString(C.PLAYER_DEFAULT_CELLULAR_QUALITY, "saved") == "saved")) {
+                            prefs().edit { putString(C.PLAYER_QUALITY, quality.name) }
+                        }
                     }
                 }
             }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/Media3Fragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/Media3Fragment.kt
@@ -250,7 +250,7 @@ class Media3Fragment : Media3PlayerFragment() {
                         if (viewModel.qualities?.find { it.name == AUTO_QUALITY } != null
                             && viewModel.quality?.name != AUDIO_ONLY_QUALITY
                             && !viewModel.hidden) {
-                            changeQuality(viewModel.quality)
+                            changeQuality(viewModel.quality, persistSavedQuality = false)
                         }
                         chatFragment?.startReplayChatLoad()
                     }
@@ -312,7 +312,7 @@ class Media3Fragment : Media3PlayerFragment() {
                                         setDefaultQuality()
                                         changePlayerMode()
                                         if (viewModel.quality?.name == AUDIO_ONLY_QUALITY) {
-                                            changeQuality(viewModel.quality)
+                                            changeQuality(viewModel.quality, persistSavedQuality = false)
                                         }
                                     }
                                     if (reason == Player.TIMELINE_CHANGE_REASON_SOURCE_UPDATE) {
@@ -1041,7 +1041,7 @@ class Media3Fragment : Media3PlayerFragment() {
         }
     }
 
-    override fun changeQuality(selectedQuality: VideoQuality?) {
+    override fun changeQuality(selectedQuality: VideoQuality?, persistSavedQuality: Boolean) {
         viewModel.previousQuality = viewModel.quality
         viewModel.quality = selectedQuality
         viewModel.quality?.let { quality ->
@@ -1164,11 +1164,13 @@ class Media3Fragment : Media3PlayerFragment() {
                             }
                         }
                     }
-                    val connectivityManager = requireContext().getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
-                    val networkCapabilities = connectivityManager.getNetworkCapabilities(connectivityManager.activeNetwork)
-                    val cellular = networkCapabilities?.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR) == true
-                    if ((!cellular && requireContext().prefs().getString(C.PLAYER_DEFAULT_QUALITY, "saved") == "saved") || (cellular && requireContext().prefs().getString(C.PLAYER_DEFAULT_CELLULAR_QUALITY, "saved") == "saved")) {
-                        requireContext().prefs().edit { putString(C.PLAYER_QUALITY, quality.name) }
+                    if (persistSavedQuality) {
+                        val connectivityManager = requireContext().getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+                        val networkCapabilities = connectivityManager.getNetworkCapabilities(connectivityManager.activeNetwork)
+                        val cellular = networkCapabilities?.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR) == true
+                        if ((!cellular && requireContext().prefs().getString(C.PLAYER_DEFAULT_QUALITY, "saved") == "saved") || (cellular && requireContext().prefs().getString(C.PLAYER_DEFAULT_CELLULAR_QUALITY, "saved") == "saved")) {
+                            requireContext().prefs().edit { putString(C.PLAYER_QUALITY, quality.name) }
+                        }
                     }
                 }
             }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/Media3PlayerFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/Media3PlayerFragment.kt
@@ -163,7 +163,7 @@ abstract class Media3PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFr
     open fun setSubtitlesButton() {}
     open fun toggleSubtitles(enabled: Boolean) {}
     open fun showPlaylistTags(mediaPlaylist: Boolean) {}
-    open fun changeQuality(selectedQuality: VideoQuality?) {}
+    open fun changeQuality(selectedQuality: VideoQuality?, persistSavedQuality: Boolean = true) {}
     open fun startAudioOnly() {}
     open fun downloadVideo() {}
     open fun close() {}
@@ -1795,12 +1795,16 @@ abstract class Media3PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFr
         val connectivityManager = requireContext().getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
         val networkCapabilities = connectivityManager.getNetworkCapabilities(connectivityManager.activeNetwork)
         val cellular = networkCapabilities?.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR) == true
+        viewModel.quality = resolveDefaultQualityForNetwork(cellular)
+    }
+
+    private fun resolveDefaultQualityForNetwork(cellular: Boolean): VideoQuality? {
         val defaultQuality = if (cellular) {
             requireContext().prefs().getString(C.PLAYER_DEFAULT_CELLULAR_QUALITY, "saved")
         } else {
             requireContext().prefs().getString(C.PLAYER_DEFAULT_QUALITY, "saved")
         }?.substringBefore(" ")
-        viewModel.quality = when (defaultQuality) {
+        return when (defaultQuality) {
             "saved" -> {
                 val savedQuality = requireContext().prefs().getString(C.PLAYER_QUALITY, "720p60")?.substringBefore(" ")
                 when (savedQuality) {
@@ -1816,6 +1820,29 @@ abstract class Media3PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFr
             CHAT_ONLY_QUALITY -> viewModel.qualities?.find { it.name == CHAT_ONLY_QUALITY }
             else -> findQuality(defaultQuality)
         } ?: viewModel.qualities?.firstOrNull()
+    }
+
+    fun reapplyNetworkDefaultQuality(cellular: Boolean) {
+        if (videoType != STREAM) {
+            return
+        }
+
+        if (viewModel.qualities.isNullOrEmpty()) {
+            // Startup/playlist discovery will select the current network's
+            // default itself.
+            return
+        }
+
+        val target = resolveDefaultQualityForNetwork(cellular) ?: return
+
+        if (viewModel.quality?.name == target.name &&
+            viewModel.quality?.url == target.url
+        ) {
+            return
+        }
+
+        changeQuality(target, persistSavedQuality = false)
+        setQualityText()
     }
 
     private fun findQuality(targetQualityString: String?): VideoQuality? {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/MediaPlayerFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/MediaPlayerFragment.kt
@@ -392,8 +392,11 @@ class MediaPlayerFragment : PlayerFragment() {
         }
     }
 
-    override fun changeQuality(selectedQuality: VideoQuality?) {
-        playbackService?.changeQuality(selectedQuality)
+    override fun changeQuality(selectedQuality: VideoQuality?, persistSavedQuality: Boolean) {
+        playbackService?.changeQuality(
+            selectedQuality,
+            persistSavedQuality = persistSavedQuality,
+        )
     }
 
     override fun startAudioOnly() {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/MediaPlayerService.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/MediaPlayerService.kt
@@ -1258,7 +1258,10 @@ class MediaPlayerService : BasePlaybackService() {
         }
     }
 
-    fun changeQuality(selectedQuality: VideoQuality?) {
+    fun changeQuality(
+        selectedQuality: VideoQuality?,
+        persistSavedQuality: Boolean = true,
+    ) {
         previousQuality = quality
         quality = selectedQuality
         quality?.let { quality ->
@@ -1298,11 +1301,13 @@ class MediaPlayerService : BasePlaybackService() {
                         serviceListener?.changeSurfaceVisibility(true)
                     }
                 }
-                val connectivityManager = getSystemService(CONNECTIVITY_SERVICE) as ConnectivityManager
-                val networkCapabilities = connectivityManager.getNetworkCapabilities(connectivityManager.activeNetwork)
-                val cellular = networkCapabilities?.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR) == true
-                if ((!cellular && prefs().getString(C.PLAYER_DEFAULT_QUALITY, "saved") == "saved") || (cellular && prefs().getString(C.PLAYER_DEFAULT_CELLULAR_QUALITY, "saved") == "saved")) {
-                    prefs().edit { putString(C.PLAYER_QUALITY, quality.name) }
+                if (persistSavedQuality) {
+                    val connectivityManager = getSystemService(CONNECTIVITY_SERVICE) as ConnectivityManager
+                    val networkCapabilities = connectivityManager.getNetworkCapabilities(connectivityManager.activeNetwork)
+                    val cellular = networkCapabilities?.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR) == true
+                    if ((!cellular && prefs().getString(C.PLAYER_DEFAULT_QUALITY, "saved") == "saved") || (cellular && prefs().getString(C.PLAYER_DEFAULT_CELLULAR_QUALITY, "saved") == "saved")) {
+                        prefs().edit { putString(C.PLAYER_QUALITY, quality.name) }
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/PlayerFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/PlayerFragment.kt
@@ -158,7 +158,7 @@ abstract class PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFragment
     open fun setSubtitlesButton() {}
     open fun toggleSubtitles(enabled: Boolean) {}
     open fun showPlaylistTags(mediaPlaylist: Boolean) {}
-    open fun changeQuality(selectedQuality: VideoQuality?) {}
+    open fun changeQuality(selectedQuality: VideoQuality?, persistSavedQuality: Boolean = true) {}
     open fun startAudioOnly() {}
     open val supportsLiveClipping: Boolean = false
     open fun prepareLiveClip() {}
@@ -1639,6 +1639,33 @@ abstract class PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFragment
         (childFragmentManager.findFragmentByTag("closeOnPip") as? PlayerSettingsDialog?)?.let { dialog ->
             dialog.setQuality(label)
         }
+    }
+
+    fun reapplyNetworkDefaultQuality(cellular: Boolean) {
+        val service = playbackService ?: return
+
+        // This feature is specifically for a live stream handoff.
+        // Do not unexpectedly change VOD/clip/offline playback.
+        if (service.type != BasePlaybackService.STREAM) {
+            return
+        }
+
+        if (service.qualities.isNullOrEmpty()) {
+            // If qualities are not loaded yet, the normal startup path will call
+            // setDefaultQuality() once they become available.
+            return
+        }
+
+        val target = service.resolveDefaultQualityForNetwork(cellular) ?: return
+
+        if (service.quality?.name == target.name &&
+            service.quality?.url == target.url
+        ) {
+            return
+        }
+
+        changeQuality(target, persistSavedQuality = false)
+        setQualityText()
     }
 
     fun updateViewerCount(viewerCount: Int?) {


### PR DESCRIPTION
Reapply the configured live-stream quality when Android changes the default network between Wi-Fi and cellular. Supports both player architectures and auto quality.