### PR TITLE
Extend local clips to VODs

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/ExoPlayerFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/ExoPlayerFragment.kt
@@ -35,7 +35,6 @@ import androidx.media3.common.text.CueGroup
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.common.util.Util
 import androidx.media3.exoplayer.hls.HlsManifest
-import androidx.media3.exoplayer.source.MediaSource
 import androidx.navigation.fragment.findNavController
 import com.github.andreyasadchy.xtra.BuildConfig
 import com.github.andreyasadchy.xtra.R
@@ -157,9 +156,6 @@ class ExoPlayerFragment : PlayerFragment(), ClipEditorDialogFragment.Host {
                 if (useController) {
                     showController(show = playbackService?.type != BasePlaybackService.STREAM && playbackState == Player.STATE_ENDED)
                 }
-                if (playbackState == Player.STATE_READY && playbackService?.type == BasePlaybackService.VIDEO) {
-                    refreshClipAvailability()
-                }
             }
 
             override fun onPlayWhenReadyChanged(playWhenReady: Boolean, reason: Int) {
@@ -265,9 +261,6 @@ class ExoPlayerFragment : PlayerFragment(), ClipEditorDialogFragment.Host {
                     binding.playerControls.duration.text,
                 )
                 updateProgress()
-                if (playbackService?.type == BasePlaybackService.VIDEO) {
-                    refreshClipAvailability()
-                }
             }
 
             override fun onTrackSelectionParametersChanged(parameters: TrackSelectionParameters) {
@@ -330,7 +323,7 @@ class ExoPlayerFragment : PlayerFragment(), ClipEditorDialogFragment.Host {
 
             override fun updateLiveClipStatus() {
                 if (view != null) {
-                    refreshClipAvailability()
+                    setLiveClipAvailability(playbackService?.liveClipStatus()?.available == true)
                 }
             }
 
@@ -393,7 +386,6 @@ class ExoPlayerFragment : PlayerFragment(), ClipEditorDialogFragment.Host {
 
                         val editorRestored = restoreClipEditorIfNeeded()
                         connectedService.serviceListener = serviceListener
-                        refreshClipAvailability()
                         if (!editorRestored) {
                             val restored = connectedService.restoreVideoOutputIfNeeded {
                                 val player = connectedService.player
@@ -481,7 +473,6 @@ class ExoPlayerFragment : PlayerFragment(), ClipEditorDialogFragment.Host {
                 serviceSetupJob?.cancel()
                 serviceSetupJob = null
                 playbackService = null
-                refreshClipAvailability()
             }
         }
         val intent = Intent(requireContext(), ExoPlayerService::class.java).apply {
@@ -521,21 +512,11 @@ class ExoPlayerFragment : PlayerFragment(), ClipEditorDialogFragment.Host {
     }
 
     override fun requestLiveClipStatus() {
-        refreshClipAvailability()
-    }
-
-    override fun createVodClipPreviewMediaSource(uri: String): MediaSource =
-        playbackService?.createVodClipPreviewMediaSource(uri)
-            ?: error("VOD clip preview is unavailable")
-
-    private fun refreshClipAvailability() {
-        if (view == null) return
-        val service = playbackService
         setLiveClipAvailability(
-            when (service?.type) {
-                BasePlaybackService.STREAM -> service.liveClipStatus()?.available == true
-                BasePlaybackService.VIDEO -> service.canCreateVodClip()
-                else -> false
+            if (playbackService?.type == BasePlaybackService.VIDEO) {
+                playbackService?.createVodClipDescriptor() != null
+            } else {
+                playbackService?.liveClipStatus()?.available == true
             },
         )
     }
@@ -598,6 +579,16 @@ class ExoPlayerFragment : PlayerFragment(), ClipEditorDialogFragment.Host {
         playbackService?.cancelVodClipPreparation()
     }
 
+    override fun estimateVodClipBytes(
+        startIndex: Int,
+        endIndexExclusive: Int,
+        selectedDurationUs: Long,
+    ): Long? = playbackService?.estimateVodClipBytes(
+        startIndex = startIndex,
+        endIndexExclusive = endIndexExclusive,
+        selectedDurationUs = selectedDurationUs,
+    )
+
     override fun releaseVodClip(directoryPath: String) {
         playbackService?.releaseVodClip(directoryPath)
     }
@@ -624,10 +615,9 @@ class ExoPlayerFragment : PlayerFragment(), ClipEditorDialogFragment.Host {
                     R.id.clipEditorContainer,
                     ClipEditorDialogFragment.newVodInstance(
                         previewUri = descriptor.previewUri,
-                        boundariesUs = descriptor.boundariesUs,
+                        segmentDurationsUs = descriptor.segmentDurationsUs,
                         initialPositionUs = descriptor.initialPositionUs,
                         bitrateBitsPerSecond = descriptor.bitrateBitsPerSecond,
-                        byteRangeLengths = descriptor.byteRangeLengths,
                         channelName = service.channelName,
                     ),
                     CLIP_EDITOR_TAG,

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/ExoPlayerFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/ExoPlayerFragment.kt
@@ -35,6 +35,7 @@ import androidx.media3.common.text.CueGroup
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.common.util.Util
 import androidx.media3.exoplayer.hls.HlsManifest
+import androidx.media3.exoplayer.source.MediaSource
 import androidx.navigation.fragment.findNavController
 import com.github.andreyasadchy.xtra.BuildConfig
 import com.github.andreyasadchy.xtra.R
@@ -156,6 +157,9 @@ class ExoPlayerFragment : PlayerFragment(), ClipEditorDialogFragment.Host {
                 if (useController) {
                     showController(show = playbackService?.type != BasePlaybackService.STREAM && playbackState == Player.STATE_ENDED)
                 }
+                if (playbackState == Player.STATE_READY && playbackService?.type == BasePlaybackService.VIDEO) {
+                    refreshClipAvailability()
+                }
             }
 
             override fun onPlayWhenReadyChanged(playWhenReady: Boolean, reason: Int) {
@@ -261,6 +265,9 @@ class ExoPlayerFragment : PlayerFragment(), ClipEditorDialogFragment.Host {
                     binding.playerControls.duration.text,
                 )
                 updateProgress()
+                if (playbackService?.type == BasePlaybackService.VIDEO) {
+                    refreshClipAvailability()
+                }
             }
 
             override fun onTrackSelectionParametersChanged(parameters: TrackSelectionParameters) {
@@ -323,7 +330,7 @@ class ExoPlayerFragment : PlayerFragment(), ClipEditorDialogFragment.Host {
 
             override fun updateLiveClipStatus() {
                 if (view != null) {
-                    setLiveClipAvailability(playbackService?.liveClipStatus()?.available == true)
+                    refreshClipAvailability()
                 }
             }
 
@@ -386,6 +393,7 @@ class ExoPlayerFragment : PlayerFragment(), ClipEditorDialogFragment.Host {
 
                         val editorRestored = restoreClipEditorIfNeeded()
                         connectedService.serviceListener = serviceListener
+                        refreshClipAvailability()
                         if (!editorRestored) {
                             val restored = connectedService.restoreVideoOutputIfNeeded {
                                 val player = connectedService.player
@@ -473,6 +481,7 @@ class ExoPlayerFragment : PlayerFragment(), ClipEditorDialogFragment.Host {
                 serviceSetupJob?.cancel()
                 serviceSetupJob = null
                 playbackService = null
+                refreshClipAvailability()
             }
         }
         val intent = Intent(requireContext(), ExoPlayerService::class.java).apply {
@@ -512,11 +521,21 @@ class ExoPlayerFragment : PlayerFragment(), ClipEditorDialogFragment.Host {
     }
 
     override fun requestLiveClipStatus() {
+        refreshClipAvailability()
+    }
+
+    override fun createVodClipPreviewMediaSource(uri: String): MediaSource =
+        playbackService?.createVodClipPreviewMediaSource(uri)
+            ?: error("VOD clip preview is unavailable")
+
+    private fun refreshClipAvailability() {
+        if (view == null) return
+        val service = playbackService
         setLiveClipAvailability(
-            if (playbackService?.type == BasePlaybackService.VIDEO) {
-                playbackService?.createVodClipDescriptor() != null
-            } else {
-                playbackService?.liveClipStatus()?.available == true
+            when (service?.type) {
+                BasePlaybackService.STREAM -> service.liveClipStatus()?.available == true
+                BasePlaybackService.VIDEO -> service.canCreateVodClip()
+                else -> false
             },
         )
     }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/ExoPlayerFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/ExoPlayerFragment.kt
@@ -35,6 +35,7 @@ import androidx.media3.common.text.CueGroup
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.common.util.Util
 import androidx.media3.exoplayer.hls.HlsManifest
+import androidx.media3.exoplayer.source.MediaSource
 import androidx.navigation.fragment.findNavController
 import com.github.andreyasadchy.xtra.BuildConfig
 import com.github.andreyasadchy.xtra.R
@@ -56,7 +57,7 @@ import kotlinx.coroutines.launch
 import java.io.File
 
 @OptIn(UnstableApi::class)
-class ExoPlayerFragment : PlayerFragment() {
+class ExoPlayerFragment : PlayerFragment(), ClipEditorDialogFragment.Host {
 
     override val supportsLiveClipping = true
     override var playbackService: ExoPlayerService? = null
@@ -67,6 +68,9 @@ class ExoPlayerFragment : PlayerFragment() {
     private var clipPreparationJob: Job? = null
     private var clipPreparationSnackbar: Snackbar? = null
     private var livePlaybackBeforeClipEditor: Boolean? = null
+    private var playbackPositionBeforeClipEditor: Long? = null
+    private var playbackBeforeClipEditor: Boolean? = null
+    private var vodClipEditorOpen = false
     private var liveClipDirectoryPath: String? = null
     private var liveSurfaceRestoreListener: Player.Listener? = null
     private var liveSurfaceRestoreTimeout: Runnable? = null
@@ -83,6 +87,11 @@ class ExoPlayerFragment : PlayerFragment() {
         livePlaybackBeforeClipEditor = savedInstanceState
             ?.takeIf { it.containsKey(STATE_CLIP_PLAYING) }
             ?.getBoolean(STATE_CLIP_PLAYING)
+        playbackPositionBeforeClipEditor = savedInstanceState?.getLong(STATE_CLIP_POSITION)
+            ?.takeIf { savedInstanceState.containsKey(STATE_CLIP_POSITION) }
+        playbackBeforeClipEditor = savedInstanceState?.getBoolean(STATE_CLIP_VOD_PLAYING)
+            ?.takeIf { savedInstanceState.containsKey(STATE_CLIP_VOD_PLAYING) }
+        vodClipEditorOpen = savedInstanceState?.getBoolean(STATE_CLIP_VOD_OPEN, false) == true
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -113,7 +122,8 @@ class ExoPlayerFragment : PlayerFragment() {
         ) { _, _ ->
             hideClipEditorTransitionCover()
         }
-        if (childFragmentManager.findFragmentByTag(CLIP_EDITOR_TAG) is ClipEditorDialogFragment) {
+        (childFragmentManager.findFragmentByTag(CLIP_EDITOR_TAG) as? ClipEditorDialogFragment)?.let { editor ->
+            vodClipEditorOpen = editor.isVodSource
             binding.clipEditorContainer.visibility = View.VISIBLE
             binding.clipEditorTransitionCover.visibility = View.VISIBLE
             scheduleClipEditorCoverFallback()
@@ -146,6 +156,9 @@ class ExoPlayerFragment : PlayerFragment() {
                 controllerAutoHide = !showPlayButton
                 if (useController) {
                     showController(show = playbackService?.type != BasePlaybackService.STREAM && playbackState == Player.STATE_ENDED)
+                }
+                if (playbackState == Player.STATE_READY && playbackService?.type == BasePlaybackService.VIDEO) {
+                    refreshClipAvailability()
                 }
             }
 
@@ -252,6 +265,9 @@ class ExoPlayerFragment : PlayerFragment() {
                     binding.playerControls.duration.text,
                 )
                 updateProgress()
+                if (playbackService?.type == BasePlaybackService.VIDEO) {
+                    refreshClipAvailability()
+                }
             }
 
             override fun onTrackSelectionParametersChanged(parameters: TrackSelectionParameters) {
@@ -314,7 +330,7 @@ class ExoPlayerFragment : PlayerFragment() {
 
             override fun updateLiveClipStatus() {
                 if (view != null) {
-                    setLiveClipAvailability(playbackService?.liveClipStatus()?.available == true)
+                    refreshClipAvailability()
                 }
             }
 
@@ -377,6 +393,7 @@ class ExoPlayerFragment : PlayerFragment() {
 
                         val editorRestored = restoreClipEditorIfNeeded()
                         connectedService.serviceListener = serviceListener
+                        refreshClipAvailability()
                         if (!editorRestored) {
                             val restored = connectedService.restoreVideoOutputIfNeeded {
                                 val player = connectedService.player
@@ -464,6 +481,7 @@ class ExoPlayerFragment : PlayerFragment() {
                 serviceSetupJob?.cancel()
                 serviceSetupJob = null
                 playbackService = null
+                refreshClipAvailability()
             }
         }
         val intent = Intent(requireContext(), ExoPlayerService::class.java).apply {
@@ -503,12 +521,32 @@ class ExoPlayerFragment : PlayerFragment() {
     }
 
     override fun requestLiveClipStatus() {
-        setLiveClipAvailability(playbackService?.liveClipStatus()?.available == true)
+        refreshClipAvailability()
+    }
+
+    override fun createVodClipPreviewMediaSource(uri: String): MediaSource =
+        playbackService?.createVodClipPreviewMediaSource(uri)
+            ?: error("VOD clip preview is unavailable")
+
+    private fun refreshClipAvailability() {
+        if (view == null) return
+        val service = playbackService
+        setLiveClipAvailability(
+            when (service?.type) {
+                BasePlaybackService.STREAM -> service.liveClipStatus()?.available == true
+                BasePlaybackService.VIDEO -> service.canCreateVodClip()
+                else -> false
+            },
+        )
     }
 
     override fun prepareLiveClip() {
         val service = playbackService ?: return
         if (clipPreparationJob?.isActive == true || childFragmentManager.findFragmentByTag(CLIP_EDITOR_TAG) != null) {
+            return
+        }
+        if (service.type == BasePlaybackService.VIDEO) {
+            openVodClipEditor()
             return
         }
         clipDebug("editor open requested")
@@ -548,6 +586,61 @@ class ExoPlayerFragment : PlayerFragment() {
         }
     }
 
+    override suspend fun prepareVodClip(
+        startIndex: Int,
+        endIndexExclusive: Int,
+    ): ClipPreparationRepository.PreparedLiveClip {
+        return playbackService?.prepareVodClip(startIndex, endIndexExclusive)?.await()
+            ?: error("VOD clip preparation is unavailable")
+    }
+
+    override fun cancelVodClipPreparation() {
+        playbackService?.cancelVodClipPreparation()
+    }
+
+    override fun releaseVodClip(directoryPath: String) {
+        playbackService?.releaseVodClip(directoryPath)
+    }
+
+    private fun openVodClipEditor() {
+        val service = playbackService ?: return
+        val descriptor = service.createVodClipDescriptor()
+            ?: run {
+                Snackbar.make(binding.playerBackground, R.string.player_clip_prepare_failed, Snackbar.LENGTH_LONG).show()
+                return
+            }
+        if (!canOpenClipEditor()) return
+        playbackPositionBeforeClipEditor = service.player?.currentPosition
+        playbackBeforeClipEditor = service.player?.playWhenReady == true
+        vodClipEditorOpen = true
+        clipDebug("VOD editor entry cover visible playing=$playbackBeforeClipEditor position=$playbackPositionBeforeClipEditor")
+        binding.clipEditorTransitionCover.visibility = View.VISIBLE
+        binding.clipEditorContainer.visibility = View.VISIBLE
+        scheduleClipEditorCoverFallback()
+        pauseLiveClipPlayback()
+        try {
+            childFragmentManager.beginTransaction()
+                .replace(
+                    R.id.clipEditorContainer,
+                    ClipEditorDialogFragment.newVodInstance(
+                        previewUri = descriptor.previewUri,
+                        boundariesUs = descriptor.boundariesUs,
+                        initialPositionUs = descriptor.initialPositionUs,
+                        bitrateBitsPerSecond = descriptor.bitrateBitsPerSecond,
+                        byteRangeLengths = descriptor.byteRangeLengths,
+                        channelName = service.channelName,
+                    ),
+                    CLIP_EDITOR_TAG,
+                )
+                .commitNow()
+        } catch (_: IllegalStateException) {
+            binding.clipEditorContainer.visibility = View.GONE
+            clipEditorCoverTimeout?.let(binding.root::removeCallbacks)
+            clipEditorCoverTimeout = null
+            restoreLiveClipPlayback()
+        }
+    }
+
     private fun openClipEditor(prepared: ClipPreparationRepository.PreparedLiveClip) {
         if (childFragmentManager.findFragmentByTag(CLIP_EDITOR_TAG) != null) {
             playbackService?.releaseLiveClip(prepared.directory.absolutePath)
@@ -558,6 +651,7 @@ class ExoPlayerFragment : PlayerFragment() {
             return
         }
         livePlaybackBeforeClipEditor = playbackService?.player?.playWhenReady == true
+        vodClipEditorOpen = false
         liveClipDirectoryPath = prepared.directory.absolutePath
         clipDebug("editor entry cover visible playing=$livePlaybackBeforeClipEditor")
         binding.clipEditorTransitionCover.visibility = View.VISIBLE
@@ -608,17 +702,22 @@ class ExoPlayerFragment : PlayerFragment() {
     private fun isClipEditorVisible(): Boolean = view != null && binding.clipEditorContainer.isVisible
 
     private fun closeClipEditor(directoryPath: String?) {
-        if (binding.clipEditorContainer.visibility != View.VISIBLE && liveClipDirectoryPath == null) return
+        if (binding.clipEditorContainer.visibility != View.VISIBLE && liveClipDirectoryPath == null && !vodClipEditorOpen) return
         clipDebug("editor close requested")
         binding.clipEditorTransitionCover.visibility = View.VISIBLE
         binding.clipEditorContainer.visibility = View.GONE
         clipEditorCoverTimeout?.let(binding.root::removeCallbacks)
         clipEditorCoverTimeout = null
-        val directoryToRelease = directoryPath ?: liveClipDirectoryPath
-        binding.root.post {
-            playbackService?.releaseLiveClip(directoryToRelease)
+        if (vodClipEditorOpen) {
+            playbackService?.clearVodClipSource()
+            liveClipDirectoryPath = null
+        } else {
+            val directoryToRelease = directoryPath ?: liveClipDirectoryPath
+            binding.root.post {
+                playbackService?.releaseLiveClip(directoryToRelease)
+            }
+            liveClipDirectoryPath = null
         }
-        liveClipDirectoryPath = null
         restoreLiveClipPlayback()
     }
 
@@ -630,6 +729,16 @@ class ExoPlayerFragment : PlayerFragment() {
         )
         restoration.staleParentDirectoryPath?.let { playbackService?.releaseLiveClip(it) }
         val directoryPath = restoration.directoryPath
+        val vodEditor = editor?.isVodSource == true
+        if (vodEditor && playbackService?.type == BasePlaybackService.VIDEO) {
+            if (playbackService?.createVodClipDescriptor() != null) {
+                vodClipEditorOpen = true
+                binding.clipEditorContainer.visibility = View.VISIBLE
+                binding.clipEditorTransitionCover.visibility = View.VISIBLE
+                scheduleClipEditorCoverFallback()
+                return true
+            }
+        }
         val validEditor = playbackService?.type == BasePlaybackService.STREAM &&
             restoration.shouldRestoreEditor &&
             directoryPath != null &&
@@ -644,6 +753,9 @@ class ExoPlayerFragment : PlayerFragment() {
             }
             liveClipDirectoryPath = null
             livePlaybackBeforeClipEditor = null
+            vodClipEditorOpen = false
+            playbackPositionBeforeClipEditor = null
+            playbackBeforeClipEditor = null
             binding.clipEditorContainer.visibility = View.GONE
             binding.clipEditorTransitionCover.visibility = View.GONE
             clipEditorCoverTimeout?.let(binding.root::removeCallbacks)
@@ -681,12 +793,16 @@ class ExoPlayerFragment : PlayerFragment() {
         val livePlayer = playbackService?.player
         if (livePlayer == null) {
             livePlaybackBeforeClipEditor = null
+            playbackPositionBeforeClipEditor = null
+            playbackBeforeClipEditor = null
+            vodClipEditorOpen = false
             binding.clipEditorTransitionCover.visibility = View.GONE
             return
         }
         liveSurfaceRestoreTimeout?.let(binding.root::removeCallbacks)
         liveSurfaceRestoreListener?.let(livePlayer::removeListener)
-        val resumePlayback = livePlaybackBeforeClipEditor == true
+        val isVod = vodClipEditorOpen
+        val resumePlayback = if (isVod) playbackBeforeClipEditor == true else livePlaybackBeforeClipEditor == true
         val firstFrameListener = object : Player.Listener {
             override fun onRenderedFirstFrame() {
                 logVideoSurfaceBinding("first_frame", livePlayer, binding.playerTextureView)
@@ -700,7 +816,10 @@ class ExoPlayerFragment : PlayerFragment() {
         setVideoOutputVisible(true)
         clipDebug("live surface reattach")
         attachVideoOutput(livePlayer)
-        if (resumePlayback) {
+        if (isVod) {
+            playbackPositionBeforeClipEditor?.let(livePlayer::seekTo)
+            livePlayer.playWhenReady = resumePlayback
+        } else if (resumePlayback) {
             livePlayer.seekToDefaultPosition()
             livePlayer.playWhenReady = true
         } else {
@@ -717,6 +836,9 @@ class ExoPlayerFragment : PlayerFragment() {
         liveSurfaceRestoreListener?.let(livePlayer::removeListener)
         liveSurfaceRestoreListener = null
         livePlaybackBeforeClipEditor = null
+        playbackPositionBeforeClipEditor = null
+        playbackBeforeClipEditor = null
+        vodClipEditorOpen = false
         binding.clipEditorTransitionCover.visibility = View.GONE
         clipDebug("live first frame/timeout cover hidden")
     }
@@ -849,6 +971,7 @@ class ExoPlayerFragment : PlayerFragment() {
     override fun close(deleteStates: Boolean) {
         detachVideoOutput()
         playbackService?.cancelLiveClipPreparation()
+        playbackService?.clearVodClipSource()
         liveClipDirectoryPath?.let { playbackService?.releaseLiveClip(it) }
         liveClipDirectoryPath = null
         playbackService?.player?.pause()
@@ -905,6 +1028,9 @@ class ExoPlayerFragment : PlayerFragment() {
     override fun onSaveInstanceState(outState: Bundle) {
         outState.putString(STATE_CLIP_DIRECTORY, liveClipDirectoryPath)
         livePlaybackBeforeClipEditor?.let { outState.putBoolean(STATE_CLIP_PLAYING, it) }
+        playbackPositionBeforeClipEditor?.let { outState.putLong(STATE_CLIP_POSITION, it) }
+        playbackBeforeClipEditor?.let { outState.putBoolean(STATE_CLIP_VOD_PLAYING, it) }
+        outState.putBoolean(STATE_CLIP_VOD_OPEN, vodClipEditorOpen)
         super.onSaveInstanceState(outState)
     }
 
@@ -955,6 +1081,7 @@ class ExoPlayerFragment : PlayerFragment() {
     }
     override fun onDestroy() {
         playbackService?.cancelLiveClipPreparation()
+        playbackService?.clearVodClipSource()
         super.onDestroy()
         playbackService = null
     }
@@ -979,6 +1106,9 @@ class ExoPlayerFragment : PlayerFragment() {
         private const val CLIP_EDITOR_TAG = "liveClipEditor"
         private const val STATE_CLIP_DIRECTORY = "liveClipDirectory"
         private const val STATE_CLIP_PLAYING = "liveClipPlaying"
+        private const val STATE_CLIP_POSITION = "clipPlaybackPosition"
+        private const val STATE_CLIP_VOD_PLAYING = "vodClipPlaying"
+        private const val STATE_CLIP_VOD_OPEN = "vodClipOpen"
         private const val LIVE_SURFACE_RESTORE_TIMEOUT_MS = 4_000L
         private const val CLIP_EDITOR_COVER_TIMEOUT_MS = 5_000L
         private const val CLIP_LOG_TAG = "XtraClipPlayer"

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/ExoPlayerFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/ExoPlayerFragment.kt
@@ -530,6 +530,7 @@ class ExoPlayerFragment : PlayerFragment(), ClipEditorDialogFragment.Host {
 
     private fun refreshClipAvailability() {
         if (view == null) return
+        refreshClipControl()
         val service = playbackService
         setLiveClipAvailability(
             when (service?.type) {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/ExoPlayerService.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/ExoPlayerService.kt
@@ -58,6 +58,7 @@ import androidx.media3.exoplayer.hls.playlist.HlsMediaPlaylist
 import androidx.media3.exoplayer.hls.playlist.HlsMultivariantPlaylist
 import androidx.media3.exoplayer.hls.playlist.HlsPlaylist
 import androidx.media3.exoplayer.hls.playlist.HlsPlaylistParserFactory
+import androidx.media3.exoplayer.source.MediaSource
 import androidx.media3.exoplayer.source.ProgressiveMediaSource
 import androidx.media3.exoplayer.upstream.DefaultLoadErrorHandlingPolicy
 import androidx.media3.exoplayer.upstream.ParsingLoadable
@@ -237,6 +238,8 @@ class ExoPlayerService : BasePlaybackService() {
                             liveClipBufferManager.capture(manifest)
                             serviceListener?.updateLiveClipStatus()
                         }
+                    } else if (type == VIDEO) {
+                        serviceListener?.updateLiveClipStatus()
                     }
                     if (reason == Player.TIMELINE_CHANGE_REASON_PLAYLIST_CHANGED && !timeline.isEmpty && qualities?.find { it.name == AUTO_QUALITY } != null) {
                         updateQualities = quality?.name != AUDIO_ONLY_QUALITY
@@ -1526,6 +1529,15 @@ class ExoPlayerService : BasePlaybackService() {
         val bitrateBitsPerSecond: Int?,
     )
 
+    fun canCreateVodClip(): Boolean {
+        if (type != VIDEO || hlsClipDataSourceFactory == null) return false
+        val playlist = (player?.currentManifest as? HlsManifest)?.mediaPlaylist ?: return false
+        if (playlist.protectionSchemes != null) return false
+        if (playlist.segments.any { it.drmInitData != null }) return false
+        if (playlist.segments.none { it.durationUs > 0L }) return false
+        return player?.currentMediaItem?.localConfiguration?.uri != null || quality?.url != null
+    }
+
     fun createVodClipDescriptor(): VodClipDescriptor? {
         if (type != VIDEO) return null
         val manifest = player?.currentManifest as? HlsManifest ?: return null
@@ -1548,6 +1560,22 @@ class ExoPlayerService : BasePlaybackService() {
             initialPositionUs = (player?.currentPosition ?: 0L) * 1_000L,
             bitrateBitsPerSecond = quality?.bitrate,
         )
+    }
+
+    fun createVodClipPreviewMediaSource(uri: String): MediaSource {
+        check(type == VIDEO)
+        val factory = requireNotNull(hlsClipDataSourceFactory) {
+            "VOD HLS data source is unavailable"
+        }
+        val mediaItem = MediaItem.Builder()
+            .setUri(uri)
+            .setMimeType(MimeTypes.APPLICATION_M3U8)
+            .build()
+        return HlsMediaSource.Factory(factory)
+            .apply {
+                setPlaylistParserFactory(CustomHlsPlaylistParserFactory())
+            }
+            .createMediaSource(mediaItem)
     }
 
     fun estimateVodClipBytes(

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/ExoPlayerService.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/ExoPlayerService.kt
@@ -25,6 +25,7 @@ import android.os.Bundle
 import android.os.Handler
 import android.os.IBinder
 import android.os.Looper
+import android.os.StatFs
 import android.util.Base64
 import android.util.Log
 import android.view.KeyEvent
@@ -57,6 +58,7 @@ import androidx.media3.exoplayer.hls.playlist.HlsMediaPlaylist
 import androidx.media3.exoplayer.hls.playlist.HlsMultivariantPlaylist
 import androidx.media3.exoplayer.hls.playlist.HlsPlaylist
 import androidx.media3.exoplayer.hls.playlist.HlsPlaylistParserFactory
+import androidx.media3.exoplayer.source.MediaSource
 import androidx.media3.exoplayer.source.ProgressiveMediaSource
 import androidx.media3.exoplayer.upstream.DefaultLoadErrorHandlingPolicy
 import androidx.media3.exoplayer.upstream.ParsingLoadable
@@ -71,6 +73,9 @@ import com.github.andreyasadchy.xtra.player.lowlatency.HttpEngineDataSource
 import com.github.andreyasadchy.xtra.player.lowlatency.OkHttpDataSource
 import com.github.andreyasadchy.xtra.ui.main.MainActivity
 import com.github.andreyasadchy.xtra.ui.player.clip.ClipPreparationRepository
+import com.github.andreyasadchy.xtra.ui.player.clip.ClipSizeEstimator
+import com.github.andreyasadchy.xtra.ui.player.clip.ClipSnapshot
+import com.github.andreyasadchy.xtra.ui.player.clip.HlsClipSnapshotMapper
 import com.github.andreyasadchy.xtra.ui.player.clip.LiveClipBufferManager
 import com.github.andreyasadchy.xtra.util.C
 import com.github.andreyasadchy.xtra.util.MediaButtonReceiver
@@ -149,8 +154,10 @@ class ExoPlayerService : BasePlaybackService() {
     private var streamRecoveryAttempt = 0
     private val initialRestore = CompletableDeferred<Unit>()
     private val liveClipBufferManager = LiveClipBufferManager()
-    private var liveClipDataSourceFactory: DataSource.Factory? = null
+    private var hlsClipDataSourceFactory: DataSource.Factory? = null
     private var liveClipPreparation: Deferred<ClipPreparationRepository.PreparedLiveClip>? = null
+    private var vodClipSnapshot: ClipSnapshot? = null
+    private var vodClipPreparation: Deferred<ClipPreparationRepository.PreparedLiveClip>? = null
 
     override fun isViewingPlaybackPlaying(): Boolean = player?.isPlaying == true
 
@@ -176,6 +183,7 @@ class ExoPlayerService : BasePlaybackService() {
         xtraModule = (application as XtraApp).xtraModule
         lifecycleScope.launch(Dispatchers.IO) {
             ClipPreparationRepository.cleanupStale(File(cacheDir, LIVE_CLIP_DIRECTORY))
+            ClipPreparationRepository.cleanupStale(File(cacheDir, VOD_CLIP_DIRECTORY))
         }
     }
 
@@ -230,6 +238,8 @@ class ExoPlayerService : BasePlaybackService() {
                             liveClipBufferManager.capture(manifest)
                             serviceListener?.updateLiveClipStatus()
                         }
+                    } else if (type == VIDEO) {
+                        serviceListener?.updateLiveClipStatus()
                     }
                     if (reason == Player.TIMELINE_CHANGE_REASON_PLAYLIST_CHANGED && !timeline.isEmpty && qualities?.find { it.name == AUTO_QUALITY } != null) {
                         updateQualities = quality?.name != AUDIO_ONLY_QUALITY
@@ -392,23 +402,23 @@ class ExoPlayerService : BasePlaybackService() {
                                                         setTrackTypeDisabled(androidx.media3.common.C.TRACK_TYPE_VIDEO, false)
                                                     }.build()
                                                     val networkLibrary = prefs().getString(C.NETWORK_LIBRARY, C.OKHTTP)
+                                                    val dataSourceFactory = DefaultDataSource.Factory(
+                                                        this@ExoPlayerService,
+                                                        when {
+                                                            networkLibrary == C.HTTP_ENGINE && xtraModule.httpEngine.value != null -> @SuppressLint("NewApi") {
+                                                                HttpEngineDataSource.Factory(xtraModule.httpEngine.value, xtraModule.cronetExecutor.value, false, false, null, null, null) { false }
+                                                            }
+                                                            networkLibrary == C.CRONET && xtraModule.cronetEngine.value != null -> {
+                                                                CronetDataSource.Factory(xtraModule.cronetEngine.value, xtraModule.cronetExecutor.value, false, false, null, null, null) { false }
+                                                            }
+                                                            else -> {
+                                                                OkHttpDataSource.Factory(xtraModule.okHttpClient.value, null) { false }
+                                                            }
+                                                        }
+                                                    )
+                                                    hlsClipDataSourceFactory = dataSourceFactory
                                                     player.setMediaSource(
-                                                        HlsMediaSource.Factory(
-                                                            DefaultDataSource.Factory(
-                                                                this@ExoPlayerService,
-                                                                when {
-                                                                    networkLibrary == C.HTTP_ENGINE && xtraModule.httpEngine.value != null -> @SuppressLint("NewApi") {
-                                                                        HttpEngineDataSource.Factory(xtraModule.httpEngine.value, xtraModule.cronetExecutor.value, false, false, null, null, null) { false }
-                                                                    }
-                                                                    networkLibrary == C.CRONET && xtraModule.cronetEngine.value != null -> {
-                                                                        CronetDataSource.Factory(xtraModule.cronetEngine.value, xtraModule.cronetExecutor.value, false, false, null, null, null) { false }
-                                                                    }
-                                                                    else -> {
-                                                                        OkHttpDataSource.Factory(xtraModule.okHttpClient.value, null) { false }
-                                                                    }
-                                                                }
-                                                            )
-                                                        ).apply {
+                                                        HlsMediaSource.Factory(dataSourceFactory).apply {
                                                             setPlaylistParserFactory(CustomHlsPlaylistParserFactory())
                                                         }.createMediaSource(
                                                             MediaItem.fromUri(url)
@@ -692,23 +702,23 @@ class ExoPlayerService : BasePlaybackService() {
                             if (url != null) {
                                 player?.let { player ->
                                     val networkLibrary = prefs().getString(C.NETWORK_LIBRARY, C.OKHTTP)
+                                    val dataSourceFactory = DefaultDataSource.Factory(
+                                        this@ExoPlayerService,
+                                        when {
+                                            networkLibrary == C.HTTP_ENGINE && xtraModule.httpEngine.value != null -> @SuppressLint("NewApi") {
+                                                HttpEngineDataSource.Factory(xtraModule.httpEngine.value, xtraModule.cronetExecutor.value, false, false, null, null, null) { false }
+                                            }
+                                            networkLibrary == C.CRONET && xtraModule.cronetEngine.value != null -> {
+                                                CronetDataSource.Factory(xtraModule.cronetEngine.value, xtraModule.cronetExecutor.value, false, false, null, null, null) { false }
+                                            }
+                                            else -> {
+                                                OkHttpDataSource.Factory(xtraModule.okHttpClient.value, null) { false }
+                                            }
+                                        }
+                                    )
+                                    hlsClipDataSourceFactory = dataSourceFactory
                                     player.setMediaSource(
-                                        HlsMediaSource.Factory(
-                                            DefaultDataSource.Factory(
-                                                this@ExoPlayerService,
-                                                when {
-                                                    networkLibrary == C.HTTP_ENGINE && xtraModule.httpEngine.value != null -> @SuppressLint("NewApi") {
-                                                        HttpEngineDataSource.Factory(xtraModule.httpEngine.value, xtraModule.cronetExecutor.value, false, false, null, null, null) { false }
-                                                    }
-                                                    networkLibrary == C.CRONET && xtraModule.cronetEngine.value != null -> {
-                                                        CronetDataSource.Factory(xtraModule.cronetEngine.value, xtraModule.cronetExecutor.value, false, false, null, null, null) { false }
-                                                    }
-                                                    else -> {
-                                                        OkHttpDataSource.Factory(xtraModule.okHttpClient.value, null) { false }
-                                                    }
-                                                }
-                                            )
-                                        ).apply {
+                                        HlsMediaSource.Factory(dataSourceFactory).apply {
                                             setPlaylistParserFactory(CustomHlsPlaylistParserFactory())
                                         }.createMediaSource(
                                             MediaItem.fromUri(url)
@@ -1231,7 +1241,7 @@ class ExoPlayerService : BasePlaybackService() {
                                     }
                                 }
                             )
-                    liveClipDataSourceFactory = dataSourceFactory
+                    hlsClipDataSourceFactory = dataSourceFactory
                     player.setMediaSource(
                         HlsMediaSource.Factory(dataSourceFactory).apply {
                             setPlaylistParserFactory(CustomHlsPlaylistParserFactory())
@@ -1264,6 +1274,7 @@ class ExoPlayerService : BasePlaybackService() {
     }
 
     private suspend fun loadVideo(restorePauseState: Boolean = false) {
+        clearVodClipSource()
         videoId?.let { videoId ->
             val playbackPosition = if (prefs().getBoolean(C.PLAYER_USE_VIDEO_POSITIONS, true)) {
                 videoId.toLongOrNull()?.let { xtraModule.playerRepository.getVideoPosition(it)?.position }
@@ -1291,23 +1302,23 @@ class ExoPlayerService : BasePlaybackService() {
             if (url != null) {
                 player?.let { player ->
                     val networkLibrary = prefs().getString(C.NETWORK_LIBRARY, C.OKHTTP)
+                    val dataSourceFactory = DefaultDataSource.Factory(
+                        this@ExoPlayerService,
+                        when {
+                            networkLibrary == C.HTTP_ENGINE && xtraModule.httpEngine.value != null -> @SuppressLint("NewApi") {
+                                HttpEngineDataSource.Factory(xtraModule.httpEngine.value, xtraModule.cronetExecutor.value, false, false, null, null, null) { false }
+                            }
+                            networkLibrary == C.CRONET && xtraModule.cronetEngine.value != null -> {
+                                CronetDataSource.Factory(xtraModule.cronetEngine.value, xtraModule.cronetExecutor.value, false, false, null, null, null) { false }
+                            }
+                            else -> {
+                                OkHttpDataSource.Factory(xtraModule.okHttpClient.value, null) { false }
+                            }
+                        }
+                    )
+                    hlsClipDataSourceFactory = dataSourceFactory
                     player.setMediaSource(
-                        HlsMediaSource.Factory(
-                            DefaultDataSource.Factory(
-                                this@ExoPlayerService,
-                                when {
-                                    networkLibrary == C.HTTP_ENGINE && xtraModule.httpEngine.value != null -> @SuppressLint("NewApi") {
-                                        HttpEngineDataSource.Factory(xtraModule.httpEngine.value, xtraModule.cronetExecutor.value, false, false, null, null, null) { false }
-                                    }
-                                    networkLibrary == C.CRONET && xtraModule.cronetEngine.value != null -> {
-                                        CronetDataSource.Factory(xtraModule.cronetEngine.value, xtraModule.cronetExecutor.value, false, false, null, null, null) { false }
-                                    }
-                                    else -> {
-                                        OkHttpDataSource.Factory(xtraModule.okHttpClient.value, null) { false }
-                                    }
-                                }
-                            )
-                        ).apply {
+                        HlsMediaSource.Factory(dataSourceFactory).apply {
                             setPlaylistParserFactory(CustomHlsPlaylistParserFactory())
                         }.createMediaSource(
                             MediaItem.fromUri(url)
@@ -1471,7 +1482,7 @@ class ExoPlayerService : BasePlaybackService() {
         }
     }
 
-    fun liveClipStatus(): LiveClipBufferManager.Status? = if (type == STREAM && liveClipDataSourceFactory != null) {
+    fun liveClipStatus(): LiveClipBufferManager.Status? = if (type == STREAM && hlsClipDataSourceFactory != null) {
         val maxDurationUs = configureLiveClipBuffer()
         liveClipBufferManager.status(maxDurationUs)
     } else {
@@ -1486,7 +1497,7 @@ class ExoPlayerService : BasePlaybackService() {
         liveClipPreparation?.takeUnless { it.isCompleted }?.let { return it }
         val maxDurationUs = configureLiveClipBuffer()
         val snapshot = liveClipBufferManager.snapshot(maxDurationUs)
-        val dataSourceFactory = liveClipDataSourceFactory
+        val dataSourceFactory = hlsClipDataSourceFactory
         val preparation = lifecycleScope.async(Dispatchers.IO) {
             check(type == STREAM && dataSourceFactory != null && snapshot != null) {
                 "There is not enough live video available for a clip"
@@ -1509,6 +1520,124 @@ class ExoPlayerService : BasePlaybackService() {
             }
         }
         return preparation
+    }
+
+    data class VodClipDescriptor(
+        val previewUri: String,
+        val boundariesUs: LongArray,
+        val initialPositionUs: Long,
+        val bitrateBitsPerSecond: Int?,
+        val byteRangeLengths: LongArray,
+    )
+
+    fun canCreateVodClip(): Boolean {
+        if (type != VIDEO || hlsClipDataSourceFactory == null) return false
+        val playlist = (player?.currentManifest as? HlsManifest)?.mediaPlaylist ?: return false
+        if (playlist.protectionSchemes != null) return false
+        if (playlist.segments.any { it.drmInitData != null }) return false
+        if (playlist.segments.none { it.durationUs > 0L }) return false
+        return player?.currentMediaItem?.localConfiguration?.uri != null || quality?.url != null
+    }
+
+    fun createVodClipDescriptor(): VodClipDescriptor? {
+        if (type != VIDEO) return null
+        val manifest = player?.currentManifest as? HlsManifest ?: return null
+        val snapshot = HlsClipSnapshotMapper.fromManifest(manifest, generation = 0L)
+        if (snapshot.segments.isEmpty() || snapshot.drmInitDataPresent) return null
+        val previewUri = player?.currentMediaItem?.localConfiguration?.uri?.toString()
+            ?: quality?.url
+            ?: return null
+        vodClipSnapshot = snapshot
+        return VodClipDescriptor(
+            previewUri = previewUri,
+            boundariesUs = snapshot.boundariesUs,
+            initialPositionUs = (player?.currentPosition ?: 0L) * 1_000L,
+            bitrateBitsPerSecond = quality?.bitrate,
+            byteRangeLengths = snapshot.segments.map { it.byteRangeLength }.toLongArray(),
+        )
+    }
+
+    fun createVodClipPreviewMediaSource(uri: String): MediaSource {
+        check(type == VIDEO)
+        val factory = requireNotNull(hlsClipDataSourceFactory) {
+            "VOD HLS data source is unavailable"
+        }
+        val mediaItem = MediaItem.Builder()
+            .setUri(uri)
+            .setMimeType(MimeTypes.APPLICATION_M3U8)
+            .build()
+        return HlsMediaSource.Factory(factory)
+            .apply {
+                setPlaylistParserFactory(CustomHlsPlaylistParserFactory())
+            }
+            .createMediaSource(mediaItem)
+    }
+
+    fun prepareVodClip(
+        startIndex: Int,
+        endIndexExclusive: Int,
+    ): Deferred<ClipPreparationRepository.PreparedLiveClip> {
+        vodClipPreparation?.takeUnless { it.isCompleted }?.let { return it }
+        val source = requireNotNull(vodClipSnapshot) { "VOD clip source is no longer available" }
+        val factory = requireNotNull(hlsClipDataSourceFactory) { "VOD HLS data source is unavailable" }
+        require(startIndex in source.segments.indices)
+        require(endIndexExclusive in (startIndex + 1)..source.segments.size)
+        val selectedSegments = source.segments.subList(startIndex, endIndexExclusive)
+        check(selectedSegments.none { it.hasGap }) {
+            "The selected VOD range contains an unavailable HLS segment"
+        }
+        val selected = ClipSnapshot(source.generation, source.renditionId, selectedSegments.toList())
+        check(!selected.drmInitDataPresent) { "DRM-protected VOD clipping is not supported" }
+        val root = File(cacheDir, VOD_CLIP_DIRECTORY)
+        val preparation = lifecycleScope.async(Dispatchers.IO) {
+            val availableBytes = StatFs(cacheDir.absolutePath).availableBytes
+            val safetyBytes = VOD_STORAGE_SAFETY_BYTES
+            val estimatedBytes = ClipSizeEstimator.estimateBytes(
+                segments = selected.segments,
+                startIndex = 0,
+                endIndexExclusive = selected.segments.size,
+                bitrateBitsPerSecond = quality?.bitrate,
+            )
+            val requiredBytes = estimatedBytes?.let { estimate ->
+                estimate.coerceAtMost((Long.MAX_VALUE - safetyBytes) / 2L) * 2L + safetyBytes
+            }
+            check(requiredBytes == null || requiredBytes <= availableBytes) {
+                "Not enough temporary storage to create this clip"
+            }
+            val maxPreparedBytes = ((availableBytes - safetyBytes).coerceAtLeast(0L) / 2L)
+            check(maxPreparedBytes > 0L) { "Not enough temporary storage to create this clip" }
+            ClipPreparationRepository(
+                dataSourceFactory = factory,
+                rootDirectory = root,
+                maxBytes = maxPreparedBytes,
+            ).prepare(selected)
+        }
+        vodClipPreparation = preparation
+        preparation.invokeOnCompletion {
+            if (vodClipPreparation === preparation) vodClipPreparation = null
+        }
+        return preparation
+    }
+
+    fun cancelVodClipPreparation() {
+        vodClipPreparation?.cancel()
+        vodClipPreparation = null
+    }
+
+    fun releaseVodClip(directoryPath: String?) {
+        if (directoryPath.isNullOrBlank()) return
+        lifecycleScope.launch(Dispatchers.IO) {
+            runCatching {
+                val root = File(cacheDir, VOD_CLIP_DIRECTORY).canonicalFile
+                val target = File(directoryPath).canonicalFile
+                if (target.parentFile == root) target.deleteRecursively()
+            }
+        }
+    }
+
+    fun clearVodClipSource() {
+        cancelVodClipPreparation()
+        vodClipSnapshot = null
     }
 
     private fun configureLiveClipBuffer(): Long {
@@ -1552,7 +1681,7 @@ class ExoPlayerService : BasePlaybackService() {
     ) {
         cancelLiveClipPreparation()
         if (clearDataSourceFactory) {
-            liveClipDataSourceFactory = null
+            hlsClipDataSourceFactory = null
         }
         proxyMediaPlaylist?.let { this.proxyMediaPlaylist = it }
         liveClipBufferManager.startNewGeneration()
@@ -1569,7 +1698,8 @@ class ExoPlayerService : BasePlaybackService() {
 
     private fun clearLiveClipState() {
         cancelLiveClipPreparation()
-        liveClipDataSourceFactory = null
+        clearVodClipSource()
+        hlsClipDataSourceFactory = null
         liveClipBufferManager.reset()
     }
 
@@ -1595,8 +1725,8 @@ class ExoPlayerService : BasePlaybackService() {
 
     private fun setQualityMediaItem(player: ExoPlayer, mediaItem: MediaItem, uri: String) {
         val updatedMediaItem = mediaItem.buildUpon().setUri(uri).build()
-        val dataSourceFactory = liveClipDataSourceFactory
-        if (type == STREAM && dataSourceFactory != null) {
+        val dataSourceFactory = hlsClipDataSourceFactory
+        if ((type == STREAM || type == VIDEO) && dataSourceFactory != null) {
             player.setMediaSource(
                 HlsMediaSource.Factory(dataSourceFactory).apply {
                     setPlaylistParserFactory(CustomHlsPlaylistParserFactory())
@@ -1617,6 +1747,7 @@ class ExoPlayerService : BasePlaybackService() {
         if (type == STREAM && qualityChanged && resetLiveClipGeneration) {
             advanceLiveClipGeneration()
         }
+        if (type == VIDEO && qualityChanged) clearVodClipSource()
         previousQuality = quality
         quality = selectedQuality
         quality?.let { quality ->
@@ -2439,6 +2570,8 @@ class ExoPlayerService : BasePlaybackService() {
 
     companion object {
         private const val LIVE_CLIP_DIRECTORY = "live-clips"
+        private const val VOD_CLIP_DIRECTORY = "vod-clips"
+        private const val VOD_STORAGE_SAFETY_BYTES = 128L * 1024L * 1024L
         private const val AD_TAG = "XtraAd"
 
         const val MULTIVARIANT_PLAYLIST_REGEX = "^usher\\.ttvnw\\.net$"

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/ExoPlayerService.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/ExoPlayerService.kt
@@ -58,7 +58,6 @@ import androidx.media3.exoplayer.hls.playlist.HlsMediaPlaylist
 import androidx.media3.exoplayer.hls.playlist.HlsMultivariantPlaylist
 import androidx.media3.exoplayer.hls.playlist.HlsPlaylist
 import androidx.media3.exoplayer.hls.playlist.HlsPlaylistParserFactory
-import androidx.media3.exoplayer.source.MediaSource
 import androidx.media3.exoplayer.source.ProgressiveMediaSource
 import androidx.media3.exoplayer.upstream.DefaultLoadErrorHandlingPolicy
 import androidx.media3.exoplayer.upstream.ParsingLoadable
@@ -238,8 +237,6 @@ class ExoPlayerService : BasePlaybackService() {
                             liveClipBufferManager.capture(manifest)
                             serviceListener?.updateLiveClipStatus()
                         }
-                    } else if (type == VIDEO) {
-                        serviceListener?.updateLiveClipStatus()
                     }
                     if (reason == Player.TIMELINE_CHANGE_REASON_PLAYLIST_CHANGED && !timeline.isEmpty && qualities?.find { it.name == AUTO_QUALITY } != null) {
                         updateQualities = quality?.name != AUDIO_ONLY_QUALITY
@@ -1524,20 +1521,10 @@ class ExoPlayerService : BasePlaybackService() {
 
     data class VodClipDescriptor(
         val previewUri: String,
-        val boundariesUs: LongArray,
+        val segmentDurationsUs: IntArray,
         val initialPositionUs: Long,
         val bitrateBitsPerSecond: Int?,
-        val byteRangeLengths: LongArray,
     )
-
-    fun canCreateVodClip(): Boolean {
-        if (type != VIDEO || hlsClipDataSourceFactory == null) return false
-        val playlist = (player?.currentManifest as? HlsManifest)?.mediaPlaylist ?: return false
-        if (playlist.protectionSchemes != null) return false
-        if (playlist.segments.any { it.drmInitData != null }) return false
-        if (playlist.segments.none { it.durationUs > 0L }) return false
-        return player?.currentMediaItem?.localConfiguration?.uri != null || quality?.url != null
-    }
 
     fun createVodClipDescriptor(): VodClipDescriptor? {
         if (type != VIDEO) return null
@@ -1547,30 +1534,35 @@ class ExoPlayerService : BasePlaybackService() {
         val previewUri = player?.currentMediaItem?.localConfiguration?.uri?.toString()
             ?: quality?.url
             ?: return null
+        val segmentDurationsUs = IntArray(snapshot.segments.size) { index ->
+            val durationUs = snapshot.segments[index].durationUs
+            require(durationUs in 1L..Int.MAX_VALUE.toLong()) {
+                "Unsupported HLS segment duration: $durationUs"
+            }
+            durationUs.toInt()
+        }
         vodClipSnapshot = snapshot
         return VodClipDescriptor(
             previewUri = previewUri,
-            boundariesUs = snapshot.boundariesUs,
+            segmentDurationsUs = segmentDurationsUs,
             initialPositionUs = (player?.currentPosition ?: 0L) * 1_000L,
             bitrateBitsPerSecond = quality?.bitrate,
-            byteRangeLengths = snapshot.segments.map { it.byteRangeLength }.toLongArray(),
         )
     }
 
-    fun createVodClipPreviewMediaSource(uri: String): MediaSource {
-        check(type == VIDEO)
-        val factory = requireNotNull(hlsClipDataSourceFactory) {
-            "VOD HLS data source is unavailable"
-        }
-        val mediaItem = MediaItem.Builder()
-            .setUri(uri)
-            .setMimeType(MimeTypes.APPLICATION_M3U8)
-            .build()
-        return HlsMediaSource.Factory(factory)
-            .apply {
-                setPlaylistParserFactory(CustomHlsPlaylistParserFactory())
-            }
-            .createMediaSource(mediaItem)
+    fun estimateVodClipBytes(
+        startIndex: Int,
+        endIndexExclusive: Int,
+        selectedDurationUs: Long,
+    ): Long? {
+        val snapshot = vodClipSnapshot ?: return null
+        return ClipSizeEstimator.estimateBytes(
+            selectedDurationUs = selectedDurationUs,
+            segments = snapshot.segments,
+            startIndex = startIndex,
+            endIndexExclusive = endIndexExclusive,
+            bitrateBitsPerSecond = quality?.bitrate,
+        )
     }
 
     fun prepareVodClip(
@@ -1593,6 +1585,7 @@ class ExoPlayerService : BasePlaybackService() {
             val availableBytes = StatFs(cacheDir.absolutePath).availableBytes
             val safetyBytes = VOD_STORAGE_SAFETY_BYTES
             val estimatedBytes = ClipSizeEstimator.estimateBytes(
+                selectedDurationUs = selected.segments.sumOf { it.durationUs },
                 segments = selected.segments,
                 startIndex = 0,
                 endIndexExclusive = selected.segments.size,

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/PlayerFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/PlayerFragment.kt
@@ -861,7 +861,7 @@ abstract class PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFragment
                     isClickable = false
                     isFocusable = false
                 }
-                if (playbackService?.type == BasePlaybackService.STREAM) {
+                if (playbackService?.type == BasePlaybackService.STREAM || playbackService?.type == BasePlaybackService.VIDEO) {
                     if (supportsLiveClipping) {
                         clip.visibility = View.VISIBLE
                         clip.isEnabled = false
@@ -871,6 +871,8 @@ abstract class PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFragment
                         }
                         requestLiveClipStatus()
                     }
+                }
+                if (playbackService?.type == BasePlaybackService.STREAM) {
                     if (!requireContext().tokenPrefs().getString(C.USERNAME, null).isNullOrBlank() &&
                         (!TwitchApiHelper.getGQLHeaders(requireContext(), true)[C.HEADER_TOKEN].isNullOrBlank() ||
                                 !TwitchApiHelper.getHelixHeaders(requireContext())[C.HEADER_TOKEN].isNullOrBlank())

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/PlayerFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/PlayerFragment.kt
@@ -178,6 +178,34 @@ abstract class PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFragment
         binding.playerControls.clip.isEnabled = available
     }
 
+    protected fun configureClipControl() {
+        if (_binding == null) return
+        val playbackType = playbackService?.type
+        val clipAvailable = supportsLiveClipping &&
+            (playbackType == BasePlaybackService.STREAM || playbackType == BasePlaybackService.VIDEO)
+        with(binding.playerControls.clip) {
+            if (clipAvailable) {
+                visibility = View.VISIBLE
+                isEnabled = false
+                setOnClickListener {
+                    showController(force = true)
+                    prepareLiveClip()
+                }
+            } else {
+                visibility = View.GONE
+                isEnabled = false
+                setOnClickListener(null)
+            }
+        }
+    }
+
+    protected fun refreshClipControl() {
+        if (_binding == null) return
+        configureClipControl()
+        refreshPlayerControls()
+        applyControlLayout()
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         if (arguments?.getBoolean(KEY_OFFLINE) == true) {
             enableNetworkCheck = false
@@ -763,9 +791,7 @@ abstract class PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFragment
                 changeQuality(playbackService?.previousQuality)
             }
             with(playerControls) {
-                clip.visibility = View.GONE
-                clip.isEnabled = false
-                clip.setOnClickListener(null)
+                configureClipControl()
                 val channelLogin = playbackService?.channelLogin
                 val channelName = playbackService?.channelName
                 val displayName = if (channelLogin != null && !channelLogin.equals(channelName, true)) {
@@ -861,16 +887,11 @@ abstract class PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFragment
                     isClickable = false
                     isFocusable = false
                 }
-                if (playbackService?.type == BasePlaybackService.STREAM || playbackService?.type == BasePlaybackService.VIDEO) {
-                    if (supportsLiveClipping) {
-                        clip.visibility = View.VISIBLE
-                        clip.isEnabled = false
-                        clip.setOnClickListener {
-                            showController(force = true)
-                            prepareLiveClip()
-                        }
-                        requestLiveClipStatus()
-                    }
+                if (supportsLiveClipping &&
+                    (playbackService?.type == BasePlaybackService.STREAM ||
+                        playbackService?.type == BasePlaybackService.VIDEO)
+                ) {
+                    requestLiveClipStatus()
                 }
                 if (playbackService?.type == BasePlaybackService.STREAM) {
                     if (!requireContext().tokenPrefs().getString(C.USERNAME, null).isNullOrBlank() &&

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/clip/ClipEditorDialogFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/clip/ClipEditorDialogFragment.kt
@@ -13,6 +13,8 @@ import android.os.Looper
 import android.os.Environment
 import android.util.Log
 import android.provider.MediaStore
+import android.text.Editable
+import android.text.TextWatcher
 import android.text.format.DateUtils
 import android.view.LayoutInflater
 import android.view.MotionEvent
@@ -34,6 +36,7 @@ import androidx.media3.common.util.UnstableApi
 import androidx.media3.datasource.DefaultDataSource
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.hls.HlsMediaSource
+import androidx.media3.exoplayer.source.MediaSource
 import androidx.media3.ui.TimeBar
 import com.github.andreyasadchy.xtra.R
 import com.github.andreyasadchy.xtra.BuildConfig
@@ -49,15 +52,37 @@ import java.io.File
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
+import android.os.StatFs
 
-/** Full-screen segment-aligned editor for a prepared local live snapshot. */
+/** Full-screen segment-aligned editor for a prepared live snapshot or remote VOD. */
 @OptIn(UnstableApi::class)
 class ClipEditorDialogFragment : Fragment() {
+    interface Host {
+        suspend fun prepareVodClip(
+            startIndex: Int,
+            endIndexExclusive: Int,
+        ): ClipPreparationRepository.PreparedLiveClip
+
+        fun cancelVodClipPreparation()
+
+        fun releaseVodClip(directoryPath: String)
+
+        fun createVodClipPreviewMediaSource(uri: String): MediaSource
+    }
+
+    private enum class SourceMode {
+        LIVE_PREPARED,
+        VOD_REMOTE,
+    }
+
     private var _binding: FragmentClipEditorBinding? = null
     private val binding get() = _binding!!
 
-    private lateinit var playlistFile: File
-    private lateinit var directory: File
+    private lateinit var sourceMode: SourceMode
+    private var playlistFile: File? = null
+    private var directory: File? = null
+    private var previewUri: String? = null
+    private var byteRangeLengths = LongArray(0)
     private lateinit var boundariesUs: LongArray
     private var durationUs = 0L
     private var channelName: String? = null
@@ -70,9 +95,11 @@ class ClipEditorDialogFragment : Fragment() {
     private var savedUri: Uri? = null
     private var savedDisplayName: String? = null
     private var shareFile: File? = null
+    private var preparedVodClip: ClipPreparationRepository.PreparedLiveClip? = null
     private var defaultFileBaseName = ""
     private var restoredFileBaseName: String? = null
     private var updatingSlider = false
+    private var updatingTimeFields = false
     private var previewStartUs = 0L
     private var previewEndUs = 0L
     private var lastPreviewSeekStartUs = 0L
@@ -112,8 +139,16 @@ class ClipEditorDialogFragment : Fragment() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        playlistFile = File(requireArguments().getString(ARG_PLAYLIST)!!)
-        directory = File(requireArguments().getString(ARG_DIRECTORY)!!)
+        sourceMode = SourceMode.valueOf(
+            requireArguments().getString(ARG_SOURCE_MODE, SourceMode.LIVE_PREPARED.name),
+        )
+        if (sourceMode == SourceMode.LIVE_PREPARED) {
+            playlistFile = File(requireArguments().getString(ARG_PLAYLIST)!!)
+            directory = File(requireArguments().getString(ARG_DIRECTORY)!!)
+        } else {
+            previewUri = requireArguments().getString(ARG_PREVIEW_URI)
+            byteRangeLengths = requireArguments().getLongArray(ARG_BYTE_RANGE_LENGTHS) ?: LongArray(0)
+        }
         boundariesUs = ClipTimeline.normalizeBoundaries(
             requireArguments().getLongArray(ARG_BOUNDARIES) ?: longArrayOf(0L),
         )
@@ -126,14 +161,23 @@ class ClipEditorDialogFragment : Fragment() {
             ?.times(1_000L)
             ?: 5_000L
         defaultFileBaseName = "${sanitize(channelName)}_${SimpleDateFormat("yyyy-MM-dd_HH-mm-ss", Locale.US).format(Date())}"
-        startUs = savedInstanceState
+        val savedStartUs = savedInstanceState
             ?.takeIf { it.containsKey(STATE_START_US) }
             ?.getLong(STATE_START_US)
-            ?: 0L
-        endUs = savedInstanceState
+        val savedEndUs = savedInstanceState
             ?.takeIf { it.containsKey(STATE_END_US) }
             ?.getLong(STATE_END_US)
-            ?: durationUs
+        if (sourceMode == SourceMode.VOD_REMOTE && savedStartUs == null && savedEndUs == null) {
+            val initial = defaultVodSelection(
+                playheadUs = requireArguments().getLong(ARG_INITIAL_POSITION_US).coerceIn(0L, durationUs),
+                wantedDurationUs = configuredClipDurationUs(),
+            )
+            startUs = initial.startUs
+            endUs = initial.endUs
+        } else {
+            startUs = savedStartUs ?: 0L
+            endUs = savedEndUs ?: durationUs
+        }
         restoredFileBaseName = savedInstanceState?.getString(STATE_FILE_NAME)
         savedDisplayName = savedInstanceState?.getString(STATE_SAVED_DISPLAY_NAME)
         shareFile = savedInstanceState?.getString(STATE_SHARE_FILE)?.let(::File)
@@ -154,6 +198,8 @@ class ClipEditorDialogFragment : Fragment() {
         binding.channel.text = channelName.orEmpty()
         binding.fileNameLayout.hint = defaultFileBaseName
         binding.fileName.setText(restoredFileBaseName.orEmpty())
+        binding.vodRangeControls.isVisible = sourceMode == SourceMode.VOD_REMOTE
+        if (sourceMode == SourceMode.VOD_REMOTE) setupVodRangeControls()
         binding.close.setOnClickListener { closeEditor() }
         binding.done.setOnClickListener { closeEditor() }
         requireActivity().onBackPressedDispatcher.addCallback(
@@ -321,12 +367,18 @@ class ClipEditorDialogFragment : Fragment() {
         binding.previewLoading.isVisible = true
         player = ExoPlayer.Builder(requireContext()).build().also { exoPlayer ->
             binding.preview.player = exoPlayer
-            val mediaItem = MediaItem.Builder()
-                .setUri(playlistFile.toUri())
-                .setMimeType(MimeTypes.APPLICATION_M3U8)
-                .build()
-            val mediaSource = HlsMediaSource.Factory(DefaultDataSource.Factory(requireContext()))
-                .createMediaSource(mediaItem)
+            val mediaSource = if (sourceMode == SourceMode.VOD_REMOTE) {
+                val host = parentFragment as? Host
+                    ?: error("VOD clip editor has no host")
+                host.createVodClipPreviewMediaSource(requireNotNull(previewUri))
+            } else {
+                val mediaItem = MediaItem.Builder()
+                    .setUri(requireNotNull(playlistFile).toUri())
+                    .setMimeType(MimeTypes.APPLICATION_M3U8)
+                    .build()
+                HlsMediaSource.Factory(DefaultDataSource.Factory(requireContext()))
+                    .createMediaSource(mediaItem)
+            }
             exoPlayer.addListener(object : Player.Listener {
                 override fun onPlaybackStateChanged(playbackState: Int) {
                     if (playbackState == Player.STATE_ENDED) {
@@ -392,7 +444,11 @@ class ClipEditorDialogFragment : Fragment() {
         applySelection(selectionForSlider(binding.rangeSlider.values), seekPreview = false)
     }
 
-    private fun applySelection(selection: Selection, seekPreview: Boolean) {
+    private fun applySelection(
+        selection: Selection,
+        seekPreview: Boolean,
+        syncTimeFields: Boolean = true,
+    ) {
         val startChangedSinceLastSeek = selection.startUs != lastPreviewSeekStartUs
         startUs = selection.startUs
         endUs = selection.endUs
@@ -400,10 +456,18 @@ class ClipEditorDialogFragment : Fragment() {
         previewEndUs = endUs
         binding.selectionDuration.text = getString(
             R.string.clip_editor_selected_duration,
-            formatDuration((endUs - startUs) / 1_000L),
+            if (sourceMode == SourceMode.VOD_REMOTE) {
+                ClipTime.formatMs((endUs - startUs) / 1_000L)
+            } else {
+                formatDuration((endUs - startUs) / 1_000L)
+            },
         )
         binding.startLabel.text = formatRelativePosition(startUs)
         binding.endLabel.text = formatRelativePosition(endUs)
+        if (sourceMode == SourceMode.VOD_REMOTE) {
+            if (syncTimeFields) syncVodTimeFields()
+            updateVodDetails()
+        }
         if (seekPreview && startChangedSinceLastSeek) {
             val previewPlayer = player
             if (previewPlayer != null) {
@@ -418,6 +482,143 @@ class ClipEditorDialogFragment : Fragment() {
         }
         updatePreviewProgressDuration()
     }
+
+    private fun setupVodRangeControls() {
+        val watcher = object : TextWatcher {
+            override fun beforeTextChanged(s: CharSequence, start: Int, count: Int, after: Int) = Unit
+            override fun onTextChanged(s: CharSequence, start: Int, before: Int, count: Int) = Unit
+            override fun afterTextChanged(s: Editable) {
+                if (updatingTimeFields) return
+                val milliseconds = ClipTime.parseMs(s) ?: return
+                val valueUs = milliseconds.coerceIn(0L, durationUs / 1_000L) * 1_000L
+                val selection = if (binding.startTime.hasFocus()) {
+                    selectionForUs(valueUs, endUs)
+                } else if (binding.endTime.hasFocus()) {
+                    selectionForUs(startUs, valueUs)
+                } else {
+                    return
+                }
+                applySelection(selection, seekPreview = binding.startTime.hasFocus(), syncTimeFields = false)
+                updateSlider(selection)
+            }
+        }
+        binding.startTime.addTextChangedListener(watcher)
+        binding.endTime.addTextChangedListener(watcher)
+        binding.startTime.setOnFocusChangeListener { _, hasFocus ->
+            if (!hasFocus) commitTimeField(binding.startTime, isStart = true)
+        }
+        binding.endTime.setOnFocusChangeListener { _, hasFocus ->
+            if (!hasFocus) commitTimeField(binding.endTime, isStart = false)
+        }
+        binding.preset15.setOnClickListener { setPresetSelection(15_000_000L) }
+        binding.preset30.setOnClickListener { setPresetSelection(30_000_000L) }
+        binding.preset1m.setOnClickListener { setPresetSelection(60_000_000L) }
+        binding.preset5m.setOnClickListener { setPresetSelection(5 * 60_000_000L) }
+        binding.preset10m.setOnClickListener { setPresetSelection(10 * 60_000_000L) }
+        binding.setStartPlayhead.setOnClickListener { setStartToPreviewPosition() }
+        binding.setEndPlayhead.setOnClickListener { setEndToPreviewPosition() }
+    }
+
+    private fun commitTimeField(field: android.widget.EditText, isStart: Boolean) {
+        val milliseconds = ClipTime.parseMs(field.text)
+        if (milliseconds == null) {
+            field.error = getString(R.string.invalid_time)
+            syncVodTimeFields()
+            return
+        }
+        field.error = null
+        val valueUs = milliseconds.coerceIn(0L, durationUs / 1_000L) * 1_000L
+        val selection = if (isStart) selectionForUs(valueUs, endUs) else selectionForUs(startUs, valueUs)
+        applySelection(selection, seekPreview = isStart)
+        updateSlider(selection)
+    }
+
+    private fun syncVodTimeFields() {
+        if (sourceMode != SourceMode.VOD_REMOTE || updatingTimeFields || _binding == null) return
+        updatingTimeFields = true
+        binding.startTime.setText(ClipTime.formatMs(startUs / 1_000L))
+        binding.endTime.setText(ClipTime.formatMs(endUs / 1_000L))
+        updatingTimeFields = false
+    }
+
+    private fun updateSlider(selection: Selection) {
+        updatingSlider = true
+        binding.rangeSlider.setValues(selection.startUs / 1_000f, selection.endUs / 1_000f)
+        updatingSlider = false
+    }
+
+    private fun setPresetSelection(wantedDurationUs: Long) {
+        val playheadUs = (player?.currentPosition ?: return) * 1_000L
+        val start = (playheadUs - wantedDurationUs / 2L).coerceAtLeast(0L)
+        val end = (start + wantedDurationUs).coerceAtMost(durationUs)
+        val adjustedStart = (end - wantedDurationUs).coerceAtLeast(0L)
+        val selection = selectionForUs(adjustedStart, end)
+        updateSlider(selection)
+        applySelection(selection, seekPreview = true)
+    }
+
+    private fun setStartToPreviewPosition() {
+        val positionUs = (player?.currentPosition ?: return) * 1_000L
+        val selection = selectionForUs(positionUs, endUs)
+        updateSlider(selection)
+        applySelection(selection, seekPreview = true)
+    }
+
+    private fun setEndToPreviewPosition() {
+        val positionUs = (player?.currentPosition ?: return) * 1_000L
+        val selection = selectionForUs(startUs, positionUs)
+        updateSlider(selection)
+        applySelection(selection, seekPreview = false)
+    }
+
+    private fun updateVodDetails() {
+        val startIndex = ClipTimeline.boundaryIndexUs(startUs, boundariesUs)
+        val endIndex = ClipTimeline.boundaryIndexUs(endUs, boundariesUs)
+        val estimatedBytes = ClipSizeEstimator.estimateBytes(
+            selectedDurationUs = endUs - startUs,
+            byteRangeLengths = byteRangeLengths,
+            startIndex = startIndex,
+            endIndexExclusive = endIndex,
+            bitrateBitsPerSecond = arguments?.getInt(ARG_BITRATE, 0)?.takeIf { it > 0 },
+        )
+        binding.vodSegmentCount.text = getString(R.string.clip_editor_segment_count, (endIndex - startIndex).coerceAtLeast(0))
+        if (estimatedBytes == null) {
+            binding.estimatedSize.text = getString(R.string.clip_editor_estimated_size_unknown)
+            binding.temporarySpace.text = getString(R.string.clip_editor_temporary_space_unknown)
+            binding.save.isEnabled = true
+        } else {
+            val requiredBytes = estimatedBytes.coerceAtMost((Long.MAX_VALUE - STORAGE_SAFETY_BYTES) / 2L) * 2L + STORAGE_SAFETY_BYTES
+            binding.estimatedSize.text = getString(R.string.clip_editor_estimated_size, ClipSizeEstimator.formatBytes(estimatedBytes))
+            binding.temporarySpace.text = getString(R.string.clip_editor_temporary_space, ClipSizeEstimator.formatBytes(requiredBytes))
+            val enoughSpace = requiredBytes <= StatFs(requireContext().cacheDir.absolutePath).availableBytes
+            binding.save.isEnabled = enoughSpace
+            if (!enoughSpace) {
+                binding.temporarySpace.append(" ${getString(R.string.clip_editor_insufficient_storage)}")
+            }
+        }
+    }
+
+    private fun defaultVodSelection(playheadUs: Long, wantedDurationUs: Long): Selection {
+        var start = playheadUs - wantedDurationUs / 2L
+        var end = start + wantedDurationUs
+        if (start < 0L) {
+            end -= start
+            start = 0L
+        }
+        if (end > durationUs) {
+            val overflow = end - durationUs
+            start = (start - overflow).coerceAtLeast(0L)
+            end = durationUs
+        }
+        return selectionForUs(start, end)
+    }
+
+    private fun configuredClipDurationUs(): Long = requireContext().prefs()
+        .getString(C.CLIP_MAX_DURATION_SECONDS, LiveClipBufferManager.DEFAULT_CLIP_DURATION_SECONDS.toString())
+        ?.toLongOrNull()
+        ?.coerceIn(1L, 10 * 60L)
+        ?.times(1_000_000L)
+        ?: LiveClipBufferManager.DEFAULT_CLIP_DURATION_US
 
     private fun selectionForSlider(values: List<Float>): Selection {
         if (values.size < 2) return Selection(startUs, endUs)
@@ -529,6 +730,7 @@ class ClipEditorDialogFragment : Fragment() {
     }
 
     private fun formatRelativePosition(positionUs: Long): String {
+        if (sourceMode == SourceMode.VOD_REMOTE) return ClipTime.formatMs(positionUs / 1_000L)
         val remainingUs = (durationUs - positionUs).coerceAtLeast(0L)
         return if (remainingUs <= 500_000L) {
             getString(R.string.clip_editor_now)
@@ -556,30 +758,56 @@ class ClipEditorDialogFragment : Fragment() {
         binding.rangeSlider.isEnabled = false
         exportJob = viewLifecycleOwner.lifecycleScope.launch {
             try {
-                val selectedPlaylist = ClipSelectionPlaylistWriter.write(
-                    prepared = ClipPreparationRepository.PreparedLiveClip.read(directory),
-                    output = File(directory, "selected.m3u8"),
-                    startIndex = startIndex,
-                    endIndexExclusive = endIndex,
-                )
-                val outputFile = File(directory, "clip.mp4")
+                val preparedForExport = if (sourceMode == SourceMode.VOD_REMOTE) {
+                    val host = parentFragment as? Host ?: error("VOD clip editor has no host")
+                    host.prepareVodClip(startIndex, endIndex).also { preparedVodClip = it }
+                } else {
+                    null
+                }
+                val selectedPlaylist = if (sourceMode == SourceMode.VOD_REMOTE) {
+                    requireNotNull(preparedForExport).playlist
+                } else {
+                    val liveDirectory = requireNotNull(directory)
+                    ClipSelectionPlaylistWriter.write(
+                        prepared = ClipPreparationRepository.PreparedLiveClip.read(liveDirectory),
+                        output = File(liveDirectory, "selected.m3u8"),
+                        startIndex = startIndex,
+                        endIndexExclusive = endIndex,
+                    )
+                }
+                val outputDirectory = preparedForExport?.directory ?: requireNotNull(directory)
+                val outputFile = File(outputDirectory, "clip.mp4")
                 val exported = ClipExporter(requireContext()).export(selectedPlaylist, outputFile)
+                if (sourceMode == SourceMode.VOD_REMOTE) {
+                    withContext(Dispatchers.IO) {
+                        outputDirectory.listFiles()?.forEach { file ->
+                            if (file != exported.file) file.deleteRecursively()
+                        }
+                    }
+                }
                 val published = publishToMediaStore(exported.file, displayName)
                     ?: throw IllegalStateException("MediaStore insert failed")
-                shareFile = withContext(Dispatchers.IO) {
-                    val namedFile = File(directory, displayName)
-                    if (exported.file != namedFile && !exported.file.renameTo(namedFile)) {
-                        exported.file.copyTo(namedFile, overwrite = true)
-                        exported.file.delete()
+                val actualBytes = exported.file.length()
+                if (sourceMode == SourceMode.VOD_REMOTE) {
+                    cleanupPreparedVodClip()
+                    shareFile = null
+                } else {
+                    shareFile = withContext(Dispatchers.IO) {
+                        val liveDirectory = requireNotNull(directory)
+                        val namedFile = File(liveDirectory, displayName)
+                        if (exported.file != namedFile && !exported.file.renameTo(namedFile)) {
+                            exported.file.copyTo(namedFile, overwrite = true)
+                            exported.file.delete()
+                        }
+                        namedFile
                     }
-                    namedFile
                 }
                 savedUri = published.uri
                 savedDisplayName = published.displayName
                 restoredFileBaseName = published.displayName.removeMp4Extension()
                 binding.fileName.setText(restoredFileBaseName)
                 binding.fileNameLayout.isEnabled = false
-                showSavedInfo(published.displayName, published.location)
+                showSavedInfo(published.displayName, published.location, actualBytes)
                 binding.progress.isVisible = false
                 binding.save.isVisible = false
                 binding.share.isVisible = true
@@ -591,9 +819,11 @@ class ClipEditorDialogFragment : Fragment() {
                 ).show()
             } catch (_: kotlinx.coroutines.CancellationException) {
                 // Dismissal or rotation can cancel an in-flight export.
+                if (sourceMode == SourceMode.VOD_REMOTE) cleanupPreparedVodClip()
             } catch (_: Throwable) {
+                if (sourceMode == SourceMode.VOD_REMOTE) cleanupPreparedVodClip()
                 binding.progress.isVisible = false
-                binding.save.isEnabled = true
+                if (sourceMode == SourceMode.VOD_REMOTE) updateVodDetails() else binding.save.isEnabled = true
                 binding.rangeSlider.isEnabled = true
                 Toast.makeText(requireContext(), R.string.clip_export_failed, Toast.LENGTH_LONG).show()
             }
@@ -674,9 +904,24 @@ class ClipEditorDialogFragment : Fragment() {
         return "${sanitize(baseName)}.mp4"
     }
 
-    private fun showSavedInfo(displayName: String, location: String) {
-        binding.savedInfo.text = "$displayName\n$location"
+    private fun showSavedInfo(displayName: String, location: String, actualBytes: Long? = null) {
+        binding.savedInfo.text = buildString {
+            append(displayName)
+            append('\n')
+            append(location)
+            actualBytes?.let {
+                append('\n')
+                append(getString(R.string.clip_editor_actual_size, ClipSizeEstimator.formatBytes(it)))
+            }
+        }
         binding.savedInfo.isVisible = true
+    }
+
+    private fun cleanupPreparedVodClip() {
+        preparedVodClip?.directory?.absolutePath?.let { path ->
+            (parentFragment as? Host)?.releaseVodClip(path)
+        }
+        preparedVodClip = null
     }
 
     private fun sanitize(value: String?): String = value.orEmpty()
@@ -728,6 +973,10 @@ class ClipEditorDialogFragment : Fragment() {
 
     override fun onDestroy() {
         exportJob?.cancel()
+        if (sourceMode == SourceMode.VOD_REMOTE) {
+            (parentFragment as? Host)?.cancelVodClipPreparation()
+            cleanupPreparedVodClip()
+        }
         clipDebug("preview player release")
         player?.release()
         player = null
@@ -737,12 +986,18 @@ class ClipEditorDialogFragment : Fragment() {
     internal val preparedDirectoryPath: String?
         get() = arguments?.getString(ARG_DIRECTORY)
 
+    internal val isVodSource: Boolean
+        get() = ::sourceMode.isInitialized && sourceMode == SourceMode.VOD_REMOTE
+
     private fun sendResult() {
         if (!resultSent && isAdded) {
             resultSent = true
             parentFragmentManager.setFragmentResult(
                 RESULT_KEY,
-                Bundle().apply { putString(RESULT_DIRECTORY, directory.absolutePath) },
+                Bundle().apply {
+                    directory?.absolutePath?.let { putString(RESULT_DIRECTORY, it) }
+                    putString(RESULT_SOURCE_MODE, sourceMode.name)
+                },
             )
         }
     }
@@ -761,7 +1016,12 @@ class ClipEditorDialogFragment : Fragment() {
     companion object {
         private const val ARG_PLAYLIST = "playlist"
         private const val ARG_DIRECTORY = "directory"
+        private const val ARG_SOURCE_MODE = "sourceMode"
+        private const val ARG_PREVIEW_URI = "previewUri"
         private const val ARG_BOUNDARIES = "boundariesUs"
+        private const val ARG_INITIAL_POSITION_US = "initialPositionUs"
+        private const val ARG_BITRATE = "bitrateBitsPerSecond"
+        private const val ARG_BYTE_RANGE_LENGTHS = "byteRangeLengths"
         private const val ARG_CHANNEL_NAME = "channelName"
         private const val STATE_START_US = "startUs"
         private const val STATE_END_US = "endUs"
@@ -771,12 +1031,14 @@ class ClipEditorDialogFragment : Fragment() {
         private const val STATE_SAVED_URI = "savedUri"
         const val RESULT_KEY = "liveClipEditorResult"
         const val RESULT_DIRECTORY = "directoryPath"
+        const val RESULT_SOURCE_MODE = "sourceMode"
         const val PREVIEW_READY_KEY = "liveClipEditorPreviewReady"
         private const val STORAGE_PERMISSION_REQUEST = 1001
         private const val PREVIEW_POLL_MS = 100L
         private const val PREVIEW_CONTROLS_HIDE_MS = 3_000L
         private const val CLIP_LOCATION = "Movies/Xtra/Clips"
         private const val CLIP_LOG_TAG = "XtraClipEditor"
+        private const val STORAGE_SAFETY_BYTES = 128L * 1024L * 1024L
 
         private data class PublishedClip(
             val uri: Uri,
@@ -791,9 +1053,29 @@ class ClipEditorDialogFragment : Fragment() {
             channelName: String?,
         ) = ClipEditorDialogFragment().apply {
             arguments = Bundle().apply {
+                putString(ARG_SOURCE_MODE, SourceMode.LIVE_PREPARED.name)
                 putString(ARG_PLAYLIST, playlistPath)
                 putString(ARG_DIRECTORY, directoryPath)
                 putLongArray(ARG_BOUNDARIES, boundariesUs)
+                putString(ARG_CHANNEL_NAME, channelName)
+            }
+        }
+
+        fun newVodInstance(
+            previewUri: String,
+            boundariesUs: LongArray,
+            initialPositionUs: Long,
+            bitrateBitsPerSecond: Int?,
+            byteRangeLengths: LongArray,
+            channelName: String?,
+        ) = ClipEditorDialogFragment().apply {
+            arguments = Bundle().apply {
+                putString(ARG_SOURCE_MODE, SourceMode.VOD_REMOTE.name)
+                putString(ARG_PREVIEW_URI, previewUri)
+                putLongArray(ARG_BOUNDARIES, boundariesUs)
+                putLong(ARG_INITIAL_POSITION_US, initialPositionUs)
+                putInt(ARG_BITRATE, bitrateBitsPerSecond ?: 0)
+                putLongArray(ARG_BYTE_RANGE_LENGTHS, byteRangeLengths)
                 putString(ARG_CHANNEL_NAME, channelName)
             }
         }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/clip/ClipEditorDialogFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/clip/ClipEditorDialogFragment.kt
@@ -36,6 +36,7 @@ import androidx.media3.common.util.UnstableApi
 import androidx.media3.datasource.DefaultDataSource
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.hls.HlsMediaSource
+import androidx.media3.exoplayer.source.MediaSource
 import androidx.media3.ui.TimeBar
 import com.github.andreyasadchy.xtra.R
 import com.github.andreyasadchy.xtra.BuildConfig
@@ -71,6 +72,8 @@ class ClipEditorDialogFragment : Fragment() {
         ): Long?
 
         fun releaseVodClip(directoryPath: String)
+
+        fun createVodClipPreviewMediaSource(uri: String): MediaSource
     }
 
     private enum class SourceMode {
@@ -374,17 +377,18 @@ class ClipEditorDialogFragment : Fragment() {
         binding.previewLoading.isVisible = true
         player = ExoPlayer.Builder(requireContext()).build().also { exoPlayer ->
             binding.preview.player = exoPlayer
-            val preview = if (sourceMode == SourceMode.VOD_REMOTE) {
-                requireNotNull(previewUri).toUri()
+            val mediaSource = if (sourceMode == SourceMode.VOD_REMOTE) {
+                val host = parentFragment as? Host
+                    ?: error("VOD clip editor has no host")
+                host.createVodClipPreviewMediaSource(requireNotNull(previewUri))
             } else {
-                requireNotNull(playlistFile).toUri()
+                val mediaItem = MediaItem.Builder()
+                    .setUri(requireNotNull(playlistFile).toUri())
+                    .setMimeType(MimeTypes.APPLICATION_M3U8)
+                    .build()
+                HlsMediaSource.Factory(DefaultDataSource.Factory(requireContext()))
+                    .createMediaSource(mediaItem)
             }
-            val mediaItem = MediaItem.Builder()
-                .setUri(preview)
-                .setMimeType(MimeTypes.APPLICATION_M3U8)
-                .build()
-            val mediaSource = HlsMediaSource.Factory(DefaultDataSource.Factory(requireContext()))
-                .createMediaSource(mediaItem)
             exoPlayer.addListener(object : Player.Listener {
                 override fun onPlaybackStateChanged(playbackState: Int) {
                     if (playbackState == Player.STATE_ENDED) {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/clip/ClipEditorDialogFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/clip/ClipEditorDialogFragment.kt
@@ -36,7 +36,6 @@ import androidx.media3.common.util.UnstableApi
 import androidx.media3.datasource.DefaultDataSource
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.hls.HlsMediaSource
-import androidx.media3.exoplayer.source.MediaSource
 import androidx.media3.ui.TimeBar
 import com.github.andreyasadchy.xtra.R
 import com.github.andreyasadchy.xtra.BuildConfig
@@ -65,9 +64,13 @@ class ClipEditorDialogFragment : Fragment() {
 
         fun cancelVodClipPreparation()
 
-        fun releaseVodClip(directoryPath: String)
+        fun estimateVodClipBytes(
+            startIndex: Int,
+            endIndexExclusive: Int,
+            selectedDurationUs: Long,
+        ): Long?
 
-        fun createVodClipPreviewMediaSource(uri: String): MediaSource
+        fun releaseVodClip(directoryPath: String)
     }
 
     private enum class SourceMode {
@@ -82,7 +85,6 @@ class ClipEditorDialogFragment : Fragment() {
     private var playlistFile: File? = null
     private var directory: File? = null
     private var previewUri: String? = null
-    private var byteRangeLengths = LongArray(0)
     private lateinit var boundariesUs: LongArray
     private var durationUs = 0L
     private var channelName: String? = null
@@ -147,11 +149,16 @@ class ClipEditorDialogFragment : Fragment() {
             directory = File(requireArguments().getString(ARG_DIRECTORY)!!)
         } else {
             previewUri = requireArguments().getString(ARG_PREVIEW_URI)
-            byteRangeLengths = requireArguments().getLongArray(ARG_BYTE_RANGE_LENGTHS) ?: LongArray(0)
+            boundariesUs = ClipTimeline.boundariesFromDurationsUs(
+                requireArguments().getIntArray(ARG_SEGMENT_DURATIONS_US)
+                    ?: intArrayOf(),
+            )
         }
-        boundariesUs = ClipTimeline.normalizeBoundaries(
-            requireArguments().getLongArray(ARG_BOUNDARIES) ?: longArrayOf(0L),
-        )
+        if (sourceMode == SourceMode.LIVE_PREPARED) {
+            boundariesUs = ClipTimeline.normalizeBoundaries(
+                requireArguments().getLongArray(ARG_BOUNDARIES) ?: longArrayOf(0L),
+            )
+        }
         durationUs = boundariesUs.last()
         channelName = requireArguments().getString(ARG_CHANNEL_NAME)
         previewSeekMs = requireContext().prefs()
@@ -367,18 +374,17 @@ class ClipEditorDialogFragment : Fragment() {
         binding.previewLoading.isVisible = true
         player = ExoPlayer.Builder(requireContext()).build().also { exoPlayer ->
             binding.preview.player = exoPlayer
-            val mediaSource = if (sourceMode == SourceMode.VOD_REMOTE) {
-                val host = parentFragment as? Host
-                    ?: error("VOD clip editor has no host")
-                host.createVodClipPreviewMediaSource(requireNotNull(previewUri))
+            val preview = if (sourceMode == SourceMode.VOD_REMOTE) {
+                requireNotNull(previewUri).toUri()
             } else {
-                val mediaItem = MediaItem.Builder()
-                    .setUri(requireNotNull(playlistFile).toUri())
-                    .setMimeType(MimeTypes.APPLICATION_M3U8)
-                    .build()
-                HlsMediaSource.Factory(DefaultDataSource.Factory(requireContext()))
-                    .createMediaSource(mediaItem)
+                requireNotNull(playlistFile).toUri()
             }
+            val mediaItem = MediaItem.Builder()
+                .setUri(preview)
+                .setMimeType(MimeTypes.APPLICATION_M3U8)
+                .build()
+            val mediaSource = HlsMediaSource.Factory(DefaultDataSource.Factory(requireContext()))
+                .createMediaSource(mediaItem)
             exoPlayer.addListener(object : Player.Listener {
                 override fun onPlaybackStateChanged(playbackState: Int) {
                     if (playbackState == Player.STATE_ENDED) {
@@ -574,12 +580,10 @@ class ClipEditorDialogFragment : Fragment() {
     private fun updateVodDetails() {
         val startIndex = ClipTimeline.boundaryIndexUs(startUs, boundariesUs)
         val endIndex = ClipTimeline.boundaryIndexUs(endUs, boundariesUs)
-        val estimatedBytes = ClipSizeEstimator.estimateBytes(
-            selectedDurationUs = endUs - startUs,
-            byteRangeLengths = byteRangeLengths,
+        val estimatedBytes = (parentFragment as? Host)?.estimateVodClipBytes(
             startIndex = startIndex,
             endIndexExclusive = endIndex,
-            bitrateBitsPerSecond = arguments?.getInt(ARG_BITRATE, 0)?.takeIf { it > 0 },
+            selectedDurationUs = endUs - startUs,
         )
         binding.vodSegmentCount.text = getString(R.string.clip_editor_segment_count, (endIndex - startIndex).coerceAtLeast(0))
         if (estimatedBytes == null) {
@@ -1019,9 +1023,9 @@ class ClipEditorDialogFragment : Fragment() {
         private const val ARG_SOURCE_MODE = "sourceMode"
         private const val ARG_PREVIEW_URI = "previewUri"
         private const val ARG_BOUNDARIES = "boundariesUs"
+        private const val ARG_SEGMENT_DURATIONS_US = "segmentDurationsUs"
         private const val ARG_INITIAL_POSITION_US = "initialPositionUs"
         private const val ARG_BITRATE = "bitrateBitsPerSecond"
-        private const val ARG_BYTE_RANGE_LENGTHS = "byteRangeLengths"
         private const val ARG_CHANNEL_NAME = "channelName"
         private const val STATE_START_US = "startUs"
         private const val STATE_END_US = "endUs"
@@ -1063,19 +1067,17 @@ class ClipEditorDialogFragment : Fragment() {
 
         fun newVodInstance(
             previewUri: String,
-            boundariesUs: LongArray,
+            segmentDurationsUs: IntArray,
             initialPositionUs: Long,
             bitrateBitsPerSecond: Int?,
-            byteRangeLengths: LongArray,
             channelName: String?,
         ) = ClipEditorDialogFragment().apply {
             arguments = Bundle().apply {
                 putString(ARG_SOURCE_MODE, SourceMode.VOD_REMOTE.name)
                 putString(ARG_PREVIEW_URI, previewUri)
-                putLongArray(ARG_BOUNDARIES, boundariesUs)
+                putIntArray(ARG_SEGMENT_DURATIONS_US, segmentDurationsUs)
                 putLong(ARG_INITIAL_POSITION_US, initialPositionUs)
                 putInt(ARG_BITRATE, bitrateBitsPerSecond ?: 0)
-                putLongArray(ARG_BYTE_RANGE_LENGTHS, byteRangeLengths)
                 putString(ARG_CHANNEL_NAME, channelName)
             }
         }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/clip/ClipPreparationRepository.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/clip/ClipPreparationRepository.kt
@@ -132,7 +132,7 @@ class ClipPreparationRepository(
     }
 
     private fun ByteCounter.add(amount: Long) {
-        check(value <= maxBytes - amount) { "Live clip exceeds the temporary storage limit" }
+        check(value <= maxBytes - amount) { "Clip exceeds the temporary storage limit" }
         value += amount
     }
 

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/clip/ClipSizeEstimator.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/clip/ClipSizeEstimator.kt
@@ -6,6 +6,7 @@ import kotlin.math.roundToLong
 
 internal object ClipSizeEstimator {
     fun estimateBytes(
+        selectedDurationUs: Long,
         segments: List<ClipSegmentRef>,
         startIndex: Int,
         endIndexExclusive: Int,
@@ -14,43 +15,19 @@ internal object ClipSizeEstimator {
         if (startIndex < 0 || endIndexExclusive <= startIndex || endIndexExclusive > segments.size) {
             return null
         }
-        val selected = segments.subList(startIndex, endIndexExclusive)
-        if (selected.isNotEmpty() && selected.all { it.byteRangeLength != C.LENGTH_UNSET.toLong() }) {
-            return selected.sumOf { it.byteRangeLength.coerceAtLeast(0L) }
-        }
-        val bitrate = bitrateBitsPerSecond?.takeIf { it > 0 } ?: return null
-        val durationUs = selected.sumOf { it.durationUs }
-        return (durationUs.toDouble() / 1_000_000.0 * bitrate.toDouble() / 8.0).roundToLong()
-    }
-
-    fun estimateBytes(
-        selectedDurationUs: Long,
-        byteRangeLengths: LongArray,
-        startIndex: Int,
-        endIndexExclusive: Int,
-        bitrateBitsPerSecond: Int?,
-    ): Long? {
-        if (startIndex < 0 ||
-            endIndexExclusive <= startIndex ||
-            endIndexExclusive > byteRangeLengths.size
-        ) {
-            return null
-        }
-
-        var allRangesKnown = true
         var exactBytes = 0L
+        var allRangesKnown = true
         for (index in startIndex until endIndexExclusive) {
-            val length = byteRangeLengths[index]
-            if (length == C.LENGTH_UNSET.toLong()) {
+            val byteRangeLength = segments[index].byteRangeLength
+            if (byteRangeLength == C.LENGTH_UNSET.toLong()) {
                 allRangesKnown = false
                 break
             }
-            exactBytes += length.coerceAtLeast(0L)
+            exactBytes += byteRangeLength.coerceAtLeast(0L)
         }
         if (allRangesKnown) {
             return exactBytes
         }
-
         val bitrate = bitrateBitsPerSecond?.takeIf { it > 0 } ?: return null
         return (selectedDurationUs.toDouble() / 1_000_000.0 * bitrate.toDouble() / 8.0).roundToLong()
     }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/clip/ClipSizeEstimator.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/clip/ClipSizeEstimator.kt
@@ -1,0 +1,72 @@
+package com.github.andreyasadchy.xtra.ui.player.clip
+
+import androidx.media3.common.C
+import java.util.Locale
+import kotlin.math.roundToLong
+
+internal object ClipSizeEstimator {
+    fun estimateBytes(
+        segments: List<ClipSegmentRef>,
+        startIndex: Int,
+        endIndexExclusive: Int,
+        bitrateBitsPerSecond: Int?,
+    ): Long? {
+        if (startIndex < 0 || endIndexExclusive <= startIndex || endIndexExclusive > segments.size) {
+            return null
+        }
+        val selected = segments.subList(startIndex, endIndexExclusive)
+        if (selected.isNotEmpty() && selected.all { it.byteRangeLength != C.LENGTH_UNSET.toLong() }) {
+            return selected.sumOf { it.byteRangeLength.coerceAtLeast(0L) }
+        }
+        val bitrate = bitrateBitsPerSecond?.takeIf { it > 0 } ?: return null
+        val durationUs = selected.sumOf { it.durationUs }
+        return (durationUs.toDouble() / 1_000_000.0 * bitrate.toDouble() / 8.0).roundToLong()
+    }
+
+    fun estimateBytes(
+        selectedDurationUs: Long,
+        byteRangeLengths: LongArray,
+        startIndex: Int,
+        endIndexExclusive: Int,
+        bitrateBitsPerSecond: Int?,
+    ): Long? {
+        if (startIndex < 0 ||
+            endIndexExclusive <= startIndex ||
+            endIndexExclusive > byteRangeLengths.size
+        ) {
+            return null
+        }
+
+        var allRangesKnown = true
+        var exactBytes = 0L
+        for (index in startIndex until endIndexExclusive) {
+            val length = byteRangeLengths[index]
+            if (length == C.LENGTH_UNSET.toLong()) {
+                allRangesKnown = false
+                break
+            }
+            exactBytes += length.coerceAtLeast(0L)
+        }
+        if (allRangesKnown) {
+            return exactBytes
+        }
+
+        val bitrate = bitrateBitsPerSecond?.takeIf { it > 0 } ?: return null
+        return (selectedDurationUs.toDouble() / 1_000_000.0 * bitrate.toDouble() / 8.0).roundToLong()
+    }
+
+    fun formatBytes(bytes: Long): String {
+        val units = arrayOf("B", "KB", "MB", "GB", "TB")
+        var value = bytes.toDouble()
+        var unit = 0
+        while (value >= 1024.0 && unit < units.lastIndex) {
+            value /= 1024.0
+            unit++
+        }
+        return if (unit == 0) {
+            "${value.toLong()} ${units[unit]}"
+        } else {
+            String.format(Locale.US, "%.1f %s", value, units[unit])
+        }
+    }
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/clip/ClipTime.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/clip/ClipTime.kt
@@ -1,0 +1,36 @@
+package com.github.andreyasadchy.xtra.ui.player.clip
+
+import java.util.Locale
+
+internal object ClipTime {
+    fun parseMs(text: CharSequence): Long? {
+        val parts = text.toString().trim().split(':', limit = 3).reversed()
+        val seconds = parts.getOrNull(0)
+            ?.toLongOrNull()
+            ?.takeIf { it in 0L..59L }
+            ?: return null
+        val minutes = parts.getOrNull(1)?.let {
+            it.toLongOrNull()?.takeIf { value -> value in 0L..59L } ?: return null
+        } ?: 0L
+        val hours = parts.getOrNull(2)?.let {
+            it.toLongOrNull()?.takeIf { value -> value >= 0L } ?: return null
+        } ?: 0L
+        return runCatching {
+            Math.addExact(
+                Math.addExact(
+                    Math.multiplyExact(hours, 3_600_000L),
+                    Math.multiplyExact(minutes, 60_000L),
+                ),
+                Math.multiplyExact(seconds, 1_000L),
+            )
+        }.getOrNull()
+    }
+
+    fun formatMs(milliseconds: Long): String {
+        val totalSeconds = milliseconds.coerceAtLeast(0L) / 1_000L
+        val hours = totalSeconds / 3_600L
+        val minutes = (totalSeconds % 3_600L) / 60L
+        val seconds = totalSeconds % 60L
+        return String.format(Locale.US, "%02d:%02d:%02d", hours, minutes, seconds)
+    }
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/clip/ClipTimeline.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/clip/ClipTimeline.kt
@@ -2,6 +2,21 @@ package com.github.andreyasadchy.xtra.ui.player.clip
 
 /** Keeps the frozen editor timeline exact until values cross the slider's millisecond API. */
 internal object ClipTimeline {
+    fun boundariesFromDurationsUs(durationsUs: IntArray): LongArray {
+        require(durationsUs.isNotEmpty())
+
+        val result = LongArray(durationsUs.size + 1)
+        var totalUs = 0L
+        for (index in durationsUs.indices) {
+            val durationUs = durationsUs[index].toLong()
+            require(durationUs > 0L)
+            require(totalUs <= Long.MAX_VALUE - durationUs)
+            totalUs += durationUs
+            result[index + 1] = totalUs
+        }
+        return result
+    }
+
     fun normalizeBoundaries(boundariesUs: LongArray): LongArray {
         val durationUs = boundariesUs.lastOrNull()?.takeIf { it > 0L } ?: 1_000L
         return boundariesUs

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/clip/ClipTimeline.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/clip/ClipTimeline.kt
@@ -1,7 +1,5 @@
 package com.github.andreyasadchy.xtra.ui.player.clip
 
-import kotlin.math.abs
-
 /** Keeps the frozen editor timeline exact until values cross the slider's millisecond API. */
 internal object ClipTimeline {
     fun normalizeBoundaries(boundariesUs: LongArray): LongArray {
@@ -16,13 +14,24 @@ internal object ClipTimeline {
     }
 
     fun boundaryIndex(positionMs: Float, boundariesUs: LongArray): Int {
-        require(boundariesUs.isNotEmpty())
-        val positionUs = positionMs.toDouble() * 1_000.0
-        return boundariesUs.indices.minBy { abs(boundariesUs[it].toDouble() - positionUs) }
+        return boundaryIndexUs((positionMs.toDouble() * 1_000.0).toLong(), boundariesUs)
     }
 
     fun boundaryIndexUs(positionUs: Long, boundariesUs: LongArray): Int {
         require(boundariesUs.isNotEmpty())
-        return boundariesUs.indices.minBy { abs(boundariesUs[it] - positionUs) }
+        val result = boundariesUs.binarySearch(positionUs)
+        if (result >= 0) return result
+
+        val insertion = -result - 1
+        if (insertion <= 0) return 0
+        if (insertion >= boundariesUs.size) return boundariesUs.lastIndex
+
+        val before = boundariesUs[insertion - 1]
+        val after = boundariesUs[insertion]
+        return if (positionUs - before <= after - positionUs) {
+            insertion - 1
+        } else {
+            insertion
+        }
     }
 }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/clip/HlsClipSnapshotMapper.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/clip/HlsClipSnapshotMapper.kt
@@ -1,0 +1,78 @@
+package com.github.andreyasadchy.xtra.ui.player.clip
+
+import androidx.annotation.OptIn
+import androidx.media3.common.C
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.common.util.UriUtil
+import androidx.media3.exoplayer.hls.HlsManifest
+import androidx.media3.exoplayer.hls.playlist.HlsMediaPlaylist
+
+/** Converts Media3's complete HLS segment metadata into the clip model. */
+@OptIn(UnstableApi::class)
+internal object HlsClipSnapshotMapper {
+    fun fromManifest(
+        manifest: HlsManifest,
+        generation: Long,
+    ): ClipSnapshot {
+        val playlist = manifest.mediaPlaylist
+        val renditionId = playlist.baseUri
+            .substringBefore('#')
+            .substringBefore('?')
+        val refs = playlist.segments.mapIndexedNotNull { index, segment ->
+            if (segment.durationUs <= 0L) {
+                null
+            } else {
+                segment.toClipSegmentRef(
+                    playlist = playlist,
+                    generation = generation,
+                    renditionId = renditionId,
+                    mediaSequence = playlist.mediaSequence + index,
+                )
+            }
+        }
+        return ClipSnapshot(
+            generation = generation,
+            renditionId = renditionId,
+            segments = refs,
+        )
+    }
+
+    private fun HlsMediaPlaylist.Segment.toClipSegmentRef(
+        playlist: HlsMediaPlaylist,
+        generation: Long,
+        renditionId: String,
+        mediaSequence: Long,
+    ): ClipSegmentRef {
+        val absoluteStartUs = if (playlist.startTimeUs != C.TIME_UNSET) {
+            playlist.startTimeUs + relativeStartTimeUs
+        } else {
+            relativeStartTimeUs
+        }
+        val init = initializationSegment?.let {
+            ClipResourceRef(
+                uri = UriUtil.resolve(playlist.baseUri, it.url),
+                byteRangeOffset = it.byteRangeOffset,
+                byteRangeLength = it.byteRangeLength,
+            )
+        }
+        return ClipSegmentRef(
+            generation = generation,
+            renditionId = renditionId,
+            mediaSequence = mediaSequence,
+            absoluteUri = UriUtil.resolve(playlist.baseUri, url),
+            durationUs = durationUs,
+            absoluteStartUs = absoluteStartUs,
+            relativeStartUs = relativeStartTimeUs,
+            discontinuitySequence = playlist.discontinuitySequence + relativeDiscontinuitySequence,
+            byteRangeOffset = byteRangeOffset,
+            byteRangeLength = byteRangeLength,
+            initSegment = init,
+            encryptionKeyUri = fullSegmentEncryptionKeyUri?.let {
+                UriUtil.resolve(playlist.baseUri, it)
+            },
+            encryptionIv = encryptionIV,
+            drmInitDataPresent = drmInitData != null || playlist.protectionSchemes != null,
+            hasGap = hasGapTag,
+        )
+    }
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/clip/LiveClipBufferManager.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/clip/LiveClipBufferManager.kt
@@ -1,11 +1,8 @@
 package com.github.andreyasadchy.xtra.ui.player.clip
 
 import androidx.annotation.OptIn
-import androidx.media3.common.C
 import androidx.media3.common.util.UnstableApi
-import androidx.media3.common.util.UriUtil
 import androidx.media3.exoplayer.hls.HlsManifest
-import androidx.media3.exoplayer.hls.playlist.HlsMediaPlaylist
 
 /**
  * Keeps a small rolling journal of complete HLS segment metadata.
@@ -67,17 +64,15 @@ class LiveClipBufferManager(
                 .filter { it.generation == generation && it.renditionId == currentRenditionId }
                 .map { it.mediaSequence }
                 .toHashSet()
+            val mappedSegments = HlsClipSnapshotMapper.fromManifest(manifest, generation)
+                .segments
+                .associateBy { it.mediaSequence }
             playlist.segments.forEachIndexed { index, segment ->
                 val mediaSequence = playlist.mediaSequence + index
                 if (mediaSequence in existingSequences || segment.durationUs <= 0L) {
                     return@forEachIndexed
                 }
-                history += segment.toRef(
-                    playlist = playlist,
-                    generation = generation,
-                    renditionId = currentRenditionId,
-                    mediaSequence = mediaSequence,
-                )
+                mappedSegments[mediaSequence]?.let(history::add)
             }
             history.sortBy { it.mediaSequence }
             trimHistory()
@@ -138,43 +133,6 @@ class LiveClipBufferManager(
         val drmProtected: Boolean,
         val available: Boolean,
     )
-
-    private fun HlsMediaPlaylist.Segment.toRef(
-        playlist: HlsMediaPlaylist,
-        generation: Long,
-        renditionId: String,
-        mediaSequence: Long,
-    ): ClipSegmentRef {
-        val absoluteStartUs = if (playlist.startTimeUs != C.TIME_UNSET) {
-            playlist.startTimeUs + relativeStartTimeUs
-        } else {
-            relativeStartTimeUs
-        }
-        val init = initializationSegment?.let {
-            ClipResourceRef(
-                uri = UriUtil.resolve(playlist.baseUri, it.url),
-                byteRangeOffset = it.byteRangeOffset,
-                byteRangeLength = it.byteRangeLength,
-            )
-        }
-        return ClipSegmentRef(
-            generation = generation,
-            renditionId = renditionId,
-            mediaSequence = mediaSequence,
-            absoluteUri = UriUtil.resolve(playlist.baseUri, url),
-            durationUs = durationUs,
-            absoluteStartUs = absoluteStartUs,
-            relativeStartUs = relativeStartTimeUs,
-            discontinuitySequence = playlist.discontinuitySequence + relativeDiscontinuitySequence,
-            byteRangeOffset = byteRangeOffset,
-            byteRangeLength = byteRangeLength,
-            initSegment = init,
-            encryptionKeyUri = fullSegmentEncryptionKeyUri?.let { UriUtil.resolve(playlist.baseUri, it) },
-            encryptionIv = encryptionIV,
-            drmInitDataPresent = drmInitData != null || playlist.protectionSchemes != null,
-            hasGap = hasGapTag,
-        )
-    }
 
     companion object {
         const val MIN_CLIP_DURATION_SECONDS = 10

--- a/app/src/main/res/layout/fragment_clip_editor.xml
+++ b/app/src/main/res/layout/fragment_clip_editor.xml
@@ -205,6 +205,172 @@
 
             </LinearLayout>
 
+            <LinearLayout
+                android:id="@+id/vodRangeControls"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:visibility="gone"
+                tools:visibility="visible">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal">
+
+                    <com.google.android.material.textfield.TextInputLayout
+                        android:id="@+id/startTimeLayout"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:hint="@string/clip_editor_start"
+                        app:boxBackgroundMode="outline">
+
+                        <com.google.android.material.textfield.TextInputEditText
+                            android:id="@+id/startTime"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:imeOptions="actionNext"
+                            android:inputType="text"
+                            android:maxLines="1"
+                            android:singleLine="true"
+                            tools:text="01:42:13" />
+
+                    </com.google.android.material.textfield.TextInputLayout>
+
+                    <Space
+                        android:layout_width="8dp"
+                        android:layout_height="1dp" />
+
+                    <com.google.android.material.textfield.TextInputLayout
+                        android:id="@+id/endTimeLayout"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:hint="@string/clip_editor_end"
+                        app:boxBackgroundMode="outline">
+
+                        <com.google.android.material.textfield.TextInputEditText
+                            android:id="@+id/endTime"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:imeOptions="actionDone"
+                            android:inputType="text"
+                            android:maxLines="1"
+                            android:singleLine="true"
+                            tools:text="03:11:54" />
+
+                    </com.google.android.material.textfield.TextInputLayout>
+
+                </LinearLayout>
+
+                <HorizontalScrollView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:scrollbars="none">
+
+                    <LinearLayout
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:orientation="horizontal">
+
+                        <com.google.android.material.button.MaterialButton
+                            android:id="@+id/preset15"
+                            style="?attr/materialButtonOutlinedStyle"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:minHeight="40dp"
+                            android:text="15s"
+                            android:textAllCaps="false" />
+
+                        <com.google.android.material.button.MaterialButton
+                            android:id="@+id/preset30"
+                            style="?attr/materialButtonOutlinedStyle"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:minHeight="40dp"
+                            android:text="30s"
+                            android:textAllCaps="false" />
+
+                        <com.google.android.material.button.MaterialButton
+                            android:id="@+id/preset1m"
+                            style="?attr/materialButtonOutlinedStyle"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:minHeight="40dp"
+                            android:text="1m"
+                            android:textAllCaps="false" />
+
+                        <com.google.android.material.button.MaterialButton
+                            android:id="@+id/preset5m"
+                            style="?attr/materialButtonOutlinedStyle"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:minHeight="40dp"
+                            android:text="5m"
+                            android:textAllCaps="false" />
+
+                        <com.google.android.material.button.MaterialButton
+                            android:id="@+id/preset10m"
+                            style="?attr/materialButtonOutlinedStyle"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:minHeight="40dp"
+                            android:text="10m"
+                            android:textAllCaps="false" />
+
+                    </LinearLayout>
+
+                </HorizontalScrollView>
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal">
+
+                    <com.google.android.material.button.MaterialButton
+                        android:id="@+id/setStartPlayhead"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="Start ← playhead"
+                        android:textAllCaps="false" />
+
+                    <com.google.android.material.button.MaterialButton
+                        android:id="@+id/setEndPlayhead"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="End ← playhead"
+                        android:textAllCaps="false" />
+
+                </LinearLayout>
+
+                <TextView
+                    android:id="@+id/vodSegmentCount"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:gravity="center"
+                    android:textAppearance="?attr/textAppearanceBodySmall" />
+
+                <TextView
+                    android:id="@+id/estimatedSize"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:gravity="center"
+                    android:textAppearance="?attr/textAppearanceBodyMedium"
+                    tools:text="Estimated file size: ~1.4 GB" />
+
+                <TextView
+                    android:id="@+id/temporarySpace"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:gravity="center"
+                    android:textAppearance="?attr/textAppearanceBodySmall"
+                    tools:text="Temporary space needed: ~2.9 GB" />
+
+            </LinearLayout>
+
             <com.google.android.material.textfield.TextInputLayout
                 android:id="@+id/fileNameLayout"
                 android:layout_width="match_parent"

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -1432,13 +1432,4 @@
     <string name="user_card_unfollow">Unfollow</string>
     <string name="user_card_whisper">Whisper</string>
     <string name="user_card_follow_failed">Couldn’t update follow status</string>
-    <string name="clip_editor_start">Start</string>
-    <string name="clip_editor_end">End</string>
-    <string name="clip_editor_segment_count">%d segments</string>
-    <string name="clip_editor_estimated_size">Estimated file size: ~%s</string>
-    <string name="clip_editor_estimated_size_unknown">Estimated file size: unavailable</string>
-    <string name="clip_editor_temporary_space">Temporary space needed: ~%s</string>
-    <string name="clip_editor_temporary_space_unknown">Temporary space needed: unavailable</string>
-    <string name="clip_editor_insufficient_storage">Not enough free space</string>
-    <string name="clip_editor_actual_size">File size: %s</string>
 </resources>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -1432,4 +1432,13 @@
     <string name="user_card_unfollow">Unfollow</string>
     <string name="user_card_whisper">Whisper</string>
     <string name="user_card_follow_failed">Couldn’t update follow status</string>
+    <string name="clip_editor_start">Start</string>
+    <string name="clip_editor_end">End</string>
+    <string name="clip_editor_segment_count">%d segments</string>
+    <string name="clip_editor_estimated_size">Estimated file size: ~%s</string>
+    <string name="clip_editor_estimated_size_unknown">Estimated file size: unavailable</string>
+    <string name="clip_editor_temporary_space">Temporary space needed: ~%s</string>
+    <string name="clip_editor_temporary_space_unknown">Temporary space needed: unavailable</string>
+    <string name="clip_editor_insufficient_storage">Not enough free space</string>
+    <string name="clip_editor_actual_size">File size: %s</string>
 </resources>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -1455,13 +1455,4 @@
     <string name="user_card_unfollow">Unfollow</string>
     <string name="user_card_whisper">Whisper</string>
     <string name="user_card_follow_failed">Couldn’t update follow status</string>
-    <string name="clip_editor_start">Start</string>
-    <string name="clip_editor_end">End</string>
-    <string name="clip_editor_segment_count">%d segments</string>
-    <string name="clip_editor_estimated_size">Estimated file size: ~%s</string>
-    <string name="clip_editor_estimated_size_unknown">Estimated file size: unavailable</string>
-    <string name="clip_editor_temporary_space">Temporary space needed: ~%s</string>
-    <string name="clip_editor_temporary_space_unknown">Temporary space needed: unavailable</string>
-    <string name="clip_editor_insufficient_storage">Not enough free space</string>
-    <string name="clip_editor_actual_size">File size: %s</string>
 </resources>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -1455,4 +1455,13 @@
     <string name="user_card_unfollow">Unfollow</string>
     <string name="user_card_whisper">Whisper</string>
     <string name="user_card_follow_failed">Couldn’t update follow status</string>
+    <string name="clip_editor_start">Start</string>
+    <string name="clip_editor_end">End</string>
+    <string name="clip_editor_segment_count">%d segments</string>
+    <string name="clip_editor_estimated_size">Estimated file size: ~%s</string>
+    <string name="clip_editor_estimated_size_unknown">Estimated file size: unavailable</string>
+    <string name="clip_editor_temporary_space">Temporary space needed: ~%s</string>
+    <string name="clip_editor_temporary_space_unknown">Temporary space needed: unavailable</string>
+    <string name="clip_editor_insufficient_storage">Not enough free space</string>
+    <string name="clip_editor_actual_size">File size: %s</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1432,13 +1432,4 @@
     <string name="user_card_unfollow">Unfollow</string>
     <string name="user_card_whisper">Whisper</string>
     <string name="user_card_follow_failed">Couldn’t update follow status</string>
-    <string name="clip_editor_start">Start</string>
-    <string name="clip_editor_end">End</string>
-    <string name="clip_editor_segment_count">%d segments</string>
-    <string name="clip_editor_estimated_size">Estimated file size: ~%s</string>
-    <string name="clip_editor_estimated_size_unknown">Estimated file size: unavailable</string>
-    <string name="clip_editor_temporary_space">Temporary space needed: ~%s</string>
-    <string name="clip_editor_temporary_space_unknown">Temporary space needed: unavailable</string>
-    <string name="clip_editor_insufficient_storage">Not enough free space</string>
-    <string name="clip_editor_actual_size">File size: %s</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1432,4 +1432,13 @@
     <string name="user_card_unfollow">Unfollow</string>
     <string name="user_card_whisper">Whisper</string>
     <string name="user_card_follow_failed">Couldn’t update follow status</string>
+    <string name="clip_editor_start">Start</string>
+    <string name="clip_editor_end">End</string>
+    <string name="clip_editor_segment_count">%d segments</string>
+    <string name="clip_editor_estimated_size">Estimated file size: ~%s</string>
+    <string name="clip_editor_estimated_size_unknown">Estimated file size: unavailable</string>
+    <string name="clip_editor_temporary_space">Temporary space needed: ~%s</string>
+    <string name="clip_editor_temporary_space_unknown">Temporary space needed: unavailable</string>
+    <string name="clip_editor_insufficient_storage">Not enough free space</string>
+    <string name="clip_editor_actual_size">File size: %s</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1437,13 +1437,4 @@
     <string name="user_card_unfollow">Unfollow</string>
     <string name="user_card_whisper">Whisper</string>
     <string name="user_card_follow_failed">Couldn’t update follow status</string>
-    <string name="clip_editor_start">Start</string>
-    <string name="clip_editor_end">End</string>
-    <string name="clip_editor_segment_count">%d segments</string>
-    <string name="clip_editor_estimated_size">Estimated file size: ~%s</string>
-    <string name="clip_editor_estimated_size_unknown">Estimated file size: unavailable</string>
-    <string name="clip_editor_temporary_space">Temporary space needed: ~%s</string>
-    <string name="clip_editor_temporary_space_unknown">Temporary space needed: unavailable</string>
-    <string name="clip_editor_insufficient_storage">Not enough free space</string>
-    <string name="clip_editor_actual_size">File size: %s</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1437,4 +1437,13 @@
     <string name="user_card_unfollow">Unfollow</string>
     <string name="user_card_whisper">Whisper</string>
     <string name="user_card_follow_failed">Couldn’t update follow status</string>
+    <string name="clip_editor_start">Start</string>
+    <string name="clip_editor_end">End</string>
+    <string name="clip_editor_segment_count">%d segments</string>
+    <string name="clip_editor_estimated_size">Estimated file size: ~%s</string>
+    <string name="clip_editor_estimated_size_unknown">Estimated file size: unavailable</string>
+    <string name="clip_editor_temporary_space">Temporary space needed: ~%s</string>
+    <string name="clip_editor_temporary_space_unknown">Temporary space needed: unavailable</string>
+    <string name="clip_editor_insufficient_storage">Not enough free space</string>
+    <string name="clip_editor_actual_size">File size: %s</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1432,13 +1432,4 @@
     <string name="user_card_unfollow">Unfollow</string>
     <string name="user_card_whisper">Whisper</string>
     <string name="user_card_follow_failed">Couldn’t update follow status</string>
-    <string name="clip_editor_start">Start</string>
-    <string name="clip_editor_end">End</string>
-    <string name="clip_editor_segment_count">%d segments</string>
-    <string name="clip_editor_estimated_size">Estimated file size: ~%s</string>
-    <string name="clip_editor_estimated_size_unknown">Estimated file size: unavailable</string>
-    <string name="clip_editor_temporary_space">Temporary space needed: ~%s</string>
-    <string name="clip_editor_temporary_space_unknown">Temporary space needed: unavailable</string>
-    <string name="clip_editor_insufficient_storage">Not enough free space</string>
-    <string name="clip_editor_actual_size">File size: %s</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1432,4 +1432,13 @@
     <string name="user_card_unfollow">Unfollow</string>
     <string name="user_card_whisper">Whisper</string>
     <string name="user_card_follow_failed">Couldn’t update follow status</string>
+    <string name="clip_editor_start">Start</string>
+    <string name="clip_editor_end">End</string>
+    <string name="clip_editor_segment_count">%d segments</string>
+    <string name="clip_editor_estimated_size">Estimated file size: ~%s</string>
+    <string name="clip_editor_estimated_size_unknown">Estimated file size: unavailable</string>
+    <string name="clip_editor_temporary_space">Temporary space needed: ~%s</string>
+    <string name="clip_editor_temporary_space_unknown">Temporary space needed: unavailable</string>
+    <string name="clip_editor_insufficient_storage">Not enough free space</string>
+    <string name="clip_editor_actual_size">File size: %s</string>
 </resources>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -1432,13 +1432,4 @@
     <string name="user_card_unfollow">Unfollow</string>
     <string name="user_card_whisper">Whisper</string>
     <string name="user_card_follow_failed">Couldn’t update follow status</string>
-    <string name="clip_editor_start">Start</string>
-    <string name="clip_editor_end">End</string>
-    <string name="clip_editor_segment_count">%d segments</string>
-    <string name="clip_editor_estimated_size">Estimated file size: ~%s</string>
-    <string name="clip_editor_estimated_size_unknown">Estimated file size: unavailable</string>
-    <string name="clip_editor_temporary_space">Temporary space needed: ~%s</string>
-    <string name="clip_editor_temporary_space_unknown">Temporary space needed: unavailable</string>
-    <string name="clip_editor_insufficient_storage">Not enough free space</string>
-    <string name="clip_editor_actual_size">File size: %s</string>
 </resources>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -1432,4 +1432,13 @@
     <string name="user_card_unfollow">Unfollow</string>
     <string name="user_card_whisper">Whisper</string>
     <string name="user_card_follow_failed">Couldn’t update follow status</string>
+    <string name="clip_editor_start">Start</string>
+    <string name="clip_editor_end">End</string>
+    <string name="clip_editor_segment_count">%d segments</string>
+    <string name="clip_editor_estimated_size">Estimated file size: ~%s</string>
+    <string name="clip_editor_estimated_size_unknown">Estimated file size: unavailable</string>
+    <string name="clip_editor_temporary_space">Temporary space needed: ~%s</string>
+    <string name="clip_editor_temporary_space_unknown">Temporary space needed: unavailable</string>
+    <string name="clip_editor_insufficient_storage">Not enough free space</string>
+    <string name="clip_editor_actual_size">File size: %s</string>
 </resources>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -1433,4 +1433,13 @@
     <string name="user_card_unfollow">Unfollow</string>
     <string name="user_card_whisper">Whisper</string>
     <string name="user_card_follow_failed">Couldn’t update follow status</string>
+    <string name="clip_editor_start">Start</string>
+    <string name="clip_editor_end">End</string>
+    <string name="clip_editor_segment_count">%d segments</string>
+    <string name="clip_editor_estimated_size">Estimated file size: ~%s</string>
+    <string name="clip_editor_estimated_size_unknown">Estimated file size: unavailable</string>
+    <string name="clip_editor_temporary_space">Temporary space needed: ~%s</string>
+    <string name="clip_editor_temporary_space_unknown">Temporary space needed: unavailable</string>
+    <string name="clip_editor_insufficient_storage">Not enough free space</string>
+    <string name="clip_editor_actual_size">File size: %s</string>
 </resources>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -1433,13 +1433,4 @@
     <string name="user_card_unfollow">Unfollow</string>
     <string name="user_card_whisper">Whisper</string>
     <string name="user_card_follow_failed">Couldn’t update follow status</string>
-    <string name="clip_editor_start">Start</string>
-    <string name="clip_editor_end">End</string>
-    <string name="clip_editor_segment_count">%d segments</string>
-    <string name="clip_editor_estimated_size">Estimated file size: ~%s</string>
-    <string name="clip_editor_estimated_size_unknown">Estimated file size: unavailable</string>
-    <string name="clip_editor_temporary_space">Temporary space needed: ~%s</string>
-    <string name="clip_editor_temporary_space_unknown">Temporary space needed: unavailable</string>
-    <string name="clip_editor_insufficient_storage">Not enough free space</string>
-    <string name="clip_editor_actual_size">File size: %s</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1432,13 +1432,4 @@
     <string name="user_card_unfollow">Unfollow</string>
     <string name="user_card_whisper">Whisper</string>
     <string name="user_card_follow_failed">Couldn’t update follow status</string>
-    <string name="clip_editor_start">Start</string>
-    <string name="clip_editor_end">End</string>
-    <string name="clip_editor_segment_count">%d segments</string>
-    <string name="clip_editor_estimated_size">Estimated file size: ~%s</string>
-    <string name="clip_editor_estimated_size_unknown">Estimated file size: unavailable</string>
-    <string name="clip_editor_temporary_space">Temporary space needed: ~%s</string>
-    <string name="clip_editor_temporary_space_unknown">Temporary space needed: unavailable</string>
-    <string name="clip_editor_insufficient_storage">Not enough free space</string>
-    <string name="clip_editor_actual_size">File size: %s</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1432,4 +1432,13 @@
     <string name="user_card_unfollow">Unfollow</string>
     <string name="user_card_whisper">Whisper</string>
     <string name="user_card_follow_failed">Couldn’t update follow status</string>
+    <string name="clip_editor_start">Start</string>
+    <string name="clip_editor_end">End</string>
+    <string name="clip_editor_segment_count">%d segments</string>
+    <string name="clip_editor_estimated_size">Estimated file size: ~%s</string>
+    <string name="clip_editor_estimated_size_unknown">Estimated file size: unavailable</string>
+    <string name="clip_editor_temporary_space">Temporary space needed: ~%s</string>
+    <string name="clip_editor_temporary_space_unknown">Temporary space needed: unavailable</string>
+    <string name="clip_editor_insufficient_storage">Not enough free space</string>
+    <string name="clip_editor_actual_size">File size: %s</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1432,13 +1432,4 @@
     <string name="user_card_unfollow">Unfollow</string>
     <string name="user_card_whisper">Whisper</string>
     <string name="user_card_follow_failed">Couldn’t update follow status</string>
-    <string name="clip_editor_start">Start</string>
-    <string name="clip_editor_end">End</string>
-    <string name="clip_editor_segment_count">%d segments</string>
-    <string name="clip_editor_estimated_size">Estimated file size: ~%s</string>
-    <string name="clip_editor_estimated_size_unknown">Estimated file size: unavailable</string>
-    <string name="clip_editor_temporary_space">Temporary space needed: ~%s</string>
-    <string name="clip_editor_temporary_space_unknown">Temporary space needed: unavailable</string>
-    <string name="clip_editor_insufficient_storage">Not enough free space</string>
-    <string name="clip_editor_actual_size">File size: %s</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1432,4 +1432,13 @@
     <string name="user_card_unfollow">Unfollow</string>
     <string name="user_card_whisper">Whisper</string>
     <string name="user_card_follow_failed">Couldn’t update follow status</string>
+    <string name="clip_editor_start">Start</string>
+    <string name="clip_editor_end">End</string>
+    <string name="clip_editor_segment_count">%d segments</string>
+    <string name="clip_editor_estimated_size">Estimated file size: ~%s</string>
+    <string name="clip_editor_estimated_size_unknown">Estimated file size: unavailable</string>
+    <string name="clip_editor_temporary_space">Temporary space needed: ~%s</string>
+    <string name="clip_editor_temporary_space_unknown">Temporary space needed: unavailable</string>
+    <string name="clip_editor_insufficient_storage">Not enough free space</string>
+    <string name="clip_editor_actual_size">File size: %s</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -1430,4 +1430,13 @@
     <string name="user_card_unfollow">Unfollow</string>
     <string name="user_card_whisper">Whisper</string>
     <string name="user_card_follow_failed">Couldn’t update follow status</string>
+    <string name="clip_editor_start">Start</string>
+    <string name="clip_editor_end">End</string>
+    <string name="clip_editor_segment_count">%d segments</string>
+    <string name="clip_editor_estimated_size">Estimated file size: ~%s</string>
+    <string name="clip_editor_estimated_size_unknown">Estimated file size: unavailable</string>
+    <string name="clip_editor_temporary_space">Temporary space needed: ~%s</string>
+    <string name="clip_editor_temporary_space_unknown">Temporary space needed: unavailable</string>
+    <string name="clip_editor_insufficient_storage">Not enough free space</string>
+    <string name="clip_editor_actual_size">File size: %s</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -1430,13 +1430,4 @@
     <string name="user_card_unfollow">Unfollow</string>
     <string name="user_card_whisper">Whisper</string>
     <string name="user_card_follow_failed">Couldn’t update follow status</string>
-    <string name="clip_editor_start">Start</string>
-    <string name="clip_editor_end">End</string>
-    <string name="clip_editor_segment_count">%d segments</string>
-    <string name="clip_editor_estimated_size">Estimated file size: ~%s</string>
-    <string name="clip_editor_estimated_size_unknown">Estimated file size: unavailable</string>
-    <string name="clip_editor_temporary_space">Temporary space needed: ~%s</string>
-    <string name="clip_editor_temporary_space_unknown">Temporary space needed: unavailable</string>
-    <string name="clip_editor_insufficient_storage">Not enough free space</string>
-    <string name="clip_editor_actual_size">File size: %s</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -1432,13 +1432,4 @@
     <string name="user_card_unfollow">Unfollow</string>
     <string name="user_card_whisper">Whisper</string>
     <string name="user_card_follow_failed">Couldn’t update follow status</string>
-    <string name="clip_editor_start">Start</string>
-    <string name="clip_editor_end">End</string>
-    <string name="clip_editor_segment_count">%d segments</string>
-    <string name="clip_editor_estimated_size">Estimated file size: ~%s</string>
-    <string name="clip_editor_estimated_size_unknown">Estimated file size: unavailable</string>
-    <string name="clip_editor_temporary_space">Temporary space needed: ~%s</string>
-    <string name="clip_editor_temporary_space_unknown">Temporary space needed: unavailable</string>
-    <string name="clip_editor_insufficient_storage">Not enough free space</string>
-    <string name="clip_editor_actual_size">File size: %s</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -1432,4 +1432,13 @@
     <string name="user_card_unfollow">Unfollow</string>
     <string name="user_card_whisper">Whisper</string>
     <string name="user_card_follow_failed">Couldn’t update follow status</string>
+    <string name="clip_editor_start">Start</string>
+    <string name="clip_editor_end">End</string>
+    <string name="clip_editor_segment_count">%d segments</string>
+    <string name="clip_editor_estimated_size">Estimated file size: ~%s</string>
+    <string name="clip_editor_estimated_size_unknown">Estimated file size: unavailable</string>
+    <string name="clip_editor_temporary_space">Temporary space needed: ~%s</string>
+    <string name="clip_editor_temporary_space_unknown">Temporary space needed: unavailable</string>
+    <string name="clip_editor_insufficient_storage">Not enough free space</string>
+    <string name="clip_editor_actual_size">File size: %s</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1432,13 +1432,4 @@
     <string name="user_card_unfollow">Unfollow</string>
     <string name="user_card_whisper">Whisper</string>
     <string name="user_card_follow_failed">Couldn’t update follow status</string>
-    <string name="clip_editor_start">Start</string>
-    <string name="clip_editor_end">End</string>
-    <string name="clip_editor_segment_count">%d segments</string>
-    <string name="clip_editor_estimated_size">Estimated file size: ~%s</string>
-    <string name="clip_editor_estimated_size_unknown">Estimated file size: unavailable</string>
-    <string name="clip_editor_temporary_space">Temporary space needed: ~%s</string>
-    <string name="clip_editor_temporary_space_unknown">Temporary space needed: unavailable</string>
-    <string name="clip_editor_insufficient_storage">Not enough free space</string>
-    <string name="clip_editor_actual_size">File size: %s</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1432,4 +1432,13 @@
     <string name="user_card_unfollow">Unfollow</string>
     <string name="user_card_whisper">Whisper</string>
     <string name="user_card_follow_failed">Couldn’t update follow status</string>
+    <string name="clip_editor_start">Start</string>
+    <string name="clip_editor_end">End</string>
+    <string name="clip_editor_segment_count">%d segments</string>
+    <string name="clip_editor_estimated_size">Estimated file size: ~%s</string>
+    <string name="clip_editor_estimated_size_unknown">Estimated file size: unavailable</string>
+    <string name="clip_editor_temporary_space">Temporary space needed: ~%s</string>
+    <string name="clip_editor_temporary_space_unknown">Temporary space needed: unavailable</string>
+    <string name="clip_editor_insufficient_storage">Not enough free space</string>
+    <string name="clip_editor_actual_size">File size: %s</string>
 </resources>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -1455,13 +1455,4 @@
     <string name="user_card_unfollow">Unfollow</string>
     <string name="user_card_whisper">Whisper</string>
     <string name="user_card_follow_failed">Couldn’t update follow status</string>
-    <string name="clip_editor_start">Start</string>
-    <string name="clip_editor_end">End</string>
-    <string name="clip_editor_segment_count">%d segments</string>
-    <string name="clip_editor_estimated_size">Estimated file size: ~%s</string>
-    <string name="clip_editor_estimated_size_unknown">Estimated file size: unavailable</string>
-    <string name="clip_editor_temporary_space">Temporary space needed: ~%s</string>
-    <string name="clip_editor_temporary_space_unknown">Temporary space needed: unavailable</string>
-    <string name="clip_editor_insufficient_storage">Not enough free space</string>
-    <string name="clip_editor_actual_size">File size: %s</string>
 </resources>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -1455,4 +1455,13 @@
     <string name="user_card_unfollow">Unfollow</string>
     <string name="user_card_whisper">Whisper</string>
     <string name="user_card_follow_failed">Couldn’t update follow status</string>
+    <string name="clip_editor_start">Start</string>
+    <string name="clip_editor_end">End</string>
+    <string name="clip_editor_segment_count">%d segments</string>
+    <string name="clip_editor_estimated_size">Estimated file size: ~%s</string>
+    <string name="clip_editor_estimated_size_unknown">Estimated file size: unavailable</string>
+    <string name="clip_editor_temporary_space">Temporary space needed: ~%s</string>
+    <string name="clip_editor_temporary_space_unknown">Temporary space needed: unavailable</string>
+    <string name="clip_editor_insufficient_storage">Not enough free space</string>
+    <string name="clip_editor_actual_size">File size: %s</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -1433,4 +1433,13 @@
     <string name="user_card_unfollow">Unfollow</string>
     <string name="user_card_whisper">Whisper</string>
     <string name="user_card_follow_failed">Couldn’t update follow status</string>
+    <string name="clip_editor_start">Start</string>
+    <string name="clip_editor_end">End</string>
+    <string name="clip_editor_segment_count">%d segments</string>
+    <string name="clip_editor_estimated_size">Estimated file size: ~%s</string>
+    <string name="clip_editor_estimated_size_unknown">Estimated file size: unavailable</string>
+    <string name="clip_editor_temporary_space">Temporary space needed: ~%s</string>
+    <string name="clip_editor_temporary_space_unknown">Temporary space needed: unavailable</string>
+    <string name="clip_editor_insufficient_storage">Not enough free space</string>
+    <string name="clip_editor_actual_size">File size: %s</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -1433,13 +1433,4 @@
     <string name="user_card_unfollow">Unfollow</string>
     <string name="user_card_whisper">Whisper</string>
     <string name="user_card_follow_failed">Couldn’t update follow status</string>
-    <string name="clip_editor_start">Start</string>
-    <string name="clip_editor_end">End</string>
-    <string name="clip_editor_segment_count">%d segments</string>
-    <string name="clip_editor_estimated_size">Estimated file size: ~%s</string>
-    <string name="clip_editor_estimated_size_unknown">Estimated file size: unavailable</string>
-    <string name="clip_editor_temporary_space">Temporary space needed: ~%s</string>
-    <string name="clip_editor_temporary_space_unknown">Temporary space needed: unavailable</string>
-    <string name="clip_editor_insufficient_storage">Not enough free space</string>
-    <string name="clip_editor_actual_size">File size: %s</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1432,13 +1432,4 @@
     <string name="user_card_unfollow">Unfollow</string>
     <string name="user_card_whisper">Whisper</string>
     <string name="user_card_follow_failed">Couldn’t update follow status</string>
-    <string name="clip_editor_start">Start</string>
-    <string name="clip_editor_end">End</string>
-    <string name="clip_editor_segment_count">%d segments</string>
-    <string name="clip_editor_estimated_size">Estimated file size: ~%s</string>
-    <string name="clip_editor_estimated_size_unknown">Estimated file size: unavailable</string>
-    <string name="clip_editor_temporary_space">Temporary space needed: ~%s</string>
-    <string name="clip_editor_temporary_space_unknown">Temporary space needed: unavailable</string>
-    <string name="clip_editor_insufficient_storage">Not enough free space</string>
-    <string name="clip_editor_actual_size">File size: %s</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1432,4 +1432,13 @@
     <string name="user_card_unfollow">Unfollow</string>
     <string name="user_card_whisper">Whisper</string>
     <string name="user_card_follow_failed">Couldn’t update follow status</string>
+    <string name="clip_editor_start">Start</string>
+    <string name="clip_editor_end">End</string>
+    <string name="clip_editor_segment_count">%d segments</string>
+    <string name="clip_editor_estimated_size">Estimated file size: ~%s</string>
+    <string name="clip_editor_estimated_size_unknown">Estimated file size: unavailable</string>
+    <string name="clip_editor_temporary_space">Temporary space needed: ~%s</string>
+    <string name="clip_editor_temporary_space_unknown">Temporary space needed: unavailable</string>
+    <string name="clip_editor_insufficient_storage">Not enough free space</string>
+    <string name="clip_editor_actual_size">File size: %s</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -1432,13 +1432,4 @@
     <string name="user_card_unfollow">Unfollow</string>
     <string name="user_card_whisper">Whisper</string>
     <string name="user_card_follow_failed">Couldn’t update follow status</string>
-    <string name="clip_editor_start">Start</string>
-    <string name="clip_editor_end">End</string>
-    <string name="clip_editor_segment_count">%d segments</string>
-    <string name="clip_editor_estimated_size">Estimated file size: ~%s</string>
-    <string name="clip_editor_estimated_size_unknown">Estimated file size: unavailable</string>
-    <string name="clip_editor_temporary_space">Temporary space needed: ~%s</string>
-    <string name="clip_editor_temporary_space_unknown">Temporary space needed: unavailable</string>
-    <string name="clip_editor_insufficient_storage">Not enough free space</string>
-    <string name="clip_editor_actual_size">File size: %s</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -1432,4 +1432,13 @@
     <string name="user_card_unfollow">Unfollow</string>
     <string name="user_card_whisper">Whisper</string>
     <string name="user_card_follow_failed">Couldn’t update follow status</string>
+    <string name="clip_editor_start">Start</string>
+    <string name="clip_editor_end">End</string>
+    <string name="clip_editor_segment_count">%d segments</string>
+    <string name="clip_editor_estimated_size">Estimated file size: ~%s</string>
+    <string name="clip_editor_estimated_size_unknown">Estimated file size: unavailable</string>
+    <string name="clip_editor_temporary_space">Temporary space needed: ~%s</string>
+    <string name="clip_editor_temporary_space_unknown">Temporary space needed: unavailable</string>
+    <string name="clip_editor_insufficient_storage">Not enough free space</string>
+    <string name="clip_editor_actual_size">File size: %s</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -567,6 +567,15 @@
     <string name="clip_editor_done">Done</string>
     <string name="clip_editor_exporting">Creating clip…</string>
     <string name="clip_editor_selected_duration">Selected: %s</string>
+    <string name="clip_editor_start">Start</string>
+    <string name="clip_editor_end">End</string>
+    <string name="clip_editor_segment_count">%d segments</string>
+    <string name="clip_editor_estimated_size">Estimated file size: ~%s</string>
+    <string name="clip_editor_estimated_size_unknown">Estimated file size: unavailable</string>
+    <string name="clip_editor_temporary_space">Temporary space needed: ~%s</string>
+    <string name="clip_editor_temporary_space_unknown">Temporary space needed: unavailable</string>
+    <string name="clip_editor_insufficient_storage">Not enough free space</string>
+    <string name="clip_editor_actual_size">File size: %s</string>
     <string name="clip_editor_now">Now</string>
     <string name="clip_editor_seconds_ago">-%1$d s</string>
     <string name="clip_saved">Clip saved</string>

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/player/clip/ClipSelectionPlaylistWriterTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/player/clip/ClipSelectionPlaylistWriterTest.kt
@@ -1,0 +1,79 @@
+package com.github.andreyasadchy.xtra.ui.player.clip
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+import java.nio.file.Files
+
+class ClipSelectionPlaylistWriterTest {
+    @Test
+    fun canSelectTheFirstAndLastVodSegments() {
+        val directory = Files.createTempDirectory("vod-selection").toFile()
+        try {
+            val prepared = ClipPreparationRepository.PreparedLiveClip(
+                directory = directory,
+                playlist = File(directory, "clip.m3u8"),
+                segments = (0L until 4L).map { segment(it) },
+            )
+            val playlist = ClipSelectionPlaylistWriter.write(
+                prepared = prepared,
+                output = File(directory, "selected.m3u8"),
+                startIndex = 0,
+                endIndexExclusive = prepared.segments.size,
+            )
+
+            assertEquals(4, playlist.readLines().count { it.startsWith("segment_") })
+            assertTrue(playlist.readText().contains("segment_0.ts"))
+            assertTrue(playlist.readText().contains("segment_3.ts"))
+        } finally {
+            directory.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun rejectsAReversedSelection() {
+        val directory = Files.createTempDirectory("vod-selection-invalid").toFile()
+        try {
+            val prepared = ClipPreparationRepository.PreparedLiveClip(
+                directory = directory,
+                playlist = File(directory, "clip.m3u8"),
+                segments = listOf(segment(0L), segment(1L)),
+            )
+
+            assertThrows(IllegalArgumentException::class.java) {
+                ClipSelectionPlaylistWriter.write(prepared, File(directory, "selected.m3u8"), 1, 1)
+            }
+        } finally {
+            directory.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun keepsDiscontinuitiesAcrossLongSelections() {
+        val directory = Files.createTempDirectory("vod-selection-discontinuity").toFile()
+        try {
+            val prepared = ClipPreparationRepository.PreparedLiveClip(
+                directory = directory,
+                playlist = File(directory, "clip.m3u8"),
+                segments = (0L until 180L).map { segment(it, (it / 60).toInt()) },
+            )
+            val playlist = ClipSelectionPlaylistWriter.write(prepared, File(directory, "selected.m3u8"), 0, 180)
+
+            assertEquals(2, playlist.readLines().count { it == "#EXT-X-DISCONTINUITY" })
+        } finally {
+            directory.deleteRecursively()
+        }
+    }
+
+    private fun segment(sequence: Long, discontinuitySequence: Int = 0) = PreparedClipSegment(
+        mediaSequence = sequence,
+        durationUs = 2_000_000L,
+        discontinuitySequence = discontinuitySequence,
+        segmentFile = "segment_$sequence.ts",
+        initFile = null,
+        keyFile = null,
+        encryptionIv = null,
+    )
+}

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/player/clip/ClipSizeEstimatorTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/player/clip/ClipSizeEstimatorTest.kt
@@ -1,0 +1,74 @@
+package com.github.andreyasadchy.xtra.ui.player.clip
+
+import androidx.media3.common.C
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ClipSizeEstimatorTest {
+    @Test
+    fun sixtySecondsAtSixMbpsIsAbout45MB() {
+        val estimated = ClipSizeEstimator.estimateBytes(
+            selectedDurationUs = 60_000_000L,
+            byteRangeLengths = longArrayOf(C.LENGTH_UNSET.toLong()),
+            startIndex = 0,
+            endIndexExclusive = 1,
+            bitrateBitsPerSecond = 6_000_000,
+        )
+
+        assertEquals(45_000_000L, estimated)
+    }
+
+    @Test
+    fun usesByteRangesWhenEverySelectedSegmentHasOne() {
+        val estimated = ClipSizeEstimator.estimateBytes(
+            selectedDurationUs = 4_000_000L,
+            byteRangeLengths = longArrayOf(12_345L, 6_789L),
+            startIndex = 0,
+            endIndexExclusive = 2,
+            bitrateBitsPerSecond = null,
+        )
+
+        assertEquals(19_134L, estimated)
+    }
+
+    @Test
+    fun rejectsAnEmptyOrReversedSelection() {
+        assertNull(
+            ClipSizeEstimator.estimateBytes(
+                selectedDurationUs = 1_000_000L,
+                byteRangeLengths = longArrayOf(C.LENGTH_UNSET.toLong()),
+                startIndex = 1,
+                endIndexExclusive = 1,
+                bitrateBitsPerSecond = 6_000_000,
+            ),
+        )
+    }
+
+    @Test
+    fun estimatesOnlyTheSelectedByteRanges() {
+        val estimated = ClipSizeEstimator.estimateBytes(
+            selectedDurationUs = 60_000_000L,
+            byteRangeLengths = longArrayOf(100L, 200L, 300L, 400L),
+            startIndex = 1,
+            endIndexExclusive = 3,
+            bitrateBitsPerSecond = null,
+        )
+
+        assertEquals(500L, estimated)
+    }
+
+    @Test
+    fun rejectsAnOutOfBoundsSelection() {
+        assertNull(
+            ClipSizeEstimator.estimateBytes(
+                selectedDurationUs = 1_000_000L,
+                byteRangeLengths = longArrayOf(100L),
+                startIndex = 0,
+                endIndexExclusive = 2,
+                bitrateBitsPerSecond = 6_000_000,
+            ),
+        )
+    }
+
+}

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/player/clip/ClipSizeEstimatorTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/player/clip/ClipSizeEstimatorTest.kt
@@ -4,13 +4,14 @@ import androidx.media3.common.C
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
+import java.util.AbstractList
 
 class ClipSizeEstimatorTest {
     @Test
     fun sixtySecondsAtSixMbpsIsAbout45MB() {
         val estimated = ClipSizeEstimator.estimateBytes(
             selectedDurationUs = 60_000_000L,
-            byteRangeLengths = longArrayOf(C.LENGTH_UNSET.toLong()),
+            segments = listOf(segment(60_000_000L)),
             startIndex = 0,
             endIndexExclusive = 1,
             bitrateBitsPerSecond = 6_000_000,
@@ -23,7 +24,10 @@ class ClipSizeEstimatorTest {
     fun usesByteRangesWhenEverySelectedSegmentHasOne() {
         val estimated = ClipSizeEstimator.estimateBytes(
             selectedDurationUs = 4_000_000L,
-            byteRangeLengths = longArrayOf(12_345L, 6_789L),
+            segments = listOf(
+                segment(2_000_000L, byteRangeLength = 12_345L),
+                segment(2_000_000L, byteRangeLength = 6_789L),
+            ),
             startIndex = 0,
             endIndexExclusive = 2,
             bitrateBitsPerSecond = null,
@@ -37,7 +41,7 @@ class ClipSizeEstimatorTest {
         assertNull(
             ClipSizeEstimator.estimateBytes(
                 selectedDurationUs = 1_000_000L,
-                byteRangeLengths = longArrayOf(C.LENGTH_UNSET.toLong()),
+                segments = listOf(segment(1_000_000L)),
                 startIndex = 1,
                 endIndexExclusive = 1,
                 bitrateBitsPerSecond = 6_000_000,
@@ -49,7 +53,12 @@ class ClipSizeEstimatorTest {
     fun estimatesOnlyTheSelectedByteRanges() {
         val estimated = ClipSizeEstimator.estimateBytes(
             selectedDurationUs = 60_000_000L,
-            byteRangeLengths = longArrayOf(100L, 200L, 300L, 400L),
+            segments = listOf(
+                segment(20_000_000L, byteRangeLength = 100L),
+                segment(20_000_000L, byteRangeLength = 200L),
+                segment(20_000_000L, byteRangeLength = 300L),
+                segment(20_000_000L, byteRangeLength = 400L),
+            ),
             startIndex = 1,
             endIndexExclusive = 3,
             bitrateBitsPerSecond = null,
@@ -63,7 +72,7 @@ class ClipSizeEstimatorTest {
         assertNull(
             ClipSizeEstimator.estimateBytes(
                 selectedDurationUs = 1_000_000L,
-                byteRangeLengths = longArrayOf(100L),
+                segments = listOf(segment(1_000_000L)),
                 startIndex = 0,
                 endIndexExclusive = 2,
                 bitrateBitsPerSecond = 6_000_000,
@@ -71,4 +80,49 @@ class ClipSizeEstimatorTest {
         )
     }
 
+    @Test
+    fun estimatesWithoutCreatingASelectedRangeList() {
+        val source = listOf(
+            segment(1_000_000L, byteRangeLength = 100L),
+            segment(1_000_000L, byteRangeLength = 200L),
+            segment(1_000_000L, byteRangeLength = 300L),
+        )
+        val segments = object : AbstractList<ClipSegmentRef>() {
+            override val size = source.size
+
+            override fun get(index: Int): ClipSegmentRef = source[index]
+
+            override fun subList(fromIndex: Int, toIndex: Int): MutableList<ClipSegmentRef> =
+                error("range copies are not allowed during estimation")
+        }
+
+        assertEquals(
+            500L,
+            ClipSizeEstimator.estimateBytes(
+                selectedDurationUs = 2_000_000L,
+                segments = segments,
+                startIndex = 1,
+                endIndexExclusive = 3,
+                bitrateBitsPerSecond = null,
+            ),
+        )
+    }
+
+    private fun segment(durationUs: Long, byteRangeLength: Long = C.LENGTH_UNSET.toLong()) = ClipSegmentRef(
+        generation = 0L,
+        renditionId = "vod",
+        mediaSequence = 0L,
+        absoluteUri = "https://example.invalid/segment.ts",
+        durationUs = durationUs,
+        absoluteStartUs = 0L,
+        relativeStartUs = 0L,
+        discontinuitySequence = 0,
+        byteRangeOffset = 0L,
+        byteRangeLength = byteRangeLength,
+        initSegment = null,
+        encryptionKeyUri = null,
+        encryptionIv = null,
+        drmInitDataPresent = false,
+        hasGap = false,
+    )
 }

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/player/clip/ClipTimeTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/player/clip/ClipTimeTest.kt
@@ -1,0 +1,21 @@
+package com.github.andreyasadchy.xtra.ui.player.clip
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ClipTimeTest {
+    @Test
+    fun parsesHoursMinutesAndSeconds() {
+        assertEquals(6_133_000L, ClipTime.parseMs("01:42:13"))
+        assertEquals(90_000L, ClipTime.parseMs("01:30"))
+        assertEquals("04:30:00", ClipTime.formatMs(16_200_000L))
+    }
+
+    @Test
+    fun rejectsInvalidMinuteAndSecondValues() {
+        assertNull(ClipTime.parseMs("01:60:00"))
+        assertNull(ClipTime.parseMs("01:00:60"))
+        assertNull(ClipTime.parseMs("not-a-time"))
+    }
+}

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/player/clip/ClipTimelineTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/player/clip/ClipTimelineTest.kt
@@ -5,6 +5,24 @@ import org.junit.Test
 
 class ClipTimelineTest {
     @Test
+    fun buildsBoundariesFromCompactSegmentDurations() {
+        assertEquals(
+            longArrayOf(0L, 2_000_000L, 5_500_000L, 6_000_000L).toList(),
+            ClipTimeline.boundariesFromDurationsUs(
+                intArrayOf(2_000_000, 3_500_000, 500_000),
+            ).toList(),
+        )
+    }
+
+    @Test
+    fun keepsManyHourTotalDurationAsLong() {
+        val segmentCount = 2_160
+        val boundaries = ClipTimeline.boundariesFromDurationsUs(IntArray(segmentCount) { 10_000_000 })
+
+        assertEquals(21_600_000_000L, boundaries.last())
+    }
+
+    @Test
     fun preservesExactFinalBoundaryForUnevenSegmentDurations() {
         val durationsUs = longArrayOf(1_500_500L, 2_001_250L, 1_998_750L)
         val boundariesUs = LongArray(durationsUs.size + 1).also { boundaries ->

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/player/clip/ClipTimelineTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/player/clip/ClipTimelineTest.kt
@@ -23,4 +23,26 @@ class ClipTimelineTest {
         assertEquals(3, endIndex)
         assertEquals(0 until durationsUs.size, startIndex until endIndex)
     }
+
+    @Test
+    fun binarySearchKeepsNearestBoundaryAndLowerIndexOnATie() {
+        val boundaries = longArrayOf(0L, 10_000_000L, 20_000_000L)
+
+        assertEquals(0, ClipTimeline.boundaryIndexUs(-1L, boundaries))
+        assertEquals(1, ClipTimeline.boundaryIndexUs(15_000_000L, boundaries))
+        assertEquals(2, ClipTimeline.boundaryIndexUs(99_000_000L, boundaries))
+        assertEquals(2, ClipTimeline.boundaryIndexUs(20_000_000L, boundaries))
+    }
+
+    @Test
+    fun wholeVodsDoNotApplyTheLiveDurationLimit() {
+        val boundaries = LongArray(361) { it * 60_000_000L }
+
+        val start = ClipTimeline.boundaryIndexUs(60 * 60_000_000L, boundaries)
+        val end = ClipTimeline.boundaryIndexUs(4 * 60 * 60_000_000L, boundaries)
+
+        assertEquals(60, start)
+        assertEquals(240, end)
+        assertEquals(180, end - start)
+    }
 }


### PR DESCRIPTION
Adds VOD support to the existing Local Clips editor. VODs open from the current HLS manifest, download only the selected segments on save, and publish the transformed MP4 through the existing MediaStore flow. Live clipping remains unchanged.