### PR TITLE
Restore sharp fullscreen video output

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/VideoSurfaceDebug.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/VideoSurfaceDebug.kt
@@ -19,6 +19,7 @@ internal fun logVideoSurfaceBinding(
     Log.d(
         "VideoSurface",
         "$action player=${player.identityId()} target=${target.identityId()} " +
+            "targetType=${target?.javaClass?.simpleName} " +
             "target.player=${targetPlayer.identityId()} " +
             "attached=${target?.isAttachedToWindow} visible=${target?.visibility} " +
             "size=${target?.width}x${target?.height} xy=${target?.x},${target?.y}",

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/VideoTrackDiagnostics.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/VideoTrackDiagnostics.kt
@@ -1,0 +1,72 @@
+package com.github.andreyasadchy.xtra.ui.common
+
+import android.util.Log
+import androidx.media3.common.C
+import androidx.media3.common.Player
+import com.github.andreyasadchy.xtra.BuildConfig
+
+private const val VIDEO_TRACK_TAG = "XtraVideoTrack"
+
+internal fun logVideoTracks(
+    reason: String,
+    player: Player?,
+) {
+    if (!BuildConfig.DEBUG || player == null) return
+
+    var foundVideo = false
+    var foundSelected = false
+
+    player.currentTracks.groups.forEachIndexed { groupIndex, group ->
+        if (group.type != C.TRACK_TYPE_VIDEO) {
+            return@forEachIndexed
+        }
+
+        foundVideo = true
+
+        for (trackIndex in 0 until group.length) {
+            val format = group.mediaTrackGroup.getFormat(trackIndex)
+            val selected = group.isTrackSelected(trackIndex)
+
+            if (selected) {
+                foundSelected = true
+            }
+
+            Log.d(
+                VIDEO_TRACK_TAG,
+                buildString {
+                    append("reason=")
+                    append(reason)
+                    append(" group=")
+                    append(groupIndex)
+                    append(" track=")
+                    append(trackIndex)
+                    append(" selected=")
+                    append(selected)
+                    append(" size=")
+                    append(format.width)
+                    append('x')
+                    append(format.height)
+                    append(" fps=")
+                    append(format.frameRate)
+                    append(" bitrate=")
+                    append(format.bitrate)
+                    append(" codecs=")
+                    append(format.codecs)
+                    append(" mime=")
+                    append(format.sampleMimeType)
+                    append(" label=")
+                    append(format.label)
+                    append(" id=")
+                    append(format.id)
+                },
+            )
+        }
+    }
+
+    if (!foundVideo || !foundSelected) {
+        Log.d(
+            VIDEO_TRACK_TAG,
+            "reason=$reason videoGroup=$foundVideo selectedVideo=$foundSelected",
+        )
+    }
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/ExoPlayerFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/ExoPlayerFragment.kt
@@ -12,8 +12,8 @@ import android.os.Bundle
 import android.os.IBinder
 import android.text.format.DateUtils
 import android.util.Log
+import android.view.SurfaceView
 import android.view.View
-import android.view.TextureView
 import android.widget.FrameLayout
 import android.widget.HorizontalScrollView
 import android.widget.TextView
@@ -39,8 +39,8 @@ import androidx.navigation.fragment.findNavController
 import com.github.andreyasadchy.xtra.BuildConfig
 import com.github.andreyasadchy.xtra.R
 import com.github.andreyasadchy.xtra.model.VideoQuality
-import com.github.andreyasadchy.xtra.ui.game.GamePagerFragmentDirections
 import com.github.andreyasadchy.xtra.ui.common.logVideoSurfaceBinding
+import com.github.andreyasadchy.xtra.ui.game.GamePagerFragmentDirections
 import com.github.andreyasadchy.xtra.ui.main.MainActivity
 import com.github.andreyasadchy.xtra.ui.player.clip.ClipEditorDialogFragment
 import com.github.andreyasadchy.xtra.ui.player.clip.ClipEditorRestorationState
@@ -72,9 +72,9 @@ class ExoPlayerFragment : PlayerFragment() {
     private var liveSurfaceRestoreTimeout: Runnable? = null
     private var clipEditorCoverTimeout: Runnable? = null
     private var videoOutputCover: View? = null
-    private val videoOutputOwner = VideoOutputOwner<Player, TextureView>(
-        attachTarget = { currentPlayer, target -> currentPlayer.setVideoTextureView(target) },
-        detachTarget = { currentPlayer, target -> currentPlayer.clearVideoTextureView(target) },
+    private val videoOutputOwner = VideoOutputOwner<Player, SurfaceView>(
+        attachTarget = { currentPlayer, target -> currentPlayer.setVideoSurfaceView(target) },
+        detachTarget = { currentPlayer, target -> currentPlayer.clearVideoSurfaceView(target) },
     )
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -96,11 +96,16 @@ class ExoPlayerFragment : PlayerFragment() {
             importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_NO
         }
         videoOutputCover = outputCover
-        // Keep the TextureView renderer in the moving player layout. The cover is a normal
+        // Keep the SurfaceView renderer for lower composition overhead. The cover is a normal
         // view above it and remains visible until the player confirms a new decoded frame.
         binding.aspectRatioFrameLayout.addView(outputCover)
-        binding.playerSurface.visibility = View.GONE
-        binding.playerTextureView.visibility = View.VISIBLE
+        binding.playerTextureView.visibility = View.GONE
+        binding.playerSurface.visibility = View.VISIBLE
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            binding.playerSurface.setSurfaceLifecycle(
+                SurfaceView.SURFACE_LIFECYCLE_FOLLOWS_ATTACHMENT,
+            )
+        }
         childFragmentManager.setFragmentResultListener(
             ClipEditorDialogFragment.RESULT_KEY,
             viewLifecycleOwner,
@@ -264,7 +269,7 @@ class ExoPlayerFragment : PlayerFragment() {
             }
 
             override fun onRenderedFirstFrame() {
-                logVideoSurfaceBinding("first_frame", playbackService?.player, binding.playerTextureView)
+                logVideoSurfaceBinding("first_frame", playbackService?.player, binding.playerSurface)
                 hideVideoOutputCover()
             }
         }
@@ -599,9 +604,9 @@ class ExoPlayerFragment : PlayerFragment() {
         livePlayer?.pause()
         clipDebug("live player paused")
         setVideoOutputVisible(false)
-        clipDebug("live surface hidden parentVisible=${binding.playerTextureView.visibility == View.VISIBLE}")
+        clipDebug("live surface hidden parentVisible=${binding.playerSurface.visibility == View.VISIBLE}")
         detachVideoOutput(livePlayer)
-        clipDebug("live surface cleared parentVisible=${binding.playerTextureView.visibility == View.VISIBLE}")
+        clipDebug("live surface cleared parentVisible=${binding.playerSurface.visibility == View.VISIBLE}")
         binding.playerLayout.visibility = View.GONE
     }
 
@@ -689,7 +694,7 @@ class ExoPlayerFragment : PlayerFragment() {
         val resumePlayback = livePlaybackBeforeClipEditor == true
         val firstFrameListener = object : Player.Listener {
             override fun onRenderedFirstFrame() {
-                logVideoSurfaceBinding("first_frame", livePlayer, binding.playerTextureView)
+                logVideoSurfaceBinding("first_frame", livePlayer, binding.playerSurface)
                 finishLiveSurfaceRestore(livePlayer)
             }
         }
@@ -927,20 +932,20 @@ class ExoPlayerFragment : PlayerFragment() {
     }
 
     private fun attachVideoOutput(currentPlayer: Player) {
-        videoOutputOwner.attach(currentPlayer, binding.playerTextureView)
-        logVideoSurfaceBinding("attach", currentPlayer, binding.playerTextureView)
+        videoOutputOwner.attach(currentPlayer, binding.playerSurface)
+        logVideoSurfaceBinding("attach", currentPlayer, binding.playerSurface)
     }
 
     private fun detachVideoOutput(currentPlayer: Player? = videoOutputOwner.attachedPlayer()) {
         if (currentPlayer == null) return
         if (videoOutputOwner.attachedPlayer() === currentPlayer) {
-            logVideoSurfaceBinding("detach", currentPlayer, binding.playerTextureView)
+            logVideoSurfaceBinding("detach", currentPlayer, binding.playerSurface)
             videoOutputOwner.clear()
         }
     }
 
     private fun setVideoOutputVisible(visible: Boolean) {
-        binding.playerTextureView.visibility = if (visible) View.VISIBLE else View.GONE
+        binding.playerSurface.visibility = if (visible) View.VISIBLE else View.GONE
         if (!visible) {
             showVideoOutputCover()
         }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/ExoPlayerService.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/ExoPlayerService.kt
@@ -69,6 +69,7 @@ import com.github.andreyasadchy.xtra.player.lowlatency.CronetDataSource
 import com.github.andreyasadchy.xtra.player.lowlatency.HlsPlaylistParser
 import com.github.andreyasadchy.xtra.player.lowlatency.HttpEngineDataSource
 import com.github.andreyasadchy.xtra.player.lowlatency.OkHttpDataSource
+import com.github.andreyasadchy.xtra.ui.common.logVideoTracks
 import com.github.andreyasadchy.xtra.ui.main.MainActivity
 import com.github.andreyasadchy.xtra.ui.player.clip.ClipPreparationRepository
 import com.github.andreyasadchy.xtra.ui.player.clip.LiveClipBufferManager
@@ -204,6 +205,10 @@ class ExoPlayerService : BasePlaybackService() {
                 }
 
                 override fun onTracksChanged(tracks: Tracks) {
+                    logVideoTracks(
+                        reason = "ExoPlayerService.onTracksChanged",
+                        player = player,
+                    )
                     if (!tracks.isEmpty) {
                         if (!loaded) {
                             loaded = true

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/Media3Fragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/Media3Fragment.kt
@@ -10,10 +10,10 @@ import android.os.Build
 import android.os.Bundle
 import android.text.format.DateUtils
 import android.util.Log
+import android.view.SurfaceView
 import android.view.View
 import android.widget.HorizontalScrollView
 import android.widget.TextView
-import android.view.TextureView
 import androidx.annotation.OptIn
 import androidx.core.content.ContextCompat
 import androidx.core.content.edit
@@ -41,9 +41,10 @@ import com.github.andreyasadchy.xtra.model.ui.Clip
 import com.github.andreyasadchy.xtra.model.ui.OfflineVideo
 import com.github.andreyasadchy.xtra.model.ui.Stream
 import com.github.andreyasadchy.xtra.model.ui.Video
+import com.github.andreyasadchy.xtra.ui.common.logVideoSurfaceBinding
+import com.github.andreyasadchy.xtra.ui.common.logVideoTracks
 import com.github.andreyasadchy.xtra.ui.download.DownloadDialog
 import com.github.andreyasadchy.xtra.ui.main.MainActivity
-import com.github.andreyasadchy.xtra.ui.common.logVideoSurfaceBinding
 import com.github.andreyasadchy.xtra.util.C
 import com.github.andreyasadchy.xtra.util.PlayerControlLayout
 import com.github.andreyasadchy.xtra.util.getAlertDialogBuilder
@@ -80,10 +81,22 @@ class Media3Fragment : Media3PlayerFragment() {
     private var adAvoidanceJob: Job? = null
     private var primaryStreamRestoreJob: Job? = null
     private val updateProgressAction = Runnable { if (view != null) updateProgress() }
-    private val videoOutputOwner = VideoOutputOwner<Player, TextureView>(
-        attachTarget = { currentPlayer, target -> currentPlayer.setVideoTextureView(target) },
-        detachTarget = { currentPlayer, target -> currentPlayer.clearVideoTextureView(target) },
+    private val videoOutputOwner = VideoOutputOwner<Player, SurfaceView>(
+        attachTarget = { currentPlayer, target -> currentPlayer.setVideoSurfaceView(target) },
+        detachTarget = { currentPlayer, target -> currentPlayer.clearVideoSurfaceView(target) },
     )
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        binding.playerTextureView.visibility = View.GONE
+        binding.playerSurface.visibility = View.VISIBLE
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            binding.playerSurface.setSurfaceLifecycle(
+                SurfaceView.SURFACE_LIFECYCLE_FOLLOWS_ATTACHMENT,
+            )
+        }
+    }
 
     override fun onViewingMetadataChanged(title: String?, gameId: String?, gameName: String?) {
         if (videoType != STREAM) return
@@ -241,6 +254,10 @@ class Media3Fragment : Media3PlayerFragment() {
                 }
 
                 override fun onTracksChanged(tracks: Tracks) {
+                    logVideoTracks(
+                        reason = "Media3Fragment.onTracksChanged",
+                        player = player,
+                    )
                     if (!tracks.isEmpty && !viewModel.loaded.value) {
                         viewModel.loaded.value = true
                         toggleSubtitles(requireContext().prefs().getBoolean(C.PLAYER_SUBTITLES_ENABLED, false))
@@ -470,11 +487,11 @@ class Media3Fragment : Media3PlayerFragment() {
                 }
 
                 override fun onRenderedFirstFrame() {
-                    logVideoSurfaceBinding("first_frame", controller, binding.playerTextureView)
+                    logVideoSurfaceBinding("first_frame", controller, binding.playerSurface)
                 }
             }
             val restored = viewModel.videoOutputState.restoreIfNeeded {
-                binding.playerTextureView.visibility = View.VISIBLE
+                binding.playerSurface.visibility = View.VISIBLE
                 attachVideoOutput(controller)
                 true
             }
@@ -604,7 +621,7 @@ class Media3Fragment : Media3PlayerFragment() {
                     player.trackSelectionParameters = player.trackSelectionParameters.buildUpon().apply {
                         setTrackTypeDisabled(androidx.media3.common.C.TRACK_TYPE_VIDEO, true)
                     }.build()
-                    binding.playerTextureView.visibility = View.GONE
+                    binding.playerSurface.visibility = View.GONE
                 }
                 player.volume = 0f
             }
@@ -620,7 +637,7 @@ class Media3Fragment : Media3PlayerFragment() {
                     player.trackSelectionParameters = player.trackSelectionParameters.buildUpon().apply {
                         setTrackTypeDisabled(androidx.media3.common.C.TRACK_TYPE_VIDEO, false)
                     }.build()
-                    binding.playerTextureView.visibility = View.VISIBLE
+                    binding.playerSurface.visibility = View.VISIBLE
                 }
                 player.volume = requireContext().prefs().getInt(C.PLAYER_VOLUME, 100) / 100f
             }
@@ -794,7 +811,7 @@ class Media3Fragment : Media3PlayerFragment() {
             player.trackSelectionParameters = player.trackSelectionParameters.buildUpon().apply {
                 setTrackTypeDisabled(androidx.media3.common.C.TRACK_TYPE_VIDEO, false)
             }.build()
-            binding.playerTextureView.visibility = View.VISIBLE
+            binding.playerSurface.visibility = View.VISIBLE
             player.sendCustomCommand(
                 SessionCommand(
                     PlaybackService.START_VIDEO, Bundle().apply {
@@ -821,12 +838,12 @@ class Media3Fragment : Media3PlayerFragment() {
                 player.trackSelectionParameters = player.trackSelectionParameters.buildUpon().apply {
                     setTrackTypeDisabled(androidx.media3.common.C.TRACK_TYPE_VIDEO, true)
                 }.build()
-                binding.playerTextureView.visibility = View.GONE
+                binding.playerSurface.visibility = View.GONE
             } else {
                 player.trackSelectionParameters = player.trackSelectionParameters.buildUpon().apply {
                     setTrackTypeDisabled(androidx.media3.common.C.TRACK_TYPE_VIDEO, false)
                 }.build()
-                binding.playerTextureView.visibility = View.VISIBLE
+                binding.playerSurface.visibility = View.VISIBLE
             }
             player.sendCustomCommand(
                 SessionCommand(
@@ -853,12 +870,12 @@ class Media3Fragment : Media3PlayerFragment() {
                 player.trackSelectionParameters = player.trackSelectionParameters.buildUpon().apply {
                     setTrackTypeDisabled(androidx.media3.common.C.TRACK_TYPE_VIDEO, true)
                 }.build()
-                binding.playerTextureView.visibility = View.GONE
+                binding.playerSurface.visibility = View.GONE
             } else {
                 player.trackSelectionParameters = player.trackSelectionParameters.buildUpon().apply {
                     setTrackTypeDisabled(androidx.media3.common.C.TRACK_TYPE_VIDEO, false)
                 }.build()
-                binding.playerTextureView.visibility = View.VISIBLE
+                binding.playerSurface.visibility = View.VISIBLE
             }
             player.sendCustomCommand(
                 SessionCommand(
@@ -1062,7 +1079,7 @@ class Media3Fragment : Media3PlayerFragment() {
                                 setTrackTypeDisabled(androidx.media3.common.C.TRACK_TYPE_VIDEO, false)
                                 clearOverridesOfType(androidx.media3.common.C.TRACK_TYPE_VIDEO)
                             }.build()
-                            binding.playerTextureView.visibility = View.VISIBLE
+                            binding.playerSurface.visibility = View.VISIBLE
                         }
                         AUDIO_ONLY_QUALITY -> {
                             if (viewModel.usingProxy) {
@@ -1078,7 +1095,7 @@ class Media3Fragment : Media3PlayerFragment() {
                             player.trackSelectionParameters = player.trackSelectionParameters.buildUpon().apply {
                                 setTrackTypeDisabled(androidx.media3.common.C.TRACK_TYPE_VIDEO, true)
                             }.build()
-                            binding.playerTextureView.visibility = View.GONE
+                            binding.playerSurface.visibility = View.GONE
                             quality.url?.let {
                                 val position = player.currentPosition
                                 if (viewModel.qualities?.find { it.name == AUTO_QUALITY } != null) {
@@ -1115,7 +1132,7 @@ class Media3Fragment : Media3PlayerFragment() {
                                 } ?: player.prepare()
                                 player.trackSelectionParameters = player.trackSelectionParameters.buildUpon().apply {
                                     setTrackTypeDisabled(androidx.media3.common.C.TRACK_TYPE_VIDEO, false)
-                                    binding.playerTextureView.visibility = View.VISIBLE
+                                    binding.playerSurface.visibility = View.VISIBLE
                                     if (!player.currentTracks.isEmpty) {
                                         player.currentTracks.groups.find { it.type == androidx.media3.common.C.TRACK_TYPE_VIDEO }?.let { trackGroup ->
                                             val selectedQuality = quality.name?.split("p")
@@ -1160,7 +1177,7 @@ class Media3Fragment : Media3PlayerFragment() {
                                 player.trackSelectionParameters = player.trackSelectionParameters.buildUpon().apply {
                                     setTrackTypeDisabled(androidx.media3.common.C.TRACK_TYPE_VIDEO, false)
                                 }.build()
-                                binding.playerTextureView.visibility = View.VISIBLE
+                                binding.playerSurface.visibility = View.VISIBLE
                             }
                         }
                     }
@@ -1200,7 +1217,7 @@ class Media3Fragment : Media3PlayerFragment() {
                             player.trackSelectionParameters = player.trackSelectionParameters.buildUpon().apply {
                                 setTrackTypeDisabled(androidx.media3.common.C.TRACK_TYPE_VIDEO, true)
                             }.build()
-                            binding.playerTextureView.visibility = View.GONE
+                            binding.playerSurface.visibility = View.GONE
                         }
                     }
                 }
@@ -1309,7 +1326,7 @@ class Media3Fragment : Media3PlayerFragment() {
                     if (!isInPIPMode && player.playWhenReady && viewModel.quality?.name != AUDIO_ONLY_QUALITY) {
                         if (player.currentMediaItem != null) {
                             viewModel.videoOutputState.markDetachedForBackground()
-                            binding.playerTextureView.visibility = View.GONE
+                            binding.playerSurface.visibility = View.GONE
                         }
                     }
                 } else {
@@ -1361,13 +1378,13 @@ class Media3Fragment : Media3PlayerFragment() {
     }
 
     private fun attachVideoOutput(currentPlayer: Player) {
-        videoOutputOwner.attach(currentPlayer, binding.playerTextureView)
-        logVideoSurfaceBinding("attach", currentPlayer, binding.playerTextureView)
+        videoOutputOwner.attach(currentPlayer, binding.playerSurface)
+        logVideoSurfaceBinding("attach", currentPlayer, binding.playerSurface)
     }
 
     private fun detachVideoOutput() {
         val currentPlayer = videoOutputOwner.attachedPlayer() ?: return
-        logVideoSurfaceBinding("detach", currentPlayer, binding.playerTextureView)
+        logVideoSurfaceBinding("detach", currentPlayer, binding.playerSurface)
         videoOutputOwner.clear()
     }
 

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/Media3PlayerFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/Media3PlayerFragment.kt
@@ -198,8 +198,8 @@ abstract class Media3PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFr
     @SuppressLint("ClickableViewAccessibility")
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        binding.playerSurface.visibility = View.GONE
-        binding.playerTextureView.visibility = View.VISIBLE
+        binding.playerTextureView.visibility = View.GONE
+        binding.playerSurface.visibility = View.VISIBLE
         with(binding) {
             val ignoreCutouts = requireContext().prefs().getBoolean(C.UI_DRAW_BEHIND_CUTOUTS, false)
             val cornerPadding = requireContext().prefs().getBoolean(C.PLAYER_ROUNDED_CORNER_PADDING, false)


### PR DESCRIPTION
Restore SurfaceView for fullscreen playback and add debug logs for the actual selected video tracks. Keep the existing output ownership and transition handling unchanged.