### PR TITLE
Fix chat images during scroll

### DIFF
--- a/app/src/androidTest/java/com/github/andreyasadchy/xtra/util/chat/ChatImagePrefetchTest.kt
+++ b/app/src/androidTest/java/com/github/andreyasadchy/xtra/util/chat/ChatImagePrefetchTest.kt
@@ -1,0 +1,46 @@
+package com.github.andreyasadchy.xtra.util.chat
+
+import com.bumptech.glide.load.model.GlideUrl
+import com.github.andreyasadchy.xtra.BuildConfig
+import com.github.andreyasadchy.xtra.model.chat.Image
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ChatImagePrefetchTest {
+
+    @Test
+    fun thirdPartyLocalDataRemainsBinaryGlideModel() {
+        val bytes = byteArrayOf(1, 2, 3)
+        val image = Image(localData = bytes, thirdParty = true, start = 0, end = 1)
+
+        val model = ChatAdapterUtils.glideImageModel(image, bytes)
+
+        assertSame(bytes, model)
+        assertTrue(model !is GlideUrl)
+    }
+
+    @Test
+    fun thirdPartyRemoteDataUsesXtraUserAgent() {
+        val image = Image(thirdParty = true, start = 0, end = 1)
+
+        val model = ChatAdapterUtils.glideImageModel(image, "https://example.com/emote.png") as GlideUrl
+
+        assertEquals("https://example.com/emote.png", model.toString())
+        assertEquals("Xtra/${BuildConfig.VERSION_NAME}", model.headers["User-Agent"])
+    }
+
+    @Test
+    fun failedPrefetchCanBeRetriedAfterCrossCallDeduplication() {
+        val tracker = ChatAdapterUtils.ChatImagePrefetchTracker(maxEntries = 2)
+        val firstToken = tracker.tryStart("same-request")
+
+        assertNotNull(firstToken)
+        assertNull(tracker.tryStart("same-request"))
+        tracker.markFailed("same-request", firstToken!!)
+        assertNotNull(tracker.tryStart("same-request"))
+    }
+}

--- a/app/src/androidTest/java/com/github/andreyasadchy/xtra/util/chat/ChatImagePrefetchTest.kt
+++ b/app/src/androidTest/java/com/github/andreyasadchy/xtra/util/chat/ChatImagePrefetchTest.kt
@@ -5,6 +5,7 @@ import com.github.andreyasadchy.xtra.BuildConfig
 import com.github.andreyasadchy.xtra.model.chat.Image
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
@@ -42,5 +43,14 @@ class ChatImagePrefetchTest {
         assertNull(tracker.tryStart("same-request"))
         tracker.markFailed("same-request", firstToken!!)
         assertNotNull(tracker.tryStart("same-request"))
+    }
+
+    @Test
+    fun rawByteArraySourceKeyUsesSha256() {
+        val first = ChatAdapterUtils.byteArraySourceKey(byteArrayOf(0, 31))
+        val second = ChatAdapterUtils.byteArraySourceKey(byteArrayOf(1, 0))
+
+        assertNotEquals(first, second)
+        assertTrue(first.matches(Regex("bytes:2:[0-9a-f]{64}")))
     }
 }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatAdapter.kt
@@ -22,6 +22,8 @@ import com.github.andreyasadchy.xtra.R
 import com.github.andreyasadchy.xtra.model.chat.ChatMessage
 import com.github.andreyasadchy.xtra.model.chat.CheerEmote
 import com.github.andreyasadchy.xtra.model.chat.Emote
+import com.github.andreyasadchy.xtra.model.chat.Image
+import com.github.andreyasadchy.xtra.model.chat.ImageKind
 import com.github.andreyasadchy.xtra.model.chat.NamePaint
 import com.github.andreyasadchy.xtra.model.chat.STVBadge
 import com.github.andreyasadchy.xtra.model.chat.STVUser
