### PR TITLE
Fix automatic release publishing permissions

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -135,7 +135,20 @@ jobs:
           echo "RELEASE_TAG=$tag"
         } >> "$GITHUB_ENV"
 
+    - name: Validate release token
+      env:
+        RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+      shell: bash
+      run: |
+        set -euo pipefail
+        if [[ -z "${RELEASE_TOKEN:-}" ]]; then
+          echo "RELEASE_TOKEN repository secret is required for publishing releases" >&2
+          exit 1
+        fi
+
     - name: Create or verify immutable build tag
+      env:
+        GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
       shell: bash
       run: |
         set -euo pipefail
@@ -155,6 +168,8 @@ jobs:
         fi
 
     - name: Create or recover draft release
+      env:
+        GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
       shell: bash
       run: |
         set -euo pipefail
@@ -189,6 +204,8 @@ jobs:
         fi
 
     - name: Upload and verify release assets
+      env:
+        GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
       shell: bash
       run: |
         set -euo pipefail
@@ -239,6 +256,8 @@ jobs:
         done
 
     - name: Publish verified release
+      env:
+        GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
       shell: bash
       run: |
         set -euo pipefail


### PR DESCRIPTION
## What this fixes

Automatic master releases can now create their tag and public GitHub Release.

## Why

The release workflow was using the restricted default Actions token for tag and release mutations. The repository already provides `RELEASE_TOKEN` for this publishing path, so the workflow now uses it for GitHub API commands while keeping the Actions token for artifact downloads.