### PR TITLE
Automate master build releases

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -3,7 +3,6 @@ name: Build
 on:
   push:
     branches: [ master ]
-    tags: [ 'v*' ]
   pull_request:
     branches: [ master ]
   workflow_dispatch:
@@ -101,51 +100,27 @@ jobs:
         {
           echo "name=$version"
           echo "code=$version_code"
+          echo "build=$GITHUB_RUN_NUMBER"
         } >> "$GITHUB_OUTPUT"
     - name: Write release metadata
       env:
         VERSION_NAME: ${{ steps.version.outputs.name }}
         VERSION_CODE: ${{ steps.version.outputs.code }}
+        BUILD_NUMBER: ${{ steps.version.outputs.build }}
       shell: bash
       run: |
         set -euo pipefail
-        printf '{"versionName":"%s","versionCode":%s}\n' "$VERSION_NAME" "$VERSION_CODE" > xtra-release-metadata.json
+        jq -n \
+          --arg version_name "$VERSION_NAME" \
+          --argjson version_code "$VERSION_CODE" \
+          --argjson build_number "$BUILD_NUMBER" \
+          '{versionName: $version_name, versionCode: $version_code, buildNumber: $build_number}' \
+          > xtra-release-metadata.json
     - name: Run JVM tests
       run: ./gradlew testDebugUnitTest
 
     - name: Check resource localization hygiene
       run: python3 .github/scripts/check-resources.py