@@ -124,7 +126,7 @@ class ChatAdapter(
     private val messages = ArrayList(initialMessages)
     private val generatedStableIds = IdentityHashMap<ChatMessage, Long>()
     private var nextGeneratedStableId = Long.MIN_VALUE
-    private class RenderCacheKey(
+    internal class RenderCacheKey(
         val message: ChatMessage,
         val catalogRevision: Int,
         val translateAllMessages: Boolean,
@@ -180,7 +182,6 @@ class ChatAdapter(
     private val pendingRenderedMessages = Collections.newSetFromMap(
         IdentityHashMap<ChatMessage, Boolean>(),
     )
-    private var renderUpdatesPaused = false
     private var prewarmJob: Job? = null
     @Volatile
     private var prewarmGeneration = 0L
@@ -283,11 +284,11 @@ class ChatAdapter(
     }
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
-        holder.imageRequests.cancel()
         val configuration = activeConfiguration
-        val bindGeneration = holder.beginBind(configuration.revision)
         val chatMessage = messages.getOrNull(position) ?: return
         val cacheKey = createRenderKey(chatMessage, configuration)
+        if (holder.isAlreadyBoundTo(chatMessage, cacheKey)) return
+        val bindGeneration = holder.beginBind(configuration.revision)
         val cachedResult = cachedRender(cacheKey)
         val result = checkNotNull(cachedResult) {
             "Chat message was displayed before its render plan was prepared"
@@ -303,15 +304,16 @@ class ChatAdapter(
             result.userNameStartIndex,
             backgroundColor,
         )
-        holder.bind(chatMessage, result)
+        holder.bind(chatMessage, cacheKey, result)
         ChatAdapterUtils.loadImages(
             fragment, holder.textView, result.images, result.imagePaint, result.userName, result.userNameStartIndex,
             backgroundColor, imageLibrary, result.builder, emoteQuality, animateGifs,
             isCurrent = { holder.isCurrentBind(bindGeneration) },
             shouldAnimate = { holder.canAnimate(bindGeneration) },
             requestBag = holder.imageRequests,
-            shouldLoad = { holder.canLoadImages(bindGeneration) },
-            onLoadDeferred = { holder.hasDeferredImageLoad = true },
+            emoteSize = emoteSize,
+            badgeSize = badgeSize,
+            inlineIconSize = inlineIconSize,
         )
     }
 
@@ -453,10 +455,6 @@ class ChatAdapter(
             holder.postCatalogRefresh()
             return
         }
-        if (holder.hasDeferredImageLoad) {
-            holder.postDeferredImageReload()
-            return
-        }
         if (animateGifs && !animationsPaused) setAnimations(holder.textView, start = true)
     }
 
@@ -511,6 +509,7 @@ class ChatAdapter(
         attachedRecyclerView = recyclerView
         super.onAttachedToRecyclerView(recyclerView)
         recyclerView.addOnScrollListener(prewarmScrollListener)
+        prefetchCatalogAssets()
         scheduleVisiblePrewarm(recyclerView)
     }
 
@@ -523,7 +522,7 @@ class ChatAdapter(
         }
 
         override fun onScrollStateChanged(recyclerView: RecyclerView, newState: Int) {
-            if (newState == RecyclerView.SCROLL_STATE_IDLE && !prewarmPosted) {
+            if (!prewarmPosted) {
                 prewarmPosted = true
                 recyclerView.postOnAnimation(prewarmRunnable)
             }
@@ -549,28 +548,14 @@ class ChatAdapter(
                 recyclerView.postOnAnimation(pauseAnimationsRunnable)
             }
         } else {
-            for (i in 0 until recyclerView.childCount) {
-                (recyclerView.getChildViewHolder(recyclerView.getChildAt(i)) as? ViewHolder)?.let { holder ->
-                    holder.postDeferredImageReload()
-                }
-            }
             if (!animateGifs) return
             resumeAnimationsPosted = true
             recyclerView.postOnAnimation(resumeAnimationsRunnable)
         }
     }
 
-    /** Keeps completed background renders from invalidating rows while the list is flinging. */
-    fun setRenderUpdatesPaused(paused: Boolean) {
-        if (renderUpdatesPaused == paused) return
-        renderUpdatesPaused = paused
-        // Keep visible work responsive while the list is moving. Release the
-        // second CPU-heavy renderer only after scrolling has settled.
-        renderWorkerLimit.value = if (paused) 1 else MAX_RENDER_WORKERS
-        if (!paused) attachedRecyclerView?.postOnAnimation { flushRenderedMessages() }
-    }
-
     fun notifyCatalogChanged() {
+        prefetchCatalogAssets()
         scheduleConfigurationSwitch(
             composeChatRenderConfiguration(
                 active = activeConfiguration,
@@ -659,8 +644,8 @@ class ChatAdapter(
         val textView = itemView as TextView
         val imageRequests = ChatAdapterUtils.ImageRequestBag()
         private var boundMessage: ChatMessage? = null
+        private var boundRenderKey: RenderCacheKey? = null
         private var boundReplyMessage: Boolean? = null
-        var hasDeferredImageLoad = false
         private var bindGeneration = 0
         private var catalogRefreshPosted = false
         var catalogRevision = 0
@@ -686,7 +671,6 @@ class ChatAdapter(
         fun beginBind(catalogRevision: Int): Int {
             if (animateGifs) setAnimations(textView, start = false)
             imageRequests.cancel()
-            hasDeferredImageLoad = false
             itemView.removeCallbacks(catalogRefreshRunnable)
             catalogRefreshPosted = false
             this.catalogRevision = catalogRevision
@@ -696,30 +680,17 @@ class ChatAdapter(
 
         fun isCurrentBind(generation: Int): Boolean = generation == bindGeneration
 
+        internal fun isAlreadyBoundTo(message: ChatMessage, key: RenderCacheKey): Boolean =
+            boundMessage === message && boundRenderKey == key && itemView.isAttachedToWindow
+
         fun canAnimate(generation: Int): Boolean = isCurrentBind(generation) && itemView.isAttachedToWindow && !animationsPaused
-
-        fun canLoadImages(generation: Int): Boolean {
-            val recyclerView = attachedRecyclerView
-            return isCurrentBind(generation) &&
-                itemView.isAttachedToWindow &&
-                !animationsPaused &&
-                (recyclerView == null || recyclerView.scrollState == RecyclerView.SCROLL_STATE_IDLE)
-        }
-
-        fun postDeferredImageReload() {
-            if (!hasDeferredImageLoad) return
-            hasDeferredImageLoad = false
-            itemView.post {
-                if (itemView.isAttachedToWindow) {
-                    bindingAdapterPosition.takeIf { it != RecyclerView.NO_POSITION }?.let(::notifyItemChanged)
-                }
-            }
-        }
 
         fun cancelBind() {
             itemView.removeCallbacks(catalogRefreshRunnable)
             catalogRefreshPosted = false
             bindGeneration++
+            boundMessage = null
+            boundRenderKey = null
         }
 
         fun postCatalogRefresh() {
@@ -728,8 +699,9 @@ class ChatAdapter(
             itemView.post(catalogRefreshRunnable)
         }
 
-        fun bind(chatMessage: ChatMessage, result: ChatAdapterUtils.MessageResult) {
+        internal fun bind(chatMessage: ChatMessage, cacheKey: RenderCacheKey, result: ChatAdapterUtils.MessageResult) {
             itemView.setBackgroundResource(result.backgroundResource)
+            boundRenderKey = cacheKey
             bindContent(chatMessage, result.builder, result.accessibilityDescription)
         }
 
@@ -776,6 +748,8 @@ class ChatAdapter(
         const val PREWARM_BEFORE = 8
         const val PREWARM_AFTER = 24
         const val PREWARM_DEBOUNCE_MS = 100L
+        const val MAX_CATALOG_BADGES = 128
+        const val MAX_CATALOG_EMOTES = 192
     }
 
     private fun cachedRender(key: RenderCacheKey): ChatAdapterUtils.MessageResult? = synchronized(renderCache) {
@@ -898,6 +872,15 @@ class ChatAdapter(
                 request.configuration.indexes,
                 request.cacheKey.translateAllMessages,
                 offMain = true,
+            )
+            ChatAdapterUtils.prefetchImages(
+                request.context,
+                prepared.images,
+                imageLibrary,
+                emoteQuality,
+                emoteSize,
+                badgeSize,
+                inlineIconSize,
             )
             withContext(Dispatchers.Main.immediate) {
                 if (isKnownConfiguration(request.configuration) && currentRenderKey(chatMessage, request.configuration) == cacheKey) {
@@ -1026,6 +1009,101 @@ class ChatAdapter(
         }
     }
 
+    private fun prefetchCatalogAssets() {
+        val images = ArrayList<Image>()
+
+        fun add(
+            url1x: String?,
+            url2x: String?,
+            url3x: String?,
+            url4x: String?,
+            kind: ImageKind,
+            format: String? = null,
+            isAnimated: Boolean = false,
+            thirdParty: Boolean = false,
+            sourceWidth: Int? = null,
+            sourceHeight: Int? = null,
+        ) {
+            if (url1x != null || url2x != null || url3x != null || url4x != null) {
+                images += Image(
+                    url1x = url1x,
+                    url2x = url2x,
+                    url3x = url3x,
+                    url4x = url4x,
+                    format = format,
+                    isAnimated = isAnimated,
+                    kind = kind,
+                    thirdParty = thirdParty,
+                    sourceWidth = sourceWidth,
+                    sourceHeight = sourceHeight,
+                    start = 0,
+                    end = 1,
+                )
+            }
+        }
+
+        synchronized(globalBadges) {
+            globalBadges.take(MAX_CATALOG_BADGES).forEach { badge ->
+                add(badge.url1x, badge.url2x, badge.url3x, badge.url4x, ImageKind.BADGE)
+            }
+        }
+        synchronized(channelBadges) {
+            channelBadges.take(MAX_CATALOG_BADGES).forEach { badge ->
+                add(badge.url1x, badge.url2x, badge.url3x, badge.url4x, ImageKind.BADGE)
+            }
+        }
+        synchronized(stvBadges) {
+            stvBadges.take(MAX_CATALOG_BADGES).forEach { badge ->
+                add(badge.url1x, badge.url2x, badge.url3x, badge.url4x, ImageKind.BADGE, badge.format, true, true)
+            }
+        }
+        synchronized(localTwitchEmotes) {
+            localTwitchEmotes.take(MAX_CATALOG_EMOTES).forEach { emote ->
+                add(emote.url1x, emote.url2x, emote.url3x, emote.url4x, ImageKind.EMOTE, emote.format, emote.isAnimated)
+            }
+        }
+        synchronized(thirdPartyEmotes) {
+            thirdPartyEmotes.asSequence()
+                .filter {
+                    it.source == Emote.CHANNEL_STV ||
+                        it.source == Emote.CHANNEL_BTTV ||
+                        it.source == Emote.CHANNEL_FFZ ||
+                        it.source == Emote.PERSONAL_STV
+                }
+                .take(MAX_CATALOG_EMOTES)
+                .forEach { emote ->
+                    add(
+                        emote.url1x,
+                        emote.url2x,
+                        emote.url3x,
+                        emote.url4x,
+                        ImageKind.EMOTE,
+                        emote.format,
+                        emote.isAnimated,
+                        emote.thirdParty,
+                        emote.width,
+                        emote.height,
+                    )
+                }
+        }
+        synchronized(cheerEmotes) {
+            cheerEmotes.take(MAX_CATALOG_EMOTES).forEach { emote ->
+                add(emote.url1x, emote.url2x, emote.url3x, emote.url4x, ImageKind.EMOTE, emote.format, emote.isAnimated)
+            }
+        }
+
+        val context = fragment.context ?: return
+        ChatAdapterUtils.prefetchImages(
+            context,
+            images.distinctBy { it.url4x ?: it.url3x ?: it.url2x ?: it.url1x },
+            imageLibrary,
+            emoteQuality,
+            emoteSize,
+            badgeSize,
+            inlineIconSize,
+        )
+    }
+
     private fun currentRenderKey(message: ChatMessage, configuration: ChatRenderConfiguration = activeConfiguration): RenderCacheKey =
         createRenderKey(message, configuration)
 
@@ -1068,14 +1146,13 @@ class ChatAdapter(
 
     private fun scheduleRenderedFlush() {
         val recyclerView = attachedRecyclerView ?: return
-        if (renderedFlushPosted || renderUpdatesPaused || recyclerView.scrollState != RecyclerView.SCROLL_STATE_IDLE) return
+        if (renderedFlushPosted) return
         renderedFlushPosted = true
         recyclerView.postOnAnimation(renderedFlushRunnable)
     }
 
     private fun flushRenderedMessages() {
         val recyclerView = attachedRecyclerView ?: return
-        if (renderUpdatesPaused || recyclerView.scrollState != RecyclerView.SCROLL_STATE_IDLE) return
         if (recyclerView.isComputingLayout) {
             recyclerView.postOnAnimation { flushRenderedMessages() }
             return

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatAdapter.kt
@@ -40,9 +40,6 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.cancel
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.filter
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -177,7 +174,7 @@ class ChatAdapter(
     /** One signal represents one queued request; this keeps both workers fed during bursts. */
     private var renderSignal = Channel<Unit>(Channel.UNLIMITED)
     private var renderWorkers = emptyList<Job>()
-    private val renderWorkerLimit = MutableStateFlow(MAX_RENDER_WORKERS)
+    private val imagePrefetchTracker = ChatAdapterUtils.ChatImagePrefetchTracker()
     private val mainHandler = Handler(Looper.getMainLooper())
     private val pendingRenderedMessages = Collections.newSetFromMap(
         IdentityHashMap<ChatMessage, Boolean>(),
@@ -509,7 +506,6 @@ class ChatAdapter(
         attachedRecyclerView = recyclerView
         super.onAttachedToRecyclerView(recyclerView)
         recyclerView.addOnScrollListener(prewarmScrollListener)
-        prefetchCatalogAssets()
         scheduleVisiblePrewarm(recyclerView)
     }
 
@@ -555,7 +551,6 @@ class ChatAdapter(
     }
 
     fun notifyCatalogChanged() {
-        prefetchCatalogAssets()
         scheduleConfigurationSwitch(
             composeChatRenderConfiguration(
                 active = activeConfiguration,
@@ -586,6 +581,9 @@ class ChatAdapter(
             prepareForDisplay(currentSnapshot, configuration)
             withContext(Dispatchers.Main.immediate) {
                 if (pendingConfiguration !== configuration) return@withContext
+                // Actual message assets have already been discovered and queued above. Start the
+                // small reusable badge warm-up only after that higher-priority work is in flight.
+                prefetchCatalogAssets()
                 activeConfiguration = configuration
                 pendingConfiguration = null
                 configurationJob = null
@@ -748,8 +746,7 @@ class ChatAdapter(
         const val PREWARM_BEFORE = 8
         const val PREWARM_AFTER = 24
         const val PREWARM_DEBOUNCE_MS = 100L
-        const val MAX_CATALOG_BADGES = 128
-        const val MAX_CATALOG_EMOTES = 192
+        const val MAX_CATALOG_BADGES_PER_SOURCE = 32
     }
 
     private fun cachedRender(key: RenderCacheKey): ChatAdapterUtils.MessageResult? = synchronized(renderCache) {
@@ -813,12 +810,9 @@ class ChatAdapter(
         }
     }
 
-    private fun startRenderWorkers(): List<Job> = List(MAX_RENDER_WORKERS) { workerIndex ->
+    private fun startRenderWorkers(): List<Job> = List(MAX_RENDER_WORKERS) {
         renderScope.launch {
             while (isActive) {
-                if (workerIndex >= renderWorkerLimit.value) {
-                    renderWorkerLimit.filter { it > workerIndex }.first()
-                }
                 if (renderSignal.receiveCatching().getOrNull() == null) break
                 val request = visibleRenderQueue.tryReceive().getOrNull()
                     ?: prewarmRenderQueue.tryReceive().getOrNull()
@@ -873,15 +867,19 @@ class ChatAdapter(
                 request.cacheKey.translateAllMessages,
                 offMain = true,
             )
-            ChatAdapterUtils.prefetchImages(
-                request.context,
-                prepared.images,
-                imageLibrary,
-                emoteQuality,
-                emoteSize,
-                badgeSize,
-                inlineIconSize,
-            )
+            // Enqueue only. Coil and Glide do the actual network/decode work asynchronously.
+            withContext(Dispatchers.Main.immediate) {
+                ChatAdapterUtils.prefetchImages(
+                    request.context,
+                    prepared.images,
+                    imageLibrary,
+                    emoteQuality,
+                    emoteSize,
+                    badgeSize,
+                    inlineIconSize,
+                    imagePrefetchTracker,
+                )
+            }
             withContext(Dispatchers.Main.immediate) {
                 if (isKnownConfiguration(request.configuration) && currentRenderKey(chatMessage, request.configuration) == cacheKey) {
                     synchronized(renderCache) { renderCache[cacheKey] = prepared }
@@ -1010,86 +1008,43 @@ class ChatAdapter(
     }
 
     private fun prefetchCatalogAssets() {
-        val images = ArrayList<Image>()
+        val images = ArrayList<Image>(MAX_CATALOG_BADGES_PER_SOURCE * 3)
 
-        fun add(
-            url1x: String?,
-            url2x: String?,
-            url3x: String?,
-            url4x: String?,
-            kind: ImageKind,
-            format: String? = null,
-            isAnimated: Boolean = false,
-            thirdParty: Boolean = false,
-            sourceWidth: Int? = null,
-            sourceHeight: Int? = null,
-        ) {
-            if (url1x != null || url2x != null || url3x != null || url4x != null) {
-                images += Image(
-                    url1x = url1x,
-                    url2x = url2x,
-                    url3x = url3x,
-                    url4x = url4x,
-                    format = format,
-                    isAnimated = isAnimated,
-                    kind = kind,
-                    thirdParty = thirdParty,
-                    sourceWidth = sourceWidth,
-                    sourceHeight = sourceHeight,
-                    start = 0,
-                    end = 1,
-                )
-            }
+        fun addBadge(badge: TwitchBadge) {
+            images += Image(
+                url1x = badge.url1x,
+                url2x = badge.url2x,
+                url3x = badge.url3x,
+                url4x = badge.url4x,
+                kind = ImageKind.BADGE,
+                start = 0,
+                end = 1,
+            )
+        }
+
+        fun addStvBadge(badge: STVBadge) {
+            images += Image(
+                url1x = badge.url1x,
+                url2x = badge.url2x,
+                url3x = badge.url3x,
+                url4x = badge.url4x,
+                format = badge.format,
+                isAnimated = true,
+                kind = ImageKind.BADGE,
+                thirdParty = true,
+                start = 0,
+                end = 1,
+            )
         }
 
         synchronized(globalBadges) {
-            globalBadges.take(MAX_CATALOG_BADGES).forEach { badge ->
-                add(badge.url1x, badge.url2x, badge.url3x, badge.url4x, ImageKind.BADGE)
-            }
+            globalBadges.take(MAX_CATALOG_BADGES_PER_SOURCE).forEach(::addBadge)
         }
         synchronized(channelBadges) {
-            channelBadges.take(MAX_CATALOG_BADGES).forEach { badge ->
-                add(badge.url1x, badge.url2x, badge.url3x, badge.url4x, ImageKind.BADGE)
-            }
+            channelBadges.take(MAX_CATALOG_BADGES_PER_SOURCE).forEach(::addBadge)
         }
         synchronized(stvBadges) {
-            stvBadges.take(MAX_CATALOG_BADGES).forEach { badge ->
-                add(badge.url1x, badge.url2x, badge.url3x, badge.url4x, ImageKind.BADGE, badge.format, true, true)
-            }
-        }
-        synchronized(localTwitchEmotes) {
-            localTwitchEmotes.take(MAX_CATALOG_EMOTES).forEach { emote ->
-                add(emote.url1x, emote.url2x, emote.url3x, emote.url4x, ImageKind.EMOTE, emote.format, emote.isAnimated)
-            }
-        }
-        synchronized(thirdPartyEmotes) {
-            thirdPartyEmotes.asSequence()
-                .filter {
-                    it.source == Emote.CHANNEL_STV ||
-                        it.source == Emote.CHANNEL_BTTV ||
-                        it.source == Emote.CHANNEL_FFZ ||
-                        it.source == Emote.PERSONAL_STV
-                }
-                .take(MAX_CATALOG_EMOTES)
-                .forEach { emote ->
-                    add(
-                        emote.url1x,
-                        emote.url2x,
-                        emote.url3x,
-                        emote.url4x,
-                        ImageKind.EMOTE,
-                        emote.format,
-                        emote.isAnimated,
-                        emote.thirdParty,
-                        emote.width,
-                        emote.height,
-                    )
-                }
-        }
-        synchronized(cheerEmotes) {
-            cheerEmotes.take(MAX_CATALOG_EMOTES).forEach { emote ->
-                add(emote.url1x, emote.url2x, emote.url3x, emote.url4x, ImageKind.EMOTE, emote.format, emote.isAnimated)
-            }
+            stvBadges.take(MAX_CATALOG_BADGES_PER_SOURCE).forEach(::addStvBadge)
         }
 
         val context = fragment.context ?: return
@@ -1101,6 +1056,7 @@ class ChatAdapter(
             emoteSize,
             badgeSize,
             inlineIconSize,
+            imagePrefetchTracker,
         )
     }
 

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatFragment.kt
@@ -487,7 +487,6 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
                                     chatAdapterUpdatePosted = false
                                 }
                                 adapter?.setAnimationsPaused(newState != RecyclerView.SCROLL_STATE_IDLE)
-                                adapter?.setRenderUpdatesPaused(newState != RecyclerView.SCROLL_STATE_IDLE)
                                 val offset = recyclerView.computeVerticalScrollOffset()
                                 if (offset < 0) {
                                     btnDown.isVisible = false

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/MessageClickedChatAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/MessageClickedChatAdapter.kt
@@ -142,6 +142,9 @@ class MessageClickedChatAdapter(
         ChatAdapterUtils.loadImages(
             fragment, holder.textView, result.images, result.imagePaint, result.userName, result.userNameStartIndex,
             backgroundColor, imageLibrary, result.builder, emoteQuality, animateGifs,
+            emoteSize = emoteSize,
+            badgeSize = badgeSize,
+            inlineIconSize = inlineIconSize,
         )
     }
 

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ReplyClickedChatAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ReplyClickedChatAdapter.kt
@@ -131,6 +131,9 @@ class ReplyClickedChatAdapter(
         ChatAdapterUtils.loadImages(
             fragment, holder.textView, result.images, result.imagePaint, result.userName, result.userNameStartIndex,
             backgroundColor, imageLibrary, result.builder, emoteQuality, animateGifs,
+            emoteSize = emoteSize,
+            badgeSize = badgeSize,
+            inlineIconSize = inlineIconSize,
         )
     }
 

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/chat/ChatAdapterUtils.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/chat/ChatAdapterUtils.kt
@@ -59,6 +59,10 @@ import java.io.IOException
 import java.io.RandomAccessFile
 import android.util.Base64
 import coil3.request.Disposable
+import com.bumptech.glide.load.DataSource
+import com.bumptech.glide.load.engine.GlideException
+import com.bumptech.glide.request.RequestListener
+import com.bumptech.glide.request.target.Target
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
@@ -68,6 +72,33 @@ import kotlin.math.floor
 import kotlin.math.pow
 
 object ChatAdapterUtils {
+
+    class ChatImagePrefetchTracker(private val maxEntries: Int = 512) {
+        private val keys = LinkedHashMap<String, Long>(maxEntries, 0.75f, true)
+        private var nextToken = 0L
+
+        init {
+            require(maxEntries > 0)
+        }
+
+        fun tryStart(key: String): Long? = synchronized(keys) {
+            if (keys.containsKey(key)) {
+                null
+            }
+            else {
+                val token = ++nextToken
+                keys[key] = token
+                while (keys.size > maxEntries) {
+                    keys.entries.iterator().next().let { keys.remove(it.key) }
+                }
+                token
+            }
+        }
+
+        fun markFailed(key: String, token: Long) = synchronized(keys) {
+            if (keys[key] == token) keys.remove(key)
+        }
+    }
 
     private data class LocalEmoteKey(val source: String, val offset: Long, val length: Int)
 
@@ -622,6 +653,7 @@ object ChatAdapterUtils {
         emoteSize: Int,
         badgeSize: Int,
         inlineIconSize: Int,
+        prefetchTracker: ChatImagePrefetchTracker,
     ) {
         val queued = HashSet<String>()
 
@@ -629,21 +661,62 @@ object ChatAdapterUtils {
             val targetSize = imageSizeForKind(image.kind, emoteSize, badgeSize, inlineIconSize)
             val geometry = imageGeometry(image, targetSize)
             val data = imageData(image, emoteQuality) ?: return
-            val cacheKey = imageCacheKey(image, emoteQuality, geometry.widthPx, geometry.heightPx)
-            if (!queued.add(cacheKey)) {
+            val sourceKey = stableImageSourceKey(image, emoteQuality)
+            val usesCoil = imageLibrary == "0" || (imageLibrary == "1" && !image.format.equals("webp", true))
+            val requestKey = prefetchRequestKey(usesCoil, sourceKey, geometry.widthPx, geometry.heightPx)
+            if (!queued.add(requestKey)) {
                 image.overlayEmote?.let(::prefetch)
                 return
             }
-            if (imageLibrary == "0" || (imageLibrary == "1" && !image.format.equals("webp", true))) {
+            val prefetchToken = prefetchTracker.tryStart(requestKey)
+            if (prefetchToken == null) {
+                image.overlayEmote?.let(::prefetch)
+                return
+            }
+            if (usesCoil) {
                 context.imageLoader.enqueue(
-                    chatImageRequest(context, image, data, geometry.widthPx, geometry.heightPx, cacheKey).build(),
+                    chatImageRequest(
+                        context,
+                        image,
+                        data,
+                        geometry.widthPx,
+                        geometry.heightPx,
+                        imageMemoryCacheKey(sourceKey, geometry.widthPx, geometry.heightPx),
+                        sourceKey,
+                    ).listener(object : ImageRequest.Listener {
+                        override fun onError(request: ImageRequest, result: coil3.request.ErrorResult) {
+                            prefetchTracker.markFailed(requestKey, prefetchToken)
+                        }
+
+                        override fun onSuccess(request: ImageRequest, result: coil3.request.SuccessResult) = Unit
+                    }).build(),
                 )
             } else {
+                val model = glideImageModel(image, data)
                 Glide.with(context)
-                    .load(data)
+                    .load(model)
                     .override(geometry.widthPx, geometry.heightPx)
                     .diskCacheStrategy(DiskCacheStrategy.DATA)
                     .dontAnimate()
+                    .listener(object : RequestListener<Drawable> {
+                        override fun onLoadFailed(
+                            e: GlideException?,
+                            model: Any?,
+                            target: Target<Drawable>,
+                            isFirstResource: Boolean,
+                        ): Boolean {
+                            prefetchTracker.markFailed(requestKey, prefetchToken)
+                            return false
+                        }
+
+                        override fun onResourceReady(
+                            resource: Drawable,
+                            model: Any,
+                            target: Target<Drawable>,
+                            dataSource: DataSource,
+                            isFirstResource: Boolean,
+                        ): Boolean = false
+                    })
                     .preload()
             }
             image.overlayEmote?.let(::prefetch)
@@ -1191,9 +1264,17 @@ object ChatAdapterUtils {
     private fun loadCoil(fragment: Fragment, image: Image, emoteQuality: String, requestBag: ImageRequestBag?, widthPx: Int?, heightPx: Int?, onLoaded: (Drawable) -> Unit) {
         val context = fragment.requireContext()
         val data = imageData(image, emoteQuality) ?: return
-        val cacheKey = imageCacheKey(image, emoteQuality, widthPx ?: 0, heightPx ?: 0)
+        val sourceKey = stableImageSourceKey(image, emoteQuality)
         val disposable = context.imageLoader.enqueue(
-            chatImageRequest(context, image, data, widthPx, heightPx, cacheKey).apply {
+            chatImageRequest(
+                context,
+                image,
+                data,
+                widthPx,
+                heightPx,
+                imageMemoryCacheKey(sourceKey, widthPx ?: 0, heightPx ?: 0),
+                sourceKey,
+            ).apply {
                 target(
                     onSuccess = {
                         onLoaded((it.asDrawable(fragment.resources)))
@@ -1212,11 +1293,7 @@ object ChatAdapterUtils {
             override fun onLoadCleared(placeholder: Drawable?) {}
         }
         requestManager
-            .load(data.let {
-                if (image.thirdParty) {
-                    GlideUrl(it.toString()) { mapOf("User-Agent" to "Xtra/" + BuildConfig.VERSION_NAME) }
-                } else it
-            })
+            .load(glideImageModel(image, data))
             .diskCacheStrategy(DiskCacheStrategy.DATA)
             .dontAnimate()
             .override(widthPx ?: com.bumptech.glide.request.target.Target.SIZE_ORIGINAL, heightPx ?: com.bumptech.glide.request.target.Target.SIZE_ORIGINAL)
@@ -1231,12 +1308,31 @@ object ChatAdapterUtils {
         else -> image.url1x
     }
 
-    private fun imageCacheKey(image: Image, emoteQuality: String, widthPx: Int, heightPx: Int): String {
-        val source = image.localDataUrl?.let { url ->
-            image.localDataRange?.let { range -> "$url:${range.first}:${range.second}" }
-        } ?: imageData(image, emoteQuality)?.toString().orEmpty()
-        return "xtra:chat-image:$source:$emoteQuality:${widthPx}x$heightPx"
+    internal fun glideImageModel(image: Image, data: Any): Any = if (image.thirdParty && data is String) {
+        GlideUrl(data) { mapOf("User-Agent" to "Xtra/" + BuildConfig.VERSION_NAME) }
+    } else {
+        data
     }
+
+    private fun stableImageSourceKey(image: Image, emoteQuality: String): String {
+        val localSource = image.localDataUrl?.let { url ->
+            image.localDataRange?.let { range -> "local:$url:${range.first}:${range.second}" }
+        }
+        if (localSource != null) return localSource
+
+        return when (val data = imageData(image, emoteQuality)) {
+            is String -> "url:$data"
+            is ByteArray -> "bytes:${data.size}:${data.contentHashCode()}"
+            null -> "missing"
+            else -> "data:${data::class.java.name}:${data.hashCode()}"
+        }
+    }
+
+    private fun imageMemoryCacheKey(sourceKey: String, widthPx: Int, heightPx: Int): String =
+        "xtra:chat-image:$sourceKey:${widthPx}x$heightPx"
+
+    private fun prefetchRequestKey(usesCoil: Boolean, sourceKey: String, widthPx: Int, heightPx: Int): String =
+        "${if (usesCoil) "coil" else "glide"}:$sourceKey:${widthPx}x$heightPx"
 
     private fun chatImageRequest(
         context: Context,
@@ -1244,12 +1340,13 @@ object ChatAdapterUtils {
         data: Any,
         widthPx: Int?,
         heightPx: Int?,
-        cacheKey: String,
+        memoryKey: String,
+        sourceKey: String,
     ): ImageRequest.Builder = ImageRequest.Builder(context).apply {
         data(data)
         if (widthPx != null && heightPx != null) size(widthPx, heightPx)
-        memoryCacheKey(cacheKey)
-        diskCacheKey(cacheKey)
+        memoryCacheKey(memoryKey)
+        diskCacheKey(sourceKey)
         memoryCachePolicy(CachePolicy.ENABLED)
         diskCachePolicy(CachePolicy.ENABLED)
         networkCachePolicy(CachePolicy.ENABLED)

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/chat/ChatAdapterUtils.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/chat/ChatAdapterUtils.kt
@@ -67,6 +67,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import java.security.MessageDigest
 import java.util.Random
 import kotlin.math.floor
 import kotlin.math.pow
@@ -1314,6 +1315,21 @@ object ChatAdapterUtils {
         data
     }
 
+    internal fun byteArraySourceKey(data: ByteArray): String =
+        "bytes:${data.size}:${sha256Hex(data)}"
+
+    private fun sha256Hex(data: ByteArray): String {
+        val digest = MessageDigest.getInstance("SHA-256").digest(data)
+        val hex = CharArray(digest.size * 2)
+        val digits = "0123456789abcdef"
+        digest.forEachIndexed { index, byte ->
+            val value = byte.toInt() and 0xff
+            hex[index * 2] = digits[value ushr 4]
+            hex[index * 2 + 1] = digits[value and 0x0f]
+        }
+        return String(hex)
+    }
+
     private fun stableImageSourceKey(image: Image, emoteQuality: String): String {
         val localSource = image.localDataUrl?.let { url ->
             image.localDataRange?.let { range -> "local:$url:${range.first}:${range.second}" }
@@ -1322,7 +1338,7 @@ object ChatAdapterUtils {
 
         return when (val data = imageData(image, emoteQuality)) {
             is String -> "url:$data"
-            is ByteArray -> "bytes:${data.size}:${data.contentHashCode()}"
+            is ByteArray -> byteArraySourceKey(data)
             null -> "missing"
             else -> "data:${data::class.java.name}:${data.hashCode()}"
         }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/chat/ChatAdapterUtils.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/chat/ChatAdapterUtils.kt
@@ -31,6 +31,7 @@ import coil3.network.NetworkHeaders
 import coil3.network.httpHeaders
 import coil3.request.CachePolicy
 import coil3.request.ImageRequest
+import coil3.request.crossfade
 import com.bumptech.glide.Glide
 import com.bumptech.glide.load.engine.DiskCacheStrategy
 import com.bumptech.glide.load.model.GlideUrl
@@ -612,6 +613,45 @@ object ChatAdapterUtils {
         }
     }
 
+    /** Starts bounded chat image work without attaching it to a transient ViewHolder. */
+    fun prefetchImages(
+        context: Context,
+        images: List<Image>,
+        imageLibrary: String?,
+        emoteQuality: String,
+        emoteSize: Int,
+        badgeSize: Int,
+        inlineIconSize: Int,
+    ) {
+        val queued = HashSet<String>()
+
+        fun prefetch(image: Image) {
+            val targetSize = imageSizeForKind(image.kind, emoteSize, badgeSize, inlineIconSize)
+            val geometry = imageGeometry(image, targetSize)
+            val data = imageData(image, emoteQuality) ?: return
+            val cacheKey = imageCacheKey(image, emoteQuality, geometry.widthPx, geometry.heightPx)
+            if (!queued.add(cacheKey)) {
+                image.overlayEmote?.let(::prefetch)
+                return
+            }
+            if (imageLibrary == "0" || (imageLibrary == "1" && !image.format.equals("webp", true))) {
+                context.imageLoader.enqueue(
+                    chatImageRequest(context, image, data, geometry.widthPx, geometry.heightPx, cacheKey).build(),
+                )
+            } else {
+                Glide.with(context)
+                    .load(data)
+                    .override(geometry.widthPx, geometry.heightPx)
+                    .diskCacheStrategy(DiskCacheStrategy.DATA)
+                    .dontAnimate()
+                    .preload()
+            }
+            image.overlayEmote?.let(::prefetch)
+        }
+
+        images.forEach(::prefetch)
+    }
+
     private fun getSavedColor(color: String, savedColors: HashMap<String, Int>, useReadableColors: Boolean, isLightTheme: Boolean): Int {
         return synchronized(savedColors) {
             savedColors[color] ?: Color.parseColor(color).let { newColor ->
@@ -918,18 +958,13 @@ object ChatAdapterUtils {
         }
     }
 
-    fun loadImages(fragment: Fragment, itemView: View, images: List<Image>, imagePaint: NamePaint?, userName: String?, userNameStartIndex: Int?, backgroundColor: Int, imageLibrary: String?, builder: SpannableStringBuilder, emoteQuality: String, animateGifs: Boolean, isCurrent: () -> Boolean = { true }, shouldAnimate: () -> Boolean = { true }, requestBag: ImageRequestBag? = null, shouldLoad: () -> Boolean = { true }, onLoadDeferred: () -> Unit = {}) {
-        // During a fling the placeholder layout is sufficient. Deferring every request, including
-        // static badges and name paints, prevents decode/cache work from competing with scrolling.
-        if (!shouldLoad()) {
-            if (imagePaint != null || images.isNotEmpty()) onLoadDeferred()
-            return
-        }
+    fun loadImages(fragment: Fragment, itemView: View, images: List<Image>, imagePaint: NamePaint?, userName: String?, userNameStartIndex: Int?, backgroundColor: Int, imageLibrary: String?, builder: SpannableStringBuilder, emoteQuality: String, animateGifs: Boolean, isCurrent: () -> Boolean = { true }, shouldAnimate: () -> Boolean = { true }, requestBag: ImageRequestBag? = null, emoteSize: Int = 1, badgeSize: Int = 1, inlineIconSize: Int = 1) {
         if (imagePaint != null) {
             if (imageLibrary == "0") {
                 val disposable = fragment.requireContext().imageLoader.enqueue(
                     ImageRequest.Builder(fragment.requireContext()).apply {
                         data(imagePaint.imageUrl)
+                        crossfade(false)
                         httpHeaders(NetworkHeaders.Builder().apply {
                             add("User-Agent", "Xtra/" + BuildConfig.VERSION_NAME)
                         }.build())
@@ -1012,12 +1047,14 @@ object ChatAdapterUtils {
                 requestManager
                     .load(GlideUrl(imagePaint.imageUrl) { mapOf("User-Agent" to "Xtra/" + BuildConfig.VERSION_NAME) })
                     .diskCacheStrategy(DiskCacheStrategy.DATA)
+                    .dontAnimate()
                     .into(target)
                 requestBag?.addClearer { requestManager.clear(target) }
             }
         }
         images.forEach { image ->
-            loadImage(imageLibrary, fragment, image, emoteQuality, requestBag) imageLoaded@{ result ->
+            val geometry = imageGeometry(image, imageSizeForKind(image.kind, emoteSize, badgeSize, inlineIconSize))
+            loadImage(imageLibrary, fragment, image, emoteQuality, requestBag, imageLoaded@{ result ->
                 if (!isCurrent()) return@imageLoaded
                 if (result is Animatable && image.isAnimated && animateGifs) {
                     result.callback = object : Drawable.Callback {
@@ -1037,21 +1074,18 @@ object ChatAdapterUtils {
                 }
                 if (image.overlayEmote != null) {
                     val drawables = arrayOf(result)
-                    nextOverlayEmote(imageLibrary, fragment, drawables, image.overlayEmote!!, image, itemView, builder, emoteQuality, animateGifs, isCurrent, shouldAnimate, requestBag, shouldLoad, onLoadDeferred)
+                    nextOverlayEmote(imageLibrary, fragment, drawables, image.overlayEmote!!, image, itemView, builder, emoteQuality, animateGifs, isCurrent, shouldAnimate, requestBag, emoteSize, badgeSize, inlineIconSize)
                 } else {
                     builder.getSpans(image.start, image.end, CenteredImageSpan::class.java).firstOrNull()?.imageDrawable = result
                     itemView.invalidate()
                 }
-            }
+            }, geometry.widthPx, geometry.heightPx)
         }
     }
 
-    private fun nextOverlayEmote(imageLibrary: String?, fragment: Fragment, drawables: Array<Drawable>, image: Image, bottomImage: Image, itemView: View, builder: SpannableStringBuilder, emoteQuality: String, animateGifs: Boolean, isCurrent: () -> Boolean, shouldAnimate: () -> Boolean, requestBag: ImageRequestBag?, shouldLoad: () -> Boolean, onLoadDeferred: () -> Unit) {
-        if (!shouldLoad()) {
-            onLoadDeferred()
-            return
-        }
-        loadImage(imageLibrary, fragment, image, emoteQuality, requestBag) overlayLoaded@{ result ->
+    private fun nextOverlayEmote(imageLibrary: String?, fragment: Fragment, drawables: Array<Drawable>, image: Image, bottomImage: Image, itemView: View, builder: SpannableStringBuilder, emoteQuality: String, animateGifs: Boolean, isCurrent: () -> Boolean, shouldAnimate: () -> Boolean, requestBag: ImageRequestBag?, emoteSize: Int, badgeSize: Int, inlineIconSize: Int) {
+        val geometry = imageGeometry(image, imageSizeForKind(image.kind, emoteSize, badgeSize, inlineIconSize))
+        loadImage(imageLibrary, fragment, image, emoteQuality, requestBag, overlayLoaded@{ result ->
             if (!isCurrent()) return@overlayLoaded
             if (result is Animatable && image.isAnimated && animateGifs) {
                 result.callback = object : Drawable.Callback {
@@ -1071,35 +1105,35 @@ object ChatAdapterUtils {
             }
             val array = drawables.plus(result)
             if (image.overlayEmote != null) {
-                nextOverlayEmote(imageLibrary, fragment, array, image.overlayEmote!!, bottomImage, itemView, builder, emoteQuality, animateGifs, isCurrent, shouldAnimate, requestBag, shouldLoad, onLoadDeferred)
+                nextOverlayEmote(imageLibrary, fragment, array, image.overlayEmote!!, bottomImage, itemView, builder, emoteQuality, animateGifs, isCurrent, shouldAnimate, requestBag, emoteSize, badgeSize, inlineIconSize)
             } else {
                 val layer = LayerDrawable(array)
                 builder.getSpans(bottomImage.start, bottomImage.end, CenteredImageSpan::class.java).firstOrNull()?.imageDrawable = layer
                 itemView.invalidate()
             }
-        }
+        }, geometry.widthPx, geometry.heightPx)
     }
 
-    private fun loadImage(imageLibrary: String?, fragment: Fragment, image: Image, emoteQuality: String, requestBag: ImageRequestBag?, onLoaded: (Drawable) -> Unit) {
+    private fun loadImage(imageLibrary: String?, fragment: Fragment, image: Image, emoteQuality: String, requestBag: ImageRequestBag?, onLoaded: (Drawable) -> Unit, widthPx: Int? = null, heightPx: Int? = null) {
         if (image.localData == null && image.localDataUrl != null && image.localDataRange != null) {
             val context = fragment.requireContext()
             val range = image.localDataRange
             getCachedLocalEmote(image.localDataUrl, range)?.let { bytes ->
-                loadImage(imageLibrary, fragment, image.withLocalData(bytes), emoteQuality, requestBag, onLoaded)
+                loadImage(imageLibrary, fragment, image.withLocalData(bytes), emoteQuality, requestBag, onLoaded, widthPx, heightPx)
                 return
             }
             val job = fragment.viewLifecycleOwner.lifecycleScope.launch(Dispatchers.IO) {
                 val bytes = readLocalEmote(context, image.localDataUrl, range)
                 cacheLocalEmote(image.localDataUrl, range, bytes)
-                withContext(Dispatchers.Main.immediate) { loadImage(imageLibrary, fragment, image.withLocalData(bytes), emoteQuality, requestBag, onLoaded) }
+                withContext(Dispatchers.Main.immediate) { loadImage(imageLibrary, fragment, image.withLocalData(bytes), emoteQuality, requestBag, onLoaded, widthPx, heightPx) }
             }
             requestBag?.add(job)
             return
         }
         if (imageLibrary == "0" || (imageLibrary == "1" && !image.format.equals("webp", true))) {
-            loadCoil(fragment, image, emoteQuality, requestBag, onLoaded)
+            loadCoil(fragment, image, emoteQuality, requestBag, widthPx, heightPx, onLoaded)
         } else {
-            loadGlide(fragment, image, emoteQuality, requestBag, onLoaded)
+            loadGlide(fragment, image, emoteQuality, requestBag, widthPx, heightPx, onLoaded)
         }
     }
 
@@ -1154,55 +1188,76 @@ object ChatAdapterUtils {
         }
     }
 
-    private fun loadCoil(fragment: Fragment, image: Image, emoteQuality: String, requestBag: ImageRequestBag?, onLoaded: (Drawable) -> Unit) {
-        val disposable = fragment.requireContext().imageLoader.enqueue(
-            ImageRequest.Builder(fragment.requireContext()).apply {
-                data(image.localData ?: when (emoteQuality) {
-                    "4" -> image.url4x ?: image.url3x ?: image.url2x ?: image.url1x
-                    "3" -> image.url3x ?: image.url2x ?: image.url1x
-                    "2" -> image.url2x ?: image.url1x
-                    else -> image.url1x
-                })
-                image.localDataUrl?.let { source ->
-                    image.localDataRange?.let { range ->
-                        memoryCacheKey("xtra:chat-local-emote:$source:${range.first}:${range.second}:$emoteQuality")
-                    }
-                }
-                diskCachePolicy(CachePolicy.ENABLED)
-                if (image.thirdParty) {
-                    httpHeaders(NetworkHeaders.Builder().apply {
-                        add("User-Agent", "Xtra/" + BuildConfig.VERSION_NAME)
-                    }.build())
-                }
+    private fun loadCoil(fragment: Fragment, image: Image, emoteQuality: String, requestBag: ImageRequestBag?, widthPx: Int?, heightPx: Int?, onLoaded: (Drawable) -> Unit) {
+        val context = fragment.requireContext()
+        val data = imageData(image, emoteQuality) ?: return
+        val cacheKey = imageCacheKey(image, emoteQuality, widthPx ?: 0, heightPx ?: 0)
+        val disposable = context.imageLoader.enqueue(
+            chatImageRequest(context, image, data, widthPx, heightPx, cacheKey).apply {
                 target(
                     onSuccess = {
                         onLoaded((it.asDrawable(fragment.resources)))
                     },
                 )
-            }.build()
+            }.build(),
         )
         requestBag?.add(disposable)
     }
 
-    private fun loadGlide(fragment: Fragment, image: Image, emoteQuality: String, requestBag: ImageRequestBag?, onLoaded: (Drawable) -> Unit) {
+    private fun loadGlide(fragment: Fragment, image: Image, emoteQuality: String, requestBag: ImageRequestBag?, widthPx: Int?, heightPx: Int?, onLoaded: (Drawable) -> Unit) {
+        val data = imageData(image, emoteQuality) ?: return
         val requestManager = Glide.with(fragment)
         val target = object : CustomTarget<Drawable>() {
             override fun onResourceReady(resource: Drawable, transition: Transition<in Drawable>?) { onLoaded(resource) }
             override fun onLoadCleared(placeholder: Drawable?) {}
         }
         requestManager
-            .load(image.localData ?: when (emoteQuality) {
-                "4" -> image.url4x ?: image.url3x ?: image.url2x ?: image.url1x
-                "3" -> image.url3x ?: image.url2x ?: image.url1x
-                "2" -> image.url2x ?: image.url1x
-                else -> image.url1x
-            }.let {
+            .load(data.let {
                 if (image.thirdParty) {
-                    GlideUrl(it) { mapOf("User-Agent" to "Xtra/" + BuildConfig.VERSION_NAME) }
+                    GlideUrl(it.toString()) { mapOf("User-Agent" to "Xtra/" + BuildConfig.VERSION_NAME) }
                 } else it
             })
             .diskCacheStrategy(DiskCacheStrategy.DATA)
+            .dontAnimate()
+            .override(widthPx ?: com.bumptech.glide.request.target.Target.SIZE_ORIGINAL, heightPx ?: com.bumptech.glide.request.target.Target.SIZE_ORIGINAL)
             .into(target)
         requestBag?.addClearer { requestManager.clear(target) }
+    }
+
+    private fun imageData(image: Image, emoteQuality: String): Any? = image.localData ?: when (emoteQuality) {
+        "4" -> image.url4x ?: image.url3x ?: image.url2x ?: image.url1x
+        "3" -> image.url3x ?: image.url2x ?: image.url1x
+        "2" -> image.url2x ?: image.url1x
+        else -> image.url1x
+    }
+
+    private fun imageCacheKey(image: Image, emoteQuality: String, widthPx: Int, heightPx: Int): String {
+        val source = image.localDataUrl?.let { url ->
+            image.localDataRange?.let { range -> "$url:${range.first}:${range.second}" }
+        } ?: imageData(image, emoteQuality)?.toString().orEmpty()
+        return "xtra:chat-image:$source:$emoteQuality:${widthPx}x$heightPx"
+    }
+
+    private fun chatImageRequest(
+        context: Context,
+        image: Image,
+        data: Any,
+        widthPx: Int?,
+        heightPx: Int?,
+        cacheKey: String,
+    ): ImageRequest.Builder = ImageRequest.Builder(context).apply {
+        data(data)
+        if (widthPx != null && heightPx != null) size(widthPx, heightPx)
+        memoryCacheKey(cacheKey)
+        diskCacheKey(cacheKey)
+        memoryCachePolicy(CachePolicy.ENABLED)
+        diskCachePolicy(CachePolicy.ENABLED)
+        networkCachePolicy(CachePolicy.ENABLED)
+        crossfade(false)
+        if (image.thirdParty) {
+            httpHeaders(NetworkHeaders.Builder().apply {
+                add("User-Agent", "Xtra/" + BuildConfig.VERSION_NAME)
+            }.build())
+        }
     }
 }

--- a/app/src/main/res/layout/player_layout.xml
+++ b/app/src/main/res/layout/player_layout.xml
@@ -502,17 +502,20 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginEnd="6dp"
+            android:minWidth="48dp"
+            android:minHeight="48dp"
+            android:gravity="center"
             android:visibility="gone"
             tools:visibility="visible">
 
             <ImageView
                 android:id="@+id/uptimeIcon"
-                android:layout_width="12dp"
-                android:layout_height="12dp"
-                android:layout_marginTop="9dp"
+                android:layout_width="24dp"
+                android:layout_height="24dp"
                 android:layout_marginEnd="4dp"
                 android:background="@android:color/transparent"
                 android:importantForAccessibility="no"
+                android:padding="0dp"
                 android:src="@drawable/baseline_circle_24"
                 android:visibility="gone"
                 app:tint="@color/liveStreamRed"
@@ -539,10 +542,11 @@
 
             <ImageView
                 android:id="@+id/viewersIcon"
-                android:layout_width="30dp"
-                android:layout_height="30dp"
+                android:layout_width="24dp"
+                android:layout_height="24dp"
                 android:background="@android:color/transparent"
                 android:importantForAccessibility="no"
+                android:padding="0dp"
                 android:src="@drawable/baseline_person_black_24"
                 android:visibility="gone"
                 app:tint="@android:color/white"


### PR DESCRIPTION
Keeps chat emotes and badges loading and repainting while scrolling, with bounded prefetching and stable inline image sizing. Aligns the two centered stream-info controls with the existing overlay touch-target and icon sizes.