### PR TITLE
Harden live stream startup and player transitions

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatAdapter.kt
@@ -10,6 +10,7 @@ import android.text.SpannableStringBuilder
 import android.text.TextUtils
 import android.text.method.LinkMovementMethod
 import android.text.style.ImageSpan
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -287,9 +288,18 @@ class ChatAdapter(
         if (holder.isAlreadyBoundTo(chatMessage, cacheKey)) return
         val bindGeneration = holder.beginBind(configuration.revision)
         val cachedResult = cachedRender(cacheKey)
-        val result = checkNotNull(cachedResult) {
-            "Chat message was displayed before its render plan was prepared"
-        }.copyForBind()
+        val result = selectRenderResultForBind(cachedResult) {
+            Log.w(
+                "ChatAdapter",
+                "Render cache miss during bind: position=$position revision=${configuration.revision}",
+            )
+            ensureRenderScheduled(
+                chatMessage = chatMessage,
+                cacheKey = cacheKey,
+                configuration = configuration,
+            )
+            fastFallback(chatMessage)
+        }
         ChatAdapterUtils.installImagePlaceholders(
             result.builder,
             result.images,
@@ -753,6 +763,30 @@ class ChatAdapter(
         renderCache[key]
     }
 
+    private fun ensureRenderScheduled(
+        chatMessage: ChatMessage,
+        cacheKey: RenderCacheKey,
+        configuration: ChatRenderConfiguration,
+    ) {
+        val context = fragment.context ?: return
+
+        renderScope.launch {
+            try {
+                enqueueRender(
+                    chatMessage = chatMessage,
+                    cacheKey = cacheKey,
+                    context = context,
+                    configuration = configuration,
+                )
+            } catch (e: CancellationException) {
+                throw e
+            } catch (_: Exception) {
+                // The row is already displaying fastFallback(). A render failure
+                // must not turn a cache miss into a process crash.
+            }
+        }
+    }
+
     private fun stableIdFor(message: ChatMessage): Long {
         val explicitId = message.id?.trim()?.takeIf { it.isNotEmpty() }
         if (explicitId != null) {
@@ -856,6 +890,7 @@ class ChatAdapter(
     private suspend fun renderMessage(request: RenderRequest) {
         val chatMessage = request.message
         val cacheKey = request.cacheKey
+        var waitersCompleted = false
         try {
             if (!isKnownConfiguration(request.configuration)) return
             if (cachedRender(cacheKey) != null) return
@@ -867,25 +902,33 @@ class ChatAdapter(
                 request.cacheKey.translateAllMessages,
                 offMain = true,
             )
-            // Enqueue only. Coil and Glide do the actual network/decode work asynchronously.
-            withContext(Dispatchers.Main.immediate) {
-                ChatAdapterUtils.prefetchImages(
-                    request.context,
-                    prepared.images,
-                    imageLibrary,
-                    emoteQuality,
-                    emoteSize,
-                    badgeSize,
-                    inlineIconSize,
-                    imagePrefetchTracker,
-                )
-            }
             withContext(Dispatchers.Main.immediate) {
                 if (isKnownConfiguration(request.configuration) && currentRenderKey(chatMessage, request.configuration) == cacheKey) {
                     synchronized(renderCache) { renderCache[cacheKey] = prepared }
                     if (isActiveConfiguration(request.configuration) && addPendingRenderedMessage(chatMessage)) {
                         scheduleRenderedFlush()
                     }
+                    completeRenderWaiters(cacheKey)
+                    waitersCompleted = true
+                }
+            }
+            // Enqueue only. Coil and Glide do the actual network/decode work asynchronously.
+            withContext(Dispatchers.Main.immediate) {
+                try {
+                    ChatAdapterUtils.prefetchImages(
+                        request.context,
+                        prepared.images,
+                        imageLibrary,
+                        emoteQuality,
+                        emoteSize,
+                        badgeSize,
+                        inlineIconSize,
+                        imagePrefetchTracker,
+                    )
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (_: Exception) {
+                    // A valid text/render plan is already available in renderCache.
                 }
             }
         } catch (e: CancellationException) {
@@ -904,7 +947,7 @@ class ChatAdapter(
                 prewarmRenderJobs.remove(cacheKey)
                 visibleRenderJobs.remove(cacheKey)
             }
-            completeRenderWaiters(cacheKey)
+            if (!waitersCompleted) completeRenderWaiters(cacheKey)
         }
     }
 
@@ -1211,3 +1254,8 @@ class ChatAdapter(
         return ChatAdapterUtils.MessageResult(builder, arrayListOf(), null, displayName, null, false, backgroundResource)
     }
 }
+
+internal fun selectRenderResultForBind(
+    cachedResult: ChatAdapterUtils.MessageResult?,
+    fallback: () -> ChatAdapterUtils.MessageResult,
+): ChatAdapterUtils.MessageResult = (cachedResult ?: fallback()).copyForBind()

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatFragment.kt
@@ -1133,9 +1133,12 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
 
     fun enterVideoReplay(videoId: String, createdAt: String?, positionMs: Long) {
         val args = requireArguments()
+        val alreadyInReplay = !shouldCaptureReplayComposerState(viewModel.activeChatMode)
         _binding?.let {
-            messageViewWasVisibleBeforeReplay = it.messageView.isVisible
-            messagingEnabledBeforeReplay = messagingEnabled
+            if (!alreadyInReplay) {
+                messageViewWasVisibleBeforeReplay = it.messageView.isVisible
+                messagingEnabledBeforeReplay = messagingEnabled
+            }
             it.messageView.isVisible = false
             it.editText.clearFocus()
             toggleEmoteMenu(false)
@@ -2166,5 +2169,8 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
         }
     }
 }
+
+internal fun shouldCaptureReplayComposerState(mode: ChatViewModel.ActiveChatMode): Boolean =
+    mode !is ChatViewModel.ActiveChatMode.VideoReplay
 
 

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/VideoSurfaceDebug.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/VideoSurfaceDebug.kt
@@ -2,6 +2,7 @@ package com.github.andreyasadchy.xtra.ui.common
 
 import android.util.Log
 import android.view.View
+import android.view.SurfaceView
 import androidx.media3.common.Player
 import com.github.andreyasadchy.xtra.BuildConfig
 
@@ -22,6 +23,8 @@ internal fun logVideoSurfaceBinding(
             "targetType=${target?.javaClass?.simpleName} " +
             "target.player=${targetPlayer.identityId()} " +
             "attached=${target?.isAttachedToWindow} visible=${target?.visibility} " +
+            "surfaceValid=${(target as? SurfaceView)?.holder?.surface?.isValid} " +
+            "playerState=${player?.playbackState} " +
             "size=${target?.width}x${target?.height} xy=${target?.x},${target?.y}",
     )
 }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/main/MainActivity.kt
@@ -1282,10 +1282,12 @@ class MainActivity : AppCompatActivity() {
 
     fun closePlayer() {
         onPlayerReturnedToBrowsing(playerStillOpen = false)
-        supportFragmentManager.beginTransaction()
-            .setTransition(FragmentTransaction.TRANSIT_FRAGMENT_FADE)
-            .remove(supportFragmentManager.findFragmentById(R.id.playerContainer)!!)
-            .commit()
+        supportFragmentManager.findFragmentById(R.id.playerContainer)?.let { player ->
+            supportFragmentManager.beginTransaction()
+                .setTransition(FragmentTransaction.TRANSIT_FRAGMENT_FADE)
+                .remove(player)
+                .commit()
+        }
         playerFragment = null
         viewModel.isPlayerOpened = false
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && packageManager.hasSystemFeature(PackageManager.FEATURE_PICTURE_IN_PICTURE)) {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/BasePlaybackService.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/BasePlaybackService.kt
@@ -2,6 +2,7 @@ package com.github.andreyasadchy.xtra.ui.player
 
 import android.net.ConnectivityManager
 import android.net.NetworkCapabilities
+import android.util.Log
 import androidx.lifecycle.LifecycleService
 import androidx.lifecycle.lifecycleScope
 import com.github.andreyasadchy.xtra.XtraModule
@@ -12,13 +13,12 @@ import com.github.andreyasadchy.xtra.model.stats.ViewingPlaybackMetadata
 import com.github.andreyasadchy.xtra.model.stats.mergeViewingCategoryPatch
 import com.github.andreyasadchy.xtra.util.C
 import com.github.andreyasadchy.xtra.util.prefs
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.buildJsonArray
-import kotlinx.serialization.json.decodeFromJsonElement
 import kotlinx.serialization.json.encodeToJsonElement
 
 abstract class BasePlaybackService : LifecycleService() {
@@ -93,8 +93,31 @@ abstract class BasePlaybackService : LifecycleService() {
     var loaded = false
 
     protected suspend fun restorePlaybackState() {
-        val savedState = xtraModule.playbackPersistence.takePlaybackState()
+        val savedState = try {
+            xtraModule.playbackPersistence.takePlaybackState()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Log.e(
+                "PlaybackRestore",
+                "Unable to consume persisted playback state; starting without restore",
+                e,
+            )
+            return
+        }
+
         if (savedState != null) {
+            val restoredQualities = decodeRestoredQualities(savedState.qualities)
+            val decodedQuality = decodeRestoredQuality(savedState.quality, "quality")
+            val decodedPreviousQuality =
+                decodeRestoredQuality(savedState.previousQuality, "previous quality")
+            // A quality without the list it belongs to can point at a stale VOD
+            // or stream URL. Let the normal manifest/default-quality path choose
+            // instead of combining fields from different playback sessions.
+            val restoredQuality = selectRestoredQuality(restoredQualities, decodedQuality)
+            val restoredPreviousQuality =
+                selectRestoredQuality(restoredQualities, decodedPreviousQuality)
+
             type = savedState.type
             streamId = savedState.streamId
             videoId = savedState.videoId
@@ -119,20 +142,34 @@ abstract class BasePlaybackService : LifecycleService() {
             videoUrl = savedState.videoUrl
             savedPosition = savedState.position
             paused = savedState.paused
-            qualities = savedState.qualities?.let { qualities ->
-                xtraModule.json.decodeFromString<JsonArray>(qualities).map {
-                    xtraModule.json.decodeFromJsonElement<VideoQuality>(it)
-                }
-            }
-            quality = savedState.quality?.let { xtraModule.json.decodeFromString(it) }
-            previousQuality = savedState.previousQuality?.let { xtraModule.json.decodeFromString(it) }
-            restoreQuality = savedState.restoreQuality
+            qualities = restoredQualities
+            quality = restoredQuality
+            previousQuality = restoredPreviousQuality
+            restoreQuality = savedState.restoreQuality && restoredPreviousQuality != null
             playlistUrl = savedState.playlistUrl
             restorePlaylist = savedState.restorePlaylist
             useCustomProxy = savedState.useCustomProxy
             skipAccessToken = savedState.skipAccessToken
         }
     }
+
+    private fun decodeRestoredQualities(encoded: String?): List<VideoQuality>? =
+        decodePlaybackQualities(xtraModule.json, encoded) { error ->
+            Log.w(
+                "PlaybackRestore",
+                "Ignoring invalid persisted playback qualities",
+                error,
+            )
+        }
+
+    private fun decodeRestoredQuality(encoded: String?, fieldName: String): VideoQuality? =
+        decodePlaybackQuality(xtraModule.json, encoded) { error ->
+            Log.w(
+                "PlaybackRestore",
+                "Ignoring invalid persisted playback $fieldName",
+                error,
+            )
+        }
 
     protected fun savePlaybackState(position: Long?, paused: Boolean) {
         val item = PlaybackState(

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/ExoPlayerFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/ExoPlayerFragment.kt
@@ -116,6 +116,7 @@ class ExoPlayerFragment : PlayerFragment(), ClipEditorDialogFragment.Host {
                 SurfaceView.SURFACE_LIFECYCLE_FOLLOWS_ATTACHMENT,
             )
         }
+        logVideoSurfaceBinding("on_view_created", playbackService?.player, binding.playerSurface)
         childFragmentManager.setFragmentResultListener(
             ClipEditorDialogFragment.RESULT_KEY,
             viewLifecycleOwner,
@@ -138,6 +139,7 @@ class ExoPlayerFragment : PlayerFragment(), ClipEditorDialogFragment.Host {
 
     override fun onStart() {
         super.onStart()
+        logVideoSurfaceBinding("on_start", playbackService?.player, binding.playerSurface)
         val listener = object : Player.Listener {
             override fun onPlaybackStateChanged(playbackState: Int) {
                 if (playbackState == Player.STATE_ENDED) {
@@ -392,6 +394,7 @@ class ExoPlayerFragment : PlayerFragment(), ClipEditorDialogFragment.Host {
                 if (view != null) {
                     val binder = service as ExoPlayerService.ServiceBinder
                     val connectedService = binder.getService()
+                    logVideoSurfaceBinding("service_connected", connectedService.player, binding.playerSurface)
                     val connectedServiceConnection = this
                     playbackService = connectedService
                     serviceSetupJob?.cancel()
@@ -1027,6 +1030,7 @@ class ExoPlayerFragment : PlayerFragment(), ClipEditorDialogFragment.Host {
     }
 
     override fun onStop() {
+        logVideoSurfaceBinding("on_stop", playbackService?.player, view?.findViewById(R.id.playerSurface))
         serviceSetupJob?.cancel()
         serviceSetupJob = null
         super.onStop()
@@ -1069,6 +1073,7 @@ class ExoPlayerFragment : PlayerFragment(), ClipEditorDialogFragment.Host {
     }
 
     override fun onDestroyView() {
+        logVideoSurfaceBinding("on_destroy_view", playbackService?.player, view?.findViewById(R.id.playerSurface))
         detachVideoOutput()
         clipDebug("parent editor view destroyed")
         serviceSetupJob?.cancel()

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/ExoPlayerService.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/ExoPlayerService.kt
@@ -44,6 +44,7 @@ import androidx.media3.common.PlaybackParameters
 import androidx.media3.common.Player
 import androidx.media3.common.Timeline
 import androidx.media3.common.TrackSelectionOverride
+import androidx.media3.common.TrackSelectionParameters
 import androidx.media3.common.Tracks
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.common.util.Util
@@ -162,6 +163,18 @@ class ExoPlayerService : BasePlaybackService() {
     private var liveClipPreparation: Deferred<ClipPreparationRepository.PreparedLiveClip>? = null
     private var vodClipSnapshot: ClipSnapshot? = null
     private var vodClipPreparation: Deferred<ClipPreparationRepository.PreparedLiveClip>? = null
+
+    private data class PlaybackSourceSnapshot(
+        val sourceUrl: String,
+        val dataSourceFactory: DataSource.Factory,
+        val mediaItem: MediaItem?,
+        val liveClipSourceMediaId: String?,
+        val positionMs: Long,
+        val playWhenReady: Boolean,
+        val volume: Float,
+        val playbackSpeed: Float,
+        val trackSelectionParameters: TrackSelectionParameters,
+    )
 
     override fun isViewingPlaybackPlaying(): Boolean = player?.isPlaying == true
 
@@ -1003,6 +1016,8 @@ class ExoPlayerService : BasePlaybackService() {
                             proxyUser = prefs().getString(C.PROXY_USER, null),
                             proxyPassword = prefs().getString(C.PROXY_PASSWORD, null),
                         )
+                    } catch (e: CancellationException) {
+                        throw e
                     } catch (e: Exception) {
                         null
                     }
@@ -1297,15 +1312,25 @@ class ExoPlayerService : BasePlaybackService() {
 
     suspend fun startLiveRewind(vodId: String, positionMs: Long): Boolean = liveRewindTransitionMutex.withLock {
         val player = player ?: return@withLock false
+        val oldSource = snapshotPlaybackSource(player, playlistUrl, hlsClipDataSourceFactory)
+            ?: return@withLock false
         val oldVideoId = videoId
         val oldPlaylistUrl = playlistUrl
         val oldHlsClipDataSourceFactory = hlsClipDataSourceFactory
         val oldQualities = qualities
         val oldQuality = quality
         val oldBackupQualities = backupQualities
+        val oldUseCustomProxy = useCustomProxy
         val oldSavedPosition = savedPosition
         val oldLiveRewindPositionOverride = liveRewindPositionOverride
         val oldPaused = paused
+        val oldUsingAlternateStream = usingAlternateStream
+        val oldPlayingAds = playingAds
+        val oldProxyMediaPlaylist = proxyMediaPlaylist
+        val oldStopProxy = stopProxy
+        val oldHidden = hidden
+        val oldUpdateQualities = updateQualities
+        val oldLiveClipSourceMediaId = liveClipSourceMediaId
         val wasPlaying = player.playWhenReady
         beginLiveRewindTransition()
         cancelLiveClipPreparation()
@@ -1336,6 +1361,16 @@ class ExoPlayerService : BasePlaybackService() {
                     qualities = oldQualities
                     quality = oldQuality
                     backupQualities = oldBackupQualities
+                    useCustomProxy = oldUseCustomProxy
+                    usingAlternateStream = oldUsingAlternateStream
+                    playingAds = oldPlayingAds
+                    proxyMediaPlaylist = oldProxyMediaPlaylist
+                    stopProxy = oldStopProxy
+                    hidden = oldHidden
+                    updateQualities = oldUpdateQualities
+                    liveClipSourceMediaId = oldLiveClipSourceMediaId
+                    clearLiveRewindState()
+                    restorePreviousLiveRewindSource(oldSource, ::restorePlaybackSource, player::stop)
                 } else {
                     liveClipBufferManager.reset()
                 }
@@ -1348,17 +1383,28 @@ class ExoPlayerService : BasePlaybackService() {
                     clearLiveRewindState()
                 }
                 loaded
-            } catch (_: Exception) {
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
                 videoId = oldVideoId
                 playlistUrl = oldPlaylistUrl
                 hlsClipDataSourceFactory = oldHlsClipDataSourceFactory
                 qualities = oldQualities
                 quality = oldQuality
                 backupQualities = oldBackupQualities
+                useCustomProxy = oldUseCustomProxy
                 savedPosition = oldSavedPosition
                 liveRewindPositionOverride = oldLiveRewindPositionOverride
                 paused = oldPaused
+                usingAlternateStream = oldUsingAlternateStream
+                playingAds = oldPlayingAds
+                proxyMediaPlaylist = oldProxyMediaPlaylist
+                stopProxy = oldStopProxy
+                hidden = oldHidden
+                updateQualities = oldUpdateQualities
+                liveClipSourceMediaId = oldLiveClipSourceMediaId
                 clearLiveRewindState()
+                restorePreviousLiveRewindSource(oldSource, ::restorePlaybackSource, player::stop)
                 false
             }
         } finally {
@@ -1368,6 +1414,8 @@ class ExoPlayerService : BasePlaybackService() {
 
     suspend fun returnToLivePlayback(): Boolean = liveRewindTransitionMutex.withLock {
         val player = player ?: return@withLock false
+        val oldSource = snapshotPlaybackSource(player, playlistUrl, hlsClipDataSourceFactory)
+            ?: return@withLock false
         val wasPlaying = player.playWhenReady
         val rewindVodId = liveRewindVodId
         val oldPlaylistUrl = playlistUrl
@@ -1375,6 +1423,14 @@ class ExoPlayerService : BasePlaybackService() {
         val oldQualities = qualities
         val oldQuality = quality
         val oldBackupQualities = backupQualities
+        val oldUseCustomProxy = useCustomProxy
+        val oldUsingAlternateStream = usingAlternateStream
+        val oldPlayingAds = playingAds
+        val oldProxyMediaPlaylist = proxyMediaPlaylist
+        val oldStopProxy = stopProxy
+        val oldHidden = hidden
+        val oldUpdateQualities = updateQualities
+        val oldLiveClipSourceMediaId = liveClipSourceMediaId
         beginLiveRewindTransition()
         cancelLiveClipPreparation()
         playlistUrl = null
@@ -1385,6 +1441,8 @@ class ExoPlayerService : BasePlaybackService() {
             val success = try {
                 loadStream(restorePauseState = false, restart = true)
                 !playlistUrl.isNullOrBlank() && player.currentMediaItem != null
+            } catch (e: CancellationException) {
+                throw e
             } catch (_: Exception) {
                 false
             }
@@ -1396,12 +1454,70 @@ class ExoPlayerService : BasePlaybackService() {
                 qualities = oldQualities
                 quality = oldQuality
                 backupQualities = oldBackupQualities
+                useCustomProxy = oldUseCustomProxy
+                usingAlternateStream = oldUsingAlternateStream
+                playingAds = oldPlayingAds
+                proxyMediaPlaylist = oldProxyMediaPlaylist
+                stopProxy = oldStopProxy
+                hidden = oldHidden
+                updateQualities = oldUpdateQualities
+                liveClipSourceMediaId = oldLiveClipSourceMediaId
                 (rewindVodId ?: videoId)?.let(::markLiveRewindActive)
+                restorePreviousLiveRewindSource(oldSource, ::restorePlaybackSource, player::stop)
             }
-            player.playWhenReady = wasPlaying
+            if (success) player.playWhenReady = wasPlaying
             success
         } finally {
             finishLiveRewindTransition()
+        }
+    }
+
+    private fun snapshotPlaybackSource(
+        player: ExoPlayer,
+        playlistUrl: String?,
+        dataSourceFactory: DataSource.Factory?,
+    ): PlaybackSourceSnapshot? {
+        val factory = dataSourceFactory ?: return null
+        val mediaItem = player.currentMediaItem
+        val sourceUrl = mediaItem?.localConfiguration?.uri?.toString() ?: playlistUrl ?: return null
+        return PlaybackSourceSnapshot(
+            sourceUrl = sourceUrl,
+            dataSourceFactory = factory,
+            mediaItem = mediaItem,
+            liveClipSourceMediaId = liveClipSourceMediaId,
+            positionMs = player.currentPosition,
+            playWhenReady = player.playWhenReady,
+            volume = player.volume,
+            playbackSpeed = player.playbackParameters.speed,
+            trackSelectionParameters = player.trackSelectionParameters,
+        )
+    }
+
+    private fun restorePlaybackSource(snapshot: PlaybackSourceSnapshot?): Boolean {
+        val player = player ?: return false
+        val sourceUrl = snapshot?.sourceUrl ?: return false
+        return try {
+            val mediaItem = (snapshot.mediaItem ?: MediaItem.Builder().setUri(sourceUrl.toUri()).build())
+                .buildUpon()
+                .setUri(sourceUrl.toUri())
+                .build()
+            player.setMediaSource(
+                HlsMediaSource.Factory(snapshot.dataSourceFactory)
+                    .apply { setPlaylistParserFactory(CustomHlsPlaylistParserFactory()) }
+                    .createMediaSource(mediaItem),
+            )
+            player.trackSelectionParameters = snapshot.trackSelectionParameters
+            player.volume = snapshot.volume
+            player.setPlaybackSpeed(snapshot.playbackSpeed)
+            player.prepare()
+            player.seekTo(snapshot.positionMs)
+            player.playWhenReady = snapshot.playWhenReady
+            hlsClipDataSourceFactory = snapshot.dataSourceFactory
+            liveClipSourceMediaId = snapshot.liveClipSourceMediaId
+            true
+        } catch (e: Exception) {
+            Log.e("LiveRewind", "Unable to restore the previous playback source", e)
+            false
         }
     }
 
@@ -1422,6 +1538,8 @@ class ExoPlayerService : BasePlaybackService() {
                         playerType = prefs().getString(C.TOKEN_PLAYER_TYPE_VIDEO, "channel_home_live"),
                         supportedCodecs = prefs().getString(C.TOKEN_SUPPORTED_CODECS, "av1,h265,h264"),
                     )
+                } catch (e: CancellationException) {
+                    throw e
                 } catch (e: Exception) {
                     null
                 }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/LiveRewind.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/LiveRewind.kt
@@ -82,6 +82,16 @@ fun canUseLiveClipSource(
 fun isCurrentLiveClipSource(expectedMediaId: String?, actualMediaId: String?): Boolean =
     expectedMediaId != null && expectedMediaId == actualMediaId
 
+internal fun <T> restorePreviousLiveRewindSource(
+    previousSource: T,
+    restore: (T) -> Boolean,
+    onRestoreFailure: () -> Unit,
+): Boolean {
+    val restored = restore(previousSource)
+    if (!restored) onRestoreFailure()
+    return restored
+}
+
 fun shouldMarkLiveStreamOffline(
     statusKnown: Boolean,
     streamWasLive: Boolean,

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/Media3Fragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/Media3Fragment.kt
@@ -98,6 +98,7 @@ class Media3Fragment : Media3PlayerFragment() {
                 SurfaceView.SURFACE_LIFECYCLE_FOLLOWS_ATTACHMENT,
             )
         }
+        logVideoSurfaceBinding("on_view_created", player, binding.playerSurface)
     }
 
     override fun onViewingMetadataChanged(title: String?, gameId: String?, gameName: String?) {
@@ -122,6 +123,7 @@ class Media3Fragment : Media3PlayerFragment() {
 
     override fun onStart() {
         super.onStart()
+        logVideoSurfaceBinding("on_start", player, binding.playerSurface)
         controllerFuture?.let { MediaController.releaseFuture(it) }
         val future = MediaController.Builder(
             requireContext(),
@@ -141,6 +143,7 @@ class Media3Fragment : Media3PlayerFragment() {
                 MediaController.releaseFuture(future)
                 return@addListener
             }
+            logVideoSurfaceBinding("controller_connected", controller, binding.playerSurface)
             val listener = object : Player.Listener {
 
                 override fun onPlaybackStateChanged(playbackState: Int) {
@@ -1391,6 +1394,7 @@ class Media3Fragment : Media3PlayerFragment() {
     }
 
     override fun onStop() {
+        logVideoSurfaceBinding("on_stop", player, view?.findViewById(R.id.playerSurface))
         super.onStop()
         val isInPIPMode = when {
             Build.VERSION.SDK_INT >= Build.VERSION_CODES.R -> requireActivity().isInPictureInPictureMode
@@ -1461,6 +1465,7 @@ class Media3Fragment : Media3PlayerFragment() {
     }
 
     override fun onDestroyView() {
+        logVideoSurfaceBinding("on_destroy_view", player, view?.findViewById(R.id.playerSurface))
         detachVideoOutput()
         super.onDestroyView()
     }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/PlaybackStateDecoder.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/PlaybackStateDecoder.kt
@@ -1,0 +1,45 @@
+package com.github.andreyasadchy.xtra.ui.player
+
+import com.github.andreyasadchy.xtra.model.VideoQuality
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.decodeFromJsonElement
+
+internal fun decodePlaybackQualities(
+    json: Json,
+    encoded: String?,
+    onError: (Exception) -> Unit = {},
+): List<VideoQuality>? {
+    if (encoded.isNullOrBlank()) return null
+
+    return try {
+        json.decodeFromString<JsonArray>(encoded).map {
+            json.decodeFromJsonElement<VideoQuality>(it)
+        }
+    } catch (e: Exception) {
+        onError(e)
+        null
+    }
+}
+
+internal fun decodePlaybackQuality(
+    json: Json,
+    encoded: String?,
+    onError: (Exception) -> Unit = {},
+): VideoQuality? {
+    if (encoded.isNullOrBlank()) return null
+
+    return try {
+        json.decodeFromString<VideoQuality>(encoded)
+    } catch (e: Exception) {
+        onError(e)
+        null
+    }
+}
+
+internal fun selectRestoredQuality(
+    qualities: List<VideoQuality>?,
+    candidate: VideoQuality?,
+): VideoQuality? = candidate?.takeIf { quality ->
+    qualities?.any { it.name == quality.name && it.url == quality.url } == true
+}

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/ChatAdapterTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/ChatAdapterTest.kt
@@ -1,0 +1,32 @@
+package com.github.andreyasadchy.xtra.ui.chat
+
+import android.text.SpannableStringBuilder
+import com.github.andreyasadchy.xtra.util.chat.ChatAdapterUtils
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ChatAdapterTest {
+
+    @Test
+    fun renderCacheMissUsesFallbackInsteadOfThrowing() {
+        var fallbackUsed = false
+        val fallback = ChatAdapterUtils.MessageResult(
+            builder = SpannableStringBuilder(),
+            images = arrayListOf(),
+            imagePaint = null,
+            userName = null,
+            userNameStartIndex = null,
+            translated = false,
+            backgroundResource = 0,
+        )
+
+        val result = selectRenderResultForBind(null) {
+            fallbackUsed = true
+            fallback
+        }
+
+        assertTrue(fallbackUsed)
+        assertEquals(fallback.backgroundResource, result.backgroundResource)
+    }
+}

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/ChatViewModelTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/ChatViewModelTest.kt
@@ -36,4 +36,14 @@ class ChatViewModelTest {
         assertEquals("stream-b", resolveCurrentLiveStreamId("stream-b", "stream-a"))
         assertEquals("stream-a", resolveCurrentLiveStreamId(null, "stream-a"))
     }
+
+    @Test
+    fun replayEntryDoesNotOverwriteTheSavedComposerState() {
+        assertTrue(shouldCaptureReplayComposerState(ChatViewModel.ActiveChatMode.Live))
+        assertFalse(
+            shouldCaptureReplayComposerState(
+                ChatViewModel.ActiveChatMode.VideoReplay("video", null),
+            ),
+        )
+    }
 }

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/player/LiveRewindTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/player/LiveRewindTest.kt
@@ -268,6 +268,39 @@ class LiveRewindTest {
     }
 
     @Test
+    fun failedTransitionRestoresThePhysicalSourceThatExistedBeforeTheAttempt() {
+        val previousSource = "live-playlist"
+        var physicalSource = previousSource
+        physicalSource = "rewind-playlist"
+
+        val restored = try {
+            error("prepare failed after installing the rewind source")
+        } catch (_: Exception) {
+            restorePreviousLiveRewindSource(previousSource, { source ->
+                physicalSource = source
+                true
+            }, onRestoreFailure = { error("unexpected restore failure") })
+        }
+
+        assertTrue(restored)
+        assertEquals(previousSource, physicalSource)
+    }
+
+    @Test
+    fun failedSourceRestoreStopsTheTransitionSafely() {
+        var stopped = false
+
+        val restored = restorePreviousLiveRewindSource(
+            previousSource = "live-playlist",
+            restore = { false },
+            onRestoreFailure = { stopped = true },
+        )
+
+        assertFalse(restored)
+        assertTrue(stopped)
+    }
+
+    @Test
     fun rewindTimelineUsesLiveEdgeLiveAndCurrentPositionWhenRewound() {
         assertEquals(600_000L, liveRewindTimelinePositionMs(LivePlaybackMode.Live, 600_000L, 120_000L, null))
         assertEquals(120_000L, liveRewindTimelinePositionMs(LivePlaybackMode.Rewound("vod"), 600_000L, 120_000L, null))

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/player/PlaybackPersistenceTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/player/PlaybackPersistenceTest.kt
@@ -3,12 +3,15 @@ package com.github.andreyasadchy.xtra.ui.player
 import com.github.andreyasadchy.xtra.model.PlaybackState
 import com.github.andreyasadchy.xtra.model.VideoHistory
 import com.github.andreyasadchy.xtra.model.VideoPosition
+import com.github.andreyasadchy.xtra.model.VideoQuality
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.encodeToString
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertSame
@@ -66,6 +69,44 @@ class PlaybackPersistenceTest {
         persistence.flush()
 
         assertEquals(1, store.states.size)
+    }
+
+    @Test
+    fun validSerializedPlaybackStateRestoresItsQualityData() {
+        val json = Json
+        val quality = VideoQuality("720p60", bitrate = 1_000, url = "https://example.test/720")
+        val qualities = json.encodeToString(listOf(quality))
+
+        assertEquals(listOf(quality.name), decodePlaybackQualities(json, qualities)?.map { it.name })
+        assertEquals(quality.name, decodePlaybackQuality(json, json.encodeToString(quality))?.name)
+        assertEquals(quality.name, selectRestoredQuality(listOf(quality), quality)?.name)
+    }
+
+    @Test
+    fun malformedSerializedPlaybackStateFallsBackToDefaultQualityData() {
+        val json = Json
+
+        assertEquals(null, decodePlaybackQualities(json, "not-json"))
+        assertEquals(null, decodePlaybackQuality(json, "not-json"))
+        assertEquals(null, decodePlaybackQuality(json, "{\"name\":7}"))
+        val state = PlaybackState(previousQuality = "not-json")
+        assertEquals(null, decodePlaybackQuality(json, state.previousQuality))
+        assertEquals(null, selectRestoredQuality(null, VideoQuality("720p60")))
+        assertEquals(null, selectRestoredQuality(listOf(VideoQuality("720p30")), VideoQuality("720p60")))
+    }
+
+    @Test
+    fun consumingBadStateDoesNotPoisonTheFollowingStartup() = runBlocking {
+        persistence.savePlaybackState(PlaybackState(qualities = "not-json", quality = "not-json"))
+        val badState = persistence.takePlaybackState()
+        assertEquals(null, decodePlaybackQualities(Json, badState?.qualities))
+        assertEquals(emptyList<PlaybackState>(), persistence.getPlaybackStatesAndWait())
+
+        val nextState = PlaybackState(videoId = "next", qualities = "not-json")
+        persistence.savePlaybackState(nextState)
+
+        assertSame(nextState, persistence.takePlaybackState())
+        assertEquals(emptyList<PlaybackState>(), persistence.getPlaybackStatesAndWait())
     }
 
     private class FakePlaybackPersistenceStore : PlaybackPersistenceStore {


### PR DESCRIPTION
## Root cause

### Proven

The intermittent crash was not reproducible in the available logged-in emulator, so there is no captured Xtra stack frame to identify as proven root cause.

### Strongly suspected and hardened

Persisted playback quality JSON was decoded after `takePlaybackState()` had already consumed and deleted the row. A stale or malformed optional field could therefore crash the first restoration, while the bad row naturally disappeared and the next startup worked. This matches the one-shot symptom, but remains a suspected cause until production logcat confirms it.

The audit also found two unsafe timing/state paths: a render-cache miss was fatal during chat binding, and live-rewind rollback restored Kotlin fields without restoring the ExoPlayer media source. Both are now defensive.

## Changes

- Decode persisted qualities defensively, log non-sensitive diagnostics, propagate cancellation, and apply state only after parsing. Invalid quality data falls back to normal selection.
- Make ChatAdapter cache misses render a text fallback and schedule a retry. Commit the valid render plan before optional image prefetch; prefetch errors cannot replace it.
- Restore both logical fields and the physical HLS source/playback settings after failed live-rewind transitions; stop playback if source restoration itself fails. Existing transition mutex/generation guards remain intact.
- Preserve the original chat composer state across repeated video-replay entry.
- Add debug-only SurfaceView lifecycle diagnostics and make player-container closing tolerant of an already-removed fragment.

## Testing

- `./gradlew.bat testDebugUnitTest assembleDebug` — passed.
- Focused JVM coverage: `PlaybackPersistenceTest`, `ChatAdapterTest`, `ChatViewModelTest`, `LiveRewindTest`, and `VideoOutputOwnerTest` — passed.
- Android instrumentation on `xtra-api35`: `MainActivityPlayerLifecycleTest`, `StreamPreviewSurfaceTest`, and `ChatImagePrefetchTest` — passed.
- Installed the final debug APK over existing logged-in data. Repeated process-start/live-card opens (including 10 cold-start loops and 10 card-open loops) produced no fatal Java/native markers; final smoke reached service connection, SurfaceView attach, and first frame. Chat-enabled and animated-emote UI were exercised. A landscape rotation attempt was also checked without a crash.
- No production crash reproduced, so no native tombstone or exact first Xtra crash frame is available. The emulator did not provide a logged-in rewind-available stream for both rewind availability variants, and the automated smoke could not independently exercise every rapid A/B/minimize/chat-disabled combination.

## Remaining risk

SurfaceView was not implicated by the available evidence: instrumentation and repeated logged-in live playback reached first frame with no `SurfaceView`, `SurfaceControl`, `MediaCodec`, or native fatal signal. The new diagnostics remain DEBUG-only for any production reproduction build. The original intermittent cause still needs a production `PlaybackRestore`/crash capture to be proven.