### PR TITLE
Make live stream uptime badges tick locally

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/StreamCardPresentation.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/StreamCardPresentation.kt
@@ -10,8 +10,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import kotlin.time.Clock
-import kotlin.time.Instant
 
 /** Immutable, bind-ready values for a stream card. No Android views or drawables are retained. */
 internal data class StreamCardPresentation(
@@ -21,7 +19,6 @@ internal data class StreamCardPresentation(
     val title: String?,
     val gameName: String?,
     val viewerLabel: String?,
-    val uptime: String?,
     val tags: List<String>,
 )
 
@@ -33,10 +30,8 @@ internal data class StreamCardPresentationKey(
     val title: String?,
     val gameName: String?,
     val viewerCount: Int?,
-    val createdAt: String?,
     val tags: List<String>?,
     val preferences: FeedUiPreferences,
-    val uptimeMinute: Long,
 )
 
 internal object FeedPresentationDispatcher {
@@ -48,7 +43,7 @@ internal object FeedPresentationDispatcher {
 /**
  * Prepares stream-card text away from the UI thread and shares the result
  * between all stream feed adapters. The key includes every mutable display
- * input, so viewer and uptime changes cannot reuse stale text.
+ * input used by the cached presentation.
  */
 internal object StreamCardPresentationCache {
     private const val MAX_ENTRIES = 512
@@ -58,7 +53,7 @@ internal object StreamCardPresentationCache {
     private val cache = object : LruCache<StreamCardPresentationKey, StreamCardPresentation>(MAX_ENTRIES) {}
     private val pending = HashMap<StreamCardPresentationKey, MutableList<(StreamCardPresentation) -> Unit>>()
 
-    fun key(stream: Stream, preferences: FeedUiPreferences, nowMs: Long = System.currentTimeMillis()): StreamCardPresentationKey =
+    fun key(stream: Stream, preferences: FeedUiPreferences): StreamCardPresentationKey =
         StreamCardPresentationKey(
             streamIdentity = stream.streamIdentity(),
             channelId = stream.channelId,
@@ -67,10 +62,8 @@ internal object StreamCardPresentationCache {
             title = stream.title,
             gameName = stream.gameName?.trim(),
             viewerCount = stream.viewerCount,
-            createdAt = stream.createdAt,
             tags = stream.tags,
             preferences = preferences,
-            uptimeMinute = nowMs / 60_000L,
         )
 
     fun get(stream: Stream, preferences: FeedUiPreferences): StreamCardPresentation? =
@@ -133,20 +126,6 @@ internal object StreamCardPresentationCache {
                 TwitchApiHelper.formatCount(count, key.preferences.truncateViewCount),
             )
         }
-        val uptime = if (key.preferences.showUptime) {
-            stream.createdAt?.let { value ->
-                Instant.parseOrNull(value)?.takeIf { it.toEpochMilliseconds() > 0 }?.let { createdAt ->
-                    val elapsed = Clock.System.now() - createdAt
-                    if (elapsed.isPositive()) {
-                        android.text.format.DateUtils.formatElapsedTime(elapsed.inWholeSeconds)
-                    } else {
-                        null
-                    }
-                }
-            }
-        } else {
-            null
-        }
         val username = stream.channelName?.let { channelName ->
             if (stream.channelLogin != null && !stream.channelLogin.equals(channelName, true)) {
                 when (key.preferences.nameDisplay) {
@@ -175,7 +154,6 @@ internal object StreamCardPresentationCache {
             title = stream.title?.takeIf { it.isNotBlank() }?.trim(),
             gameName = stream.gameName,
             viewerLabel = viewerLabel,
-            uptime = uptime,
             tags = tags,
         )
     }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/StreamUptimeTicker.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/StreamUptimeTicker.kt
@@ -1,0 +1,67 @@
+package com.github.andreyasadchy.xtra.ui.common
+
+import android.text.format.DateUtils
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import androidx.recyclerview.widget.RecyclerView
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlin.time.Instant
+
+/**
+ * Implemented by stream ViewHolders that display a live uptime badge.
+ *
+ * A RecyclerView-level ticker calls this only for currently attached holders.
+ */
+internal interface StreamUptimeViewHolder {
+    fun updateUptime(nowMs: Long)
+}
+
+/** One ticker for one attached stream RecyclerView. */
+internal class VisibleStreamUptimeTicker(
+    private val fragment: Fragment,
+) {
+    private var job: Job? = null
+
+    fun attach(recyclerView: RecyclerView) {
+        detach()
+
+        job = fragment.viewLifecycleOwner.lifecycleScope.launch {
+            fragment.viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                while (isActive) {
+                    val nowMs = System.currentTimeMillis()
+                    for (index in 0 until recyclerView.childCount) {
+                        val child = recyclerView.getChildAt(index)
+                        val holder = recyclerView.getChildViewHolder(child)
+                        (holder as? StreamUptimeViewHolder)?.updateUptime(nowMs)
+                    }
+
+                    // Keep updates aligned to wall-clock second boundaries.
+                    val afterUpdateMs = System.currentTimeMillis()
+                    val delayMs = 1000L - (afterUpdateMs % 1000L)
+                    delay(delayMs.coerceIn(1L, 1000L))
+                }
+            }
+        }
+    }
+
+    fun detach() {
+        job?.cancel()
+        job = null
+    }
+}
+
+/** Parse the server timestamp once during a full holder bind. */
+internal fun parseStreamStartedAtMs(createdAt: String?): Long? {
+    val instant = createdAt?.let { Instant.parseOrNull(it) } ?: return null
+    return instant.toEpochMilliseconds().takeIf { it > 0L }
+}
+
+internal fun formatStreamUptime(startedAtMs: Long, nowMs: Long): String? {
+    if (nowMs <= startedAtMs) return null
+    return DateUtils.formatElapsedTime((nowMs - startedAtMs) / 1000L)
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/StreamsAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/StreamsAdapter.kt
@@ -41,12 +41,14 @@ class StreamsAdapter(
     }) {
 
     private val thumbnailLoadScheduler = StreamThumbnailIdleScheduler()
+    private val uptimeTicker = VisibleStreamUptimeTicker(fragment)
     private val presentationScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
     private var presentationPrewarmJob: Job? = null
 
     override fun onAttachedToRecyclerView(recyclerView: RecyclerView) {
         super.onAttachedToRecyclerView(recyclerView)
         thumbnailLoadScheduler.attachTo(recyclerView)
+        uptimeTicker.attach(recyclerView)
         presentationPrewarmJob?.cancel()
         presentationPrewarmJob = presentationScope.launch {
             onPagesUpdatedFlow.collectLatest {
@@ -65,6 +67,7 @@ class StreamsAdapter(
         presentationPrewarmJob?.cancel()
         presentationPrewarmJob = null
         thumbnailLoadScheduler.detach()
+        uptimeTicker.detach()
         super.onDetachedFromRecyclerView(recyclerView)
     }
 
@@ -101,13 +104,16 @@ class StreamsAdapter(
         private val fragment: Fragment,
         private val showGame: Boolean,
         private val tagViews: StreamTagViews,
-    ) : RecyclerView.ViewHolder(binding.root), FeedImageRequestOwner {
+    ) : RecyclerView.ViewHolder(binding.root), FeedImageRequestOwner, StreamUptimeViewHolder {
         val previewSurface get() = binding.previewHost
         var boundPreviewIdentity: String? = null
         private val imageRequests = FeedImageRequestBag()
         private var boundImageIdentity: String? = null
         private var boundThumbnailKey: String? = null
         private var boundStream: Stream? = null
+        private var uptimeStartedAtMs: Long? = null
+        private var uptimeEnabled = false
+        private var lastRenderedUptimeSecond = Long.MIN_VALUE
 
         init {
             binding.root.setOnClickListener { boundStream?.let(::openStream) }
@@ -141,6 +147,7 @@ class StreamsAdapter(
             cancelImageRequests()
             boundImageIdentity = null
             boundThumbnailKey = null
+            clearUptime()
         }
 
         fun bindThumbnail(item: Stream?) {
@@ -178,6 +185,10 @@ class StreamsAdapter(
                 if (item != null) {
                     val context = fragment.requireContext()
                     val uiPreferences = FeedUiPreferencesStore.current(context)
+                    uptimeEnabled = uiPreferences.showUptime
+                    uptimeStartedAtMs = if (uptimeEnabled) parseStreamStartedAtMs(item.createdAt) else null
+                    lastRenderedUptimeSecond = Long.MIN_VALUE
+                    updateUptime(System.currentTimeMillis())
                     val presentation = StreamCardPresentationCache.get(item, uiPreferences)
                     if (presentation == null) {
                         StreamCardPresentationCache.request(context, item, uiPreferences) {
@@ -243,17 +254,6 @@ class StreamsAdapter(
                     } else {
                         viewers.visibility = View.GONE
                     }
-                    if (presentation?.uptime != null || (uiPreferences.showUptime && item.createdAt != null)) {
-                        val text = presentation?.uptime
-                        if (text != null) {
-                            uptime.visibility = View.VISIBLE
-                            uptime.text = text
-                        } else {
-                            uptime.visibility = View.GONE
-                        }
-                    } else {
-                        uptime.visibility = View.GONE
-                    }
                     val tags = presentation?.tags ?: if (uiPreferences.showTags) item.tags.orEmpty() else emptyList()
                     if (tags.isNotEmpty()) {
                         bindStreamTags(tagViews, tags)
@@ -262,6 +262,7 @@ class StreamsAdapter(
                     }
                 } else {
                     boundStream = null
+                    clearUptime()
                     userImage.setImageDrawable(null)
                     userImage.tag = null
                     thumbnail.setImageDrawable(null)
@@ -270,8 +271,7 @@ class StreamsAdapter(
                     title.visibility = View.GONE
                     gameName.visibility = View.GONE
                     viewers.visibility = View.GONE
-                    uptime.visibility = View.GONE
-                        clearStreamTags(tagViews)
+                    clearStreamTags(tagViews)
                     tagsLayout.visibility = View.GONE
                     liveBadge.visibility = View.GONE
                 }
@@ -299,18 +299,36 @@ class StreamsAdapter(
                 } else {
                     viewers.visibility = View.GONE
                 }
-                if (presentation.uptime != null) {
-                    uptime.visibility = View.VISIBLE
-                    uptime.text = presentation.uptime
-                } else {
-                    uptime.visibility = View.GONE
-                }
                 if (presentation.tags.isNotEmpty()) {
                     bindStreamTags(tagViews, presentation.tags)
                 } else {
                     clearStreamTags(tagViews)
                 }
             }
+        }
+
+        override fun updateUptime(nowMs: Long) {
+            val startedAtMs = uptimeStartedAtMs
+            if (!uptimeEnabled || startedAtMs == null || nowMs <= startedAtMs) {
+                lastRenderedUptimeSecond = Long.MIN_VALUE
+                if (binding.uptime.visibility != View.GONE) binding.uptime.visibility = View.GONE
+                return
+            }
+
+            val elapsedSeconds = (nowMs - startedAtMs) / 1000L
+            if (elapsedSeconds == lastRenderedUptimeSecond) return
+
+            lastRenderedUptimeSecond = elapsedSeconds
+            val text = formatStreamUptime(startedAtMs, nowMs) ?: return
+            if (binding.uptime.text.toString() != text) binding.uptime.text = text
+            if (binding.uptime.visibility != View.VISIBLE) binding.uptime.visibility = View.VISIBLE
+        }
+
+        private fun clearUptime() {
+            uptimeEnabled = false
+            uptimeStartedAtMs = null
+            lastRenderedUptimeSecond = Long.MIN_VALUE
+            binding.uptime.visibility = View.GONE
         }
 
         private fun openStream(stream: Stream) {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/StreamsCompactAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/StreamsCompactAdapter.kt
@@ -41,6 +41,7 @@ class StreamsCompactAdapter(
     }) {
 
     private val thumbnailLoadScheduler = StreamThumbnailIdleScheduler()
+    private val uptimeTicker = VisibleStreamUptimeTicker(fragment)
     private val presentationScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
     private var presentationPrewarmJob: Job? = null
 
@@ -56,6 +57,7 @@ class StreamsCompactAdapter(
 
     internal fun attachImageScheduler(recyclerView: RecyclerView) {
         thumbnailLoadScheduler.attachTo(recyclerView)
+        uptimeTicker.attach(recyclerView)
         presentationPrewarmJob?.cancel()
         presentationPrewarmJob = presentationScope.launch {
             onPagesUpdatedFlow.collectLatest {
@@ -74,6 +76,7 @@ class StreamsCompactAdapter(
         presentationPrewarmJob?.cancel()
         presentationPrewarmJob = null
         thumbnailLoadScheduler.detach()
+        uptimeTicker.detach()
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): PagingViewHolder {
@@ -113,13 +116,16 @@ class StreamsCompactAdapter(
         private val fragment: Fragment,
         private val showGame: Boolean,
         private val tagViews: StreamTagViews,
-    ) : RecyclerView.ViewHolder(binding.root), FeedImageRequestOwner {
+    ) : RecyclerView.ViewHolder(binding.root), FeedImageRequestOwner, StreamUptimeViewHolder {
         val previewSurface get() = binding.previewHost
         var boundPreviewIdentity: String? = null
         private val imageRequests = FeedImageRequestBag()
         private var boundImageIdentity: String? = null
         private var boundThumbnailKey: String? = null
         private var boundStream: Stream? = null
+        private var uptimeStartedAtMs: Long? = null
+        private var uptimeEnabled = false
+        private var lastRenderedUptimeSecond = Long.MIN_VALUE
 
         init {
             binding.root.setOnClickListener { boundStream?.let(::openStream) }
@@ -153,6 +159,7 @@ class StreamsCompactAdapter(
             cancelImageRequests()
             boundImageIdentity = null
             boundThumbnailKey = null
+            clearUptime()
         }
 
         fun bindThumbnail(item: Stream?) {
@@ -190,6 +197,10 @@ class StreamsCompactAdapter(
                 if (item != null) {
                     val context = fragment.requireContext()
                     val uiPreferences = FeedUiPreferencesStore.current(context)
+                    uptimeEnabled = uiPreferences.showUptime
+                    uptimeStartedAtMs = if (uptimeEnabled) parseStreamStartedAtMs(item.createdAt) else null
+                    lastRenderedUptimeSecond = Long.MIN_VALUE
+                    updateUptime(System.currentTimeMillis())
                     val presentation = StreamCardPresentationCache.get(item, uiPreferences)
                     if (presentation == null) {
                         StreamCardPresentationCache.request(context, item, uiPreferences) {
@@ -255,17 +266,6 @@ class StreamsCompactAdapter(
                     } else {
                         viewers.visibility = View.GONE
                     }
-                    if (presentation?.uptime != null || (uiPreferences.showUptime && item.createdAt != null)) {
-                        val text = presentation?.uptime
-                        if (text != null) {
-                            uptime.visibility = View.VISIBLE
-                            uptime.text = text
-                        } else {
-                            uptime.visibility = View.GONE
-                        }
-                    } else {
-                        uptime.visibility = View.GONE
-                    }
                     val tags = presentation?.tags ?: if (uiPreferences.showTags) item.tags.orEmpty() else emptyList()
                     if (tags.isNotEmpty()) {
                         bindStreamTags(tagViews, tags)
@@ -274,6 +274,7 @@ class StreamsCompactAdapter(
                     }
                 } else {
                     boundStream = null
+                    clearUptime()
                     userImage.setImageDrawable(null)
                     userImage.tag = null
                     thumbnail.setImageDrawable(null)
@@ -282,8 +283,7 @@ class StreamsCompactAdapter(
                     title.visibility = View.GONE
                     gameName.visibility = View.GONE
                     viewers.visibility = View.GONE
-                    uptime.visibility = View.GONE
-                        clearStreamTags(tagViews)
+                    clearStreamTags(tagViews)
                     tagsLayout.visibility = View.GONE
                     liveBadge.visibility = View.GONE
                 }
@@ -311,18 +311,36 @@ class StreamsCompactAdapter(
                 } else {
                     viewers.visibility = View.GONE
                 }
-                if (presentation.uptime != null) {
-                    uptime.visibility = View.VISIBLE
-                    uptime.text = presentation.uptime
-                } else {
-                    uptime.visibility = View.GONE
-                }
                 if (presentation.tags.isNotEmpty()) {
                     bindStreamTags(tagViews, presentation.tags)
                 } else {
                     clearStreamTags(tagViews)
                 }
             }
+        }
+
+        override fun updateUptime(nowMs: Long) {
+            val startedAtMs = uptimeStartedAtMs
+            if (!uptimeEnabled || startedAtMs == null || nowMs <= startedAtMs) {
+                lastRenderedUptimeSecond = Long.MIN_VALUE
+                if (binding.uptime.visibility != View.GONE) binding.uptime.visibility = View.GONE
+                return
+            }
+
+            val elapsedSeconds = (nowMs - startedAtMs) / 1000L
+            if (elapsedSeconds == lastRenderedUptimeSecond) return
+
+            lastRenderedUptimeSecond = elapsedSeconds
+            val text = formatStreamUptime(startedAtMs, nowMs) ?: return
+            if (binding.uptime.text.toString() != text) binding.uptime.text = text
+            if (binding.uptime.visibility != View.VISIBLE) binding.uptime.visibility = View.VISIBLE
+        }
+
+        private fun clearUptime() {
+            uptimeEnabled = false
+            uptimeStartedAtMs = null
+            lastRenderedUptimeSecond = Long.MIN_VALUE
+            binding.uptime.visibility = View.GONE
         }
 
         private fun openStream(stream: Stream) {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/discover/DiscoverFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/discover/DiscoverFragment.kt
@@ -109,6 +109,7 @@ class DiscoverFragment : BaseNetworkFragment(), Scrollable {
             }
         }
         adapter = FollowingOverviewAdapter(
+            fragment = this,
             onStreamClick = { stream -> activity.startStream(stream) },
             onVideoClick = {},
             onUpcomingClick = { upcoming ->

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/overview/FollowingOverviewAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/overview/FollowingOverviewAdapter.kt
@@ -34,6 +34,7 @@ data class FollowingOverviewSection(
 )
 
 class FollowingOverviewAdapter(
+    private val fragment: androidx.fragment.app.Fragment,
     private val onStreamClick: (Stream) -> Unit,
     private val onVideoClick: (VideoHistory) -> Unit,
     private val onUpcomingClick: (UpcomingStream) -> Unit,
@@ -83,7 +84,7 @@ class FollowingOverviewAdapter(
         inner class ViewHolder(
         private val binding: ItemFollowingSectionBinding,
     ) : RecyclerView.ViewHolder(binding.root) {
-        private val shelfAdapter = StreamShelfAdapter(onStreamClick)
+        private val shelfAdapter = StreamShelfAdapter(fragment, onStreamClick)
         private val videoShelfAdapter = VideoShelfAdapter(onVideoClick)
         private val upcomingShelfAdapter = UpcomingStreamShelfAdapter(onUpcomingClick)
         private val gameShelfAdapter = GameShelfAdapter(onGameClick)

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/overview/FollowingOverviewFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/overview/FollowingOverviewFragment.kt
@@ -78,6 +78,7 @@ class FollowingOverviewFragment : BaseNetworkFragment(), Scrollable {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         overviewAdapter = FollowingOverviewAdapter(
+            fragment = this,
             onStreamClick = { stream -> (activity as? MainActivity)?.startStream(stream) },
             onVideoClick = { item ->
                 item.toVideo().let { video -> (activity as? MainActivity)?.startVideo(video, item.position, ignoreSavedPosition = true) }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/overview/StreamShelfAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/overview/StreamShelfAdapter.kt
@@ -21,6 +21,10 @@ import com.github.andreyasadchy.xtra.ui.common.FeedImageRequestOwner
 import com.github.andreyasadchy.xtra.ui.common.FeedUiPreferencesStore
 import com.github.andreyasadchy.xtra.ui.common.StreamCardPresentationCache
 import com.github.andreyasadchy.xtra.ui.common.StreamThumbnailIdleScheduler
+import com.github.andreyasadchy.xtra.ui.common.StreamUptimeViewHolder
+import com.github.andreyasadchy.xtra.ui.common.VisibleStreamUptimeTicker
+import com.github.andreyasadchy.xtra.ui.common.formatStreamUptime
+import com.github.andreyasadchy.xtra.ui.common.parseStreamStartedAtMs
 import com.github.andreyasadchy.xtra.ui.common.thumbnailIdentity
 import com.github.andreyasadchy.xtra.ui.common.streamContentsSame
 import com.github.andreyasadchy.xtra.ui.common.streamIdentity
@@ -28,10 +32,12 @@ import com.github.andreyasadchy.xtra.ui.common.streamThumbnailOnlyChanged
 import com.github.andreyasadchy.xtra.ui.common.StreamThumbnailChangedPayload
 
 class StreamShelfAdapter(
+    private val fragment: androidx.fragment.app.Fragment,
     private val onStreamClick: (Stream) -> Unit,
 ) : ListAdapter<Stream, StreamShelfAdapter.ViewHolder>(DIFF_CALLBACK) {
 
     private val thumbnailLoadScheduler = StreamThumbnailIdleScheduler()
+    private val uptimeTicker = VisibleStreamUptimeTicker(fragment)
 
     init {
         setHasStableIds(true)
@@ -82,25 +88,30 @@ class StreamShelfAdapter(
     override fun onAttachedToRecyclerView(recyclerView: RecyclerView) {
         super.onAttachedToRecyclerView(recyclerView)
         thumbnailLoadScheduler.attachTo(recyclerView)
+        uptimeTicker.attach(recyclerView)
         recyclerView.addOnLayoutChangeListener(layoutChangeListener)
         recyclerView.post { applyCardSizing(recyclerView) }
     }
 
     override fun onDetachedFromRecyclerView(recyclerView: RecyclerView) {
         thumbnailLoadScheduler.detach()
+        uptimeTicker.detach()
         recyclerView.removeOnLayoutChangeListener(layoutChangeListener)
         super.onDetachedFromRecyclerView(recyclerView)
     }
 
     inner class ViewHolder(
         private val binding: ItemStreamShelfBinding,
-    ) : RecyclerView.ViewHolder(binding.root), FeedImageRequestOwner {
+    ) : RecyclerView.ViewHolder(binding.root), FeedImageRequestOwner, StreamUptimeViewHolder {
         val previewSurface get() = binding.previewHost
         var boundPreviewIdentity: String? = null
         private val imageRequests = FeedImageRequestBag()
         private var boundImageIdentity: String? = null
         private var boundThumbnailKey: String? = null
         private var boundStream: Stream? = null
+        private var uptimeStartedAtMs: Long? = null
+        private var uptimeEnabled = false
+        private var lastRenderedUptimeSecond = Long.MIN_VALUE
 
         init {
             binding.root.setOnClickListener { boundStream?.let(onStreamClick) }
@@ -126,6 +137,7 @@ class StreamShelfAdapter(
             boundImageIdentity = null
             boundThumbnailKey = null
             boundStream = null
+            clearUptime()
         }
 
         fun bindThumbnail(stream: Stream?) {
@@ -156,6 +168,10 @@ class StreamShelfAdapter(
             val uiPreferences = FeedUiPreferencesStore.current(context)
             val presentation = StreamCardPresentationCache.get(stream, uiPreferences)
             boundStream = stream
+            uptimeEnabled = uiPreferences.showUptime
+            uptimeStartedAtMs = if (uptimeEnabled) parseStreamStartedAtMs(stream.createdAt) else null
+            lastRenderedUptimeSecond = Long.MIN_VALUE
+            updateUptime(System.currentTimeMillis())
             if (presentation == null) {
                 StreamCardPresentationCache.request(context, stream, uiPreferences) {
                     if (boundStream === stream && binding.root.isAttachedToWindow) applyPresentation(it)
@@ -175,10 +191,6 @@ class StreamShelfAdapter(
                 liveBadge.text = context.getString(R.string.live)
                 viewers.text = presentation?.viewerLabel ?: stream.viewerCount?.toString().orEmpty()
                 viewers.visibility = if (viewers.text.isNullOrBlank()) android.view.View.GONE else android.view.View.VISIBLE
-
-                val uptimeText = presentation?.uptime
-                uptime.text = uptimeText.orEmpty()
-                uptime.visibility = if (uptimeText.isNullOrBlank()) android.view.View.GONE else android.view.View.VISIBLE
 
                 title.text = presentation?.title ?: stream.title.orEmpty()
                 title.visibility = if (title.text.isNullOrBlank()) android.view.View.GONE else android.view.View.VISIBLE
@@ -219,8 +231,6 @@ class StreamShelfAdapter(
             with(binding) {
                 viewers.text = presentation.viewerLabel.orEmpty()
                 viewers.visibility = if (viewers.text.isNullOrBlank()) View.GONE else View.VISIBLE
-                uptime.text = presentation.uptime.orEmpty()
-                uptime.visibility = if (uptime.text.isNullOrBlank()) View.GONE else View.VISIBLE
                 title.text = presentation.title.orEmpty()
                 title.visibility = if (title.text.isNullOrBlank()) View.GONE else View.VISIBLE
                 channel.text = presentation.username.orEmpty()
@@ -233,6 +243,30 @@ class StreamShelfAdapter(
                 tagTwo.text = tags.getOrNull(1)?.trim().orEmpty()
                 tagTwo.visibility = if (tagTwo.text.isNullOrBlank()) View.GONE else View.VISIBLE
             }
+        }
+
+        override fun updateUptime(nowMs: Long) {
+            val startedAtMs = uptimeStartedAtMs
+            if (!uptimeEnabled || startedAtMs == null || nowMs <= startedAtMs) {
+                lastRenderedUptimeSecond = Long.MIN_VALUE
+                if (binding.uptime.visibility != View.GONE) binding.uptime.visibility = View.GONE
+                return
+            }
+
+            val elapsedSeconds = (nowMs - startedAtMs) / 1000L
+            if (elapsedSeconds == lastRenderedUptimeSecond) return
+
+            lastRenderedUptimeSecond = elapsedSeconds
+            val text = formatStreamUptime(startedAtMs, nowMs) ?: return
+            if (binding.uptime.text.toString() != text) binding.uptime.text = text
+            if (binding.uptime.visibility != View.VISIBLE) binding.uptime.visibility = View.VISIBLE
+        }
+
+        private fun clearUptime() {
+            uptimeEnabled = false
+            uptimeStartedAtMs = null
+            lastRenderedUptimeSecond = Long.MIN_VALUE
+            binding.uptime.visibility = View.GONE
         }
     }
     private companion object {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/streams/StreamsShelfPagingAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/streams/StreamsShelfPagingAdapter.kt
@@ -29,6 +29,10 @@ import com.github.andreyasadchy.xtra.ui.common.streamContentsSame
 import com.github.andreyasadchy.xtra.ui.common.streamIdentity
 import com.github.andreyasadchy.xtra.ui.common.streamThumbnailOnlyChanged
 import com.github.andreyasadchy.xtra.ui.common.StreamThumbnailChangedPayload
+import com.github.andreyasadchy.xtra.ui.common.StreamUptimeViewHolder
+import com.github.andreyasadchy.xtra.ui.common.VisibleStreamUptimeTicker
+import com.github.andreyasadchy.xtra.ui.common.formatStreamUptime
+import com.github.andreyasadchy.xtra.ui.common.parseStreamStartedAtMs
 import com.github.andreyasadchy.xtra.ui.game.GamePagerFragmentDirections
 import com.github.andreyasadchy.xtra.ui.main.MainActivity
 import com.github.andreyasadchy.xtra.ui.multiview.MultiviewFragment
@@ -39,6 +43,7 @@ class StreamsShelfPagingAdapter(
 ) : PagingDataAdapter<Stream, StreamsShelfPagingAdapter.ViewHolder>(DIFF_CALLBACK) {
 
     private val thumbnailLoadScheduler = StreamThumbnailIdleScheduler()
+    private val uptimeTicker = VisibleStreamUptimeTicker(fragment)
 
     override fun onAttachedToRecyclerView(recyclerView: RecyclerView) {
         super.onAttachedToRecyclerView(recyclerView)
@@ -52,9 +57,11 @@ class StreamsShelfPagingAdapter(
 
     internal fun attachImageScheduler(recyclerView: RecyclerView) {
         thumbnailLoadScheduler.attachTo(recyclerView)
+        uptimeTicker.attach(recyclerView)
     }
 
     internal fun detachImageScheduler() {
+        uptimeTicker.detach()
         thumbnailLoadScheduler.detach()
     }
 
@@ -91,7 +98,7 @@ class StreamsShelfPagingAdapter(
 
     inner class ViewHolder(
         private val binding: ItemStreamShelfBinding,
-    ) : RecyclerView.ViewHolder(binding.root), FeedImageRequestOwner {
+    ) : RecyclerView.ViewHolder(binding.root), FeedImageRequestOwner, StreamUptimeViewHolder {
         val previewSurface get() = binding.previewHost
         var boundPreviewIdentity: String? = null
         private val imageRequests = FeedImageRequestBag()
@@ -99,6 +106,9 @@ class StreamsShelfPagingAdapter(
         private var boundThumbnailKey: String? = null
         private var boundStream: Stream? = null
         private var boundTags: List<String> = emptyList()
+        private var uptimeStartedAtMs: Long? = null
+        private var uptimeEnabled = false
+        private var lastRenderedUptimeSecond = Long.MIN_VALUE
 
         init {
             binding.root.setOnClickListener {
@@ -133,6 +143,7 @@ class StreamsShelfPagingAdapter(
             boundThumbnailKey = null
             boundStream = null
             boundTags = emptyList()
+            clearUptime()
         }
 
         fun bindThumbnail(item: Stream?) {
@@ -181,6 +192,10 @@ class StreamsShelfPagingAdapter(
                 }
 
                 bindThumbnail(item)
+                uptimeEnabled = uiPreferences.showUptime
+                uptimeStartedAtMs = if (uptimeEnabled) parseStreamStartedAtMs(item.createdAt) else null
+                lastRenderedUptimeSecond = Long.MIN_VALUE
+                updateUptime(System.currentTimeMillis())
                 thumbnail.contentDescription = item.title?.takeIf { it.isNotBlank() }
                     ?: context.getString(R.string.live)
                 liveBadge.visibility = View.VISIBLE
@@ -188,10 +203,6 @@ class StreamsShelfPagingAdapter(
 
                 viewers.text = presentation?.viewerLabel ?: item.viewerCount?.toString().orEmpty()
                 viewers.visibility = if (viewers.text.isNullOrBlank()) View.GONE else View.VISIBLE
-
-                val uptimeText = presentation?.uptime
-                uptime.text = uptimeText.orEmpty()
-                uptime.visibility = if (uptimeText.isNullOrBlank()) View.GONE else View.VISIBLE
 
                 title.text = presentation?.title ?: item.title.orEmpty()
                 title.visibility = if (title.text.isNullOrBlank()) View.GONE else View.VISIBLE
@@ -239,8 +250,6 @@ class StreamsShelfPagingAdapter(
             with(binding) {
                 viewers.text = presentation.viewerLabel.orEmpty()
                 viewers.visibility = if (viewers.text.isNullOrBlank()) View.GONE else View.VISIBLE
-                uptime.text = presentation.uptime.orEmpty()
-                uptime.visibility = if (uptime.text.isNullOrBlank()) View.GONE else View.VISIBLE
                 title.text = presentation.title.orEmpty()
                 title.visibility = if (title.text.isNullOrBlank()) View.GONE else View.VISIBLE
                 channel.text = presentation.username.orEmpty()
@@ -254,6 +263,30 @@ class StreamsShelfPagingAdapter(
                 tagTwo.text = tags.getOrNull(1).orEmpty()
                 tagTwo.visibility = if (tags.size > 1) View.VISIBLE else View.GONE
             }
+        }
+
+        override fun updateUptime(nowMs: Long) {
+            val startedAtMs = uptimeStartedAtMs
+            if (!uptimeEnabled || startedAtMs == null || nowMs <= startedAtMs) {
+                lastRenderedUptimeSecond = Long.MIN_VALUE
+                if (binding.uptime.visibility != View.GONE) binding.uptime.visibility = View.GONE
+                return
+            }
+
+            val elapsedSeconds = (nowMs - startedAtMs) / 1000L
+            if (elapsedSeconds == lastRenderedUptimeSecond) return
+
+            lastRenderedUptimeSecond = elapsedSeconds
+            val text = formatStreamUptime(startedAtMs, nowMs) ?: return
+            if (binding.uptime.text.toString() != text) binding.uptime.text = text
+            if (binding.uptime.visibility != View.VISIBLE) binding.uptime.visibility = View.VISIBLE
+        }
+
+        private fun clearUptime() {
+            uptimeEnabled = false
+            uptimeStartedAtMs = null
+            lastRenderedUptimeSecond = Long.MIN_VALUE
+            binding.uptime.visibility = View.GONE
         }
 
         private fun openChannel(stream: Stream) {


### PR DESCRIPTION
Live stream uptime badges now update once per second from each stream's absolute start time. Updates cover visible list and shelf cards without re-binding cards or refreshing Paging.