### PR TITLE
Fix stale live feeds and chat layout jitter

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -53,6 +53,8 @@ jobs:
           ./gradlew --no-daemon :app:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.github.andreyasadchy.xtra.repository.MetadataCacheTest
           ./gradlew --no-daemon :app:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.github.andreyasadchy.xtra.db.AppDatabaseMigrationTest
           ./gradlew --no-daemon :app:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.github.andreyasadchy.xtra.util.DatabaseRestoreRecoveryTest
+          ./gradlew --no-daemon :app:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.github.andreyasadchy.xtra.repository.streamfeed.StreamFeedCacheTest
+          ./gradlew --no-daemon :app:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.github.andreyasadchy.xtra.ui.view.CenteredImageSpanTest
 
   build:
     runs-on: ubuntu-latest

--- a/app/src/androidTest/java/com/github/andreyasadchy/xtra/repository/streamfeed/StreamFeedCacheTest.kt
+++ b/app/src/androidTest/java/com/github/andreyasadchy/xtra/repository/streamfeed/StreamFeedCacheTest.kt
@@ -1,12 +1,10 @@
 package com.github.andreyasadchy.xtra.repository.streamfeed
 
 import androidx.room.Room
-import androidx.paging.PagingSource
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.github.andreyasadchy.xtra.db.AppDatabase
 import com.github.andreyasadchy.xtra.model.ui.Stream
-import com.github.andreyasadchy.xtra.repository.datasource.StreamFeedCursor
 import com.github.andreyasadchy.xtra.repository.datasource.StreamFeedPage
 import kotlinx.coroutines.runBlocking
 import org.junit.After
@@ -36,387 +34,58 @@ class StreamFeedCacheTest {
     }
 
     @Test