-
-    - name: Validate release tag
-      if: github.event_name == 'push' && github.ref_type == 'tag'
-      env:
-        VERSION_NAME: ${{ steps.version.outputs.name }}
-      shell: bash
-      run: |
-        set -euo pipefail
-        tag="$GITHUB_REF_NAME"
-        if [[ ! "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-          echo "Invalid release tag '$tag'. Expected vX.Y.Z, for example v2.58.6." >&2
-          exit 1
-        fi
-
-        tag_version="${tag#v}"
-        if [[ "$tag_version" != "$VERSION_NAME" ]]; then
-          echo "Release tag $tag does not match Gradle applicationVersionName $VERSION_NAME" >&2
-          exit 1
-        fi
-
-        tag_commit="$(git rev-parse --verify "refs/tags/${tag}^{commit}" 2>/dev/null || true)"
-        if [[ "$tag_commit" != "$GITHUB_SHA" ]]; then
-          echo "Release tag $tag resolves to ${tag_commit:-<missing>}, expected $GITHUB_SHA" >&2
-          exit 1
-        fi
-
-        git fetch --no-tags origin refs/heads/master:refs/remotes/origin/master
-        if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/master; then
-          echo "Release tag $tag points to a commit that is not reachable from origin/master" >&2
-          exit 1
-        fi
 
     - name: Build with Gradle
       id: build
@@ -387,194 +362,15 @@ jobs:
         retention-days: 7
 
     - name: Upload release package
-      if: success() && github.event_name == 'push' && github.ref_type == 'tag'
+      if: >-
+        success() &&
+        steps.build.outcome == 'success' &&
+        steps.verify-release-apk.outcome == 'success' &&
+        ((github.event_name == 'push' && github.ref == 'refs/heads/master') ||
+         (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/master'))
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
-        name: xtra-release-package
+        name: xtra-master-release-package
         path: release-package
         if-no-files-found: error
-        retention-days: 7
-
-  publish-release:
-    if: github.event_name == 'push' && github.ref_type == 'tag'
-    needs: [ build, clip-instrumentation ]
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-    - name: Download release package
-      uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
-      with:
-        name: xtra-release-package
-        path: release-package
-    - name: Publish GitHub Release
-      env:
-        GH_TOKEN: ${{ github.token }}
-        GH_REPO: ${{ github.repository }}
-        VERSION_NAME: ${{ needs.build.outputs.version_name }}
-        VERSION_CODE: ${{ needs.build.outputs.version_code }}
-      shell: bash
-      run: |
-        set -euo pipefail
-        tag="$GITHUB_REF_NAME"
-        tag_version="${tag#v}"
-        declare -A local_assets=(
-          [app-release.apk]=release-package/app-release.apk
-          [app-arm64-v8a-release.apk]=release-package/app-arm64-v8a-release.apk
-          [app-armeabi-v7a-release.apk]=release-package/app-armeabi-v7a-release.apk
-          [app-x86-release.apk]=release-package/app-x86-release.apk
-          [app-x86_64-release.apk]=release-package/app-x86_64-release.apk
-          [xtra-release-metadata.json]=release-package/xtra-release-metadata.json
-        )
-        required_asset_names=(
-          app-release.apk
-          app-arm64-v8a-release.apk
-          app-armeabi-v7a-release.apk
-          app-x86-release.apk
-          app-x86_64-release.apk
-          xtra-release-metadata.json
-        )
-        expected_asset_names_json="$(printf '%s\n' "${required_asset_names[@]}" | jq -Rsc 'split("\n")[:-1]')"
-        for asset_name in "${required_asset_names[@]}"; do
-          if [[ ! -f "${local_assets[$asset_name]}" ]]; then
-            echo "Release package is missing $asset_name" >&2
-            exit 1
-          fi
-        done
-        metadata_asset="${local_assets[xtra-release-metadata.json]}"
-        if [[ "$tag_version" != "$VERSION_NAME" ]]; then
-          echo "Release tag $tag does not match build versionName $VERSION_NAME" >&2
-          exit 1
-        fi
-        metadata_version_name="$(jq -er '.versionName | strings' "$metadata_asset")"
-        metadata_version_code="$(jq -er '.versionCode | numbers | tostring' "$metadata_asset")"
-        if [[ "$metadata_version_name" != "$tag_version" || "$metadata_version_code" != "$VERSION_CODE" ]]; then
-          echo "Release metadata does not match the pushed tag and build outputs" >&2
-          exit 1
-        fi
-
-        title="Xtra ${tag_version}"
-        release_api="repos/${GITHUB_REPOSITORY}/releases/tags/${tag}"
-        if gh release view "$tag" --json tagName >/dev/null 2>&1; then
-          echo "Release $tag already exists; verifying and recovering it"
-        else
-          gh release create "$tag" \
-            --draft \
-            --latest=false \
-            --verify-tag \
-            --title "$title" \
-            --generate-notes
-        fi
-
-        release_json="$(gh api "$release_api")"
-        if ! jq -e \
-          --arg tag "$tag" \
-          --arg title "$title" \
-          '(.tag_name == $tag) and (.name == $title) and (.draft | type == "boolean") and (.prerelease == false)' \
-          <<< "$release_json" >/dev/null; then
-          echo "Release $tag does not match the expected tag/title or is prerelease" >&2
-          exit 1
-        fi
-
-        asset_count() {
-          jq -r --arg name "$1" '[.assets[] | select(.name == $name)] | length' <<< "$release_json"
-        }
-
-        refresh_release() {
-          release_json="$(gh api "$release_api")"
-        }
-
-        download_asset() {
-          local name="$1"
-          local output_path="$2"
-          local asset_id
-          asset_id="$(jq -er --arg name "$name" '[.assets[] | select(.name == $name)][0].id' <<< "$release_json")"
-          gh api \
-            -H "Accept: application/octet-stream" \
-            "repos/${GITHUB_REPOSITORY}/releases/assets/${asset_id}" \
-            > "$output_path"
-        }
-
-        verify_asset() {
-          local name="$1"
-          local local_asset="${local_assets[$name]}"
-          local count
-          local verification_dir
-          count="$(asset_count "$name")"
-          if [[ "$count" != 1 ]]; then
-            echo "Release $tag does not contain exactly one $name asset" >&2
-            exit 1
-          fi
-          verification_dir="$(mktemp -d)"
-          if [[ "$name" == *.apk ]]; then
-            local local_digest
-            local remote_digest
-            local_digest="$(sha256sum "$local_asset" | awk '{print $1}')"
-            remote_digest="$(jq -r --arg name "$name" '[.assets[] | select(.name == $name)][0].digest // ""' <<< "$release_json")"
-            if [[ "$remote_digest" != "sha256:${local_digest}" ]]; then
-              if ! download_asset "$name" "$verification_dir/$name" ||
-                [[ "$(sha256sum "$verification_dir/$name" | awk '{print $1}')" != "$local_digest" ]]; then
-                echo "Release $tag APK $name does not match the build artifact" >&2
-                rm -rf "$verification_dir"
-                exit 1
-              fi
-            fi
-          elif ! download_asset "$name" "$verification_dir/$name" ||
-            ! cmp -s "$local_asset" "$verification_dir/$name"; then
-            echo "Release $tag metadata does not match the build artifact" >&2
-            rm -rf "$verification_dir"
-            exit 1
-          fi
-          rm -rf "$verification_dir"
-        }
-
-        declare -A missing_assets=()
-        for asset_name in "${required_asset_names[@]}"; do
-          count="$(asset_count "$asset_name")"
-          if [[ "$count" == 0 ]]; then
-            missing_assets["$asset_name"]="1"
-          elif [[ "$count" != 1 ]]; then
-            echo "Release $tag contains multiple assets named $asset_name" >&2
-            exit 1
-          else
-            verify_asset "$asset_name"
-          fi
-        done
-        for asset_name in "${required_asset_names[@]}"; do
-          if [[ "${missing_assets[$asset_name]:-}" == 1 ]]; then
-            echo "Uploading missing release asset $asset_name"
-            gh release upload "$tag" "${local_assets[$asset_name]}"
-          fi
-        done
-        refresh_release
-        if ! jq -e \
-          --arg tag "$tag" \
-          --arg title "$title" \
-          --argjson expected_asset_names "$expected_asset_names_json" \
-          '(.tag_name == $tag) and (.name == $title) and (.draft | type == "boolean") and (.prerelease == false) and
-           (([.assets[].name] | sort) == ($expected_asset_names | sort))' \
-          <<< "$release_json" >/dev/null; then
-          echo "Release $tag failed pre-publication asset verification" >&2
-          exit 1
-        fi
-        for asset_name in "${required_asset_names[@]}"; do
-          verify_asset "$asset_name"
-        done
-
-        echo "Publishing verified draft release $tag"
-        gh release edit "$tag" --draft=false --latest
-        refresh_release
-        if ! jq -e \
-          --arg tag "$tag" \
-          --arg title "$title" \
-          --argjson expected_asset_names "$expected_asset_names_json" \
-          '(.tag_name == $tag) and (.name == $title) and (.draft == false) and (.prerelease == false) and
-           (([.assets[].name] | sort) == ($expected_asset_names | sort))' \
-          <<< "$release_json" >/dev/null; then
-          echo "Release $tag failed final asset/state verification" >&2
-          exit 1
-        fi
-        for asset_name in "${required_asset_names[@]}"; do
-          verify_asset "$asset_name"
-        done
-        echo "Verified stable release $tag with matching APKs and metadata"
+        retention-days: 14

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,281 @@
+name: Publish build release
+
+on:
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: Successful Build workflow run ID from master
+        required: true
+        type: string
+      channel:
+        description: Publish as a prerelease for direct downloads or stable for in-app updates
+        required: true
+        default: prerelease
+        type: choice
+        options:
+          - prerelease
+          - stable
+
+concurrency:
+  group: publish-build-release
+  cancel-in-progress: false
+
+permissions:
+  actions: read
+  contents: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    env:
+      GH_REPO: ${{ github.repository }}
+      GH_TOKEN: ${{ github.token }}
+      SOURCE_RUN_ID: ${{ inputs.run_id }}
+      CHANNEL: ${{ inputs.channel }}
+    steps:
+    - name: Validate source build
+      shell: bash
+      run: |
+        set -euo pipefail
+        if [[ ! "$SOURCE_RUN_ID" =~ ^[1-9][0-9]*$ ]]; then
+          echo "run_id must be a positive GitHub Actions run ID" >&2
+          exit 1
+        fi
+
+        run_json="$(gh api "repos/${GH_REPO}/actions/runs/${SOURCE_RUN_ID}")"
+        workflow_path="$(jq -er '.path' <<< "$run_json")"
+        event="$(jq -er '.event' <<< "$run_json")"
+        branch="$(jq -er '.head_branch' <<< "$run_json")"
+        status="$(jq -er '.status' <<< "$run_json")"
+        conclusion="$(jq -er '.conclusion' <<< "$run_json")"
+        source_sha="$(jq -er '.head_sha' <<< "$run_json")"
+        build_run_number="$(jq -er '.run_number' <<< "$run_json")"
+
+        if [[ "$workflow_path" != ".github/workflows/android.yml" ||
+              "$event" != "push" ||
+              "$branch" != "master" ||
+              "$status" != "completed" ||
+              "$conclusion" != "success" ]]; then
+          echo "The selected run must be a successful Build workflow run from a master push" >&2
+          exit 1
+        fi
+
+        current_master_sha="$(gh api "repos/${GH_REPO}/git/ref/heads/master" --jq '.object.sha')"
+        ancestry_status="$(gh api "repos/${GH_REPO}/compare/${current_master_sha}...${source_sha}" --jq '.status')"
+        if [[ "$ancestry_status" != "behind" && "$ancestry_status" != "identical" ]]; then
+          echo "The selected build commit is no longer reachable from current master" >&2
+          exit 1
+        fi
+
+        {
+          echo "SOURCE_SHA=$source_sha"
+          echo "BUILD_RUN_NUMBER=$build_run_number"
+        } >> "$GITHUB_ENV"
+
+    - name: Download master build package
+      uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
+      with:
+        name: xtra-master-release-package
+        path: release-package
+        github-token: ${{ github.token }}
+        repository: ${{ github.repository }}
+        run-id: ${{ inputs.run_id }}
+
+    - name: Validate build package
+      shell: bash
+      run: |
+        set -euo pipefail
+        required_assets=(
+          app-release.apk
+          app-arm64-v8a-release.apk
+          app-armeabi-v7a-release.apk
+          app-x86-release.apk
+          app-x86_64-release.apk
+          xtra-release-metadata.json
+        )
+        for asset_name in "${required_assets[@]}"; do
+          if [[ ! -f "release-package/$asset_name" ]]; then
+            echo "Build package is missing $asset_name" >&2
+            exit 1
+          fi
+        done
+
+        metadata="release-package/xtra-release-metadata.json"
+        version_name="$(jq -er '.versionName | strings' "$metadata")"
+        version_code="$(jq -er '.versionCode | numbers | tostring' "$metadata")"
+        metadata_build_number="$(jq -er '.buildNumber | numbers | tostring' "$metadata")"
+        if [[ ! "$version_name" =~ ^[0-9]+(\.[0-9]+)*$ ]]; then
+          echo "Build metadata contains an invalid versionName: $version_name" >&2
+          exit 1
+        fi
+        if [[ "$metadata_build_number" != "$BUILD_RUN_NUMBER" ]]; then
+          echo "Build metadata run number does not match the selected Actions run" >&2
+          exit 1
+        fi
+        if [[ ! "$version_code" =~ ^[1-9][0-9]*$ ]]; then
+          echo "Build metadata contains an invalid versionCode: $version_code" >&2
+          exit 1
+        fi
+
+        tag="v${version_name}-build.${BUILD_RUN_NUMBER}"
+        {
+          echo "VERSION_NAME=$version_name"
+          echo "VERSION_CODE=$version_code"
+          echo "RELEASE_TAG=$tag"
+        } >> "$GITHUB_ENV"
+
+    - name: Create or verify immutable build tag
+      shell: bash
+      run: |
+        set -euo pipefail
+        tag_ref="repos/${GH_REPO}/git/ref/tags/${RELEASE_TAG}"
+        if tag_json="$(gh api "$tag_ref" 2>/dev/null)"; then
+          tag_sha="$(jq -er '.object.sha' <<< "$tag_json")"
+          if [[ "$tag_sha" != "$SOURCE_SHA" ]]; then
+            echo "Existing tag $RELEASE_TAG points to $tag_sha, expected $SOURCE_SHA" >&2
+            exit 1
+          fi
+          echo "Tag $RELEASE_TAG already points to the selected source commit"
+        else
+          gh api --method POST "repos/${GH_REPO}/git/refs" \
+            -f "ref=refs/tags/${RELEASE_TAG}" \
+            -f "sha=${SOURCE_SHA}" >/dev/null
+          echo "Created tag $RELEASE_TAG at $SOURCE_SHA"
+        fi
+
+    - name: Create or recover draft release
+      shell: bash
+      run: |
+        set -euo pipefail
+        title="Xtra ${VERSION_NAME} (build ${BUILD_RUN_NUMBER})"
+        release_api="repos/${GH_REPO}/releases/tags/${RELEASE_TAG}"
+        if gh api "$release_api" >/dev/null 2>&1; then
+          echo "Release $RELEASE_TAG already exists; continuing its publication"
+        else
+          gh release create "$RELEASE_TAG" \
+            --draft \
+            --latest=false \
+            --verify-tag \
+            --title "$title" \
+            --generate-notes
+        fi
+
+        release_json="$(gh api "$release_api")"
+        release_tag="$(jq -er '.tag_name' <<< "$release_json")"
+        release_title="$(jq -er '.name' <<< "$release_json")"
+        release_draft="$(jq -er '.draft' <<< "$release_json")"
+        release_prerelease="$(jq -er '.prerelease' <<< "$release_json")"
+        expected_prerelease=false
+        [[ "$CHANNEL" == "prerelease" ]] && expected_prerelease=true
+        if [[ "$release_tag" != "$RELEASE_TAG" || "$release_title" != "$title" ]]; then
+          echo "Existing release identity does not match the selected build" >&2
+          exit 1
+        fi
+        if [[ "$release_draft" == false &&
+              "$release_prerelease" != "$expected_prerelease" ]]; then
+          echo "Existing published release has a different channel: $RELEASE_TAG" >&2
+          exit 1
+        fi
+
+    - name: Upload and verify release assets
+      shell: bash
+      run: |
+        set -euo pipefail
+        required_assets=(
+          app-release.apk
+          app-arm64-v8a-release.apk
+          app-armeabi-v7a-release.apk
+          app-x86-release.apk
+          app-x86_64-release.apk
+          xtra-release-metadata.json
+        )
+        release_api="repos/${GH_REPO}/releases/tags/${RELEASE_TAG}"
+        release_json="$(gh api "$release_api")"
+        asset_count() {
+          jq -r --arg name "$1" '[.assets[] | select(.name == $name)] | length' <<< "$release_json"
+        }
+
+        for asset_name in "${required_assets[@]}"; do
+          count="$(asset_count "$asset_name")"
+          if [[ "$count" == 0 ]]; then
+            echo "Uploading $asset_name"
+            gh release upload "$RELEASE_TAG" "release-package/$asset_name"
+          elif [[ "$count" != 1 ]]; then
+            echo "Release contains multiple assets named $asset_name" >&2
+            exit 1
+          fi
+        done
+
+        release_json="$(gh api "$release_api")"
+        expected_assets_json="$(printf '%s\n' "${required_assets[@]}" | jq -Rsc 'split("\n")[:-1] | sort')"
+        if ! jq -e \
+          --argjson expected "$expected_assets_json" \
+          '([.assets[].name] | sort) == $expected' \
+          <<< "$release_json" >/dev/null; then
+          echo "Release contains assets outside the selected build package" >&2
+          exit 1
+        fi
+        verification_dir="$(mktemp -d)"
+        trap 'rm -rf -- "$verification_dir"' EXIT
+        for asset_name in "${required_assets[@]}"; do
+          asset_id="$(jq -er --arg name "$asset_name" '[.assets[] | select(.name == $name)][0].id' <<< "$release_json")"
+          gh api -H "Accept: application/octet-stream" \
+            "repos/${GH_REPO}/releases/assets/${asset_id}" > "$verification_dir/$asset_name"
+          if ! cmp -s "release-package/$asset_name" "$verification_dir/$asset_name"; then
+            echo "Published asset does not match the selected build: $asset_name" >&2
+            exit 1
+          fi
+        done
+
+    - name: Publish verified release
+      shell: bash
+      run: |
+        set -euo pipefail
+        if [[ "$CHANNEL" == "stable" ]]; then
+          latest_release="$(gh api "repos/${GH_REPO}/releases/latest" 2>/dev/null || true)"
+          if [[ -n "$latest_release" ]]; then
+            latest_tag="$(jq -er '.tag_name' <<< "$latest_release")"
+            latest_metadata_id="$(jq -er '[.assets[] | select(.name == "xtra-release-metadata.json")][0].id' <<< "$latest_release")"
+            latest_metadata="$(mktemp)"
+            trap 'rm -f -- "$latest_metadata"' EXIT
+            gh api -H "Accept: application/octet-stream" \
+              "repos/${GH_REPO}/releases/assets/${latest_metadata_id}" > "$latest_metadata"
+            latest_version_code="$(jq -er '.versionCode | numbers' "$latest_metadata")"
+            if (( latest_version_code > VERSION_CODE )); then
+              echo "Refusing to publish an older build as latest: $VERSION_CODE < $latest_version_code" >&2
+              exit 1
+            fi
+            if (( latest_version_code == VERSION_CODE )) && [[ "$latest_tag" != "$RELEASE_TAG" ]]; then
+              echo "A different stable release already has versionCode $VERSION_CODE" >&2
+              exit 1
+            fi
+          fi
+        fi
+        if [[ "$CHANNEL" == "prerelease" ]]; then
+          release_json="$(gh api "repos/${GH_REPO}/releases/tags/${RELEASE_TAG}")"
+          release_id="$(jq -er '.id' <<< "$release_json")"
+          gh api --method PATCH "repos/${GH_REPO}/releases/${release_id}" \
+            -F draft=false \
+            -F prerelease=true \
+            -f make_latest=false >/dev/null
+        else
+          release_json="$(gh api "repos/${GH_REPO}/releases/tags/${RELEASE_TAG}")"
+          release_id="$(jq -er '.id' <<< "$release_json")"
+          gh api --method PATCH "repos/${GH_REPO}/releases/${release_id}" \
+            -F draft=false \
+            -F prerelease=false \
+            -f make_latest=true >/dev/null
+        fi
+
+        release_json="$(gh api "repos/${GH_REPO}/releases/tags/${RELEASE_TAG}")"
+        expected_prerelease=false
+        [[ "$CHANNEL" == "prerelease" ]] && expected_prerelease=true
+        if ! jq -e \
+          --arg tag "$RELEASE_TAG" \
+          --argjson prerelease "$expected_prerelease" \
+          '(.tag_name == $tag) and (.draft == false) and (.prerelease == $prerelease)' \
+          <<< "$release_json" >/dev/null; then
+          echo "Release did not reach the requested published state" >&2
+          exit 1
+        fi
+        echo "Published $RELEASE_TAG as $CHANNEL"

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,19 +1,8 @@
 # Releasing Xtra
 
-1. Change `applicationVersionName` in `app/build.gradle.kts`, for example from `2.58.5` to `2.58.6`.
-2. Merge that change to `master` and make sure CI passes.
-3. Tag that exact `master` commit and push the tag:
+Every push to `master`, including a merge, runs the Build workflow. The workflow keeps the product version from `applicationVersionName` and assigns a unique Android build number from the GitHub Actions run number. It uploads the verified release APK package as the `xtra-master-release-package` Actions artifact for 14 days.
 
-   ```bash
-   git tag v2.58.6
-   git push origin v2.58.6
-   ```
-
-The existing Build workflow validates that `v2.58.6` matches `applicationVersionName` and publishes the stable release as `Xtra 2.58.6`. It also checks that the tagged commit is reachable from `master`.
-
-The first semantic release must advance beyond the last build-tag release. Since existing releases use versionName `2.58.5`, the bridge release is `2.58.6`; do not create a first semantic tag named `v2.58.5`.
-
-Each stable release contains these APKs and metadata:
+The generated package contains:
 
 ```text
 app-release.apk                  universal compatibility APK
@@ -24,6 +13,17 @@ app-x86_64-release.apk           x86 64-bit
 xtra-release-metadata.json
 ```
 
-`app-release.apk` is intentionally retained so old Xtra installations can continue updating even if they skipped the first ABI-aware version. New versions prefer the ABI-specific APK that matches the device, which reduces download size, and fall back to the universal APK when needed.
+To publish one of those builds for users:
 
-CI builds from `master`, pull requests, and manual runs are Actions artifacts, not GitHub Releases. CI generates the Android `versionCode` from the workflow's run number. That internal build number is separate from the product SemVer and should not be included in release tags.
+1. Open the `Publish build release` workflow in GitHub Actions.
+2. Enter the successful `Build` workflow run ID from a push to `master`.
+3. Select `prerelease` for a direct-download build or `stable` for a build that the in-app updater may offer.
+4. Start the workflow.
+
+The publish workflow downloads the exact package from that run. It creates the matching immutable tag `v<version>-build.<run-number>` at the original `master` commit, validates every APK and metadata file, and publishes the GitHub Release. It never rebuilds the selected source.
+
+Prereleases remain available on GitHub for manual downloads but are ignored by the app updater. Stable build releases are available through the normal update flow. The updater understands build tags and compares their build numbers, so several builds can share the same product version while still upgrading in order.
+
+Change `applicationVersionName` in `app/build.gradle.kts` only when intentionally starting a new product version. Do not commit an automatic version bump for every build. The CI build number is derived from the workflow run and is recorded in the APK versionCode and release metadata.
+
+`app-release.apk` is retained for older Xtra installations that skipped the first ABI-aware version. New versions prefer the ABI-specific APK for the device and fall back to the universal APK when needed.


### PR DESCRIPTION
## What this does

Every merge to `master` builds a uniquely numbered APK package and keeps it available as an Actions artifact for 14 days.

A separate manual workflow can publish a selected successful master build. It creates the matching build tag and GitHub Release, with a choice between:

- a prerelease for people who want to download it directly
- a stable release that the in-app updater can offer

The published release uses the exact APKs from the selected build. It does not rebuild them.

## Why

Version bumps happen at build time, not as commits pushed back to `master`. This avoids release commits and keeps the APK, tag, version code, and source commit tied together.

The existing updater already understands build tags and compares build numbers, so several builds can share the same product version while still updating in order.

## Release safety

Stable promotions are serialized and cannot move `latest` to an older build. The workflow also verifies that the selected commit is still in current `master`, rejects extra release assets, and byte-checks every published asset.

## Verification

- `actionlint` passes for both workflows.
- Gradle version metadata was checked locally.