-    fun refreshAndAppendKeepFreshPrefixAndStaleTailPositionsUnique() = runBlocking {
+    fun successfulRefreshReplacesTheCompleteSnapshot() = runBlocking {
         val cache = StreamFeedCache(database)
         val feedKey = StreamFeedKey("top:cache-layout")
 
-        cache.replaceAfterRefresh(
-            feedKey,
-            StreamFeedPage(
-                streams("a", "b", "c", "d", "e", "f", "g", "h", "i"),
-                StreamFeedCursor("gql", "old-page-2"),
-            ),
-            nowMs = 1L,
-            preserveTail = false,
-            pruneStaleOnEnd = true,
-        )
-        cache.replaceAfterRefresh(
-            feedKey,
-            StreamFeedPage(
-                streams("a", "b", "x"),
-                StreamFeedCursor("helix", "fresh-page-2"),
-            ),
-            nowMs = 2L,
-            preserveTail = true,
-            pruneStaleOnEnd = true,
-        )
-
-        assertLayout(
-            feedKey,
-            expectedKeys = listOf("a", "b", "x", "c", "d", "e", "f", "g", "h", "i"),
-            activeCount = 3,
-        )
-
-        cache.appendPage(
-            feedKey,
-            StreamFeedPage(
-                streams("d", "y", "f"),
-                StreamFeedCursor("helix", "fresh-page-3"),
-            ),
-            nowMs = 3L,
-            pruneStaleOnEnd = true,
-        )
-
-        assertLayout(
-            feedKey,
-            expectedKeys = listOf("a", "b", "x", "d", "y", "f", "c", "e", "g", "h", "i"),
-            activeCount = 6,
-        )
-        assertEquals("helix", database.streamFeedDao().state(feedKey.value)?.nextCursorApi)
-
-        cache.appendPage(
-            feedKey,
-            StreamFeedPage(emptyList(), nextCursor = null),
-            nowMs = 4L,
-            pruneStaleOnEnd = true,
-        )
-
-        assertLayout(
-            feedKey,
-            expectedKeys = listOf("a", "b", "x", "d", "y", "f"),
-            activeCount = 6,
-        )
-    }
-
-    @Test
-    fun automaticRefreshDoesNotRenderEndedRowsRetainedForCacheFallback() = runBlocking {
-        val cache = StreamFeedCache(database)
-        val feedKey = StreamFeedKey("top:visible-generation")
-
-        cache.replaceAfterRefresh(
-            feedKey,
-            StreamFeedPage(
-                streams("ended", "still-live"),
-                StreamFeedCursor("gql", "old-page-2"),
-            ),
-            nowMs = 1L,
-            preserveTail = false,
-            pruneStaleOnEnd = true,
-        )
-        cache.replaceAfterRefresh(
-            feedKey,
-            StreamFeedPage(streams("still-live"), nextCursor = null),
-            nowMs = 2L,
-            preserveTail = true,
-            pruneStaleOnEnd = false,
-        )
-
-        val allCachedRows = database.streamFeedDao().itemsForFeed(feedKey.value)
-        assertTrue(allCachedRows.any { it.itemKey == "channel:ended" })
-
-        val result = cache.pagingSource(feedKey).load(
-            PagingSource.LoadParams.Refresh(
-                key = null,
-                loadSize = 30,
-                placeholdersEnabled = false,
-            )
-        )
-        assertTrue(result is PagingSource.LoadResult.Page)
-        assertEquals(
-            listOf("channel:still-live"),
-            (result as PagingSource.LoadResult.Page).data.map { it.itemKey },
-        )
-    }
-
-    @Test
-    fun successfulRefreshReplacesAllMutableFieldsForAnExistingChannel() = runBlocking {
-        val cache = StreamFeedCache(database)
-        val feedKey = StreamFeedKey("top:mutable-fields")
-        cache.replaceAfterRefresh(
-            feedKey,
-            StreamFeedPage(
-                listOf(
-                    Stream(
-                        id = "broadcast-1",
-                        channelId = "channel-42",
-                        channelLogin = "old-login",
-                        channelName = "Old name",
-                        channelImageURL = "old-avatar",
-                        gameId = "game-old",
-                        gameSlug = "old-game",
-                        gameName = "Old game",
-                        title = "Old title",
-                        thumbnailURL = "old-thumbnail",
-                        createdAt = "old-created",
-                        viewerCount = 10,
-                        tags = listOf("old-tag"),
-                    ),
-                ),
-                nextCursor = null,
-            ),
-            nowMs = 1L,
-            preserveTail = false,
-            pruneStaleOnEnd = true,
-        )
-        cache.replaceAfterRefresh(
-            feedKey,
-            StreamFeedPage(
-                listOf(
-                    Stream(
-                        id = "broadcast-2",
-                        channelId = "channel-42",
-                        channelLogin = "new-login",
-                        channelName = "New name",
-                        channelImageURL = "new-avatar",
-                        gameId = "game-new",
-                        gameSlug = "new-game",
-                        gameName = "New game",
-                        title = "New title",
-                        thumbnailURL = "new-thumbnail",
-                        createdAt = "new-created",
-                        viewerCount = 20,
-                        tags = listOf("new-tag"),
-                    ),
-                ),
-                nextCursor = null,
-            ),
-            nowMs = 2L,
-            preserveTail = false,
-            pruneStaleOnEnd = true,
-        )
-
-        val stream = database.streamFeedDao().itemsForFeed(feedKey.value).single().toStream()
-        assertEquals("broadcast-2", stream.id)
-        assertEquals("new-login", stream.channelLogin)
-        assertEquals("New name", stream.channelName)
-        assertEquals("new-avatar", stream.channelImageURL)
-        assertEquals("game-new", stream.gameId)
-        assertEquals("new-game", stream.gameSlug)
-        assertEquals("New game", stream.gameName)
-        assertEquals("New title", stream.title)
-        assertEquals("new-thumbnail", stream.thumbnailURL)
-        assertEquals("new-created", stream.createdAt)
-        assertEquals(20, stream.viewerCount)
-        assertEquals(listOf("new-tag"), stream.tags)
-        assertEquals(2L, stream.thumbnailGeneration)
-    }
-
-    @Test
-    fun automaticRefreshEofDefersStalePruningUntilExplicitFinalization() = runBlocking {
-        val cache = StreamFeedCache(database)
-        val feedKey = StreamFeedKey("top:cache-automatic-eof")
-        seedOldFeed(cache, feedKey)
-
-        cache.replaceAfterRefresh(
-            feedKey,
-            StreamFeedPage(streams("fresh-0", "fresh-1"), nextCursor = null),
-            nowMs = 2L,
-            preserveTail = true,
-            pruneStaleOnEnd = false,
-        )
-
-        assertTrue(database.streamFeedDao().itemsForFeed(feedKey.value).any { it.itemKey == "channel:old-80" })
-        assertContiguousLayout(feedKey, activeCount = 2)
-        assertEquals(null, database.streamFeedDao().state(feedKey.value)?.nextCursor)
-
-        cache.pruneStaleGeneration(feedKey)
+        cache.replaceAfterRefresh(feedKey, StreamFeedPage(streams("a", "b", "c"), null), 1L)
+        cache.replaceAfterRefresh(feedKey, StreamFeedPage(streams("a", "c", "d"), null), 2L)
 
         val rows = database.streamFeedDao().itemsForFeed(feedKey.value)
-        assertEquals(listOf("channel:fresh-0", "channel:fresh-1"), rows.map { it.itemKey })
-        assertFalse(rows.any { it.itemKey == "channel:old-80" })
-        assertContiguousLayout(feedKey, activeCount = 2)
-    }
-
-    @Test
-    fun retainedStaleTailExpiresAfterItsBoundedBootstrapWindow() = runBlocking {
-        val cache = StreamFeedCache(database)
-        val feedKey = StreamFeedKey("top:cache-tail-expiry")
-        cache.replaceAfterRefresh(
-            feedKey,
-            StreamFeedPage(streams("old"), nextCursor = StreamFeedCursor("gql", "old-next")),
-            nowMs = 1L,
-            preserveTail = false,
-            pruneStaleOnEnd = true,
-        )
-        cache.replaceAfterRefresh(
-            feedKey,
-            StreamFeedPage(streams("fresh"), nextCursor = StreamFeedCursor("gql", "fresh-next")),
-            nowMs = 2L,
-            preserveTail = true,
-            pruneStaleOnEnd = false,
-        )
-        assertEquals(
-            listOf("channel:fresh", "channel:old"),
-            database.streamFeedDao().itemsForFeed(feedKey.value).map { it.itemKey },
-        )
-
-        cache.touchAccess(
-            feedKey,
-            nowMs = 2L + StreamFeedFreshnessPolicy.MAX_RETAINED_STALE_TAIL_AGE_MS + 1L,
-        )
-
-        assertEquals(
-            listOf("channel:fresh"),
-            database.streamFeedDao().itemsForFeed(feedKey.value).map { it.itemKey },
-        )
-    }
-
-    @Test
-    fun invalidationDoesNotDisableStaleTailExpiry() = runBlocking {
-        val cache = StreamFeedCache(database)
-        val feedKey = StreamFeedKey("top:cache-tail-invalidation")
-        cache.replaceAfterRefresh(
-            feedKey,
-            StreamFeedPage(streams("old"), StreamFeedCursor("gql", "old-next")),
-            nowMs = 1L,
-            preserveTail = false,
-            pruneStaleOnEnd = true,
-        )
-        cache.replaceAfterRefresh(
-            feedKey,
-            StreamFeedPage(streams("fresh"), StreamFeedCursor("gql", "fresh-next")),
-            nowMs = 2L,
-            preserveTail = true,
-            pruneStaleOnEnd = false,
-        )
-
-        cache.invalidatePrefix("top:", nowMs = 3L)
-        assertEquals(null, database.streamFeedDao().state(feedKey.value)?.lastSuccessAt)
-        assertEquals(
-            listOf("channel:fresh", "channel:old"),
-            database.streamFeedDao().itemsForFeed(feedKey.value).map { it.itemKey },
-        )
-
-        cache.touchAccess(
-            feedKey,
-            nowMs = 2L + StreamFeedFreshnessPolicy.MAX_RETAINED_STALE_TAIL_AGE_MS + 1L,
-        )
-
-        assertEquals(
-            listOf("channel:fresh"),
-            database.streamFeedDao().itemsForFeed(feedKey.value).map { it.itemKey },
-        )
-        assertEquals(null, database.streamFeedDao().state(feedKey.value)?.staleTailRetainedAt)
-    }
-
-    @Test
-    fun expiryDuringRefreshPreservesThePreviousActiveGenerationAsTheNewTail() = runBlocking {
-        val cache = StreamFeedCache(database)
-        val feedKey = StreamFeedKey("top:cache-tail-refresh-race")
-        cache.replaceAfterRefresh(
-            feedKey,
-            StreamFeedPage(streams("old"), StreamFeedCursor("gql", "old-next")),
-            nowMs = 1L,
-            preserveTail = false,
-            pruneStaleOnEnd = true,
-        )
-        cache.replaceAfterRefresh(
-            feedKey,
-            StreamFeedPage(streams("active"), StreamFeedCursor("gql", "active-next")),
-            nowMs = 2L,
-            preserveTail = true,
-            pruneStaleOnEnd = false,
-        )
-
-        val justBeforeExpiry = 2L + StreamFeedFreshnessPolicy.MAX_RETAINED_STALE_TAIL_AGE_MS - 1L
-        cache.markAttempt(feedKey, nowMs = justBeforeExpiry)
-        cache.replaceAfterRefresh(
-            feedKey,
-            StreamFeedPage(streams("fresh"), StreamFeedCursor("gql", "fresh-next")),
-            nowMs = justBeforeExpiry + 2L,
-            preserveTail = true,
-            pruneStaleOnEnd = false,
-        )
-
-        val rows = database.streamFeedDao().itemsForFeed(feedKey.value)
-        assertEquals(
-            listOf("channel:fresh", "channel:active"),
-            rows.map { it.itemKey },
-        )
-        assertEquals(rows.first().generation - 1L, rows.last().generation)
-        assertEquals(
-            justBeforeExpiry + 2L,
-            database.streamFeedDao().state(feedKey.value)?.staleTailRetainedAt,
-        )
-    }
-
-    @Test
-    fun speculativeEofDefersStalePruningUntilRealAppendFinalization() = runBlocking {
-        val cache = StreamFeedCache(database)
-        val feedKey = StreamFeedKey("top:cache-speculative-eof")
-        seedOldFeed(cache, feedKey)
-
-        cache.replaceAfterRefresh(
-            feedKey,
-            StreamFeedPage(
-                streams("fresh-0", "fresh-1", "fresh-2"),
-                StreamFeedCursor("gql", "fresh-page-2"),
-            ),
-            nowMs = 2L,
-            preserveTail = true,
-            pruneStaleOnEnd = false,
-        )
-        cache.appendPage(
-            feedKey,
-            StreamFeedPage(streams("fresh-3", "fresh-4"), nextCursor = null),
-            nowMs = 3L,
-            pruneStaleOnEnd = false,
-        )
-
-        val rowsBeforeFinalization = database.streamFeedDao().itemsForFeed(feedKey.value)
-        assertTrue(rowsBeforeFinalization.any { it.itemKey == "channel:old-80" })
-        assertContiguousLayout(feedKey, activeCount = 5)
-        assertEquals(null, database.streamFeedDao().state(feedKey.value)?.nextCursor)
-
-        cache.pruneStaleGeneration(feedKey)
-
-        val rowsAfterFinalization = database.streamFeedDao().itemsForFeed(feedKey.value)
-        assertEquals(5, rowsAfterFinalization.size)
-        assertFalse(rowsAfterFinalization.any { it.itemKey == "channel:old-80" })
-        assertContiguousLayout(feedKey, activeCount = 5)
-    }
-
-    private suspend fun seedOldFeed(cache: StreamFeedCache, feedKey: StreamFeedKey) {
-        cache.replaceAfterRefresh(
-            feedKey,
-            StreamFeedPage(
-                (0 until 90).map { Stream(channelId = "old-$it") },
-                StreamFeedCursor("gql", "old-page-2"),
-            ),
-            nowMs = 1L,
-            preserveTail = false,
-            pruneStaleOnEnd = true,
-        )
-    }
-
-    private fun assertLayout(feedKey: StreamFeedKey, expectedKeys: List<String>, activeCount: Int) {
-        val rows = database.streamFeedDao().itemsForFeed(feedKey.value)
-        assertEquals(expectedKeys.map { "channel:$it" }, rows.map { it.itemKey })
+        assertEquals(listOf("channel:a", "channel:c", "channel:d"), rows.map { it.itemKey })
         assertEquals(rows.indices.toList(), rows.map { it.position })
-        assertEquals(rows.size, rows.map { it.position }.distinct().size)
-        assertTrue(rows.take(activeCount).all { it.generation == rows.first().generation })
-        assertTrue(rows.drop(activeCount).all { it.generation < rows.first().generation })
+        assertEquals(3, database.streamFeedDao().activeItemCount(feedKey.value))
     }
 
-    private fun assertContiguousLayout(feedKey: StreamFeedKey, activeCount: Int) {
+    @Test
+    fun successfulEmptyRefreshRemovesEveryPreviouslyCachedStream() = runBlocking {
+        val cache = StreamFeedCache(database)
+        val feedKey = StreamFeedKey("top:empty")
+
+        cache.replaceAfterRefresh(feedKey, StreamFeedPage(streams("ended"), null), 1L)
+        cache.replaceAfterRefresh(feedKey, StreamFeedPage(emptyList(), null), 2L)
+
+        assertTrue(database.streamFeedDao().itemsForFeed(feedKey.value).isEmpty())
+        assertEquals(0, database.streamFeedDao().activeItemCount(feedKey.value))
+    }
+
+    @Test
+    fun paginationAppendsOnlyToTheCurrentRefreshGeneration() = runBlocking {
+        val cache = StreamFeedCache(database)
+        val feedKey = StreamFeedKey("top:pagination")
+
+        cache.replaceAfterRefresh(feedKey, StreamFeedPage(streams("a", "b"), "cursor".toCursor()), 1L)
+        cache.appendPage(feedKey, StreamFeedPage(streams("c"), null), 2L)
+
         val rows = database.streamFeedDao().itemsForFeed(feedKey.value)
-        assertEquals(rows.indices.toList(), rows.map { it.position })
-        assertEquals(rows.size, rows.map { it.position }.distinct().size)
-        assertTrue(rows.take(activeCount).all { it.generation == rows.first().generation })
-        assertTrue(rows.drop(activeCount).all { it.generation < rows.first().generation })
+        assertEquals(listOf("channel:a", "channel:b", "channel:c"), rows.map { it.itemKey })
+        assertTrue(rows.all { it.generation == rows.first().generation })
     }
 
-    private fun streams(vararg ids: String): List<Stream> {
-        return ids.map { Stream(channelId = it) }
+    @Test
+    fun failedRefreshRetainsTheLastSuccessfulSnapshot() = runBlocking {
+        val cache = StreamFeedCache(database)
+        val feedKey = StreamFeedKey("top:failure")
+        cache.replaceAfterRefresh(feedKey, StreamFeedPage(streams("still-live"), null), 1L)
+
+        cache.recordFailure(feedKey, nowMs = 2L, failureBackoffUntil = 3L, rateLimitUntil = null)
+
+        val rows = database.streamFeedDao().itemsForFeed(feedKey.value)
+        assertEquals(listOf("channel:still-live"), rows.map { it.itemKey })
+        assertFalse(rows.isEmpty())
     }
+
+    private fun String.toCursor() = com.github.andreyasadchy.xtra.repository.datasource.StreamFeedCursor("gql", this)
+
+    private fun streams(vararg ids: String): List<Stream> = ids.map { Stream(channelId = it) }
 }

--- a/app/src/androidTest/java/com/github/andreyasadchy/xtra/repository/streamfeed/StreamFeedCacheTest.kt
+++ b/app/src/androidTest/java/com/github/andreyasadchy/xtra/repository/streamfeed/StreamFeedCacheTest.kt
@@ -113,6 +113,28 @@ class StreamFeedCacheTest {
     }
 
     @Test
+    fun processLocalSnapshotPublishesSuccessfulEmptyRefresh() = runBlocking {
+        val cache = StreamFeedCache(database)
+        val feedKey = StreamFeedKey("top:process-local-empty")
+        cache.replaceAfterRefresh(feedKey, StreamFeedPage(streams("ended"), null), 1L)
+        val emissions = mutableListOf<List<String>>()
+        val initialEmission = CompletableDeferred<Unit>()
+        val collector = launch {
+            cache.activeItemsFlow(feedKey, Int.MAX_VALUE).take(2).collect { snapshot ->
+                emissions += snapshot.mapNotNull(Stream::channelId)
+                if (emissions.size == 1) initialEmission.complete(Unit)
+            }
+        }
+
+        initialEmission.await()
+        cache.replaceAfterRefresh(feedKey, StreamFeedPage(emptyList(), null), 2L)
+        collector.join()
+
+        assertEquals(listOf("ended"), emissions[0])
+        assertEquals(emptyList<String>(), emissions[1])
+    }
+
+    @Test
     fun processLocalSnapshotRetainsDataAfterFailure() = runBlocking {
         val cache = StreamFeedCache(database)
         val feedKey = StreamFeedKey("top:process-local-failure")

--- a/app/src/androidTest/java/com/github/andreyasadchy/xtra/repository/streamfeed/StreamFeedCacheTest.kt
+++ b/app/src/androidTest/java/com/github/andreyasadchy/xtra/repository/streamfeed/StreamFeedCacheTest.kt
@@ -7,6 +7,11 @@ import com.github.andreyasadchy.xtra.db.AppDatabase
 import com.github.andreyasadchy.xtra.model.ui.Stream
 import com.github.andreyasadchy.xtra.repository.datasource.StreamFeedPage
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.take
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -83,6 +88,38 @@ class StreamFeedCacheTest {
         val rows = database.streamFeedDao().itemsForFeed(feedKey.value)
         assertEquals(listOf("channel:still-live"), rows.map { it.itemKey })
         assertFalse(rows.isEmpty())
+    }
+
+    @Test
+    fun processLocalSnapshotReplacesRemovedStreamsAfterSuccessfulRefresh() = runBlocking {
+        val cache = StreamFeedCache(database)
+        val feedKey = StreamFeedKey("top:process-local")
+        cache.replaceAfterRefresh(feedKey, StreamFeedPage(streams("a", "b", "c"), null), 1L)
+
+        val emissions = mutableListOf<List<String>>()
+        val initialEmission = CompletableDeferred<Unit>()
+        val collector = launch {
+            cache.activeItemsFlow(feedKey, Int.MAX_VALUE).take(2).collect { snapshot ->
+                emissions += snapshot.mapNotNull(Stream::channelId)
+                if (emissions.size == 1) initialEmission.complete(Unit)
+            }
+        }
+        initialEmission.await()
+        cache.replaceAfterRefresh(feedKey, StreamFeedPage(streams("a", "c", "d"), null), 2L)
+        collector.join()
+
+        assertEquals(listOf("a", "b", "c"), emissions[0])
+        assertEquals(listOf("a", "c", "d"), emissions[1])
+    }
+
+    @Test
+    fun processLocalSnapshotRetainsDataAfterFailure() = runBlocking {
+        val cache = StreamFeedCache(database)
+        val feedKey = StreamFeedKey("top:process-local-failure")
+        cache.replaceAfterRefresh(feedKey, StreamFeedPage(streams("a"), null), 1L)
+        cache.recordFailure(feedKey, nowMs = 2L, failureBackoffUntil = 3L, rateLimitUntil = null)
+
+        assertEquals(listOf("a"), cache.activeItemsFlow(feedKey, Int.MAX_VALUE).first().mapNotNull(Stream::channelId))
     }
 
     private fun String.toCursor() = com.github.andreyasadchy.xtra.repository.datasource.StreamFeedCursor("gql", this)

--- a/app/src/androidTest/java/com/github/andreyasadchy/xtra/repository/streamfeed/StreamFeedPagingIntegrationTest.kt
+++ b/app/src/androidTest/java/com/github/andreyasadchy/xtra/repository/streamfeed/StreamFeedPagingIntegrationTest.kt
@@ -57,8 +57,6 @@ class StreamFeedPagingIntegrationTest {
                 StreamFeedCursor(C.GQL, "old-page-4"),
             ),
             nowMs = 1L,
-            preserveTail = false,
-            pruneStaleOnEnd = true,
         )
 
         val cursors = mutableListOf<StreamFeedCursor?>()

--- a/app/src/androidTest/java/com/github/andreyasadchy/xtra/ui/view/CenteredImageSpanTest.kt
+++ b/app/src/androidTest/java/com/github/andreyasadchy/xtra/ui/view/CenteredImageSpanTest.kt
@@ -1,0 +1,34 @@
+package com.github.andreyasadchy.xtra.ui.view
+
+import android.graphics.Color
+import android.graphics.Paint
+import android.graphics.drawable.ColorDrawable
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class CenteredImageSpanTest {
+
+    @Test
+    fun loadingDrawableCannotChangeReservedMeasurement() {
+        val placeholder = ColorDrawable(Color.TRANSPARENT).apply {
+            setBounds(0, 0, 48, 32)
+        }
+        val span = CenteredImageSpan(placeholder, reservedWidth = 48, reservedHeight = 32)
+        val paint = Paint().apply { textSize = 16f }
+        val beforeMetrics = Paint.FontMetricsInt()
+        val beforeWidth = span.getSize(paint, "x", 0, 1, beforeMetrics)
+
+        span.imageDrawable = ColorDrawable(Color.RED).apply {
+            setBounds(0, 0, 300, 200)
+        }
+
+        val afterMetrics = Paint.FontMetricsInt()
+        val afterWidth = span.getSize(paint, "x", 0, 1, afterMetrics)
+        assertEquals(48, beforeWidth)
+        assertEquals(beforeWidth, afterWidth)
+        assertEquals(beforeMetrics.ascent, afterMetrics.ascent)
+        assertEquals(beforeMetrics.descent, afterMetrics.descent)
+        assertEquals(beforeMetrics.top, afterMetrics.top)
+        assertEquals(beforeMetrics.bottom, afterMetrics.bottom)
+    }
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/db/CachedStreamFeedItem.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/db/CachedStreamFeedItem.kt
@@ -35,6 +35,6 @@ data class CachedStreamFeedItem(
     val createdAt: String? = null,
     val viewerCount: Int? = null,
     val tags: String? = null,
-    /** Refresh generation used to retain stale deep-page rows during SWR. */
+    /** Refresh generation used to isolate pages from an earlier live-list refresh. */
     val generation: Long = 0L,
 )

--- a/app/src/main/java/com/github/andreyasadchy/xtra/db/StreamFeedState.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/db/StreamFeedState.kt
@@ -17,6 +17,6 @@ data class StreamFeedState(
     val nextCursorApi: String? = null,
     /** Generation currently being refreshed/appended for this feed. */
     val activeGeneration: Long = 0L,
-    /** When the retained stale tail started being kept behind the active generation. */
+    /** Legacy migration field; current refreshes never retain a visible stale tail. */
     val staleTailRetainedAt: Long? = null,
 )

--- a/app/src/main/java/com/github/andreyasadchy/xtra/model/chat/Emote.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/model/chat/Emote.kt
@@ -12,6 +12,8 @@ class Emote(
     val isOverlayEmote: Boolean = false,
     val source: Int? = null,
     val id: String? = null,
+    val width: Int? = null,
+    val height: Int? = null,
 ) {
     val thirdParty = source == PERSONAL_STV || source == CHANNEL_STV || source == CHANNEL_BTTV || source == CHANNEL_FFZ || source == GLOBAL_STV || source == GLOBAL_BTTV || source == GLOBAL_FFZ
 

--- a/app/src/main/java/com/github/andreyasadchy/xtra/model/chat/Image.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/model/chat/Image.kt
@@ -18,9 +18,28 @@ class Image(
     val isAnimated: Boolean = false,
     val kind: ImageKind = ImageKind.INLINE_ICON,
     val thirdParty: Boolean = false,
+    val sourceWidth: Int? = null,
+    val sourceHeight: Int? = null,
     var overlayEmote: Image? = null,
     var start: Int,
     var end: Int,
 ) {
-    fun withLocalData(bytes: ByteArray) = Image(bytes, localDataUrl, localDataRange, url1x, url2x, url3x, url4x, format, isAnimated, kind, thirdParty, overlayEmote, start, end)
+    fun withLocalData(bytes: ByteArray) = Image(
+        localData = bytes,
+        localDataUrl = localDataUrl,
+        localDataRange = localDataRange,
+        url1x = url1x,
+        url2x = url2x,
+        url3x = url3x,
+        url4x = url4x,
+        format = format,
+        isAnimated = isAnimated,
+        kind = kind,
+        thirdParty = thirdParty,
+        sourceWidth = sourceWidth,
+        sourceHeight = sourceHeight,
+        overlayEmote = overlayEmote,
+        start = start,
+        end = end,
+    )
 }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/model/misc/STVEmoteSetResponse.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/model/misc/STVEmoteSetResponse.kt
@@ -31,5 +31,7 @@ class STVEmoteSetResponse(
     class File(
         val name: String? = null,
         val format: String? = null,
+        val width: Int? = null,
+        val height: Int? = null,
     )
 }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/PlayerRepository.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/PlayerRepository.kt
@@ -1246,14 +1246,16 @@ class PlayerRepository(
                 emote.data?.let { data ->
                     data.host?.let { host ->
                         host.url?.takeIf { it.isNotBlank() }?.let { template ->
-                            val urls = host.files?.mapNotNull { file ->
-                                file.name?.takeIf { it.isNotBlank() &&
-                                        if (useWebp) {
-                                            file.format == "WEBP"
-                                        } else {
-                                            file.format == "GIF" || file.format == "PNG"
-                                        }
-                                }?.let { name ->
+                            val selectedFiles = host.files?.filter { file ->
+                                file.name?.isNotBlank() == true &&
+                                    if (useWebp) {
+                                        file.format == "WEBP"
+                                    } else {
+                                        file.format == "GIF" || file.format == "PNG"
+                                    }
+                            }
+                            val urls = selectedFiles?.mapNotNull { file ->
+                                file.name?.takeIf(String::isNotBlank)?.let { name ->
                                     "https:${template}/${name}"
                                 }
                             }
@@ -1268,6 +1270,8 @@ class PlayerRepository(
                                 isAnimated = data.animated != false,
                                 isOverlayEmote = emote.flags == 1,
                                 source = source,
+                                width = selectedFiles?.firstOrNull()?.width,
+                                height = selectedFiles?.firstOrNull()?.height,
                             )
                         }
                     }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/streamfeed/StreamFeedCache.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/streamfeed/StreamFeedCache.kt
@@ -26,14 +26,11 @@ interface StreamFeedCacheStore {
         feedKey: StreamFeedKey,
         page: StreamFeedPage,
         nowMs: Long,
-        preserveTail: Boolean,
-        pruneStaleOnEnd: Boolean,
     )
     suspend fun appendPage(
         feedKey: StreamFeedKey,
         page: StreamFeedPage,
         nowMs: Long,
-        pruneStaleOnEnd: Boolean,
     )
     suspend fun pruneStaleGeneration(feedKey: StreamFeedKey)
     suspend fun recordFailure(feedKey: StreamFeedKey, nowMs: Long, failureBackoffUntil: Long?, rateLimitUntil: Long?)
@@ -117,53 +114,7 @@ internal fun refreshCachedItems(
         }
 }
 
-/**
- * Apply a fresh first page without dropping the rows loaded by an older
- * generation. The returned layout is already normalized so Room can upsert
- * it in one transaction without duplicate positions.
- */
-internal fun refreshCachedItemsPreservingTail(
-    feedKey: String,
-    existing: List<CachedStreamFeedItem>,
-    streams: List<Stream>,
-    generation: Long,
-): List<CachedStreamFeedItem> {
-    val refreshed = refreshCachedItems(feedKey, streams, generation)
-    val refreshedKeys = refreshed.map { it.itemKey }.toSet()
-    // Keep at most one previously verified generation as a useful stale tail.
-    // Without this bound, every successful first-page refresh could retain rows
-    // from an arbitrarily old feed snapshot until the feed's long retention
-    // cleanup ran.
-    val retainedGenerations = existing.asSequence()
-        .map { it.generation }
-        .distinct()
-        .sortedDescending()
-        .take(StreamFeedFreshnessPolicy.MAX_RETAINED_STALE_GENERATIONS)
-        .toSet()
-    val staleTail = existing
-        .filter { it.generation in retainedGenerations }
-        .filterNot { it.itemKey in refreshedKeys }
-        .sortedBy { it.position }
-        .mapIndexed { index, item ->
-            item.copy(position = refreshed.size + index)
-        }
-    return refreshed + staleTail
-}
-
-internal fun staleTailExpired(state: StreamFeedState?, nowMs: Long): Boolean {
-    return state != null &&
-            state.activeGeneration != 0L &&
-            state.staleTailRetainedAt?.let {
-                nowMs - it >= StreamFeedFreshnessPolicy.MAX_RETAINED_STALE_TAIL_AGE_MS
-            } == true
-}
-
-/**
- * Apply one newly downloaded page while retaining an older generation as a
- * stale tail. Active rows form a contiguous prefix; every remaining stale
- * row is reindexed after it. This makes position ordering deterministic even
- * when the remote page adds, removes, or overlaps different channels.
- */
+/** Apply one newly downloaded page to the current refresh generation. */
 internal fun appendCachedPage(
     feedKey: String,
     existing: List<CachedStreamFeedItem>,
@@ -172,9 +123,6 @@ internal fun appendCachedPage(
 ): List<CachedStreamFeedItem> {
     val activeRows = existing
         .filter { it.generation == generation }
-        .sortedBy { it.position }
-    val staleRows = existing
-        .filter { it.generation != generation }
         .sortedBy { it.position }
     val pageStreams = streams
         .mapNotNull { stream -> stream.cacheItemKey()?.let { it to stream } }
@@ -195,13 +143,7 @@ internal fun appendCachedPage(
     val activePrefix = (updatedActive + newActive).mapIndexed { index, item ->
         item.copy(position = index, generation = generation)
     }
-    val pageKeys = pageStreams.map { it.first }.toSet()
-    val staleTail = staleRows
-        .filterNot { it.itemKey in pageKeys }
-        .mapIndexed { index, item ->
-            item.copy(position = activePrefix.size + index)
-        }
-    return activePrefix + staleTail
+    return activePrefix
 }
 
 private fun Stream.withThumbnailGeneration(generation: Long): Stream = Stream(
@@ -227,27 +169,6 @@ private fun normalizedStreams(streams: List<Stream>, generation: Long): List<Str
             stream.cacheItemKey()?.let { stream.withThumbnailGeneration(generation) }
         }
 
-/** Mirrors [refreshCachedItemsPreservingTail] without round-tripping fresh rows through Room. */
-private fun refreshStreamsPreservingTail(
-    existing: List<Stream>,
-    streams: List<Stream>,
-    generation: Long,
-): List<Stream> {
-    val refreshed = normalizedStreams(streams, generation)
-    val refreshedKeys = refreshed.mapNotNull { it.cacheItemKey() }.toSet()
-    val retainedGenerations = existing.asSequence()
-        .map { it.thumbnailGeneration }
-        .distinct()
-        .sortedDescending()
-        .take(StreamFeedFreshnessPolicy.MAX_RETAINED_STALE_GENERATIONS)
-        .toSet()
-    val staleTail = existing
-        .filter { it.thumbnailGeneration in retainedGenerations }
-        .filterNot { it.cacheItemKey() in refreshedKeys }
-        .map { it.withThumbnailGeneration(it.thumbnailGeneration) }
-    return refreshed + staleTail
-}
-
 /** Mirrors [appendCachedPage] while keeping the live in-memory rows as Stream objects. */
 private fun appendStreams(
     existing: List<Stream>,
@@ -255,7 +176,6 @@ private fun appendStreams(
     generation: Long,
 ): List<Stream> {
     val activeRows = existing.filter { it.thumbnailGeneration == generation }
-    val staleRows = existing.filter { it.thumbnailGeneration != generation }
     val pageStreams = streams
         .mapNotNull { stream -> stream.cacheItemKey()?.let { it to stream } }
         .distinctBy { it.first }
@@ -268,9 +188,7 @@ private fun appendStreams(
         .filterNot { (key, _) -> key in activeKeys }
         .map { (_, stream) -> stream.withThumbnailGeneration(generation) }
     val activePrefix = updatedActive + newActive
-    val pageKeys = pageStreams.map { it.first }.toSet()
-    val staleTail = staleRows.filterNot { it.cacheItemKey() in pageKeys }
-    return activePrefix + staleTail
+    return activePrefix
 }
 
 /**
@@ -314,14 +232,13 @@ class StreamFeedCache(
     override suspend fun touchAccess(feedKey: StreamFeedKey, nowMs: Long) = withContext(Dispatchers.IO) {
         database.runInTransaction {
             val current = dao.state(feedKey.value)
-            val expiredTail = staleTailExpired(current, nowMs)
-            if (expiredTail) {
-                dao.deleteItemsExceptGeneration(feedKey.value, current!!.activeGeneration)
+            if (current != null) {
+                dao.deleteItemsExceptGeneration(feedKey.value, current.activeGeneration)
             }
             dao.insertState(
                 (current ?: StreamFeedState(feedKey.value)).copy(
                     lastAccessAt = nowMs,
-                    staleTailRetainedAt = if (expiredTail) null else current?.staleTailRetainedAt,
+                    staleTailRetainedAt = null,
                 )
             )
         }
@@ -330,72 +247,35 @@ class StreamFeedCache(
     override suspend fun markAttempt(feedKey: StreamFeedKey, nowMs: Long) = withContext(Dispatchers.IO) {
         database.runInTransaction {
             val current = dao.state(feedKey.value)
-            val expiredTail = staleTailExpired(current, nowMs)
-            if (expiredTail) {
-                dao.deleteItemsExceptGeneration(feedKey.value, current!!.activeGeneration)
+            if (current != null) {
+                dao.deleteItemsExceptGeneration(feedKey.value, current.activeGeneration)
             }
             dao.insertState(
                 (current ?: StreamFeedState(feedKey.value)).copy(
                     lastAttemptAt = nowMs,
                     lastAccessAt = nowMs,
-                    staleTailRetainedAt = if (expiredTail) null else current?.staleTailRetainedAt,
+                    staleTailRetainedAt = null,
                 )
             )
         }
     }
 
-    /** Replace the cached refresh page only after its network request succeeded. */
+    /** Replace the complete cached snapshot only after its network request succeeded. */
     override suspend fun replaceAfterRefresh(
         feedKey: StreamFeedKey,
         page: StreamFeedPage,
         nowMs: Long,
-        preserveTail: Boolean,
-        pruneStaleOnEnd: Boolean,
     ) = withContext(Dispatchers.IO) {
         var activeItems: List<Stream> = emptyList()
         database.runInTransaction {
             val current = dao.state(feedKey.value)
             val generation = (current?.activeGeneration ?: 0L) + 1L
-            val expiredTail = staleTailExpired(current, nowMs)
-            if (expiredTail && current != null) {
-                // The expired rows are the generations behind the active one.
-                // Keep the active generation available to become the next
-                // stale tail even when expiry is crossed during the request.
-                dao.deleteItemsExceptGeneration(feedKey.value, current.activeGeneration)
-            }
-            val existing = if (preserveTail) dao.itemsForFeed(feedKey.value) else emptyList()
-            val items = if (preserveTail) {
-                refreshCachedItemsPreservingTail(
-                    feedKey = feedKey.value,
-                    existing = existing,
-                    streams = page.items,
-                    generation = generation,
-                )
-            } else {
-                refreshCachedItems(feedKey.value, page.items, generation)
-            }
-            if (!preserveTail) {
-                dao.deleteItems(feedKey.value)
-            }
+            val items = refreshCachedItems(feedKey.value, page.items, generation)
+            dao.deleteItems(feedKey.value)
             if (items.isNotEmpty()) {
                 dao.insertItems(items)
             }
-            if (page.nextCursor == null && pruneStaleOnEnd) {
-                dao.deleteItemsExceptGeneration(feedKey.value, generation)
-            }
-            val existingStreams = activeSnapshot.current(feedKey.value)
-                ?: existing.map(CachedStreamFeedItem::toStream)
-            activeItems = if (preserveTail) {
-                refreshStreamsPreservingTail(existingStreams, page.items, generation)
-            } else {
-                normalizedStreams(page.items, generation)
-            }
-            if (page.nextCursor == null && pruneStaleOnEnd) {
-                activeItems = activeItems.filter { it.thumbnailGeneration == generation }
-            }
-            val retainsStaleTail = preserveTail &&
-                    !(page.nextCursor == null && pruneStaleOnEnd) &&
-                    items.any { it.generation != generation }
+            activeItems = normalizedStreams(page.items, generation)
             dao.insertState(
                 StreamFeedState(
                     feedKey = feedKey.value,
@@ -407,11 +287,7 @@ class StreamFeedCache(
                     rateLimitUntil = null,
                     nextCursorApi = page.nextCursor?.api,
                     activeGeneration = generation,
-                    staleTailRetainedAt = if (retainsStaleTail) {
-                        current?.staleTailRetainedAt?.takeUnless { expiredTail } ?: nowMs
-                    } else {
-                        null
-                    },
+                    staleTailRetainedAt = null,
                 )
             )
         }
@@ -423,36 +299,24 @@ class StreamFeedCache(
         feedKey: StreamFeedKey,
         page: StreamFeedPage,
         nowMs: Long,
-        pruneStaleOnEnd: Boolean,
     ) = withContext(Dispatchers.IO) {
         var activeItems: List<Stream> = emptyList()
         database.runInTransaction {
             val current = dao.state(feedKey.value) ?: StreamFeedState(feedKey.value)
-            val expiredTail = staleTailExpired(current, nowMs)
-            if (expiredTail) {
-                dao.deleteItemsExceptGeneration(feedKey.value, current.activeGeneration)
-            }
             val existing = dao.itemsForFeed(feedKey.value)
             val items = appendCachedPage(feedKey.value, existing, page.items, current.activeGeneration)
+            dao.deleteItems(feedKey.value)
             if (items.isNotEmpty()) {
                 dao.insertItems(items)
             }
-            if (page.nextCursor == null && pruneStaleOnEnd) {
-                dao.deleteItemsExceptGeneration(feedKey.value, current.activeGeneration)
-            }
-            val existingStreams = activeSnapshot.current(feedKey.value)
-                ?: existing.map(CachedStreamFeedItem::toStream)
+            val existingStreams = (activeSnapshot.current(feedKey.value)
+                ?: existing.map(CachedStreamFeedItem::toStream))
+                .filter { it.thumbnailGeneration == current.activeGeneration }
             activeItems = appendStreams(
                 existing = existingStreams,
                 streams = page.items,
                 generation = current.activeGeneration,
             )
-            if (page.nextCursor == null && pruneStaleOnEnd) {
-                activeItems = activeItems.filter { it.thumbnailGeneration == current.activeGeneration }
-            }
-            val retainsStaleTail =
-                !(page.nextCursor == null && pruneStaleOnEnd) &&
-                        items.any { it.generation != current.activeGeneration }
             dao.insertState(
                 current.copy(
                     nextCursor = page.nextCursor?.value,
@@ -462,11 +326,7 @@ class StreamFeedCache(
                     failureBackoffUntil = null,
                     rateLimitUntil = null,
                     nextCursorApi = page.nextCursor?.api,
-                    staleTailRetainedAt = if (retainsStaleTail) {
-                        current.staleTailRetainedAt?.takeUnless { expiredTail } ?: nowMs
-                    } else {
-                        null
-                    },
+                    staleTailRetainedAt = null,
                 )
             )
         }
@@ -491,17 +351,13 @@ class StreamFeedCache(
     ) = withContext(Dispatchers.IO) {
         database.runInTransaction {
             val current = dao.state(feedKey.value) ?: StreamFeedState(feedKey.value)
-            val expiredTail = staleTailExpired(current, nowMs)
-            if (expiredTail) {
-                dao.deleteItemsExceptGeneration(feedKey.value, current.activeGeneration)
-            }
             dao.insertState(
                 current.copy(
                     lastAttemptAt = nowMs,
                     lastAccessAt = nowMs,
                     failureBackoffUntil = failureBackoffUntil,
                     rateLimitUntil = rateLimitUntil,
-                    staleTailRetainedAt = if (expiredTail) null else current.staleTailRetainedAt,
+                    staleTailRetainedAt = null,
                 )
             )
         }
@@ -527,7 +383,7 @@ class StreamFeedCache(
         database.runInTransaction {
             val cutoff = nowMs - FEED_RETENTION_MS
             val states = dao.allStates()
-            states.filter { staleTailExpired(it, nowMs) }
+            states.filter { it.staleTailRetainedAt != null }
                 .forEach { state ->
                     dao.deleteItemsExceptGeneration(state.feedKey, state.activeGeneration)
                     dao.insertState(state.copy(staleTailRetainedAt = null))

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/streamfeed/StreamFeedRefreshCoordinator.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/streamfeed/StreamFeedRefreshCoordinator.kt
@@ -166,10 +166,7 @@ class StreamFeedRefreshCoordinator(
                 RefreshDecision.JOIN -> error("JOIN is handled before the feed lock")
             }
 
-            val preserveTail = reason != RefreshReason.USER_PULL &&
-                    reason != RefreshReason.FILTER_CHANGED &&
-                    reason != RefreshReason.FOLLOW_STATE_CHANGED
-            val cachedItemCount = if (preserveTail) cache.itemCount(spec.key) else 0
+            val cachedItemCount = cache.itemCount(spec.key)
             val started = elapsedRealtimeMs()
             cache.markAttempt(spec.key, now)
             try {
@@ -179,13 +176,10 @@ class StreamFeedRefreshCoordinator(
                     spec.key,
                     page,
                     completedAt,
-                    preserveTail = preserveTail,
-                    pruneStaleOnEnd = !preserveTail,
                 )
                 successfulAtByFeed[spec.key.value] = completedAt
                 if (shouldPrefetchTail(
                         reason = reason,
-                        preserveTail = preserveTail,
                         cachedItemCount = cachedItemCount,
                         firstPageItemCount = page.items.size,
                         nextCursorPresent = page.nextCursor != null,
@@ -278,7 +272,6 @@ class StreamFeedRefreshCoordinator(
                     spec.key,
                     page,
                     completedAt,
-                    pruneStaleOnEnd = !speculative,
                 )
                 scheduleCacheCleanup()
                 debug(spec, RefreshReason.SCREEN_VISIBLE, RefreshDecision.REFRESH, null, "append items=${page.items.size} duration=${elapsedRealtimeMs() - started}")
@@ -305,14 +298,12 @@ class StreamFeedRefreshCoordinator(
 
     private fun shouldPrefetchTail(
         reason: RefreshReason,
-        preserveTail: Boolean,
         cachedItemCount: Int,
         firstPageItemCount: Int,
         nextCursorPresent: Boolean,
     ): Boolean {
         return StreamFeedFreshnessPolicy.MAX_AUTOMATIC_TAIL_PREFETCH_PAGES > 0 &&
                 reason != RefreshReason.BACKGROUND_PREWARM &&
-                preserveTail &&
                 cachedItemCount > firstPageItemCount &&
                 nextCursorPresent
     }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatAdapter.kt
@@ -30,6 +30,7 @@ import com.github.andreyasadchy.xtra.model.chat.TwitchEmote
 import com.github.andreyasadchy.xtra.ui.view.NamePaintImageSpan
 import com.github.andreyasadchy.xtra.util.chat.ChatAdapterUtils
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -146,6 +147,7 @@ class ChatAdapter(
     private val renderJobs = HashSet<RenderCacheKey>()
     private val prewarmRenderJobs = HashSet<RenderCacheKey>()
     private val visibleRenderJobs = HashSet<RenderCacheKey>()
+    private val renderWaiters = HashMap<RenderCacheKey, MutableList<CompletableDeferred<Unit>>>()
     private var visibleRenderQueue = Channel<RenderRequest>(VISIBLE_RENDER_QUEUE_CAPACITY)
     private var prewarmRenderQueue = Channel<RenderRequest>(PREWARM_QUEUE_CAPACITY)
     /** One signal represents one queued request; this keeps both workers fed during bursts. */
@@ -170,7 +172,9 @@ class ChatAdapter(
         set(value) {
             if (field != value) {
                 field = value
+                val messagesSnapshot = messages.toList()
                 clearRenderCache()
+                prepareAndNotify(messagesSnapshot, visiblePositions())
             }
         }
     private var selectedMessage: ChatMessage? = null
@@ -255,20 +259,9 @@ class ChatAdapter(
             messageLanguage = chatMessage.messageLanguage,
         )
         val cachedResult = cachedRender(cacheKey)
-        val result = if (cachedResult != null) {
-            cachedResult.copyForBind()
-        } else {
-            val context = fragment.context
-            // The visible row must receive its complete render plan in this bind. Rendering a
-            // plain fallback first and replacing it with emote spans later changes wrapping and
-            // row height before the images have even started loading. Parsing is synchronous;
-            // only image decoding remains asynchronous.
-            context?.let {
-                prepareMessage(chatMessage, it, holder.textView, catalogIndexes, offMain = false).also { prepared ->
-                    synchronized(renderCache) { renderCache[cacheKey] = prepared }
-                }.copyForBind()
-            } ?: fastFallback(chatMessage).copyForBind()
-        }
+        val result = checkNotNull(cachedResult) {
+            "Chat message was displayed before its render plan was prepared"
+        }.copyForBind()
         ChatAdapterUtils.installImagePlaceholders(
             result.builder,
             result.images,
@@ -282,9 +275,8 @@ class ChatAdapter(
         )
         holder.bind(chatMessage, result)
         ChatAdapterUtils.loadImages(
-            fragment, holder.textView, { holder.bindWhenReady(bindGeneration, chatMessage, it) }, result.images, result.imagePaint, result.userName, result.userNameStartIndex,
-            backgroundColor, imageLibrary, result.builder, result.translated, emoteSize, badgeSize, inlineIconSize, emoteQuality, animateGifs, enableOverlayEmotes,
-            chatMessage, savedColors, useReadableColors, isLightTheme, showLanguageDownloadDialog, true,
+            fragment, holder.textView, result.images, result.imagePaint, result.userName, result.userNameStartIndex,
+            backgroundColor, imageLibrary, result.builder, emoteQuality, animateGifs,
             isCurrent = { holder.isCurrentBind(bindGeneration) },
             shouldAnimate = { holder.canAnimate(bindGeneration) },
             requestBag = holder.imageRequests,
@@ -297,7 +289,7 @@ class ChatAdapter(
 
     override fun onViewRecycled(holder: ViewHolder) {
         holder.imageRequests.cancel()
-        holder.cancelPendingBind()
+        holder.cancelBind()
         super.onViewRecycled(holder)
     }
 
@@ -340,10 +332,12 @@ class ChatAdapter(
     }
 
     fun notifyUserMessages(userId: String) {
-        clearRenderCache()
-        messages.forEachIndexed { index, message ->
-            if (message.userId == userId) notifyItemChanged(index)
+        val affectedPositions = messages.mapIndexedNotNull { index, message ->
+            index.takeIf { message.userId == userId }
         }
+        val messagesSnapshot = messages.toList()
+        clearRenderCache()
+        prepareAndNotify(messagesSnapshot, affectedPositions)
     }
 
     /** Used by CombinedChatFragment, which renders one message without RecyclerView ownership. */
@@ -357,7 +351,7 @@ class ChatAdapter(
     /** Cancel image work when this adapter is used to render into a non-RecyclerView TextView. */
     fun releaseDirectViewHolder(holder: ViewHolder) {
         holder.imageRequests.cancel()
-        holder.cancelPendingBind()
+        holder.cancelBind()
         if (animateGifs) setAnimations(holder.textView, start = false)
     }
 
@@ -375,6 +369,18 @@ class ChatAdapter(
                 ChatAdapterUtils.addTranslation(chatMessage, builder, builder.length, savedColors, useReadableColors, isLightTheme, showLanguageDownloadDialog, true)
             }
             item.text = builder
+        }
+        // Translation is an explicit content update. Prepare the new cache entry off-main so a
+        // later holder recycle never falls back to parsing inside onBindViewHolder.
+        renderScope.launch { prepareForDisplay(listOf(chatMessage)) }
+    }
+
+    fun rebindMessageAfterContentUpdate(chatMessage: ChatMessage, position: Int) {
+        renderScope.launch {
+            prepareForDisplay(listOf(chatMessage))
+            withContext(Dispatchers.Main.immediate) {
+                if (messages.getOrNull(position) === chatMessage) notifyItemChanged(position)
+            }
         }
     }
 
@@ -452,7 +458,13 @@ class ChatAdapter(
         renderWorkers.forEach(Job::cancel)
         renderWorkers = emptyList()
         renderScope.cancel()
-        synchronized(renderJobs) { renderJobs.clear() }
+        synchronized(renderJobs) {
+            renderWaiters.values.flatten().forEach(CompletableDeferred<Unit>::cancel)
+            renderWaiters.clear()
+            renderJobs.clear()
+            prewarmRenderJobs.clear()
+            visibleRenderJobs.clear()
+        }
         pendingRenderedMessages.clear()
         attachedRecyclerView = null
         super.onDetachedFromRecyclerView(recyclerView)
@@ -504,7 +516,6 @@ class ChatAdapter(
         } else {
             for (i in 0 until recyclerView.childCount) {
                 (recyclerView.getChildViewHolder(recyclerView.getChildAt(i)) as? ViewHolder)?.let { holder ->
-                    holder.resumePendingBind()
                     holder.postDeferredImageReload()
                 }
             }
@@ -529,15 +540,44 @@ class ChatAdapter(
             localTwitchEmotes, thirdPartyEmotes, globalBadges, channelBadges, stvUsers, stvBadges, namePaints, personalEmoteSets, cheerEmotes,
         )
         catalogRevision++
-        clearRenderCache()
-        attachedRecyclerView?.let { recyclerView ->
-            val layoutManager = recyclerView.layoutManager as? androidx.recyclerview.widget.LinearLayoutManager ?: return@let
+        val visibleRange: IntRange? = attachedRecyclerView?.let { recyclerView ->
+            val layoutManager = recyclerView.layoutManager as? androidx.recyclerview.widget.LinearLayoutManager ?: return@let null
             val firstVisiblePosition = layoutManager.findFirstVisibleItemPosition()
             val lastVisiblePosition = layoutManager.findLastVisibleItemPosition()
             if (firstVisiblePosition != RecyclerView.NO_POSITION && lastVisiblePosition >= firstVisiblePosition) {
-                notifyItemRangeChanged(firstVisiblePosition, lastVisiblePosition - firstVisiblePosition + 1)
+                firstVisiblePosition..lastVisiblePosition
+            } else null
+        }
+        clearRenderCache()
+        visibleRange?.let { range ->
+            prepareAndNotify(
+                range.mapNotNull { messages.getOrNull(it) },
+                range.toList(),
+            )
+        }
+    }
+
+    private fun prepareAndNotify(preparedMessages: List<ChatMessage>, positions: List<Int>) {
+        if (preparedMessages.isEmpty()) return
+        val expectedRevision = catalogRevision
+        renderScope.launch {
+            prepareForDisplay(preparedMessages)
+            withContext(Dispatchers.Main.immediate) {
+                if (catalogRevision != expectedRevision) return@withContext
+                positions.forEach { position ->
+                    if (messages.getOrNull(position) != null) notifyItemChanged(position)
+                }
             }
         }
+    }
+
+    private fun visiblePositions(): List<Int> {
+        val recyclerView = attachedRecyclerView ?: return emptyList()
+        val layoutManager = recyclerView.layoutManager as? androidx.recyclerview.widget.LinearLayoutManager
+            ?: return emptyList()
+        val first = layoutManager.findFirstVisibleItemPosition()
+        val last = layoutManager.findLastVisibleItemPosition()
+        return if (first == RecyclerView.NO_POSITION || last < first) emptyList() else (first..last).toList()
     }
 
     private fun setAnimations(textView: TextView, start: Boolean) {
@@ -574,10 +614,6 @@ class ChatAdapter(
         private var boundReplyMessage: Boolean? = null
         var hasDeferredImageLoad = false
         private var bindGeneration = 0
-        private var pendingBindGeneration = 0
-        private var pendingMessage: ChatMessage? = null
-        private var pendingBuilder: SpannableStringBuilder? = null
-        private var bindPosted = false
         private var catalogRefreshPosted = false
         var catalogRevision = 0
             private set
@@ -599,20 +635,6 @@ class ChatAdapter(
                 notifyItemChanged(position)
             }
         }
-        private val bindRunnable = Runnable {
-            bindPosted = false
-            val message = pendingMessage
-            val builder = pendingBuilder
-            val generation = pendingBindGeneration
-            if (!animationsPaused) {
-                pendingMessage = null
-                pendingBuilder = null
-                if (message != null && builder != null && generation == bindGeneration) {
-                    bindContent(message, builder)
-                }
-            }
-        }
-
         fun beginBind(catalogRevision: Int): Int {
             if (animateGifs) setAnimations(textView, start = false)
             imageRequests.cancel()
@@ -620,24 +642,8 @@ class ChatAdapter(
             itemView.removeCallbacks(catalogRefreshRunnable)
             catalogRefreshPosted = false
             this.catalogRevision = catalogRevision
-            itemView.removeCallbacks(bindRunnable)
-            bindPosted = false
-            pendingMessage = null
-            pendingBuilder = null
             bindGeneration++
             return bindGeneration
-        }
-
-        fun bindWhenReady(generation: Int, chatMessage: ChatMessage, formattedMessage: SpannableStringBuilder) {
-            if (generation != bindGeneration) return
-            pendingBindGeneration = generation
-            pendingMessage = chatMessage
-            pendingBuilder = formattedMessage
-            if (!animationsPaused) {
-                itemView.removeCallbacks(bindRunnable)
-                bindPosted = true
-                itemView.postDelayed(bindRunnable, IMAGE_UPDATE_DEBOUNCE_MS)
-            }
         }
 
         fun isCurrentBind(generation: Int): Boolean = generation == bindGeneration
@@ -662,20 +668,10 @@ class ChatAdapter(
             }
         }
 
-        fun cancelPendingBind() {
+        fun cancelBind() {
             itemView.removeCallbacks(catalogRefreshRunnable)
             catalogRefreshPosted = false
-            itemView.removeCallbacks(bindRunnable)
-            bindPosted = false
-            pendingMessage = null
-            pendingBuilder = null
             bindGeneration++
-        }
-
-        fun resumePendingBind() {
-            if (pendingMessage == null || pendingBuilder == null || bindPosted) return
-            bindPosted = true
-            itemView.postOnAnimation(bindRunnable)
         }
 
         fun postCatalogRefresh() {
@@ -719,9 +715,10 @@ class ChatAdapter(
     }
 
     private companion object {
-        const val MAX_RENDER_CACHE_ENTRIES = 512
+        // Chat history is capped at 600 messages. Keep one complete history plus a small
+        // prewarm window so scrolling to the beginning cannot re-enter an uncached bind.
+        const val MAX_RENDER_CACHE_ENTRIES = 768
         const val MAX_ANIMATION_OPERATIONS_PER_FRAME = 4
-        const val IMAGE_UPDATE_DEBOUNCE_MS = 48L
         const val MAX_RENDER_UPDATES_PER_FRAME = 2
         const val MAX_RENDER_WORKERS = 2
         const val VISIBLE_RENDER_QUEUE_CAPACITY = 32
@@ -758,6 +755,8 @@ class ChatAdapter(
         renderWorkers = emptyList()
         renderScope.cancel()
         synchronized(renderJobs) {
+            renderWaiters.values.flatten().forEach(CompletableDeferred<Unit>::cancel)
+            renderWaiters.clear()
             renderJobs.clear()
             prewarmRenderJobs.clear()
             visibleRenderJobs.clear()
@@ -778,16 +777,23 @@ class ChatAdapter(
     ) {
         ensureRenderWorkers()
         val isPrewarm = prewarmGeneration != null
+        var shouldEnqueue = false
         synchronized(renderJobs) {
             if (isPrewarm) {
-                if (!renderJobs.add(cacheKey)) return
-                prewarmRenderJobs.add(cacheKey)
+                if (renderJobs.add(cacheKey)) {
+                    prewarmRenderJobs.add(cacheKey)
+                    shouldEnqueue = true
+                }
             } else {
-                val promoted = prewarmRenderJobs.remove(cacheKey)
-                if (!promoted && !renderJobs.add(cacheKey)) return
+                // A visible request must have its own queue entry. Removing a prewarm marker here
+                // promotes the key without leaving the visible waiter dependent on an old,
+                // cancellable prewarm generation.
+                if (prewarmRenderJobs.remove(cacheKey)) renderJobs.remove(cacheKey)
+                if (renderJobs.add(cacheKey)) shouldEnqueue = true
                 visibleRenderJobs.add(cacheKey)
             }
         }
+        if (!shouldEnqueue) return
         val queue = if (isPrewarm) prewarmRenderQueue else visibleRenderQueue
         val result = queue.trySend(RenderRequest(chatMessage, cacheKey, context, indexes, prewarmGeneration))
         if (result.isFailure) {
@@ -796,6 +802,7 @@ class ChatAdapter(
                 prewarmRenderJobs.remove(cacheKey)
                 visibleRenderJobs.remove(cacheKey)
             }
+            completeRenderWaiters(cacheKey)
         } else {
             renderSignal.trySend(Unit)
         }
@@ -864,15 +871,63 @@ class ChatAdapter(
         } catch (e: CancellationException) {
             throw e
         } catch (_: Exception) {
-            // A malformed chat payload must not take down the render worker. The fast fallback
-            // remains visible and the next bind can retry the message.
+            // Keep malformed payloads out of the UI thread as well. This fallback is only an
+            // exceptional parse failure; ordinary rows are always committed from renderCache.
+            withContext(Dispatchers.Main.immediate) {
+                if (currentRenderKey(chatMessage) == cacheKey) {
+                    synchronized(renderCache) { renderCache[cacheKey] = fastFallback(chatMessage) }
+                }
+            }
         } finally {
             synchronized(renderJobs) {
                 renderJobs.remove(cacheKey)
                 prewarmRenderJobs.remove(cacheKey)
                 visibleRenderJobs.remove(cacheKey)
             }
+            completeRenderWaiters(cacheKey)
         }
+    }
+
+    /**
+     * Prepares complete immutable render plans before messages are inserted into RecyclerView.
+     * The existing bounded render workers do the expensive parsing; this method only coordinates
+     * their completion and never touches a child View.
+     */
+    suspend fun prepareForDisplay(messages: List<ChatMessage>) {
+        if (messages.isEmpty()) return
+        val context = fragment.context ?: return
+        messages.forEach { message ->
+            while (true) {
+                val revision = catalogRevision
+                val indexes = catalogIndexes
+                val cacheKey = createRenderKey(message, revision)
+                if (cachedRender(cacheKey) != null) break
+
+                val waiter = CompletableDeferred<Unit>()
+                synchronized(renderJobs) {
+                    if (cachedRender(cacheKey) != null) {
+                        waiter.complete(Unit)
+                    } else {
+                        renderWaiters.getOrPut(cacheKey) { ArrayList() }.add(waiter)
+                    }
+                }
+                enqueueRender(message, cacheKey, context, indexes)
+                try {
+                    waiter.await()
+                } catch (cancellation: CancellationException) {
+                    synchronized(renderJobs) {
+                        renderWaiters[cacheKey]?.remove(waiter)
+                        if (renderWaiters[cacheKey].isNullOrEmpty()) renderWaiters.remove(cacheKey)
+                    }
+                    throw cancellation
+                }
+            }
+        }
+    }
+
+    private fun completeRenderWaiters(cacheKey: RenderCacheKey) {
+        val waiters = synchronized(renderJobs) { renderWaiters.remove(cacheKey).orEmpty() }
+        waiters.forEach { it.complete(Unit) }
     }
 
     private fun enqueuePrewarmRender(

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatAdapter.kt
@@ -35,6 +35,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -131,11 +132,17 @@ class ChatAdapter(
         }
     }
 
+    private data class RenderConfiguration(
+        val revision: Int,
+        val indexes: ChatAdapterUtils.ChatCatalogIndexes,
+        val translateAllMessages: Boolean,
+    )
+
     private data class RenderRequest(
         val message: ChatMessage,
         val cacheKey: RenderCacheKey,
         val context: android.content.Context,
-        val indexes: ChatAdapterUtils.ChatCatalogIndexes,
+        val configuration: RenderConfiguration,
         val prewarmGeneration: Long?,
     )
 
@@ -168,15 +175,6 @@ class ChatAdapter(
         attachedRecyclerView?.let(::scheduleVisiblePrewarm)
     }
     private var directBinding = false
-    var translateAllMessages = false
-        set(value) {
-            if (field != value) {
-                field = value
-                val messagesSnapshot = messages.toList()
-                clearRenderCache()
-                prepareAndNotify(messagesSnapshot, visiblePositions())
-            }
-        }
     private var selectedMessage: ChatMessage? = null
     private val random = Random()
     private val userColors = HashMap<String, Int>()
@@ -185,12 +183,33 @@ class ChatAdapter(
     private val savedLocalBadges = mutableMapOf<String, ByteArray>()
     private val savedLocalCheerEmotes = mutableMapOf<String, ByteArray>()
     private val savedLocalEmotes = mutableMapOf<String, ByteArray>()
-    private var catalogIndexes = ChatAdapterUtils.ChatCatalogIndexes.create(
+    private val initialCatalogIndexes = ChatAdapterUtils.ChatCatalogIndexes.create(
         localTwitchEmotes, thirdPartyEmotes, globalBadges, channelBadges, stvUsers, stvBadges, namePaints, personalEmoteSets, cheerEmotes,
     )
+    @Volatile
+    private var activeConfiguration = RenderConfiguration(0, initialCatalogIndexes, false)
+    @Volatile
+    private var pendingConfiguration: RenderConfiguration? = null
+    private var configurationRevisionCounter = 0
+    private var configurationJob: Job? = null
+    private val catalogRevision: Int
+        get() = activeConfiguration.revision
+    private val catalogIndexes: ChatAdapterUtils.ChatCatalogIndexes
+        get() = activeConfiguration.indexes
+    var translateAllMessages: Boolean
+        get() = activeConfiguration.translateAllMessages
+        set(value) {
+            if (value == activeConfiguration.translateAllMessages || pendingConfiguration?.translateAllMessages == value) return
+            scheduleConfigurationSwitch(
+                RenderConfiguration(
+                    revision = nextConfigurationRevision(),
+                    indexes = activeConfiguration.indexes,
+                    translateAllMessages = value,
+                ),
+            )
+        }
     private var attachedRecyclerView: RecyclerView? = null
     private var animationsPaused = false
-    private var catalogRevision = 0
     private var pauseAnimationsPosted = false
     private val pendingAnimationStops = ArrayDeque<TextView>()
     private val runningAnimationTextViews = Collections.newSetFromMap(
@@ -248,16 +267,10 @@ class ChatAdapter(
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
         holder.imageRequests.cancel()
-        val bindGeneration = holder.beginBind(catalogRevision)
+        val configuration = activeConfiguration
+        val bindGeneration = holder.beginBind(configuration.revision)
         val chatMessage = messages.getOrNull(position) ?: return
-        val cacheKey = RenderCacheKey(
-            message = chatMessage,
-            catalogRevision = catalogRevision,
-            translateAllMessages = translateAllMessages,
-            translatedMessage = chatMessage.translatedMessage,
-            translationFailed = chatMessage.translationFailed,
-            messageLanguage = chatMessage.messageLanguage,
-        )
+        val cacheKey = createRenderKey(chatMessage, configuration)
         val cachedResult = cachedRender(cacheKey)
         val result = checkNotNull(cachedResult) {
             "Chat message was displayed before its render plan was prepared"
@@ -335,9 +348,14 @@ class ChatAdapter(
         val affectedPositions = messages.mapIndexedNotNull { index, message ->
             index.takeIf { message.userId == userId }
         }
-        val messagesSnapshot = messages.toList()
-        clearRenderCache()
-        prepareAndNotify(messagesSnapshot, affectedPositions)
+        scheduleConfigurationSwitch(
+            RenderConfiguration(
+                revision = nextConfigurationRevision(),
+                indexes = activeConfiguration.indexes,
+                translateAllMessages = activeConfiguration.translateAllMessages,
+            ),
+            affectedPositions,
+        )
     }
 
     /** Used by CombinedChatFragment, which renders one message without RecyclerView ownership. */
@@ -457,6 +475,9 @@ class ChatAdapter(
         renderSignal.close()
         renderWorkers.forEach(Job::cancel)
         renderWorkers = emptyList()
+        configurationJob?.cancel()
+        configurationJob = null
+        pendingConfiguration = null
         renderScope.cancel()
         synchronized(renderJobs) {
             renderWaiters.values.flatten().forEach(CompletableDeferred<Unit>::cancel)
@@ -536,40 +557,54 @@ class ChatAdapter(
     }
 
     fun notifyCatalogChanged() {
-        catalogIndexes = ChatAdapterUtils.ChatCatalogIndexes.create(
-            localTwitchEmotes, thirdPartyEmotes, globalBadges, channelBadges, stvUsers, stvBadges, namePaints, personalEmoteSets, cheerEmotes,
+        scheduleConfigurationSwitch(
+            RenderConfiguration(
+                revision = nextConfigurationRevision(),
+                indexes = ChatAdapterUtils.ChatCatalogIndexes.create(
+                    localTwitchEmotes, thirdPartyEmotes, globalBadges, channelBadges, stvUsers, stvBadges, namePaints, personalEmoteSets, cheerEmotes,
+                ),
+                translateAllMessages = activeConfiguration.translateAllMessages,
+            ),
         )
-        catalogRevision++
-        val visibleRange: IntRange? = attachedRecyclerView?.let { recyclerView ->
-            val layoutManager = recyclerView.layoutManager as? androidx.recyclerview.widget.LinearLayoutManager ?: return@let null
-            val firstVisiblePosition = layoutManager.findFirstVisibleItemPosition()
-            val lastVisiblePosition = layoutManager.findLastVisibleItemPosition()
-            if (firstVisiblePosition != RecyclerView.NO_POSITION && lastVisiblePosition >= firstVisiblePosition) {
-                firstVisiblePosition..lastVisiblePosition
-            } else null
-        }
-        clearRenderCache()
-        visibleRange?.let { range ->
-            prepareAndNotify(
-                messages.toList(),
-                range.toList(),
-            )
-        }
     }
 
-    private fun prepareAndNotify(preparedMessages: List<ChatMessage>, positions: List<Int>) {
-        if (preparedMessages.isEmpty()) return
-        val expectedRevision = catalogRevision
-        renderScope.launch {
-            prepareForDisplay(preparedMessages)
+    private fun scheduleConfigurationSwitch(
+        configuration: RenderConfiguration,
+        affectedPositions: List<Int> = emptyList(),
+    ) {
+        configurationJob?.cancel()
+        prewarmGeneration++
+        prewarmJob?.cancel()
+        prewarmJob = null
+        synchronized(renderCache) {
+            renderCache.keys.removeIf { key -> key.catalogRevision != activeConfiguration.revision }
+        }
+        pendingConfiguration = configuration
+        val initialSnapshot = messages.toList()
+        configurationJob = renderScope.launch {
+            prepareForDisplay(initialSnapshot, configuration)
+            val currentSnapshot = withContext(Dispatchers.Main.immediate) { messages.toList() }
+            prepareForDisplay(currentSnapshot, configuration)
             withContext(Dispatchers.Main.immediate) {
-                if (catalogRevision != expectedRevision) return@withContext
+                if (pendingConfiguration !== configuration) return@withContext
+                activeConfiguration = configuration
+                pendingConfiguration = null
+                configurationJob = null
+                synchronized(renderCache) {
+                    renderCache.keys.removeIf { key ->
+                        key.catalogRevision != configuration.revision ||
+                            key.translateAllMessages != configuration.translateAllMessages
+                    }
+                }
+                val positions = if (affectedPositions.isEmpty()) visiblePositions() else affectedPositions
                 positions.forEach { position ->
                     if (messages.getOrNull(position) != null) notifyItemChanged(position)
                 }
             }
         }
     }
+
+    private fun nextConfigurationRevision(): Int = ++configurationRevisionCounter
 
     private fun visiblePositions(): List<Int> {
         val recyclerView = attachedRecyclerView ?: return emptyList()
@@ -717,7 +752,9 @@ class ChatAdapter(
     private companion object {
         // Chat history is capped at 600 messages. Keep one complete history plus a small
         // prewarm window so scrolling to the beginning cannot re-enter an uncached bind.
-        const val MAX_RENDER_CACHE_ENTRIES = 768
+        // Keep both the active and the pending revision bindable while a catalog switch is
+        // prepared. Chat history is capped at 600 messages.
+        const val MAX_RENDER_CACHE_ENTRIES = 1536
         const val MAX_ANIMATION_OPERATIONS_PER_FRAME = 4
         const val MAX_RENDER_UPDATES_PER_FRAME = 2
         const val MAX_RENDER_WORKERS = 2
@@ -744,35 +781,11 @@ class ChatAdapter(
         return generatedStableIds[message] ?: nextGeneratedStableId++.also { generatedStableIds[message] = it }
     }
 
-    private fun clearRenderCache() {
-        synchronized(renderCache) { renderCache.clear() }
-        prewarmJob?.cancel()
-        prewarmJob = null
-        visibleRenderQueue.close()
-        prewarmRenderQueue.close()
-        renderSignal.close()
-        renderWorkers.forEach(Job::cancel)
-        renderWorkers = emptyList()
-        renderScope.cancel()
-        synchronized(renderJobs) {
-            renderWaiters.values.flatten().forEach(CompletableDeferred<Unit>::cancel)
-            renderWaiters.clear()
-            renderJobs.clear()
-            prewarmRenderJobs.clear()
-            visibleRenderJobs.clear()
-        }
-        renderScope = newRenderScope()
-        visibleRenderQueue = Channel(VISIBLE_RENDER_QUEUE_CAPACITY)
-        prewarmRenderQueue = Channel(PREWARM_QUEUE_CAPACITY)
-        renderSignal = Channel(Channel.UNLIMITED)
-        if (attachedRecyclerView != null) ensureRenderWorkers()
-    }
-
-    private fun enqueueRender(
+    private suspend fun enqueueRender(
         chatMessage: ChatMessage,
         cacheKey: RenderCacheKey,
         context: android.content.Context,
-        indexes: ChatAdapterUtils.ChatCatalogIndexes,
+        configuration: RenderConfiguration,
         prewarmGeneration: Long? = null,
     ) {
         ensureRenderWorkers()
@@ -795,16 +808,21 @@ class ChatAdapter(
         }
         if (!shouldEnqueue) return
         val queue = if (isPrewarm) prewarmRenderQueue else visibleRenderQueue
-        val result = queue.trySend(RenderRequest(chatMessage, cacheKey, context, indexes, prewarmGeneration))
-        if (result.isFailure) {
+        try {
+            queue.send(RenderRequest(chatMessage, cacheKey, context, configuration, prewarmGeneration))
+            renderSignal.send(Unit)
+        } catch (e: Exception) {
             synchronized(renderJobs) {
-                renderJobs.remove(cacheKey)
                 prewarmRenderJobs.remove(cacheKey)
-                visibleRenderJobs.remove(cacheKey)
+                if (!isPrewarm || cacheKey !in visibleRenderJobs) {
+                    renderJobs.remove(cacheKey)
+                    visibleRenderJobs.remove(cacheKey)
+                }
             }
-            completeRenderWaiters(cacheKey)
-        } else {
-            renderSignal.trySend(Unit)
+            if (!isPrewarm || synchronized(renderJobs) { cacheKey !in visibleRenderJobs }) {
+                completeRenderWaiters(cacheKey)
+            }
+            throw e
         }
     }
 
@@ -859,11 +877,18 @@ class ChatAdapter(
         val cacheKey = request.cacheKey
         try {
             if (cachedRender(cacheKey) != null) return
-            val prepared = prepareMessage(chatMessage, request.context, null, request.indexes, offMain = true)
+            val prepared = prepareMessage(
+                chatMessage,
+                request.context,
+                null,
+                request.configuration.indexes,
+                request.cacheKey.translateAllMessages,
+                offMain = true,
+            )
             withContext(Dispatchers.Main.immediate) {
-                if (currentRenderKey(chatMessage) == cacheKey) {
+                if (isKnownConfiguration(request.configuration) && currentRenderKey(chatMessage, request.configuration) == cacheKey) {
                     synchronized(renderCache) { renderCache[cacheKey] = prepared }
-                    if (addPendingRenderedMessage(chatMessage)) {
+                    if (isActiveConfiguration(request.configuration) && addPendingRenderedMessage(chatMessage)) {
                         scheduleRenderedFlush()
                     }
                 }
@@ -874,7 +899,7 @@ class ChatAdapter(
             // Keep malformed payloads out of the UI thread as well. This fallback is only an
             // exceptional parse failure; ordinary rows are always committed from renderCache.
             withContext(Dispatchers.Main.immediate) {
-                if (currentRenderKey(chatMessage) == cacheKey) {
+                if (isKnownConfiguration(request.configuration) && currentRenderKey(chatMessage, request.configuration) == cacheKey) {
                     synchronized(renderCache) { renderCache[cacheKey] = fastFallback(chatMessage) }
                 }
             }
@@ -895,33 +920,57 @@ class ChatAdapter(
      */
     suspend fun prepareForDisplay(messages: List<ChatMessage>) {
         if (messages.isEmpty()) return
-        val context = fragment.context ?: return
-        messages.forEach { message ->
-            while (true) {
-                val revision = catalogRevision
-                val indexes = catalogIndexes
-                val cacheKey = createRenderKey(message, revision)
-                if (cachedRender(cacheKey) != null) break
+        while (true) {
+            val configurations = buildList {
+                add(activeConfiguration)
+                pendingConfiguration?.takeUnless { it === activeConfiguration }?.let(::add)
+            }
+            configurations.forEach { configuration ->
+                prepareForDisplay(messages, configuration)
+            }
+            val preparedActive = configurations.first()
+            if (activeConfiguration === preparedActive && pendingConfiguration == configurations.drop(1).firstOrNull()) {
+                return
+            }
+        }
+    }
 
-                val waiter = CompletableDeferred<Unit>()
-                synchronized(renderJobs) {
-                    if (cachedRender(cacheKey) != null) {
-                        waiter.complete(Unit)
-                    } else {
-                        renderWaiters.getOrPut(cacheKey) { ArrayList() }.add(waiter)
-                    }
-                }
-                enqueueRender(message, cacheKey, context, indexes)
-                try {
-                    waiter.await()
-                } catch (cancellation: CancellationException) {
-                    synchronized(renderJobs) {
-                        renderWaiters[cacheKey]?.remove(waiter)
-                        if (renderWaiters[cacheKey].isNullOrEmpty()) renderWaiters.remove(cacheKey)
-                    }
-                    throw cancellation
+    private suspend fun prepareForDisplay(messages: List<ChatMessage>, configuration: RenderConfiguration) {
+        if (messages.isEmpty()) return
+        val context = fragment.context ?: throw CancellationException("Chat renderer is no longer attached")
+        val requests = LinkedHashMap<RenderCacheKey, Pair<ChatMessage, CompletableDeferred<Unit>>>()
+        messages.forEach { message ->
+            val cacheKey = createRenderKey(message, configuration)
+            if (cachedRender(cacheKey) == null) {
+                requests.putIfAbsent(cacheKey, message to CompletableDeferred())
+            }
+        }
+        if (requests.isEmpty()) return
+
+        synchronized(renderJobs) {
+            requests.forEach { (cacheKey, pair) ->
+                if (cachedRender(cacheKey) == null) {
+                    renderWaiters.getOrPut(cacheKey) { ArrayList() }.add(pair.second)
+                } else {
+                    pair.second.complete(Unit)
                 }
             }
+        }
+        try {
+            requests.forEach { (cacheKey, pair) ->
+                if (!pair.second.isCompleted) {
+                    enqueueRender(pair.first, cacheKey, context, configuration)
+                }
+            }
+            requests.values.map { it.second }.awaitAll()
+        } catch (cancellation: CancellationException) {
+            synchronized(renderJobs) {
+                requests.forEach { (cacheKey, pair) ->
+                    renderWaiters[cacheKey]?.remove(pair.second)
+                    if (renderWaiters[cacheKey].isNullOrEmpty()) renderWaiters.remove(cacheKey)
+                }
+            }
+            throw cancellation
         }
     }
 
@@ -930,14 +979,13 @@ class ChatAdapter(
         waiters.forEach { it.complete(Unit) }
     }
 
-    private fun enqueuePrewarmRender(
+    private suspend fun enqueuePrewarmRender(
         message: ChatMessage,
-        revision: Int,
+        configuration: RenderConfiguration,
         context: android.content.Context,
-        indexes: ChatAdapterUtils.ChatCatalogIndexes,
         generation: Long,
     ) {
-        enqueueRender(message, createRenderKey(message, revision), context, indexes, generation)
+        enqueueRender(message, createRenderKey(message, configuration), context, configuration, generation)
     }
 
     private fun scheduleVisiblePrewarm(recyclerView: RecyclerView) {
@@ -952,29 +1000,42 @@ class ChatAdapter(
             val end = (last + PREWARM_AFTER).coerceAtMost(messages.size - 1)
             if (end < start) return@post
             val snapshot = messages.subList(start, end + 1).toList()
-            val revision = catalogRevision
-            val indexes = catalogIndexes
+            val configuration = activeConfiguration
             val generation = ++prewarmGeneration
             prewarmJob?.cancel()
             prewarmJob = renderScope.launch {
                 snapshot.forEach { message ->
-                    enqueuePrewarmRender(message, revision, context, indexes, generation)
+                    enqueuePrewarmRender(message, configuration, context, generation)
                     yield()
                 }
             }
         }
     }
 
-    private fun currentRenderKey(message: ChatMessage): RenderCacheKey = createRenderKey(message, catalogRevision)
+    private fun currentRenderKey(message: ChatMessage, configuration: RenderConfiguration = activeConfiguration): RenderCacheKey =
+        createRenderKey(message, configuration)
 
-    private fun createRenderKey(message: ChatMessage, revision: Int = catalogRevision) = RenderCacheKey(
+    private fun createRenderKey(message: ChatMessage, configuration: RenderConfiguration) = RenderCacheKey(
         message = message,
-        catalogRevision = revision,
-        translateAllMessages = translateAllMessages,
+        catalogRevision = configuration.revision,
+        translateAllMessages = configuration.translateAllMessages,
         translatedMessage = message.translatedMessage,
         translationFailed = message.translationFailed,
         messageLanguage = message.messageLanguage,
     )
+
+    private fun isActiveConfiguration(configuration: RenderConfiguration): Boolean =
+        configuration.revision == activeConfiguration.revision &&
+            configuration.indexes === activeConfiguration.indexes &&
+            configuration.translateAllMessages == activeConfiguration.translateAllMessages
+
+    private fun isKnownConfiguration(configuration: RenderConfiguration): Boolean =
+        isActiveConfiguration(configuration) ||
+            pendingConfiguration?.let {
+                configuration.revision == it.revision &&
+                    configuration.indexes === it.indexes &&
+                    configuration.translateAllMessages == it.translateAllMessages
+            } == true
 
     private fun addPendingRenderedMessage(message: ChatMessage): Boolean {
         val recyclerView = attachedRecyclerView ?: return false
@@ -1041,6 +1102,7 @@ class ChatAdapter(
         context: android.content.Context,
         itemView: View?,
         indexes: ChatAdapterUtils.ChatCatalogIndexes,
+        translateAllMessages: Boolean,
         offMain: Boolean,
     ): ChatAdapterUtils.MessageResult {
         val deferredTranslate: (ChatMessage, String?) -> Unit = { message, language ->

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatAdapter.kt
@@ -49,6 +49,27 @@ import java.util.Random
 import java.util.Collections
 import java.util.IdentityHashMap
 
+internal data class ChatRenderConfiguration(
+    val revision: Int,
+    val indexes: ChatAdapterUtils.ChatCatalogIndexes,
+    val translateAllMessages: Boolean,
+)
+
+internal fun composeChatRenderConfiguration(
+    active: ChatRenderConfiguration,
+    pending: ChatRenderConfiguration?,
+    revision: Int,
+    indexes: ChatAdapterUtils.ChatCatalogIndexes? = null,
+    translateAllMessages: Boolean? = null,
+): ChatRenderConfiguration {
+    val base = pending ?: active
+    return base.copy(
+        revision = revision,
+        indexes = indexes ?: base.indexes,
+        translateAllMessages = translateAllMessages ?: base.translateAllMessages,
+    )
+}
+
 class ChatAdapter(
     initialMessages: List<ChatMessage>,
     private val localTwitchEmotes: List<TwitchEmote>,
@@ -132,17 +153,11 @@ class ChatAdapter(
         }
     }
 
-    private data class RenderConfiguration(
-        val revision: Int,
-        val indexes: ChatAdapterUtils.ChatCatalogIndexes,
-        val translateAllMessages: Boolean,
-    )
-
     private data class RenderRequest(
         val message: ChatMessage,
         val cacheKey: RenderCacheKey,
         val context: android.content.Context,
-        val configuration: RenderConfiguration,
+        val configuration: ChatRenderConfiguration,
         val prewarmGeneration: Long?,
     )
 
@@ -187,9 +202,9 @@ class ChatAdapter(
         localTwitchEmotes, thirdPartyEmotes, globalBadges, channelBadges, stvUsers, stvBadges, namePaints, personalEmoteSets, cheerEmotes,
     )
     @Volatile
-    private var activeConfiguration = RenderConfiguration(0, initialCatalogIndexes, false)
+    private var activeConfiguration = ChatRenderConfiguration(0, initialCatalogIndexes, false)
     @Volatile
-    private var pendingConfiguration: RenderConfiguration? = null
+    private var pendingConfiguration: ChatRenderConfiguration? = null
     private var configurationRevisionCounter = 0
     private var configurationJob: Job? = null
     private val catalogRevision: Int
@@ -199,11 +214,13 @@ class ChatAdapter(
     var translateAllMessages: Boolean
         get() = activeConfiguration.translateAllMessages
         set(value) {
-            if (value == activeConfiguration.translateAllMessages || pendingConfiguration?.translateAllMessages == value) return
+            val base = pendingConfiguration ?: activeConfiguration
+            if (value == base.translateAllMessages) return
             scheduleConfigurationSwitch(
-                RenderConfiguration(
+                composeChatRenderConfiguration(
+                    active = activeConfiguration,
+                    pending = pendingConfiguration,
                     revision = nextConfigurationRevision(),
-                    indexes = activeConfiguration.indexes,
                     translateAllMessages = value,
                 ),
             )
@@ -349,10 +366,10 @@ class ChatAdapter(
             index.takeIf { message.userId == userId }
         }
         scheduleConfigurationSwitch(
-            RenderConfiguration(
+            composeChatRenderConfiguration(
+                active = activeConfiguration,
+                pending = pendingConfiguration,
                 revision = nextConfigurationRevision(),
-                indexes = activeConfiguration.indexes,
-                translateAllMessages = activeConfiguration.translateAllMessages,
             ),
             affectedPositions,
         )
@@ -558,18 +575,19 @@ class ChatAdapter(
 
     fun notifyCatalogChanged() {
         scheduleConfigurationSwitch(
-            RenderConfiguration(
+            composeChatRenderConfiguration(
+                active = activeConfiguration,
+                pending = pendingConfiguration,
                 revision = nextConfigurationRevision(),
                 indexes = ChatAdapterUtils.ChatCatalogIndexes.create(
                     localTwitchEmotes, thirdPartyEmotes, globalBadges, channelBadges, stvUsers, stvBadges, namePaints, personalEmoteSets, cheerEmotes,
                 ),
-                translateAllMessages = activeConfiguration.translateAllMessages,
             ),
         )
     }
 
     private fun scheduleConfigurationSwitch(
-        configuration: RenderConfiguration,
+        configuration: ChatRenderConfiguration,
         affectedPositions: List<Int> = emptyList(),
     ) {
         configurationJob?.cancel()
@@ -785,7 +803,7 @@ class ChatAdapter(
         chatMessage: ChatMessage,
         cacheKey: RenderCacheKey,
         context: android.content.Context,
-        configuration: RenderConfiguration,
+        configuration: ChatRenderConfiguration,
         prewarmGeneration: Long? = null,
     ) {
         ensureRenderWorkers()
@@ -876,6 +894,7 @@ class ChatAdapter(
         val chatMessage = request.message
         val cacheKey = request.cacheKey
         try {
+            if (!isKnownConfiguration(request.configuration)) return
             if (cachedRender(cacheKey) != null) return
             val prepared = prepareMessage(
                 chatMessage,
@@ -935,7 +954,7 @@ class ChatAdapter(
         }
     }
 
-    private suspend fun prepareForDisplay(messages: List<ChatMessage>, configuration: RenderConfiguration) {
+    private suspend fun prepareForDisplay(messages: List<ChatMessage>, configuration: ChatRenderConfiguration) {
         if (messages.isEmpty()) return
         val context = fragment.context ?: throw CancellationException("Chat renderer is no longer attached")
         val requests = LinkedHashMap<RenderCacheKey, Pair<ChatMessage, CompletableDeferred<Unit>>>()
@@ -981,7 +1000,7 @@ class ChatAdapter(
 
     private suspend fun enqueuePrewarmRender(
         message: ChatMessage,
-        configuration: RenderConfiguration,
+        configuration: ChatRenderConfiguration,
         context: android.content.Context,
         generation: Long,
     ) {
@@ -1012,10 +1031,10 @@ class ChatAdapter(
         }
     }
 
-    private fun currentRenderKey(message: ChatMessage, configuration: RenderConfiguration = activeConfiguration): RenderCacheKey =
+    private fun currentRenderKey(message: ChatMessage, configuration: ChatRenderConfiguration = activeConfiguration): RenderCacheKey =
         createRenderKey(message, configuration)
 
-    private fun createRenderKey(message: ChatMessage, configuration: RenderConfiguration) = RenderCacheKey(
+    private fun createRenderKey(message: ChatMessage, configuration: ChatRenderConfiguration) = RenderCacheKey(
         message = message,
         catalogRevision = configuration.revision,
         translateAllMessages = configuration.translateAllMessages,
@@ -1024,12 +1043,12 @@ class ChatAdapter(
         messageLanguage = message.messageLanguage,
     )
 
-    private fun isActiveConfiguration(configuration: RenderConfiguration): Boolean =
+    private fun isActiveConfiguration(configuration: ChatRenderConfiguration): Boolean =
         configuration.revision == activeConfiguration.revision &&
             configuration.indexes === activeConfiguration.indexes &&
             configuration.translateAllMessages == activeConfiguration.translateAllMessages
 
-    private fun isKnownConfiguration(configuration: RenderConfiguration): Boolean =
+    private fun isKnownConfiguration(configuration: ChatRenderConfiguration): Boolean =
         isActiveConfiguration(configuration) ||
             pendingConfiguration?.let {
                 configuration.revision == it.revision &&

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatAdapter.kt
@@ -551,7 +551,7 @@ class ChatAdapter(
         clearRenderCache()
         visibleRange?.let { range ->
             prepareAndNotify(
-                range.mapNotNull { messages.getOrNull(it) },
+                messages.toList(),
                 range.toList(),
             )
         }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatAdapter.kt
@@ -99,6 +99,8 @@ class ChatAdapter(
 
     /** UI-owned snapshot. ChatViewModel may continue receiving messages while a fling is active. */
     private val messages = ArrayList(initialMessages)
+    private val generatedStableIds = IdentityHashMap<ChatMessage, Long>()
+    private var nextGeneratedStableId = Long.MIN_VALUE
     private class RenderCacheKey(
         val message: ChatMessage,
         val catalogRevision: Int,
@@ -231,6 +233,11 @@ class ChatAdapter(
         }
     }
 
+    init {
+        setHasStableIds(true)
+        messages.forEach(::stableIdFor)
+    }
+
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
         return ViewHolder(LayoutInflater.from(parent.context).inflate(R.layout.chat_list_item, parent, false))
     }
@@ -252,16 +259,27 @@ class ChatAdapter(
             cachedResult.copyForBind()
         } else {
             val context = fragment.context
-            if (directBinding && context != null) {
-                prepareMessage(chatMessage, context, holder.textView, catalogIndexes, offMain = false).also { prepared ->
+            // The visible row must receive its complete render plan in this bind. Rendering a
+            // plain fallback first and replacing it with emote spans later changes wrapping and
+            // row height before the images have even started loading. Parsing is synchronous;
+            // only image decoding remains asynchronous.
+            context?.let {
+                prepareMessage(chatMessage, it, holder.textView, catalogIndexes, offMain = false).also { prepared ->
                     synchronized(renderCache) { renderCache[cacheKey] = prepared }
                 }.copyForBind()
-            } else {
-                context?.let { enqueueRender(chatMessage, cacheKey, it, catalogIndexes) }
-                fastFallback(chatMessage).copyForBind()
-            }
+            } ?: fastFallback(chatMessage).copyForBind()
         }
-        ChatAdapterUtils.installImagePlaceholders(result.builder, result.images, emoteSize, badgeSize, inlineIconSize)
+        ChatAdapterUtils.installImagePlaceholders(
+            result.builder,
+            result.images,
+            emoteSize,
+            badgeSize,
+            inlineIconSize,
+            result.imagePaint,
+            result.userName,
+            result.userNameStartIndex,
+            backgroundColor,
+        )
         holder.bind(chatMessage, result)
         ChatAdapterUtils.loadImages(
             fragment, holder.textView, { holder.bindWhenReady(bindGeneration, chatMessage, it) }, result.images, result.imagePaint, result.userName, result.userNameStartIndex,
@@ -274,6 +292,8 @@ class ChatAdapter(
             onLoadDeferred = { holder.hasDeferredImageLoad = true },
         )
     }
+
+    override fun getItemId(position: Int): Long = stableIdFor(messages[position])
 
     override fun onViewRecycled(holder: ViewHolder) {
         holder.imageRequests.cancel()
@@ -291,6 +311,7 @@ class ChatAdapter(
         if (incoming.isNotEmpty()) {
             val start = messages.size
             messages.addAll(incoming)
+            incoming.forEach(::stableIdFor)
             notifyItemRangeInserted(start, incoming.size)
         }
     }
@@ -298,6 +319,7 @@ class ChatAdapter(
     fun prependMessages(incoming: List<ChatMessage>) {
         if (incoming.isEmpty()) return
         messages.addAll(0, incoming)
+        incoming.forEach(::stableIdFor)
         notifyItemRangeInserted(0, incoming.size)
     }
 
@@ -330,6 +352,13 @@ class ChatAdapter(
         messages.clear()
         pendingRenderedMessages.clear()
         messages += message
+    }
+
+    /** Cancel image work when this adapter is used to render into a non-RecyclerView TextView. */
+    fun releaseDirectViewHolder(holder: ViewHolder) {
+        holder.imageRequests.cancel()
+        holder.cancelPendingBind()
+        if (animateGifs) setAnimations(holder.textView, start = false)
     }
 
     fun updateTranslation(chatMessage: ChatMessage, item: TextView, previousTranslation: String?) {
@@ -375,6 +404,10 @@ class ChatAdapter(
     }
 
     override fun getItemCount(): Int = messages.size
+
+    fun stableIdAt(position: Int): Long = getItemId(position)
+
+    fun positionOfStableId(stableId: Long): Int = messages.indexOfFirst { stableIdFor(it) == stableId }
 
     override fun onViewAttachedToWindow(holder: ViewHolder) {
         super.onViewAttachedToWindow(holder)
@@ -700,6 +733,18 @@ class ChatAdapter(
 
     private fun cachedRender(key: RenderCacheKey): ChatAdapterUtils.MessageResult? = synchronized(renderCache) {
         renderCache[key]
+    }
+
+    private fun stableIdFor(message: ChatMessage): Long {
+        val explicitId = message.id?.trim()?.takeIf { it.isNotEmpty() }
+        if (explicitId != null) {
+            var hash = -0x340d631b8c467dL
+            explicitId.forEach { character ->
+                hash = (hash xor character.code.toLong()) * 0x100000001b3L
+            }
+            return if (hash == RecyclerView.NO_ID) 0L else hash
+        }
+        return generatedStableIds[message] ?: nextGeneratedStableId++.also { generatedStableIds[message] = it }
     }
 
     private fun clearRenderCache() {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatAdapter.kt
@@ -362,16 +362,13 @@ class ChatAdapter(
     }
 
     fun notifyUserMessages(userId: String) {
-        val affectedPositions = messages.mapIndexedNotNull { index, message ->
-            index.takeIf { message.userId == userId }
-        }
+        if (messages.none { it.userId == userId }) return
         scheduleConfigurationSwitch(
             composeChatRenderConfiguration(
                 active = activeConfiguration,
                 pending = pendingConfiguration,
                 revision = nextConfigurationRevision(),
             ),
-            affectedPositions,
         )
     }
 
@@ -588,7 +585,6 @@ class ChatAdapter(
 
     private fun scheduleConfigurationSwitch(
         configuration: ChatRenderConfiguration,
-        affectedPositions: List<Int> = emptyList(),
     ) {
         configurationJob?.cancel()
         prewarmGeneration++
@@ -614,8 +610,7 @@ class ChatAdapter(
                             key.translateAllMessages != configuration.translateAllMessages
                     }
                 }
-                val positions = if (affectedPositions.isEmpty()) visiblePositions() else affectedPositions
-                positions.forEach { position ->
+                visiblePositions().forEach { position ->
                     if (messages.getOrNull(position) != null) notifyItemChanged(position)
                 }
             }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatFragment.kt
@@ -130,6 +130,7 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
     private var backPressedCallbackAdded = false
     private var lastSlowModeUiState = SlowModeState()
     private var chatAdapterUpdatePosted = false
+    private var chatAdapterReady = false
     private val pendingChatMutations = ArrayDeque<ChatViewModel.ChatMutation>()
     private var chatMutationRevision = 0L
     private data class ChatViewportAnchor(val stableId: Long, val fallbackPosition: Int, val top: Int)
@@ -203,9 +204,10 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
 
     private fun scheduleChatAdapterUpdate() {
         if (chatAdapterUpdatePosted) return
+        if (!chatAdapterReady) return
         val recyclerView = _binding?.recyclerView ?: return
         chatAdapterUpdatePosted = true
-        recyclerView.postDelayed(chatAdapterUpdateRunnable, CHAT_UPDATE_BATCH_MS)
+        recyclerView.postOnAnimation(chatAdapterUpdateRunnable)
     }
 
     private fun captureChatViewportAnchor(
@@ -386,8 +388,12 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
                 if (isLive || (args.getString(KEY_VIDEO_ID) != null && args.getInt(KEY_START_TIME) != -1) || chatUrl != null) {
                     val enableMessaging = isLive && isLoggedIn
                     val sizeModifier = (requireContext().prefs().getInt(C.CHAT_SIZE_MODIFIER, 100).toFloat() / 100f)
+                    val chatSnapshot = viewModel.chatSnapshot().also { chatMutationRevision = it.revision }
+                    val initialMessages = chatSnapshot.messages
                     adapter = ChatAdapter(
-                        initialMessages = viewModel.chatSnapshot().also { chatMutationRevision = it.revision }.messages,
+                        // The initial snapshot is rendered off-main before the adapter is attached.
+                        // This prevents RecyclerView from ever binding an uncached message.
+                        initialMessages = emptyList(),
                         localTwitchEmotes = viewModel.localTwitchEmotes,
                         thirdPartyEmotes = viewModel.thirdPartyEmotes,
                         globalBadges = viewModel.globalBadges,
@@ -461,7 +467,6 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
                         },
                     )
                     recyclerView.let {
-                        it.adapter = adapter
                         it.itemAnimator = null
                         it.layoutManager = LinearLayoutManager(context).apply { stackFromEnd = true }
                         it.addOnScrollListener(object : RecyclerView.OnScrollListener() {
@@ -492,6 +497,18 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
                                 }
                             }
                         })
+                    }
+                    val chatAdapter = adapter
+                    viewLifecycleOwner.lifecycleScope.launch {
+                        chatAdapter?.prepareForDisplay(initialMessages)
+                        if (_binding?.recyclerView === recyclerView && chatAdapter === adapter) {
+                            recyclerView.adapter = chatAdapter
+                            chatAdapterReady = true
+                            chatAdapter?.appendMessages(initialMessages, 0)
+                            if (pendingChatMutations.isNotEmpty() && !isChatTouched) {
+                                scheduleChatAdapterUpdate()
+                            }
+                        }
                     }
                     btnDown.setOnClickListener {
                         view.post {
@@ -855,6 +872,14 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
                         repeatOnLifecycle(Lifecycle.State.STARTED) {
                             viewModel.chatMutations.collect { mutation ->
                                 if (mutation.revision <= chatMutationRevision) return@collect
+                                // Complete render plans are prepared by ChatAdapter's bounded
+                                // background workers before this mutation can reach RecyclerView.
+                                val messagesToPrepare = when (mutation) {
+                                    is ChatViewModel.ChatMutation.Append -> mutation.messages
+                                    is ChatViewModel.ChatMutation.Prepend -> mutation.messages
+                                    is ChatViewModel.ChatMutation.Clear -> emptyList()
+                                }
+                                adapter?.prepareForDisplay(messagesToPrepare)
                                 pendingChatMutations.addLast(mutation)
                                 when (mutation) {
                                     is ChatViewModel.ChatMutation.Append -> {
@@ -1676,7 +1701,7 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
                             }?.let {
                                 (binding.recyclerView.layoutManager?.findViewByPosition(it) as? TextView)?.let {
                                     adapter.updateTranslation(chatMessage, it, previousTranslation)
-                                } ?: adapter.notifyItemChanged(it)
+                                } ?: adapter.rebindMessageAfterContentUpdate(chatMessage, it)
                             }
                         }
                         messageDialog?.updateTranslation(chatMessage, previousTranslation)
@@ -1716,7 +1741,7 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
                             }?.let {
                                 (binding.recyclerView.layoutManager?.findViewByPosition(it) as? TextView)?.let {
                                     adapter.updateTranslation(chatMessage, it, previousTranslation)
-                                } ?: adapter.notifyItemChanged(it)
+                                } ?: adapter.rebindMessageAfterContentUpdate(chatMessage, it)
                             }
                         }
                         messageDialog?.updateTranslation(chatMessage, previousTranslation)
@@ -1734,7 +1759,7 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
                             }?.let {
                                 (binding.recyclerView.layoutManager?.findViewByPosition(it) as? TextView)?.let {
                                     adapter.updateTranslation(chatMessage, it, previousTranslation)
-                                } ?: adapter.notifyItemChanged(it)
+                                } ?: adapter.rebindMessageAfterContentUpdate(chatMessage, it)
                             }
                         }
                         messageDialog?.updateTranslation(chatMessage, previousTranslation)
@@ -1752,7 +1777,7 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
                 }?.let {
                     (binding.recyclerView.layoutManager?.findViewByPosition(it) as? TextView)?.let {
                         adapter.updateTranslation(chatMessage, it, previousTranslation)
-                    } ?: adapter.notifyItemChanged(it)
+                    } ?: adapter.rebindMessageAfterContentUpdate(chatMessage, it)
                 }
             }
             messageDialog?.updateTranslation(chatMessage, previousTranslation)
@@ -1797,7 +1822,7 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
                                         }?.let {
                                             (binding.recyclerView.layoutManager?.findViewByPosition(it) as? TextView)?.let {
                                                 adapter.updateTranslation(chatMessage, it, previousTranslation)
-                                            } ?: adapter.notifyItemChanged(it)
+                                            } ?: adapter.rebindMessageAfterContentUpdate(chatMessage, it)
                                         }
                                     }
                                     messageDialog?.updateTranslation(chatMessage, previousTranslation)
@@ -1855,6 +1880,7 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
         backPressedCallbackAdded = false
         _binding?.recyclerView?.removeCallbacks(chatAdapterUpdateRunnable)
         chatAdapterUpdatePosted = false
+        chatAdapterReady = false
         pendingChatMutations.clear()
         disposeChannelPointsIconRequest()
         channelPointsIconRequestGeneration++
@@ -1975,7 +2001,6 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
     }
 
     companion object {
-        private const val CHAT_UPDATE_BATCH_MS = 32L
         private const val KEY_IS_LIVE = "isLive"
         private const val KEY_CHANNEL_ID = "channel_id"
         private const val KEY_CHANNEL_LOGIN = "channel_login"

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatFragment.kt
@@ -129,22 +129,18 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
     private var messageViewWasVisibleBeforeOverlay: Boolean? = null
     private var backPressedCallbackAdded = false
     private var lastSlowModeUiState = SlowModeState()
-    private var chatScrollPosted = false
     private var chatAdapterUpdatePosted = false
     private val pendingChatMutations = ArrayDeque<ChatViewModel.ChatMutation>()
     private var chatMutationRevision = 0L
-    private val chatScrollRunnable = Runnable {
-        chatScrollPosted = false
-        val currentBinding = _binding ?: return@Runnable
-        if (!isChatTouched && currentBinding.btnDown.isGone) {
-            val lastIndex = adapter?.itemCount?.minus(1) ?: RecyclerView.NO_POSITION
-            currentBinding.recyclerView.scrollToPosition(lastIndex)
-        }
-    }
+    private data class ChatViewportAnchor(val stableId: Long, val fallbackPosition: Int, val top: Int)
+
     private val chatAdapterUpdateRunnable = Runnable {
         chatAdapterUpdatePosted = false
         val currentBinding = _binding ?: return@Runnable
         val currentAdapter = adapter ?: return@Runnable
+        val recyclerView = currentBinding.recyclerView
+        val followBottom = !recyclerView.canScrollVertically(1)
+        val anchor = if (followBottom) null else captureChatViewportAnchor(recyclerView, currentAdapter)
         var hasNewMessages = false
         while (pendingChatMutations.isNotEmpty()) {
             when (val firstMutation = pendingChatMutations.removeFirst()) {
@@ -183,8 +179,10 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
                 }
             }
         }
-        if (hasNewMessages && !isChatTouched && currentBinding.btnDown.isGone) {
-            scheduleChatScrollToEnd()
+        if (hasNewMessages && followBottom && currentAdapter.itemCount > 0) {
+            recyclerView.scrollToPosition(currentAdapter.itemCount - 1)
+        } else if (!followBottom) {
+            restoreChatViewportAnchor(recyclerView, currentAdapter, anchor)
         }
     }
 
@@ -203,18 +201,41 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
     private val replyDialog: ReplyClickedDialog?
         get() = childFragmentManager.findFragmentByTag("replyDialog") as? ReplyClickedDialog
 
-    private fun scheduleChatScrollToEnd() {
-        if (chatScrollPosted) return
-        val recyclerView = _binding?.recyclerView ?: return
-        chatScrollPosted = true
-        recyclerView.postOnAnimation(chatScrollRunnable)
-    }
-
     private fun scheduleChatAdapterUpdate() {
         if (chatAdapterUpdatePosted) return
         val recyclerView = _binding?.recyclerView ?: return
         chatAdapterUpdatePosted = true
         recyclerView.postDelayed(chatAdapterUpdateRunnable, CHAT_UPDATE_BATCH_MS)
+    }
+
+    private fun captureChatViewportAnchor(
+        recyclerView: RecyclerView,
+        chatAdapter: ChatAdapter,
+    ): ChatViewportAnchor? {
+        val layoutManager = recyclerView.layoutManager as? LinearLayoutManager ?: return null
+        val firstPosition = layoutManager.findFirstVisibleItemPosition()
+        if (firstPosition == RecyclerView.NO_POSITION || firstPosition >= chatAdapter.itemCount) return null
+        val firstView = layoutManager.findViewByPosition(firstPosition) ?: return null
+        return ChatViewportAnchor(
+            stableId = chatAdapter.stableIdAt(firstPosition),
+            fallbackPosition = firstPosition,
+            top = firstView.top,
+        )
+    }
+
+    private fun restoreChatViewportAnchor(
+        recyclerView: RecyclerView,
+        chatAdapter: ChatAdapter,
+        anchor: ChatViewportAnchor?,
+    ) {
+        val savedAnchor = anchor ?: return
+        val layoutManager = recyclerView.layoutManager as? LinearLayoutManager ?: return
+        val position = chatAdapter.positionOfStableId(savedAnchor.stableId)
+            .takeIf { it >= 0 }
+            ?: savedAnchor.fallbackPosition.coerceAtMost(chatAdapter.itemCount - 1)
+        if (position >= 0) {
+            layoutManager.scrollToPositionWithOffset(position, savedAnchor.top)
+        }
     }
 
     private var languageIdentifier: LanguageIdentifier? = null
@@ -1832,9 +1853,7 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
         chatIdentityBadgeUrl = null
         backPressedCallback.remove()
         backPressedCallbackAdded = false
-        _binding?.recyclerView?.removeCallbacks(chatScrollRunnable)
         _binding?.recyclerView?.removeCallbacks(chatAdapterUpdateRunnable)
-        chatScrollPosted = false
         chatAdapterUpdatePosted = false
         pendingChatMutations.clear()
         disposeChannelPointsIconRequest()

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/MessageClickedChatAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/MessageClickedChatAdapter.kt
@@ -140,9 +140,8 @@ class MessageClickedChatAdapter(
         )
         holder.bind(chatMessage, result.builder)
         ChatAdapterUtils.loadImages(
-            fragment, holder.textView, { holder.bind(chatMessage, it) }, result.images, result.imagePaint, result.userName, result.userNameStartIndex,
-            backgroundColor, imageLibrary, result.builder, result.translated, emoteSize, badgeSize, inlineIconSize, emoteQuality, animateGifs, enableOverlayEmotes,
-            chatMessage, savedColors, useReadableColors, isLightTheme, showLanguageDownloadDialog, false
+            fragment, holder.textView, result.images, result.imagePaint, result.userName, result.userNameStartIndex,
+            backgroundColor, imageLibrary, result.builder, emoteQuality, animateGifs,
         )
     }
 

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/MessageClickedChatAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/MessageClickedChatAdapter.kt
@@ -127,7 +127,17 @@ class MessageClickedChatAdapter(
         if (chatMessage == selectedMessage) {
             holder.textView.setBackgroundResource(R.color.chatMessageSelected)
         }
-        ChatAdapterUtils.installImagePlaceholders(result.builder, result.images, emoteSize, badgeSize, inlineIconSize)
+        ChatAdapterUtils.installImagePlaceholders(
+            result.builder,
+            result.images,
+            emoteSize,
+            badgeSize,
+            inlineIconSize,
+            result.imagePaint,
+            result.userName,
+            result.userNameStartIndex,
+            backgroundColor,
+        )
         holder.bind(chatMessage, result.builder)
         ChatAdapterUtils.loadImages(
             fragment, holder.textView, { holder.bind(chatMessage, it) }, result.images, result.imagePaint, result.userName, result.userNameStartIndex,

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ReplyClickedChatAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ReplyClickedChatAdapter.kt
@@ -129,9 +129,8 @@ class ReplyClickedChatAdapter(
         )
         holder.bind(chatMessage, result.builder)
         ChatAdapterUtils.loadImages(
-            fragment, holder.textView, { holder.bind(chatMessage, it) }, result.images, result.imagePaint, result.userName, result.userNameStartIndex,
-            backgroundColor, imageLibrary, result.builder, result.translated, emoteSize, badgeSize, inlineIconSize, emoteQuality, animateGifs, enableOverlayEmotes,
-            chatMessage, savedColors, useReadableColors, isLightTheme, showLanguageDownloadDialog, false
+            fragment, holder.textView, result.images, result.imagePaint, result.userName, result.userNameStartIndex,
+            backgroundColor, imageLibrary, result.builder, emoteQuality, animateGifs,
         )
     }
 

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ReplyClickedChatAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ReplyClickedChatAdapter.kt
@@ -116,7 +116,17 @@ class ReplyClickedChatAdapter(
         if (chatMessage == selectedMessage) {
             holder.textView.setBackgroundResource(R.color.chatMessageSelected)
         }
-        ChatAdapterUtils.installImagePlaceholders(result.builder, result.images, emoteSize, badgeSize, inlineIconSize)
+        ChatAdapterUtils.installImagePlaceholders(
+            result.builder,
+            result.images,
+            emoteSize,
+            badgeSize,
+            inlineIconSize,
+            result.imagePaint,
+            result.userName,
+            result.userNameStartIndex,
+            backgroundColor,
+        )
         holder.bind(chatMessage, result.builder)
         ChatAdapterUtils.loadImages(
             fragment, holder.textView, { holder.bind(chatMessage, it) }, result.images, result.imagePaint, result.userName, result.userNameStartIndex,

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/multiview/CombinedChatFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/multiview/CombinedChatFragment.kt
@@ -52,6 +52,9 @@ import com.google.mlkit.nl.translate.TranslatorOptions
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import java.util.Locale
 
@@ -70,6 +73,8 @@ class CombinedChatFragment : Fragment(R.layout.fragment_combined_chat),
     private val translators = mutableMapOf<String, Translator>()
     private var renderPosted = false
     private var submitJob: Job? = null
+    private data class PendingSubmission(val items: List<CombinedChatMessage>, val forceScroll: Boolean)
+    private var pendingSubmission: PendingSubmission? = null
     private val renderRunnable = Runnable {
         renderPosted = false
         val layoutManager = _binding?.combinedChatRecyclerView?.layoutManager as? LinearLayoutManager
@@ -184,18 +189,29 @@ class CombinedChatFragment : Fragment(R.layout.fragment_combined_chat),
         _binding?.combinedChatRecyclerView?.removeCallbacks(renderRunnable)
         renderPosted = false
         if (!::adapter.isInitialized || _binding == null) return
-        val items = viewModel.snapshot(filterIdentity)
-        submitJob?.cancel()
+        val submission = PendingSubmission(viewModel.snapshot(filterIdentity), forceScroll)
+        pendingSubmission = pendingSubmission?.let {
+            submission.copy(forceScroll = it.forceScroll || submission.forceScroll)
+        } ?: submission
+        if (submitJob?.isActive == true) return
         submitJob = viewLifecycleOwner.lifecycleScope.launch {
-            adapter.prepareForDisplay(items)
-            if (_binding == null) return@launch
-            adapter.submitList(items) {
-                binding.combinedChatEmpty.isVisible = items.isEmpty()
-                if (forceScroll && items.isNotEmpty()) {
-                    binding.combinedChatRecyclerView.scrollToPosition(items.lastIndex)
+            while (true) {
+                val nextSubmission = pendingSubmission ?: break
+                pendingSubmission = null
+                val previousBySequence = adapter.currentList.associateBy(CombinedChatMessage::sequence)
+                val changedItems = nextSubmission.items.filter { previousBySequence[it.sequence] != it }
+                adapter.prepareForDisplay(changedItems)
+                if (pendingSubmission != null) continue
+                if (_binding == null) return@launch
+                adapter.submitList(nextSubmission.items) {
+                    binding.combinedChatEmpty.isVisible = nextSubmission.items.isEmpty()
+                    if (nextSubmission.forceScroll && nextSubmission.items.isNotEmpty()) {
+                        binding.combinedChatRecyclerView.scrollToPosition(nextSubmission.items.lastIndex)
+                    }
                 }
+                binding.combinedChatEmpty.isVisible = nextSubmission.items.isEmpty()
             }
-            binding.combinedChatEmpty.isVisible = items.isEmpty()
+            submitJob = null
         }
     }
 
@@ -344,6 +360,7 @@ class CombinedChatFragment : Fragment(R.layout.fragment_combined_chat),
         languageIdentifier = null
         translators.values.forEach(Translator::close)
         translators.clear()
+        pendingSubmission = null
         submitJob?.cancel()
         submitJob = null
         _binding = null
@@ -399,6 +416,7 @@ private class CombinedChatAdapter(
     }
 
     suspend fun prepareForDisplay(items: List<CombinedChatMessage>) {
+        val batches = linkedMapOf<SessionRenderer, MutableList<ChatMessage>>()
         items.forEach { item ->
             viewModel.session(item.identity)?.let { session ->
                 val renderer = renderers[item.identity]
@@ -406,8 +424,13 @@ private class CombinedChatAdapter(
                     ?: SessionRenderer(fragment, session, viewModel.channelId(item.identity), item.identity).also {
                         renderers[item.identity] = it
                     }
-                renderer.prepareForDisplay(item.message)
+                batches.getOrPut(renderer) { ArrayList() }.add(item.message)
             }
+        }
+        coroutineScope {
+            batches.map { (renderer, messages) ->
+                async { renderer.prepareForDisplay(messages) }
+            }.awaitAll()
         }
     }
 
@@ -529,8 +552,8 @@ private class CombinedChatAdapter(
             return holder
         }
 
-        suspend fun prepareForDisplay(message: ChatMessage) {
-            adapter.prepareForDisplay(listOf(message))
+        suspend fun prepareForDisplay(messages: List<ChatMessage>) {
+            adapter.prepareForDisplay(messages)
         }
 
         fun release(holder: ChatAdapter.ViewHolder) {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/multiview/CombinedChatFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/multiview/CombinedChatFragment.kt
@@ -89,6 +89,7 @@ class CombinedChatFragment : Fragment(R.layout.fragment_combined_chat),
         val layoutManager = LinearLayoutManager(requireContext()).apply { stackFromEnd = true }
         binding.combinedChatRecyclerView.layoutManager = layoutManager
         binding.combinedChatRecyclerView.adapter = adapter
+        binding.combinedChatRecyclerView.itemAnimator = null
         submitMessages(forceScroll = true)
 
         viewLifecycleOwner.lifecycleScope.launch {
@@ -374,7 +375,7 @@ private class CombinedChatAdapter(
                 ?: SessionRenderer(fragment, session, viewModel.channelId(item.identity), item.identity).also {
                     renderers[item.identity] = it
                 }
-            renderer.bind(holder.binding.messageText, item.message)
+            holder.bind(renderer, item.message)
         }
         holder.binding.root.contentDescription = fragment.getString(
             R.string.multiview_combined_message_description,
@@ -383,9 +384,38 @@ private class CombinedChatAdapter(
         )
     }
 
-    class ViewHolder(val binding: CombinedChatListItemBinding) : RecyclerView.ViewHolder(binding.root)
+    override fun onViewRecycled(holder: ViewHolder) {
+        holder.release()
+        super.onViewRecycled(holder)
+    }
 
-    private class SessionRenderer(
+    class ViewHolder(val binding: CombinedChatListItemBinding) : RecyclerView.ViewHolder(binding.root) {
+        private var renderer: SessionRenderer? = null
+        private var directViewHolder: ChatAdapter.ViewHolder? = null
+
+        fun bind(nextRenderer: SessionRenderer, message: ChatMessage) {
+            val sameRenderer = renderer === nextRenderer
+            renderer?.let { previousRenderer ->
+                directViewHolder?.let(previousRenderer::release)
+            }
+            renderer = nextRenderer
+            directViewHolder = nextRenderer.bind(
+                binding.messageText,
+                message,
+                directViewHolder.takeIf { sameRenderer },
+            )
+        }
+
+        fun release() {
+            renderer?.let { currentRenderer ->
+                directViewHolder?.let(currentRenderer::release)
+            }
+            renderer = null
+            directViewHolder = null
+        }
+    }
+
+    class SessionRenderer(
         fragment: CombinedChatFragment,
         private val session: ChatViewModel,
         channelId: String?,
@@ -470,9 +500,15 @@ private class CombinedChatAdapter(
             )
         }
 
-        fun bind(textView: TextView, message: ChatMessage) {
+        fun bind(textView: TextView, message: ChatMessage, existingHolder: ChatAdapter.ViewHolder?): ChatAdapter.ViewHolder {
+            val holder = existingHolder?.takeIf { it.itemView === textView } ?: adapter.ViewHolder(textView)
             adapter.setDirectMessage(message)
-            adapter.onBindViewHolder(adapter.ViewHolder(textView), 0)
+            adapter.onBindViewHolder(holder, 0)
+            return holder
+        }
+
+        fun release(holder: ChatAdapter.ViewHolder) {
+            adapter.releaseDirectViewHolder(holder)
         }
 
         fun isFor(session: ChatViewModel): Boolean = this.session === session

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/multiview/CombinedChatFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/multiview/CombinedChatFragment.kt
@@ -51,6 +51,7 @@ import com.google.mlkit.nl.translate.Translator
 import com.google.mlkit.nl.translate.TranslatorOptions
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import java.util.Locale
 
@@ -68,6 +69,7 @@ class CombinedChatFragment : Fragment(R.layout.fragment_combined_chat),
     private var languageIdentifier: LanguageIdentifier? = null
     private val translators = mutableMapOf<String, Translator>()
     private var renderPosted = false
+    private var submitJob: Job? = null
     private val renderRunnable = Runnable {
         renderPosted = false
         val layoutManager = _binding?.combinedChatRecyclerView?.layoutManager as? LinearLayoutManager
@@ -183,13 +185,18 @@ class CombinedChatFragment : Fragment(R.layout.fragment_combined_chat),
         renderPosted = false
         if (!::adapter.isInitialized || _binding == null) return
         val items = viewModel.snapshot(filterIdentity)
-        adapter.submitList(items) {
-            binding.combinedChatEmpty.isVisible = items.isEmpty()
-            if (forceScroll && items.isNotEmpty()) {
-                binding.combinedChatRecyclerView.scrollToPosition(items.lastIndex)
+        submitJob?.cancel()
+        submitJob = viewLifecycleOwner.lifecycleScope.launch {
+            adapter.prepareForDisplay(items)
+            if (_binding == null) return@launch
+            adapter.submitList(items) {
+                binding.combinedChatEmpty.isVisible = items.isEmpty()
+                if (forceScroll && items.isNotEmpty()) {
+                    binding.combinedChatRecyclerView.scrollToPosition(items.lastIndex)
+                }
             }
+            binding.combinedChatEmpty.isVisible = items.isEmpty()
         }
-        binding.combinedChatEmpty.isVisible = items.isEmpty()
     }
 
     private fun scheduleMessagesRender() {
@@ -337,6 +344,8 @@ class CombinedChatFragment : Fragment(R.layout.fragment_combined_chat),
         languageIdentifier = null
         translators.values.forEach(Translator::close)
         translators.clear()
+        submitJob?.cancel()
+        submitJob = null
         _binding = null
         super.onDestroyView()
     }
@@ -387,6 +396,19 @@ private class CombinedChatAdapter(
     override fun onViewRecycled(holder: ViewHolder) {
         holder.release()
         super.onViewRecycled(holder)
+    }
+
+    suspend fun prepareForDisplay(items: List<CombinedChatMessage>) {
+        items.forEach { item ->
+            viewModel.session(item.identity)?.let { session ->
+                val renderer = renderers[item.identity]
+                    ?.takeIf { it.isFor(session) }
+                    ?: SessionRenderer(fragment, session, viewModel.channelId(item.identity), item.identity).also {
+                        renderers[item.identity] = it
+                    }
+                renderer.prepareForDisplay(item.message)
+            }
+        }
     }
 
     class ViewHolder(val binding: CombinedChatListItemBinding) : RecyclerView.ViewHolder(binding.root) {
@@ -505,6 +527,10 @@ private class CombinedChatAdapter(
             adapter.setDirectMessage(message)
             adapter.onBindViewHolder(holder, 0)
             return holder
+        }
+
+        suspend fun prepareForDisplay(message: ChatMessage) {
+            adapter.prepareForDisplay(listOf(message))
         }
 
         fun release(holder: ChatAdapter.ViewHolder) {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/view/CenteredImageSpan.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/view/CenteredImageSpan.kt
@@ -5,38 +5,63 @@ import android.graphics.Paint
 import android.graphics.Paint.FontMetricsInt
 import android.graphics.drawable.Drawable
 import android.text.style.ImageSpan
+import kotlin.math.roundToInt
 
 
-class CenteredImageSpan(initialDrawable: Drawable) : ImageSpan(initialDrawable) {
+/**
+ * An inline image span whose slot never changes after the text is measured.
+ * The drawable can be decoded later, but its pixels are always drawn inside
+ * the dimensions reserved when the message was built.
+ */
+class CenteredImageSpan(
+    initialDrawable: Drawable,
+    private val reservedWidth: Int = initialDrawable.bounds.width(),
+    private val reservedHeight: Int = initialDrawable.bounds.height(),
+) : ImageSpan(initialDrawable) {
 
-    var imageDrawable: Drawable = initialDrawable
+    private val fallbackDrawable = initialDrawable
 
-    override fun getDrawable(): Drawable = imageDrawable
+    @Volatile
+    private var drawable: Drawable? = initialDrawable
+
+    var imageDrawable: Drawable
+        get() = drawable ?: fallbackDrawable
+        set(value) {
+            drawable = value.mutate().also { it.setBounds(0, 0, reservedWidth, reservedHeight) }
+        }
+
+    override fun getDrawable(): Drawable = drawable ?: fallbackDrawable
 
     override fun getSize(paint: Paint, text: CharSequence, start: Int, end: Int, fontMetricsInt: FontMetricsInt?): Int {
-        val drawable = imageDrawable
-        val rect = drawable.bounds
         if (fontMetricsInt != null) {
-            val fmPaint = paint.fontMetricsInt
-            val fontHeight = fmPaint.descent - fmPaint.ascent
-            val drHeight = rect.bottom - rect.top
-            val centerY = fmPaint.ascent + fontHeight / 2
-            fontMetricsInt.ascent = centerY - drHeight / 2
+            val base = paint.fontMetricsInt
+            val centerY = (base.ascent + base.descent) / 2
+            val halfHeight = reservedHeight / 2
+            fontMetricsInt.ascent = centerY - halfHeight
             fontMetricsInt.top = fontMetricsInt.ascent
-            fontMetricsInt.bottom = centerY + drHeight / 2
+            fontMetricsInt.bottom = centerY + reservedHeight - halfHeight
             fontMetricsInt.descent = fontMetricsInt.bottom
         }
-        return rect.right
+        return reservedWidth
     }
 
     override fun draw(canvas: Canvas, text: CharSequence, start: Int, end: Int, x: Float, top: Int, y: Int, bottom: Int, paint: Paint) {
-        val drawable = imageDrawable
+        val drawable = drawable ?: return
+        val intrinsicWidth = drawable.intrinsicWidth.takeIf { it > 0 } ?: reservedWidth
+        val intrinsicHeight = drawable.intrinsicHeight.takeIf { it > 0 } ?: reservedHeight
+        val scale = minOf(
+            reservedWidth.toFloat() / intrinsicWidth,
+            reservedHeight.toFloat() / intrinsicHeight,
+        )
+        val drawWidth = (intrinsicWidth * scale).roundToInt().coerceAtLeast(1)
+        val drawHeight = (intrinsicHeight * scale).roundToInt().coerceAtLeast(1)
+        drawable.setBounds(0, 0, drawWidth, drawHeight)
         canvas.save()
-        val fmPaint = paint.fontMetricsInt
-        val fontHeight = fmPaint.descent - fmPaint.ascent
-        val centerY = y + fmPaint.descent - fontHeight / 2
-        val transY = centerY - (drawable.bounds.bottom - drawable.bounds.top) / 2
-        canvas.translate(x, transY.toFloat())
+        val base = paint.fontMetricsInt
+        val baselineCenter = y + (base.ascent + base.descent) / 2f
+        val drawX = x + (reservedWidth - drawWidth) / 2f
+        val drawY = baselineCenter - drawHeight / 2f
+        canvas.translate(drawX, drawY)
         drawable.draw(canvas)
         canvas.restore()
     }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/view/NamePaintImageSpan.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/view/NamePaintImageSpan.kt
@@ -16,7 +16,8 @@ class NamePaintImageSpan(
     private val shadows: List<NamePaint.Shadow>?,
     var backgroundColor: Int?,
     private val bottomBackgroundColor: Int,
-    val drawable: Drawable,
+    @Volatile
+    var drawable: Drawable,
 ) : ReplacementSpan() {
 
     override fun getSize(paint: Paint, text: CharSequence?, start: Int, end: Int, fm: Paint.FontMetricsInt?): Int {
@@ -35,8 +36,8 @@ class NamePaintImageSpan(
         val xOffset = x.toInt()
         val width = paint.measureText(name).toInt()
         val height = bottom - top
-        val drawableWidth = drawable.intrinsicWidth
-        val drawableHeight = drawable.intrinsicHeight
+        val drawableWidth = drawable.intrinsicWidth.takeIf { it > 0 } ?: drawable.bounds.width().coerceAtLeast(1)
+        val drawableHeight = drawable.intrinsicHeight.takeIf { it > 0 } ?: drawable.bounds.height().coerceAtLeast(1)
         val widthRatio = drawableWidth.toFloat() / drawableHeight.toFloat()
         val fullWidth: Int
         val fullHeight: Int

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/view/NamePaintImageSpan.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/view/NamePaintImageSpan.kt
@@ -20,6 +20,12 @@ class NamePaintImageSpan(
     var drawable: Drawable,
 ) : ReplacementSpan() {
 
+    // The name-paint mask is independent of the animated drawable pixels. Keep one bounded
+    // mask per span and rebuild it only when the text/paint geometry changes, never per draw.
+    private var maskBitmap: Bitmap? = null
+    private var maskCanvas: Canvas? = null
+    private var cachedMaskSignature = 0
+
     override fun getSize(paint: Paint, text: CharSequence?, start: Int, end: Int, fm: Paint.FontMetricsInt?): Int {
         if (fm != null) {
             val paintFm = paint.fontMetrics
@@ -64,26 +70,68 @@ class NamePaintImageSpan(
         }
         drawable.setBounds(xOffset, top, fullWidth, fullHeight)
         drawable.draw(canvas)
-        val maskBitmap = Bitmap.createBitmap(max(fullWidth - xOffset, 0), max(fullHeight - top, 0), Bitmap.Config.ARGB_8888)
-        val maskCanvas = Canvas(maskBitmap)
-        val maskPaint = Paint(paint)
-        maskPaint.style = Paint.Style.FILL
-        maskPaint.color = bottomBackgroundColor
-        maskCanvas.drawPaint(maskPaint)
-        backgroundColor?.let {
-            maskPaint.color = it
-            maskCanvas.drawPaint(maskPaint)
-        }
-        maskPaint.color = paint.color
+        val maskWidth = max(fullWidth - xOffset, 0)
+        val maskHeight = max(fullHeight - top, 0)
+        if (maskWidth == 0 || maskHeight == 0) return
         val yOffset = y.toFloat() - top
-        shadows?.forEach {
-            maskPaint.setShadowLayer(it.radius, it.xOffset, it.yOffset, it.color)
-            maskCanvas.drawText(name, 0f, yOffset, maskPaint)
+        val signature = maskSignature(paint, maskWidth, maskHeight, yOffset)
+        val cachedMask = maskBitmap
+        if (cachedMask == null || cachedMask.width != maskWidth || cachedMask.height != maskHeight || signature != cachedMaskSignature) {
+            val bitmap = if (cachedMask == null || cachedMask.width != maskWidth || cachedMask.height != maskHeight) {
+                Bitmap.createBitmap(maskWidth, maskHeight, Bitmap.Config.ARGB_8888).also {
+                    maskBitmap = it
+                    maskCanvas = Canvas(it)
+                }
+            } else {
+                cachedMask.also { it.eraseColor(android.graphics.Color.TRANSPARENT) }
+            }
+            val targetCanvas = checkNotNull(maskCanvas)
+            val maskPaint = Paint(paint).apply { style = Paint.Style.FILL }
+            maskPaint.color = bottomBackgroundColor
+            targetCanvas.drawPaint(maskPaint)
+            backgroundColor?.let {
+                maskPaint.color = it
+                targetCanvas.drawPaint(maskPaint)
+            }
+            maskPaint.color = paint.color
+            shadows?.forEach {
+                maskPaint.setShadowLayer(it.radius, it.xOffset, it.yOffset, it.color)
+                targetCanvas.drawText(name, 0f, yOffset, maskPaint)
+            }
+            maskPaint.clearShadowLayer()
+            maskPaint.xfermode = PorterDuffXfermode(PorterDuff.Mode.SRC)
+            maskPaint.alpha = 0
+            targetCanvas.drawText(name, 0f, yOffset, maskPaint)
+            cachedMaskSignature = signature
+            canvas.drawBitmap(bitmap, xOffset.toFloat(), top.toFloat(), paint)
+        } else {
+            canvas.drawBitmap(cachedMask, xOffset.toFloat(), top.toFloat(), paint)
         }
-        maskPaint.clearShadowLayer()
-        maskPaint.xfermode = PorterDuffXfermode(PorterDuff.Mode.SRC)
-        maskPaint.alpha = 0
-        maskCanvas.drawText(name, 0f, yOffset, maskPaint)
-        canvas.drawBitmap(maskBitmap, xOffset.toFloat(), top.toFloat(), paint)
+    }
+
+    private fun maskSignature(paint: Paint, width: Int, height: Int, yOffset: Float): Int {
+        var result = name.hashCode()
+        result = 31 * result + width
+        result = 31 * result + height
+        result = 31 * result + yOffset.toBits()
+        result = 31 * result + paint.color
+        result = 31 * result + paint.alpha
+        result = 31 * result + paint.flags
+        result = 31 * result + paint.style.ordinal
+        result = 31 * result + paint.strokeWidth.toBits()
+        result = 31 * result + paint.textAlign.ordinal
+        result = 31 * result + paint.textSize.toBits()
+        result = 31 * result + paint.textScaleX.toBits()
+        result = 31 * result + paint.textSkewX.toBits()
+        result = 31 * result + (paint.typeface?.hashCode() ?: 0)
+        result = 31 * result + (backgroundColor ?: 0)
+        result = 31 * result + bottomBackgroundColor
+        shadows?.forEach {
+            result = 31 * result + it.radius.toBits()
+            result = 31 * result + it.xOffset.toBits()
+            result = 31 * result + it.yOffset.toBits()
+            result = 31 * result + it.color
+        }
+        return result
     }
 }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/chat/ChatAdapterUtils.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/chat/ChatAdapterUtils.kt
@@ -575,11 +575,30 @@ object ChatAdapterUtils {
         return builderIndex
     }
 
-    fun installImagePlaceholders(builder: SpannableStringBuilder, images: List<Image>, emoteSize: Int, badgeSize: Int, inlineIconSize: Int) {
+    fun installImagePlaceholders(
+        builder: SpannableStringBuilder,
+        images: List<Image>,
+        emoteSize: Int,
+        badgeSize: Int,
+        inlineIconSize: Int,
+        imagePaint: NamePaint? = null,
+        userName: String? = null,
+        userNameStartIndex: Int? = null,
+        backgroundColor: Int = Color.TRANSPARENT,
+    ) {
         images.forEach { image ->
             val size = imageSizeForKind(image.kind, emoteSize, badgeSize, inlineIconSize)
             val placeholder = ColorDrawable(Color.TRANSPARENT).apply { setBounds(0, 0, size, size) }
             builder.setSpan(CenteredImageSpan(placeholder), image.start, image.end, SPAN_EXCLUSIVE_EXCLUSIVE)
+        }
+        if (imagePaint != null && !userName.isNullOrEmpty() && userNameStartIndex != null) {
+            val placeholder = ColorDrawable(Color.TRANSPARENT).apply { setBounds(0, 0, 1, 1) }
+            builder.setSpan(
+                NamePaintImageSpan(userName, imagePaint.shadows, null, backgroundColor, placeholder),
+                userNameStartIndex,
+                userNameStartIndex + userName.length,
+                SPAN_EXCLUSIVE_EXCLUSIVE,
+            )
         }
     }
 
@@ -921,24 +940,22 @@ object ChatAdapterUtils {
                                         if (shouldAnimate()) (result as Animatable).start()
                                     }
                                     try {
-                                        builder.setSpan(
-                                            NamePaintImageSpan(
-                                                userName!!,
-                                                imagePaint.shadows,
-                                                (itemView.background as? ColorDrawable)?.color,
-                                                backgroundColor,
-                                                result
-                                            ),
+                                        builder.getSpans(
                                             userNameStartIndex!!,
-                                            userNameStartIndex + userName.length,
-                                            SPAN_EXCLUSIVE_EXCLUSIVE
-                                        )
+                                            userNameStartIndex + userName!!.length,
+                                            NamePaintImageSpan::class.java,
+                                        ).firstOrNull()?.let { span ->
+                                            span.backgroundColor = (itemView.background as? ColorDrawable)?.color
+                                            span.drawable = result
+                                        }
                                     } catch (e: IndexOutOfBoundsException) {
                                     }
+                                    var appendedTranslation = false
                                     if (!translated && chatMessage.translatedMessage != null) {
                                         addTranslation(chatMessage, builder, builder.length, savedColors, useReadableColors, isLightTheme, showLanguageDownloadDialog, hideErrors)
+                                        appendedTranslation = true
                                     }
-                                    bind(builder)
+                                    if (appendedTranslation) bind(builder) else itemView.invalidate()
                                 }
                             },
                         )
@@ -967,24 +984,22 @@ object ChatAdapterUtils {
                             if (shouldAnimate()) (resource as Animatable).start()
                         }
                         try {
-                            builder.setSpan(
-                                NamePaintImageSpan(
-                                    userName!!,
-                                    imagePaint.shadows,
-                                    (itemView.background as? ColorDrawable)?.color,
-                                    backgroundColor,
-                                    resource
-                                ),
+                            builder.getSpans(
                                 userNameStartIndex!!,
-                                userNameStartIndex + userName.length,
-                                SPAN_EXCLUSIVE_EXCLUSIVE
-                            )
+                                userNameStartIndex + userName!!.length,
+                                NamePaintImageSpan::class.java,
+                            ).firstOrNull()?.let { span ->
+                                span.backgroundColor = (itemView.background as? ColorDrawable)?.color
+                                span.drawable = resource
+                            }
                         } catch (e: IndexOutOfBoundsException) {
                         }
+                        var appendedTranslation = false
                         if (!translated && chatMessage.translatedMessage != null) {
                             addTranslation(chatMessage, builder, builder.length, savedColors, useReadableColors, isLightTheme, showLanguageDownloadDialog, hideErrors)
+                            appendedTranslation = true
                         }
-                        bind(builder)
+                        if (appendedTranslation) bind(builder) else itemView.invalidate()
                     }
 
                     override fun onLoadCleared(placeholder: Drawable?) {
@@ -1000,14 +1015,6 @@ object ChatAdapterUtils {
         images.forEach { image ->
             loadImage(imageLibrary, fragment, image, emoteQuality, requestBag) imageLoaded@{ result ->
                 if (!isCurrent()) return@imageLoaded
-                val imageSize = imageSizeForKind(image.kind, emoteSize, badgeSize, inlineIconSize)
-                val widthRatio = result.intrinsicWidth.toFloat() / result.intrinsicHeight.toFloat()
-                val size = if (widthRatio == 1f) {
-                    imageSize to imageSize
-                } else {
-                    (imageSize * widthRatio).toInt() to imageSize
-                }
-                result.setBounds(0, 0, size.first, size.second)
                 if (result is Animatable && image.isAnimated && animateGifs) {
                     result.callback = object : Drawable.Callback {
                         override fun unscheduleDrawable(who: Drawable, what: Runnable) {
@@ -1042,13 +1049,6 @@ object ChatAdapterUtils {
         }
         loadImage(imageLibrary, fragment, image, emoteQuality, requestBag) overlayLoaded@{ result ->
             if (!isCurrent()) return@overlayLoaded
-            val widthRatio = result.intrinsicWidth.toFloat() / result.intrinsicHeight.toFloat()
-            val size = if (widthRatio == 1f) {
-                emoteSize to emoteSize
-            } else {
-                (emoteSize * widthRatio).toInt() to emoteSize
-            }
-            result.setBounds(0, 0, size.first, size.second)
             if (result is Animatable && image.isAnimated && animateGifs) {
                 result.callback = object : Drawable.Callback {
                     override fun unscheduleDrawable(who: Drawable, what: Runnable) {
@@ -1070,9 +1070,6 @@ object ChatAdapterUtils {
                 nextOverlayEmote(imageLibrary, fragment, array, image.overlayEmote!!, bottomImage, itemView, bind, builder, translated, emoteSize, emoteQuality, animateGifs, enableOverlayEmotes, chatMessage, savedColors, useReadableColors, isLightTheme, showLanguageDownloadDialog, hideErrors, isCurrent, shouldAnimate, requestBag, shouldLoad, onLoadDeferred)
             } else {
                 val layer = LayerDrawable(array)
-                val width = array.maxOf { it.bounds.right }
-                val height = array.maxOf { it.bounds.bottom }
-                layer.setBounds(0, 0, width, height)
                 builder.getSpans(bottomImage.start, bottomImage.end, CenteredImageSpan::class.java).firstOrNull()?.imageDrawable = layer
                 itemView.invalidate()
             }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/chat/ChatAdapterUtils.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/chat/ChatAdapterUtils.kt
@@ -587,9 +587,19 @@ object ChatAdapterUtils {
         backgroundColor: Int = Color.TRANSPARENT,
     ) {
         images.forEach { image ->
-            val size = imageSizeForKind(image.kind, emoteSize, badgeSize, inlineIconSize)
-            val placeholder = ColorDrawable(Color.TRANSPARENT).apply { setBounds(0, 0, size, size) }
-            builder.setSpan(CenteredImageSpan(placeholder), image.start, image.end, SPAN_EXCLUSIVE_EXCLUSIVE)
+            val geometry = imageGeometry(
+                image,
+                imageSizeForKind(image.kind, emoteSize, badgeSize, inlineIconSize),
+            )
+            val placeholder = ColorDrawable(Color.TRANSPARENT).apply {
+                setBounds(0, 0, geometry.widthPx, geometry.heightPx)
+            }
+            builder.setSpan(
+                CenteredImageSpan(placeholder, geometry.widthPx, geometry.heightPx),
+                image.start,
+                image.end,
+                SPAN_EXCLUSIVE_EXCLUSIVE,
+            )
         }
         if (imagePaint != null && !userName.isNullOrEmpty() && userNameStartIndex != null) {
             val placeholder = ColorDrawable(Color.TRANSPARENT).apply { setBounds(0, 0, 1, 1) }
@@ -732,6 +742,8 @@ object ChatAdapterUtils {
                             url4x = emote.url4x,
                             format = emote.format,
                             isAnimated = emote.isAnimated,
+                            sourceWidth = emote.width,
+                            sourceHeight = emote.height,
                             kind = ImageKind.EMOTE,
                             thirdParty = emote.thirdParty,
                             start = previousImage.start,
@@ -769,6 +781,8 @@ object ChatAdapterUtils {
                             url4x = emote.url4x,
                             format = emote.format,
                             isAnimated = emote.isAnimated,
+                            sourceWidth = emote.width,
+                            sourceHeight = emote.height,
                             kind = ImageKind.EMOTE,
                             thirdParty = emote.thirdParty,
                             start = builderIndex,
@@ -904,7 +918,7 @@ object ChatAdapterUtils {
         }
     }
 
-    fun loadImages(fragment: Fragment, itemView: View, bind: (SpannableStringBuilder) -> Unit, images: List<Image>, imagePaint: NamePaint?, userName: String?, userNameStartIndex: Int?, backgroundColor: Int, imageLibrary: String?, builder: SpannableStringBuilder, translated: Boolean, emoteSize: Int, badgeSize: Int, inlineIconSize: Int, emoteQuality: String, animateGifs: Boolean, enableOverlayEmotes: Boolean, chatMessage: ChatMessage, savedColors: HashMap<String, Int>, useReadableColors: Boolean, isLightTheme: Boolean, showLanguageDownloadDialog: (ChatMessage, String) -> Unit, hideErrors: Boolean, isCurrent: () -> Boolean = { true }, shouldAnimate: () -> Boolean = { true }, requestBag: ImageRequestBag? = null, shouldLoad: () -> Boolean = { true }, onLoadDeferred: () -> Unit = {}) {
+    fun loadImages(fragment: Fragment, itemView: View, images: List<Image>, imagePaint: NamePaint?, userName: String?, userNameStartIndex: Int?, backgroundColor: Int, imageLibrary: String?, builder: SpannableStringBuilder, emoteQuality: String, animateGifs: Boolean, isCurrent: () -> Boolean = { true }, shouldAnimate: () -> Boolean = { true }, requestBag: ImageRequestBag? = null, shouldLoad: () -> Boolean = { true }, onLoadDeferred: () -> Unit = {}) {
         // During a fling the placeholder layout is sufficient. Deferring every request, including
         // static badges and name paints, prevents decode/cache work from competing with scrolling.
         if (!shouldLoad()) {
@@ -950,12 +964,7 @@ object ChatAdapterUtils {
                                         }
                                     } catch (e: IndexOutOfBoundsException) {
                                     }
-                                    var appendedTranslation = false
-                                    if (!translated && chatMessage.translatedMessage != null) {
-                                        addTranslation(chatMessage, builder, builder.length, savedColors, useReadableColors, isLightTheme, showLanguageDownloadDialog, hideErrors)
-                                        appendedTranslation = true
-                                    }
-                                    if (appendedTranslation) bind(builder) else itemView.invalidate()
+                                    itemView.invalidate()
                                 }
                             },
                         )
@@ -994,12 +1003,7 @@ object ChatAdapterUtils {
                             }
                         } catch (e: IndexOutOfBoundsException) {
                         }
-                        var appendedTranslation = false
-                        if (!translated && chatMessage.translatedMessage != null) {
-                            addTranslation(chatMessage, builder, builder.length, savedColors, useReadableColors, isLightTheme, showLanguageDownloadDialog, hideErrors)
-                            appendedTranslation = true
-                        }
-                        if (appendedTranslation) bind(builder) else itemView.invalidate()
+                        itemView.invalidate()
                     }
 
                     override fun onLoadCleared(placeholder: Drawable?) {
@@ -1033,7 +1037,7 @@ object ChatAdapterUtils {
                 }
                 if (image.overlayEmote != null) {
                     val drawables = arrayOf(result)
-                    nextOverlayEmote(imageLibrary, fragment, drawables, image.overlayEmote!!, image, itemView, bind, builder, translated, emoteSize, emoteQuality, animateGifs, enableOverlayEmotes, chatMessage, savedColors, useReadableColors, isLightTheme, showLanguageDownloadDialog, hideErrors, isCurrent, shouldAnimate, requestBag, shouldLoad, onLoadDeferred)
+                    nextOverlayEmote(imageLibrary, fragment, drawables, image.overlayEmote!!, image, itemView, builder, emoteQuality, animateGifs, isCurrent, shouldAnimate, requestBag, shouldLoad, onLoadDeferred)
                 } else {
                     builder.getSpans(image.start, image.end, CenteredImageSpan::class.java).firstOrNull()?.imageDrawable = result
                     itemView.invalidate()
@@ -1042,7 +1046,7 @@ object ChatAdapterUtils {
         }
     }
 
-    private fun nextOverlayEmote(imageLibrary: String?, fragment: Fragment, drawables: Array<Drawable>, image: Image, bottomImage: Image, itemView: View, bind: (SpannableStringBuilder) -> Unit, builder: SpannableStringBuilder, translated: Boolean, emoteSize: Int, emoteQuality: String, animateGifs: Boolean, enableOverlayEmotes: Boolean, chatMessage: ChatMessage, savedColors: HashMap<String, Int>, useReadableColors: Boolean, isLightTheme: Boolean, showLanguageDownloadDialog: (ChatMessage, String) -> Unit, hideErrors: Boolean, isCurrent: () -> Boolean, shouldAnimate: () -> Boolean, requestBag: ImageRequestBag?, shouldLoad: () -> Boolean, onLoadDeferred: () -> Unit) {
+    private fun nextOverlayEmote(imageLibrary: String?, fragment: Fragment, drawables: Array<Drawable>, image: Image, bottomImage: Image, itemView: View, builder: SpannableStringBuilder, emoteQuality: String, animateGifs: Boolean, isCurrent: () -> Boolean, shouldAnimate: () -> Boolean, requestBag: ImageRequestBag?, shouldLoad: () -> Boolean, onLoadDeferred: () -> Unit) {
         if (!shouldLoad()) {
             onLoadDeferred()
             return
@@ -1067,7 +1071,7 @@ object ChatAdapterUtils {
             }
             val array = drawables.plus(result)
             if (image.overlayEmote != null) {
-                nextOverlayEmote(imageLibrary, fragment, array, image.overlayEmote!!, bottomImage, itemView, bind, builder, translated, emoteSize, emoteQuality, animateGifs, enableOverlayEmotes, chatMessage, savedColors, useReadableColors, isLightTheme, showLanguageDownloadDialog, hideErrors, isCurrent, shouldAnimate, requestBag, shouldLoad, onLoadDeferred)
+                nextOverlayEmote(imageLibrary, fragment, array, image.overlayEmote!!, bottomImage, itemView, builder, emoteQuality, animateGifs, isCurrent, shouldAnimate, requestBag, shouldLoad, onLoadDeferred)
             } else {
                 val layer = LayerDrawable(array)
                 builder.getSpans(bottomImage.start, bottomImage.end, CenteredImageSpan::class.java).firstOrNull()?.imageDrawable = layer

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/chat/ChatImageGeometry.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/chat/ChatImageGeometry.kt
@@ -1,0 +1,29 @@
+package com.github.andreyasadchy.xtra.util.chat
+
+import com.github.andreyasadchy.xtra.model.chat.Image
+import kotlin.math.roundToInt
+
+data class InlineImageGeometry(
+    val widthPx: Int,
+    val heightPx: Int,
+)
+
+/** Computes the immutable text-layout slot for an inline chat image. */
+fun imageGeometry(image: Image, targetHeightPx: Int): InlineImageGeometry {
+    val height = targetHeightPx.coerceAtLeast(1)
+    val ratio = if (
+        image.sourceWidth != null &&
+        image.sourceHeight != null &&
+        image.sourceWidth > 0 &&
+        image.sourceHeight > 0
+    ) {
+        image.sourceWidth.toFloat() / image.sourceHeight.toFloat()
+    } else {
+        1f
+    }
+    val width = (height * ratio).roundToInt().coerceIn(
+        (height * 0.5f).roundToInt().coerceAtLeast(1),
+        height * 4,
+    )
+    return InlineImageGeometry(width, height)
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/chat/STVEventApiUtils.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/chat/STVEventApiUtils.kt
@@ -74,6 +74,8 @@ object STVEventApiUtils {
                 val template = if (!host.isNull("url")) host.optString("url").takeIf { it.isNotBlank() } else null
                 if (template != null) {
                     val urls = mutableListOf<String>()
+                    var sourceWidth: Int? = null
+                    var sourceHeight: Int? = null
                     val files = host.optJSONArray("files")
                     if (files != null) {
                         for (i in 0 until files.length()) {
@@ -88,6 +90,8 @@ object STVEventApiUtils {
                                 }
                             ) {
                                 urls.add("https:${template}/${fileName}")
+                                if (sourceWidth == null) sourceWidth = fileObject?.optInt("width")?.takeIf { it > 0 }
+                                if (sourceHeight == null) sourceHeight = fileObject?.optInt("height")?.takeIf { it > 0 }
                             }
                         }
                     }
@@ -102,6 +106,8 @@ object STVEventApiUtils {
                         isAnimated = if (!objectData.isNull("animated")) objectData.optBoolean("animated") else true,
                         isOverlayEmote = objectData.optInt("flags") == 1,
                         source = if (channelSet) Emote.CHANNEL_STV else Emote.PERSONAL_STV,
+                        width = sourceWidth,
+                        height = sourceHeight,
                     )
                 } else null
             } else null

--- a/app/src/test/java/com/github/andreyasadchy/xtra/repository/streamfeed/StreamFeedRefreshCoordinatorTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/repository/streamfeed/StreamFeedRefreshCoordinatorTest.kt
@@ -296,7 +296,7 @@ class StreamFeedRefreshCoordinatorTest {
     }
 
     @Test
-    fun automaticRefreshKeepsDeepRowsUntilPaginationCompletes() = runBlocking {
+    fun automaticRefreshReplacesDeepRowsBeforePaginationContinues() = runBlocking {
         val key = StreamFeedKey("top:deep-scroll-automatic")
         val oldRows = refreshCachedItems(
             key.value,
@@ -340,7 +340,7 @@ class StreamFeedRefreshCoordinatorTest {
         coordinator.maybeRefresh(spec, RefreshReason.APP_FOREGROUND)
         withTimeout(1_000L) { appendCommitted.await() }
 
-        assertTrue(cache.rows.any { it.itemKey == "channel:deep-80" })
+        assertFalse(cache.rows.any { it.itemKey == "channel:deep-80" })
         assertTrue(cache.rows.size > 1)
         coordinator.append(spec)
         assertFalse(cache.rows.any { it.itemKey == "channel:deep-80" })
@@ -352,7 +352,7 @@ class StreamFeedRefreshCoordinatorTest {
     }
 
     @Test
-    fun automaticRefreshPrefetchesOneFreshPageWhenRetainingADeepTail() = runBlocking {
+    fun automaticRefreshPrefetchesOneFreshPageWithoutRetainingADeepTail() = runBlocking {
         val key = StreamFeedKey("top:bounded-tail-prefetch")
         val cache = FakeCache(
             key = key,
@@ -394,7 +394,7 @@ class StreamFeedRefreshCoordinatorTest {
 
         assertEquals(2, loads)
         assertTrue(cache.rows.any { it.itemKey == "channel:fresh-1" })
-        assertTrue(cache.rows.any { it.itemKey == "channel:old-80" })
+        assertFalse(cache.rows.any { it.itemKey == "channel:old-80" })
         scope.cancel()
     }
 
@@ -541,7 +541,7 @@ class StreamFeedRefreshCoordinatorTest {
     }
 
     @Test
-    fun automaticRefreshEofRetainsStaleRowsUntilRealAppendFinalizesGeneration() = runBlocking {
+    fun automaticRefreshEofReplacesTheSnapshotImmediately() = runBlocking {
         val key = StreamFeedKey("top:automatic-eof")
         val cache = FakeCache(
             key = key,
@@ -567,16 +567,15 @@ class StreamFeedRefreshCoordinatorTest {
 
         coordinator.maybeRefresh(spec, RefreshReason.APP_FOREGROUND)
 
-        assertTrue(cache.rows.any { it.itemKey == "channel:old-80" })
+        assertFalse(cache.rows.any { it.itemKey == "channel:old-80" })
         assertEquals(null, cache.currentState?.nextCursor)
         assertTrue(coordinator.append(spec).endOfPaginationReached)
-        assertFalse(cache.rows.any { it.itemKey == "channel:old-80" })
         assertEquals(20, cache.rows.size)
         scope.cancel()
     }
 
     @Test
-    fun speculativeEofRetainsStaleRowsUntilRealAppendFinalizesGeneration() = runBlocking {
+    fun speculativeEofReplacesTheSnapshotImmediately() = runBlocking {
         val key = StreamFeedKey("top:speculative-eof")
         val cache = FakeCache(
             key = key,
@@ -615,10 +614,9 @@ class StreamFeedRefreshCoordinatorTest {
         withTimeout(1_000L) { appendCommitted.await() }
 
         assertEquals(2, loads)
-        assertTrue(cache.rows.any { it.itemKey == "channel:old-80" })
+        assertFalse(cache.rows.any { it.itemKey == "channel:old-80" })
         assertEquals(null, cache.currentState?.nextCursor)
         assertTrue(coordinator.append(spec).endOfPaginationReached)
-        assertFalse(cache.rows.any { it.itemKey == "channel:old-80" })
         assertEquals(50, cache.rows.size)
         scope.cancel()
     }
@@ -714,18 +712,9 @@ class StreamFeedRefreshCoordinatorTest {
             feedKey: StreamFeedKey,
             page: StreamFeedPage,
             nowMs: Long,
-            preserveTail: Boolean,
-            pruneStaleOnEnd: Boolean,
         ) {
             val generation = (currentState?.activeGeneration ?: 0L) + 1L
-            rows = if (preserveTail) {
-                refreshCachedItemsPreservingTail(feedKey.value, rows, page.items, generation)
-            } else {
-                refreshCachedItems(feedKey.value, page.items, generation)
-            }
-            if (page.nextCursor == null && pruneStaleOnEnd) {
-                rows = rows.filter { it.generation == generation }
-            }
+            rows = refreshCachedItems(feedKey.value, page.items, generation)
             currentState = StreamFeedState(
                 feedKey = feedKey.value,
                 nextCursor = page.nextCursor?.value,
@@ -742,13 +731,9 @@ class StreamFeedRefreshCoordinatorTest {
             feedKey: StreamFeedKey,
             page: StreamFeedPage,
             nowMs: Long,
-            pruneStaleOnEnd: Boolean,
         ) {
             val current = currentState ?: StreamFeedState(feedKey.value)
             rows = appendCachedPage(feedKey.value, rows, page.items, current.activeGeneration)
-            if (page.nextCursor == null && pruneStaleOnEnd) {
-                rows = rows.filter { it.generation == current.activeGeneration }
-            }
             currentState = current.copy(
                 nextCursor = page.nextCursor?.value,
                 nextCursorApi = page.nextCursor?.api,

--- a/app/src/test/java/com/github/andreyasadchy/xtra/repository/streamfeed/StreamFeedRemoteMediatorTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/repository/streamfeed/StreamFeedRemoteMediatorTest.kt
@@ -146,8 +146,6 @@ class StreamFeedRemoteMediatorTest {
             feedKey: StreamFeedKey,
             page: StreamFeedPage,
             nowMs: Long,
-            preserveTail: Boolean,
-            pruneStaleOnEnd: Boolean,
         ) {
             rows = refreshCachedItems(feedKey.value, page.items)
             currentState = StreamFeedState(
@@ -164,7 +162,6 @@ class StreamFeedRemoteMediatorTest {
             feedKey: StreamFeedKey,
             page: StreamFeedPage,
             nowMs: Long,
-            pruneStaleOnEnd: Boolean,
         ) = Unit
 
         override suspend fun pruneStaleGeneration(feedKey: StreamFeedKey) {

--- a/app/src/test/java/com/github/andreyasadchy/xtra/repository/streamfeed/StreamFeedSnapshotTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/repository/streamfeed/StreamFeedSnapshotTest.kt
@@ -10,34 +10,47 @@ class StreamFeedSnapshotTest {
 
     @Test
     fun refreshRemovesEndedStreamsAddsNewStreamsAndUpdatesOrder() {
-        val old = listOf(
-            Stream(id = null, channelId = "a", title = "old-a"),
-            Stream(id = null, channelId = "b", title = "old-b"),
+        val old = refreshCachedItems(
+            "top:test",
+            listOf(
+                Stream(channelId = "a", title = "old-a"),
+                Stream(channelId = "b", title = "old-b"),
+            ),
+            generation = 1L,
         )
         val fresh = listOf(
-            Stream(id = null, channelId = "b", title = "new-b"),
-            Stream(id = null, channelId = "c", title = "new-c"),
+            Stream(channelId = "b", title = "new-b"),
+            Stream(channelId = "c", title = "new-c"),
         )
 
-        val items = refreshCachedItems("top:test", fresh)
+        val items = refreshCachedItems("top:test", fresh, generation = 2L)
 
         assertEquals(listOf("channel:b", "channel:c"), items.map { it.itemKey })
         assertEquals(listOf(0, 1), items.map { it.position })
         assertEquals("new-b", items.first().title)
         assertFalse(items.any { it.itemKey == "channel:a" })
-        assertTrue(old.any { it.channelId == "a" }) // the old snapshot is untouched until a successful commit
+        assertTrue(old.any { it.itemKey == "channel:a" })
     }
 
     @Test
-    fun appendPreservesExistingChannelPosition() {
+    fun successfulEmptyRefreshProducesAnEmptySnapshot() {
+        val items = refreshCachedItems("top:test", emptyList(), generation = 2L)
+
+        assertTrue(items.isEmpty())
+    }
+
+    @Test
+    fun appendPreservesExistingChannelPositionAndUpdatesPageItems() {
         val existing = refreshCachedItems(
             "top:test",
-            listOf(Stream(id = null, channelId = "a"), Stream(id = null, channelId = "b")),
+            listOf(Stream(channelId = "a"), Stream(channelId = "b")),
+            generation = 1L,
         )
         val appended = appendCachedPage(
             "top:test",
             existing,
-            listOf(Stream(id = null, channelId = "b", viewerCount = 4), Stream(id = null, channelId = "c")),
+            listOf(Stream(channelId = "b", viewerCount = 4), Stream(channelId = "c")),
+            generation = 1L,
         )
 
         assertEquals(listOf("channel:a", "channel:b", "channel:c"), appended.map { it.itemKey })
@@ -46,77 +59,32 @@ class StreamFeedSnapshotTest {
     }
 
     @Test
-    fun appendReindexesFreshPrefixAndStaleTailAfterOverlapAndChanges() {
+    fun appendOnlyExtendsTheCurrentRefreshGeneration() {
         val existing = refreshCachedItems(
             "top:test",
-            listOf(
-                Stream(channelId = "a"),
-                Stream(channelId = "b"),
-                Stream(channelId = "c"),
-                Stream(channelId = "d"),
-                Stream(channelId = "e"),
-                Stream(channelId = "f"),
-                Stream(channelId = "g"),
-                Stream(channelId = "h"),
-                Stream(channelId = "i"),
-            ),
+            listOf(Stream(channelId = "a"), Stream(channelId = "b")),
+            generation = 1L,
+        ) + refreshCachedItems(
+            "top:test",
+            listOf(Stream(channelId = "old-tail")),
+            generation = 0L,
+        )
+
+        val appended = appendCachedPage(
+            "top:test",
+            existing,
+            listOf(Stream(channelId = "c")),
             generation = 1L,
         )
-        val afterRefresh = refreshCachedItemsPreservingTail(
-            feedKey = "top:test",
-            existing = existing,
-            streams = listOf(Stream(channelId = "a"), Stream(channelId = "b"), Stream(channelId = "x")),
-            generation = 2L,
-        )
 
-        val afterAppend = appendCachedPage(
-            feedKey = "top:test",
-            existing = afterRefresh,
-            streams = listOf(Stream(channelId = "d"), Stream(channelId = "y"), Stream(channelId = "f")),
-            generation = 2L,
-        )
-
-        assertEquals(
-            listOf(
-                "channel:a", "channel:b", "channel:x",
-                "channel:d", "channel:y", "channel:f",
-                "channel:c", "channel:e", "channel:g", "channel:h", "channel:i",
-            ),
-            afterAppend.map { it.itemKey },
-        )
-        assertEquals(afterAppend.size, afterAppend.map { it.position }.distinct().size)
-        assertEquals(afterAppend.indices.toList(), afterAppend.map { it.position })
-        assertTrue(afterAppend.take(6).all { it.generation == 2L })
-        assertTrue(afterAppend.drop(6).all { it.generation == 1L })
+        assertEquals(listOf("channel:a", "channel:b", "channel:c"), appended.map { it.itemKey })
+        assertTrue(appended.all { it.generation == 1L })
     }
 
     @Test
     fun refreshingAnExistingChannelReplacesEveryCachedStreamField() {
-        val key = "top:v2"
-        val existing = refreshCachedItems(
-            feedKey = key,
-            streams = listOf(
-                Stream(
-                    id = "broadcast-1",
-                    channelId = "channel-42",
-                    channelLogin = "old-login",
-                    channelName = "Old name",
-                    channelImageURL = "old-avatar",
-                    gameId = "game-old",
-                    gameSlug = "old-game",
-                    gameName = "Old game",
-                    title = "Old title",
-                    thumbnailURL = "old-thumbnail",
-                    createdAt = "old-created",
-                    viewerCount = 10,
-                    tags = listOf("old-tag"),
-                ),
-            ),
-            generation = 1L,
-        )
-        val refreshed = refreshCachedItemsPreservingTail(
-            feedKey = key,
-            existing = existing,
+        val refreshed = refreshCachedItems(
+            feedKey = "top:v2",
             streams = listOf(
                 Stream(
                     id = "broadcast-2",
@@ -155,29 +123,20 @@ class StreamFeedSnapshotTest {
     }
 
     @Test
-    fun staleTailIsBoundToOnePreviouslyVerifiedGeneration() {
+    fun aNewRefreshGenerationCannotRetainThePreviousGeneration() {
         val first = refreshCachedItems(
-            "top:bounded-tail",
+            "top:test",
             listOf(Stream(channelId = "old")),
             generation = 1L,
         )
-        val second = refreshCachedItemsPreservingTail(
-            "top:bounded-tail",
-            first,
-            listOf(Stream(channelId = "middle")),
+        val second = refreshCachedItems(
+            "top:test",
+            listOf(Stream(channelId = "new")),
             generation = 2L,
         )
-        val third = refreshCachedItemsPreservingTail(
-            "top:bounded-tail",
-            second,
-            listOf(Stream(channelId = "new")),
-            generation = 3L,
-        )
 
-        assertEquals(
-            listOf("channel:new", "channel:middle"),
-            third.map { it.itemKey },
-        )
-        assertTrue(third.all { it.generation >= 2L })
+        assertEquals(listOf("channel:new"), second.map { it.itemKey })
+        assertTrue(first.any { it.itemKey == "channel:old" })
+        assertTrue(second.all { it.generation == 2L })
     }
 }

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/ChatRenderConfigurationTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/ChatRenderConfigurationTest.kt
@@ -1,0 +1,50 @@
+package com.github.andreyasadchy.xtra.ui.chat
+
+import com.github.andreyasadchy.xtra.util.chat.ChatAdapterUtils
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ChatRenderConfigurationTest {
+
+    private val catalogA = ChatAdapterUtils.ChatCatalogIndexes.create(
+        emptyList(), emptyList(), emptyList(), emptyList(), emptyList(), emptyList(), emptyList(), emptyMap(), emptyList(),
+    )
+    private val catalogB = ChatAdapterUtils.ChatCatalogIndexes.create(
+        emptyList(), emptyList(), emptyList(), emptyList(), emptyList(), emptyList(), emptyList(), emptyMap(), emptyList(),
+    )
+
+    @Test
+    fun pendingCatalogIsPreservedWhenTranslationChanges() {
+        val active = ChatRenderConfiguration(0, catalogA, false)
+        val pendingCatalog = composeChatRenderConfiguration(active, null, 1, indexes = catalogB)
+
+        val pendingBoth = composeChatRenderConfiguration(active, pendingCatalog, 2, translateAllMessages = true)
+
+        assertSame(catalogB, pendingBoth.indexes)
+        assertTrue(pendingBoth.translateAllMessages)
+    }
+
+    @Test
+    fun pendingTranslationIsPreservedWhenCatalogChanges() {
+        val active = ChatRenderConfiguration(0, catalogA, false)
+        val pendingTranslation = composeChatRenderConfiguration(active, null, 1, translateAllMessages = true)
+
+        val pendingBoth = composeChatRenderConfiguration(active, pendingTranslation, 2, indexes = catalogB)
+
+        assertSame(catalogB, pendingBoth.indexes)
+        assertTrue(pendingBoth.translateAllMessages)
+    }
+
+    @Test
+    fun revertingPendingTranslationUsesTheDesiredStateAsTheBase() {
+        val active = ChatRenderConfiguration(0, catalogA, false)
+        val pendingTranslation = composeChatRenderConfiguration(active, null, 1, translateAllMessages = true)
+
+        val reverted = composeChatRenderConfiguration(active, pendingTranslation, 2, translateAllMessages = false)
+
+        assertSame(catalogA, reverted.indexes)
+        assertFalse(reverted.translateAllMessages)
+    }
+}

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/ChatRenderConfigurationTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/ChatRenderConfigurationTest.kt
@@ -27,6 +27,17 @@ class ChatRenderConfigurationTest {
     }
 
     @Test
+    fun pendingBroadCatalogChangeSurvivesTargetedUserInvalidation() {
+        val active = ChatRenderConfiguration(0, catalogA, false)
+        val pendingCatalog = composeChatRenderConfiguration(active, null, 1, indexes = catalogB)
+
+        val afterUserInvalidation = composeChatRenderConfiguration(active, pendingCatalog, 2)
+
+        assertSame(catalogB, afterUserInvalidation.indexes)
+        assertFalse(afterUserInvalidation.translateAllMessages)
+    }
+
+    @Test
     fun pendingTranslationIsPreservedWhenCatalogChanges() {
         val active = ChatRenderConfiguration(0, catalogA, false)
         val pendingTranslation = composeChatRenderConfiguration(active, null, 1, translateAllMessages = true)

--- a/app/src/test/java/com/github/andreyasadchy/xtra/util/chat/ChatImageSizingTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/util/chat/ChatImageSizingTest.kt
@@ -1,6 +1,7 @@
 package com.github.andreyasadchy.xtra.util.chat
 
 import com.github.andreyasadchy.xtra.model.chat.ImageKind
+import com.github.andreyasadchy.xtra.model.chat.Image
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
@@ -11,5 +12,27 @@ class ChatImageSizingTest {
         assertEquals(30, imageSizeForKind(ImageKind.EMOTE, emoteSize = 30, badgeSize = 40, inlineIconSize = 18))
         assertEquals(40, imageSizeForKind(ImageKind.BADGE, emoteSize = 30, badgeSize = 40, inlineIconSize = 18))
         assertEquals(18, imageSizeForKind(ImageKind.INLINE_ICON, emoteSize = 30, badgeSize = 40, inlineIconSize = 18))
+    }
+
+    @Test
+    fun `known emote aspect ratio is reserved before decoding`() {
+        val image = Image(
+            sourceWidth = 200,
+            sourceHeight = 100,
+            kind = ImageKind.EMOTE,
+            start = 0,
+            end = 1,
+        )
+
+        assertEquals(64, imageGeometry(image, 32).widthPx)
+        assertEquals(32, imageGeometry(image, 32).heightPx)
+    }
+
+    @Test
+    fun `unknown image dimensions use deterministic square fallback`() {
+        val image = Image(kind = ImageKind.EMOTE, start = 0, end = 1)
+
+        assertEquals(32, imageGeometry(image, 32).widthPx)
+        assertEquals(32, imageGeometry(image, 32).heightPx)
     }
 }

--- a/app/src/test/java/com/github/andreyasadchy/xtra/util/updater/UpdateRepositoryTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/util/updater/UpdateRepositoryTest.kt
@@ -156,9 +156,11 @@ class UpdateRepositoryTest {
             size = 10L,
         )
         val release = UpdateRelease(
-            tagName = "v2.58.6",
+            tagName = "v2.58.6-build.999",
             versionName = "2.58.6",
-            buildNumber = null,
+            // Recovery clears candidates that are not newer than the installed build. Keep this
+            // fixture newer on both local and CI version-code configurations.
+            buildNumber = 999L,
             title = "Xtra 2.58.6",
             releaseNotes = emptyList(),
             rawBody = "",
@@ -175,6 +177,7 @@ class UpdateRepositoryTest {
             artifactSha256 = mapOf(arm64Asset.name to arm64Sha),
         )
         val repository = UpdateRepository(TestContext(preferences), QueueReleaseSource(emptyList()), null)
+        runBlocking { repository.awaitReady() }
         val replace = UpdateRepository::class.java.getDeclaredMethod(
             "replacePersistedRelease",
             UpdateRelease::class.java,
@@ -185,6 +188,7 @@ class UpdateRepositoryTest {
         assertEquals(arm64Sha, preferences.getString(C.UPDATE_AVAILABLE_EXPECTED_SHA256, null))
 
         val recovered = UpdateRepository(TestContext(preferences), QueueReleaseSource(emptyList()), null)
+        runBlocking { recovered.awaitReady() }
         val load = UpdateRepository::class.java.getDeclaredMethod("loadPersistedRelease").apply { isAccessible = true }
         val recoveredRelease = load.invoke(recovered) as UpdateRelease
         assertEquals(arm64Sha, recoveredRelease.expectedSha256)


### PR DESCRIPTION
Replace live-feed cache snapshots on successful refreshes and stabilize chat rows while media loads. Preserve cached data on failures and keep chat scrolling anchored during bursts.