### PR TITLE
Cache Twitch inbox pages

### DIFF
--- a/app/src/androidTest/java/com/github/andreyasadchy/xtra/repository/MetadataCacheTest.kt
+++ b/app/src/androidTest/java/com/github/andreyasadchy/xtra/repository/MetadataCacheTest.kt
@@ -14,10 +14,18 @@ import com.github.andreyasadchy.xtra.model.ui.Tag
 import com.github.andreyasadchy.xtra.model.ui.UpcomingStream
 import com.github.andreyasadchy.xtra.model.ui.User
 import com.github.andreyasadchy.xtra.model.ui.Video
+import com.github.andreyasadchy.xtra.model.twitchinbox.TwitchNotification
+import com.github.andreyasadchy.xtra.model.twitchinbox.TwitchNotificationAction
+import com.github.andreyasadchy.xtra.model.twitchinbox.TwitchUserSummary
+import com.github.andreyasadchy.xtra.model.twitchinbox.WhisperThread
+import com.github.andreyasadchy.xtra.model.twitchinbox.WhisperThreadPage
+import com.github.andreyasadchy.xtra.model.twitchinbox.TwitchNotificationPage
+import java.time.Instant
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -129,6 +137,84 @@ class MetadataCacheTest {
         assertNotNull(anonymousCached)
         assertEquals(snapshot.recentVideos.single().id, anonymousCached?.recentVideos?.single()?.id)
         assertEquals(snapshot.upcomingStreams, anonymousCached?.upcomingStreams)
+    }
+
+    @Test
+    fun inboxPagesRoundTripAndStayIsolatedByAccount() = runBlocking {
+        val notification = TwitchNotification(
+            id = "notification-1",
+            type = "SUBSCRIPTION",
+            title = "A sub",
+            body = "Someone subscribed",
+            createdAt = Instant.parse("2026-08-29T10:00:00Z"),
+            imageUrl = "image",
+            isUnread = true,
+            canDismiss = false,
+            action = TwitchNotificationAction.Channel("channel-1", "channel", "Channel", "avatar"),
+        )
+        val whisper = WhisperThread(
+            id = "thread-1",
+            peer = TwitchUserSummary("peer-1", "peer", "Peer", "avatar"),
+            lastMessage = null,
+            unreadCount = 1,
+            isUnread = true,
+            updatedAt = Instant.parse("2026-08-29T10:00:00Z"),
+        )
+
+        cache.writeNotifications(
+            userId = "account-1",
+            page = TwitchNotificationPage(
+                notifications = listOf(notification),
+                nextCursor = "notifications-next",
+                hasNextPage = true,
+                unreadCount = 1,
+            ),
+        )
+        cache.writeWhisperThreads(
+            userId = "account-1",
+            page = WhisperThreadPage(
+                threads = listOf(whisper),
+                nextCursor = "whispers-next",
+                hasNextPage = true,
+                unreadThreadCount = 1,
+            ),
+        )
+
+        assertEquals(notification, cache.readNotifications("account-1")?.notifications?.single())
+        assertEquals(whisper, cache.readWhisperThreads("account-1")?.threads?.single())
+        assertEquals("notifications-next", cache.readNotifications("account-1")?.nextCursor)
+        assertEquals("whispers-next", cache.readWhisperThreads("account-1")?.nextCursor)
+
+        cache.writeNotifications(
+            userId = "account-1",
+            page = TwitchNotificationPage(
+                notifications = listOf(notification.copy(id = "notification-2")),
+                nextCursor = null,
+                hasNextPage = false,
+                unreadCount = 2,
+            ),
+            replace = false,
+        )
+        cache.writeWhisperThreads(
+            userId = "account-1",
+            page = WhisperThreadPage(
+                threads = listOf(whisper.copy(id = "thread-2")),
+                nextCursor = null,
+                hasNextPage = false,
+                unreadThreadCount = 2,
+            ),
+            replace = false,
+        )
+        cache.markNotificationsRead("account-1", listOf("notification-1"))
+        cache.removeNotification("account-1", "notification-2")
+        cache.markWhisperThreadRead("account-1", "thread-1")
+
+        assertEquals(listOf("notification-1"), cache.readNotifications("account-1")?.notifications?.map { it.id })
+        assertFalse(cache.readNotifications("account-1")?.notifications?.single()?.isUnread == true)
+        assertEquals(listOf("thread-1", "thread-2"), cache.readWhisperThreads("account-1")?.threads?.map { it.id })
+        assertFalse(cache.readWhisperThreads("account-1")?.threads?.first()?.isUnread == true)
+        assertNull(cache.readNotifications("account-2"))
+        assertNull(cache.readWhisperThreads("account-2"))
     }
 
     @Test

--- a/app/src/main/java/com/github/andreyasadchy/xtra/XtraModule.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/XtraModule.kt
@@ -574,11 +574,11 @@ class XtraModule(application: Application) {
     }
 
     val twitchNotificationsRepository by lazy {
-        TwitchNotificationsRepository(application, twitchPrivateGqlClient)
+        TwitchNotificationsRepository(application, twitchPrivateGqlClient, metadataCache)
     }
 
     val whispersRepository by lazy {
-        WhispersRepository(application, twitchPrivateGqlClient, graphQLRepository)
+        WhispersRepository(application, twitchPrivateGqlClient, graphQLRepository, metadataCache)
     }
 
     val helixRepository by lazy {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/MetadataCache.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/MetadataCache.kt
@@ -13,21 +13,34 @@ import com.github.andreyasadchy.xtra.model.ui.Tag
 import com.github.andreyasadchy.xtra.model.ui.UpcomingStream
 import com.github.andreyasadchy.xtra.model.ui.User
 import com.github.andreyasadchy.xtra.model.ui.Video
+import com.github.andreyasadchy.xtra.model.twitchinbox.TwitchNotification
+import com.github.andreyasadchy.xtra.model.twitchinbox.TwitchNotificationAction
+import com.github.andreyasadchy.xtra.model.twitchinbox.TwitchNotificationPage
+import com.github.andreyasadchy.xtra.model.twitchinbox.TwitchUserSummary
+import com.github.andreyasadchy.xtra.model.twitchinbox.WhisperMessagePreview
+import com.github.andreyasadchy.xtra.model.twitchinbox.WhisperThread
+import com.github.andreyasadchy.xtra.model.twitchinbox.WhisperThreadPage
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import java.time.Instant
 import java.util.Locale
 
 private const val ACCOUNT_KIND = "account"
 private const val CHANNEL_KIND = "channel"
 private const val GAME_KIND = "game"
 private const val FOLLOWING_OVERVIEW_KIND = "following_overview"
+private const val WHISPER_THREADS_KIND = "whisper_threads"
+private const val TWITCH_NOTIFICATIONS_KIND = "twitch_notifications"
 private const val LOCAL_FOLLOWING_OVERVIEW_KEY = "local"
 private const val MAX_CACHE_ENTRIES = 240
 private const val METADATA_CACHE_FRESHNESS_VERSION = 1
+
+private fun accountIdentityKeys(userId: String?): List<String> =
+    MetadataCache.identityKeys("id", "login", userId, null)
 
 /**
  * Freshness is deliberately separate from durable retention. A cached object
@@ -388,6 +401,126 @@ class MetadataCache(
         )
     }
 
+    suspend fun readWhisperThreads(userId: String?): WhisperThreadPage? = withContext(Dispatchers.IO) {
+        readPayload<CachedWhisperThreadsPayload>(
+            kind = WHISPER_THREADS_KIND,
+            keys = accountIdentityKeys(userId),
+            expectedStableId = userId,
+            identity = { it.userId },
+        )?.payload?.toWhisperThreadPage()
+    }
+
+    suspend fun writeWhisperThreads(
+        userId: String?,
+        page: WhisperThreadPage,
+        replace: Boolean = true,
+        nowMs: Long = clockMs(),
+    ) = withContext(Dispatchers.IO) {
+        val previous = if (replace) null else readPayload<CachedWhisperThreadsPayload>(
+            kind = WHISPER_THREADS_KIND,
+            keys = accountIdentityKeys(userId),
+            expectedStableId = userId,
+            identity = { it.userId },
+        )?.payload
+        val mergedThreads = if (previous == null) {
+            page.threads
+        } else {
+            (previous.threads.map(CachedWhisperThread::toWhisperThread) + page.threads)
+                .distinctBy(WhisperThread::id)
+        }
+        val payload = CachedWhisperThreadsPayload(
+            userId = userId,
+            threads = mergedThreads.map(WhisperThread::toCachedWhisperThread),
+            nextCursor = page.nextCursor,
+            hasNextPage = page.hasNextPage,
+            unreadThreadCount = page.unreadThreadCount,
+        )
+        writePayload(
+            kind = WHISPER_THREADS_KIND,
+            keys = accountIdentityKeys(userId),
+            payload = payload,
+            stableId = userId,
+            identity = { it.userId },
+            nowMs = nowMs,
+            mergePayload = { _, _ -> payload },
+        )
+    }
+
+    suspend fun markWhisperThreadRead(userId: String?, threadId: String) = withContext(Dispatchers.IO) {
+        val cached = readWhisperThreads(userId) ?: return@withContext
+        val updated = cached.threads.map { thread ->
+            if (thread.id == threadId) thread.copy(isUnread = false, unreadCount = 0) else thread
+        }
+        if (updated != cached.threads) {
+            writeWhisperThreads(userId, cached.copy(threads = updated), nowMs = clockMs())
+        }
+    }
+
+    suspend fun readNotifications(userId: String?): TwitchNotificationPage? = withContext(Dispatchers.IO) {
+        readPayload<CachedNotificationsPayload>(
+            kind = TWITCH_NOTIFICATIONS_KIND,
+            keys = accountIdentityKeys(userId),
+            expectedStableId = userId,
+            identity = { it.userId },
+        )?.payload?.toNotificationPage()
+    }
+
+    suspend fun writeNotifications(
+        userId: String?,
+        page: TwitchNotificationPage,
+        replace: Boolean = true,
+        nowMs: Long = clockMs(),
+    ) = withContext(Dispatchers.IO) {
+        val previous = if (replace) null else readPayload<CachedNotificationsPayload>(
+            kind = TWITCH_NOTIFICATIONS_KIND,
+            keys = accountIdentityKeys(userId),
+            expectedStableId = userId,
+            identity = { it.userId },
+        )?.payload
+        val mergedNotifications = if (previous == null) {
+            page.notifications
+        } else {
+            (previous.notifications.map(CachedTwitchNotification::toTwitchNotification) + page.notifications)
+                .distinctBy(TwitchNotification::id)
+        }
+        val payload = CachedNotificationsPayload(
+            userId = userId,
+            notifications = mergedNotifications.map(TwitchNotification::toCachedTwitchNotification),
+            nextCursor = page.nextCursor,
+            hasNextPage = page.hasNextPage,
+            unreadCount = page.unreadCount,
+        )
+        writePayload(
+            kind = TWITCH_NOTIFICATIONS_KIND,
+            keys = accountIdentityKeys(userId),
+            payload = payload,
+            stableId = userId,
+            identity = { it.userId },
+            nowMs = nowMs,
+            mergePayload = { _, _ -> payload },
+        )
+    }
+
+    suspend fun markNotificationsRead(userId: String?, ids: Collection<String>) = withContext(Dispatchers.IO) {
+        if (ids.isEmpty()) return@withContext
+        val cached = readNotifications(userId) ?: return@withContext
+        val idSet = ids.toSet()
+        val updated = cached.notifications.map { item ->
+            if (item.id in idSet) item.copy(isUnread = false) else item
+        }
+        if (updated != cached.notifications) {
+            writeNotifications(userId, cached.copy(notifications = updated), nowMs = clockMs())
+        }
+    }
+
+    suspend fun removeNotification(userId: String?, id: String) = withContext(Dispatchers.IO) {
+        val cached = readNotifications(userId) ?: return@withContext
+        val updated = cached.notifications.filterNot { it.id == id }
+        if (updated != cached.notifications) {
+            writeNotifications(userId, cached.copy(notifications = updated), nowMs = clockMs())
+        }
+    }
+
     private inline fun <reified T> readPayload(
         kind: String,
         keys: List<String>,
@@ -551,6 +684,160 @@ class MetadataCache(
         private fun normalize(value: String): String = value.lowercase(Locale.ROOT)
     }
 }
+
+@Serializable
+private data class CachedWhisperThreadsPayload(
+    val freshnessVersion: Int = 0,
+    val userId: String? = null,
+    val threads: List<CachedWhisperThread> = emptyList(),
+    val nextCursor: String? = null,
+    val hasNextPage: Boolean = false,
+    val unreadThreadCount: Int? = null,
+)
+
+@Serializable
+private data class CachedWhisperThread(
+    val id: String,
+    val peer: CachedTwitchUserSummary,
+    val lastMessage: CachedWhisperMessagePreview? = null,
+    val unreadCount: Int? = null,
+    val isUnread: Boolean = false,
+    val updatedAt: String? = null,
+)
+
+@Serializable
+private data class CachedWhisperMessagePreview(
+    val text: String? = null,
+    val senderId: String? = null,
+    val sentAt: String? = null,
+)
+
+@Serializable
+private data class CachedTwitchUserSummary(
+    val id: String,
+    val login: String,
+    val displayName: String,
+    val profileImageUrl: String? = null,
+)
+
+@Serializable
+private data class CachedNotificationsPayload(
+    val freshnessVersion: Int = 0,
+    val userId: String? = null,
+    val notifications: List<CachedTwitchNotification> = emptyList(),
+    val nextCursor: String? = null,
+    val hasNextPage: Boolean = false,
+    val unreadCount: Int? = null,
+)
+
+@Serializable
+private data class CachedTwitchNotification(
+    val id: String,
+    val type: String? = null,
+    val title: String? = null,
+    val body: String,
+    val createdAt: String? = null,
+    val imageUrl: String? = null,
+    val isUnread: Boolean = false,
+    val canDismiss: Boolean = false,
+    val action: CachedTwitchNotificationAction? = null,
+)
+
+@Serializable
+private data class CachedTwitchNotificationAction(
+    val type: String,
+    val id: String? = null,
+    val login: String? = null,
+    val displayName: String? = null,
+    val imageUrl: String? = null,
+    val name: String? = null,
+    val url: String? = null,
+)
+
+private fun WhisperThread.toCachedWhisperThread() = CachedWhisperThread(
+    id = id,
+    peer = peer.toCachedTwitchUserSummary(),
+    lastMessage = lastMessage?.toCachedWhisperMessagePreview(),
+    unreadCount = unreadCount,
+    isUnread = isUnread,
+    updatedAt = updatedAt?.toString(),
+)
+
+private fun CachedWhisperThread.toWhisperThread() = WhisperThread(
+    id = id,
+    peer = peer.toTwitchUserSummary(),
+    lastMessage = lastMessage?.toWhisperMessagePreview(),
+    unreadCount = unreadCount,
+    isUnread = isUnread,
+    updatedAt = updatedAt.toInstantOrNull(),
+)
+
+private fun TwitchUserSummary.toCachedTwitchUserSummary() = CachedTwitchUserSummary(id, login, displayName, profileImageUrl)
+
+private fun CachedTwitchUserSummary.toTwitchUserSummary() = TwitchUserSummary(id, login, displayName, profileImageUrl)
+
+private fun WhisperMessagePreview.toCachedWhisperMessagePreview() = CachedWhisperMessagePreview(text, senderId, sentAt?.toString())
+
+private fun CachedWhisperMessagePreview.toWhisperMessagePreview() = WhisperMessagePreview(text, senderId, sentAt.toInstantOrNull())
+
+private fun TwitchNotification.toCachedTwitchNotification() = CachedTwitchNotification(
+    id = id,
+    type = type,
+    title = title,
+    body = body,
+    createdAt = createdAt?.toString(),
+    imageUrl = imageUrl,
+    isUnread = isUnread,
+    canDismiss = canDismiss,
+    action = action?.toCachedTwitchNotificationAction(),
+)
+
+private fun CachedTwitchNotification.toTwitchNotification() = TwitchNotification(
+    id = id,
+    type = type,
+    title = title,
+    body = body,
+    createdAt = createdAt.toInstantOrNull(),
+    imageUrl = imageUrl,
+    isUnread = isUnread,
+    canDismiss = canDismiss,
+    action = action?.toTwitchNotificationAction(),
+)
+
+private fun TwitchNotificationAction.toCachedTwitchNotificationAction(): CachedTwitchNotificationAction = when (this) {
+    is TwitchNotificationAction.Channel -> CachedTwitchNotificationAction("channel", id, login, displayName, imageUrl)
+    is TwitchNotificationAction.Video -> CachedTwitchNotificationAction("video", id = id)
+    is TwitchNotificationAction.Clip -> CachedTwitchNotificationAction("clip", id = slug)
+    is TwitchNotificationAction.Game -> CachedTwitchNotificationAction("game", id = id, name = name)
+    is TwitchNotificationAction.TwitchWebUrl -> CachedTwitchNotificationAction("web_url", url = url)
+    TwitchNotificationAction.None -> CachedTwitchNotificationAction("none")
+}
+
+private fun CachedTwitchNotificationAction.toTwitchNotificationAction(): TwitchNotificationAction? = when (type) {
+    "channel" -> TwitchNotificationAction.Channel(id, login, displayName, imageUrl)
+    "video" -> id?.let(TwitchNotificationAction::Video)
+    "clip" -> id?.let(TwitchNotificationAction::Clip)
+    "game" -> TwitchNotificationAction.Game(id, name)
+    "web_url" -> url?.let(TwitchNotificationAction::TwitchWebUrl)
+    "none" -> TwitchNotificationAction.None
+    else -> null
+}
+
+private fun String?.toInstantOrNull(): Instant? = this?.let { runCatching { Instant.parse(it) }.getOrNull() }
+
+private fun CachedWhisperThreadsPayload.toWhisperThreadPage() = WhisperThreadPage(
+    threads = threads.map(CachedWhisperThread::toWhisperThread),
+    nextCursor = nextCursor,
+    hasNextPage = hasNextPage,
+    unreadThreadCount = unreadThreadCount,
+)
+
+private fun CachedNotificationsPayload.toNotificationPage() = TwitchNotificationPage(
+    notifications = notifications.map(CachedTwitchNotification::toTwitchNotification),
+    nextCursor = nextCursor,
+    hasNextPage = hasNextPage,
+    unreadCount = unreadCount,
+)
 
 @Serializable
 private data class AccountCachePayload(

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/MetadataCacheCommitGate.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/MetadataCacheCommitGate.kt
@@ -1,0 +1,27 @@
+package com.github.andreyasadchy.xtra.repository
+
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+internal class MetadataCacheCommitGate {
+    private val mutex = Mutex()
+    private var mutationGeneration = 0L
+
+    suspend fun generationAtStart(): Long = mutex.withLock { mutationGeneration }
+
+    suspend fun commitFetch(
+        generationAtStart: Long,
+        commit: suspend () -> Unit,
+    ): Boolean = mutex.withLock {
+        if (generationAtStart != mutationGeneration) return@withLock false
+        commit()
+        true
+    }
+
+    suspend fun commitMutation(commit: suspend () -> Unit) {
+        mutex.withLock {
+            mutationGeneration++
+            commit()
+        }
+    }
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/TwitchNotificationsRepository.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/TwitchNotificationsRepository.kt
@@ -18,11 +18,14 @@ import java.util.Locale
 class TwitchNotificationsRepository(
     private val context: Context,
     private val privateGqlClient: TwitchPrivateGqlClient,
+    private val metadataCache: MetadataCache? = null,
 ) {
     private var accountKey: String? = null
+    private val cacheCommitGate = MetadataCacheCommitGate()
 
     suspend fun getNotifications(cursor: String? = null, limit: Int = 20): TwitchNotificationPage {
         val key = requireAccount()
+        val generationAtStart = cacheCommitGate.generationAtStart()
         val result = privateGqlClient.executeDocument(
             networkLibrary(),
             webHeaders(),
@@ -31,8 +34,15 @@ class TwitchNotificationsRepository(
             buildNotificationVariables(cursor, limit, notificationLanguage()),
         )
         checkAccount(key)
-        return parseNotificationPage(result)
+        val page = parseNotificationPage(result)
+        cacheCommitGate.commitFetch(generationAtStart) {
+            runCatching { metadataCache?.writeNotifications(key, page, replace = cursor == null) }
+        }
+        return page
     }
+
+    suspend fun getCachedNotifications(): TwitchNotificationPage? =
+        metadataCache?.readNotifications(currentUserId())
 
     suspend fun markNotificationsViewed() {
         val key = requireAccount()
@@ -66,6 +76,9 @@ class TwitchNotificationsRepository(
             putJsonObject("input") { putJsonArray("ids") { ids.forEach { add( kotlinx.serialization.json.JsonPrimitive(it)) } } }
         })
         checkAccount(key)
+        cacheCommitGate.commitMutation {
+            runCatching { metadataCache?.markNotificationsRead(key, ids) }
+        }
     }
 
     suspend fun dismissNotification(id: String) {
@@ -74,6 +87,9 @@ class TwitchNotificationsRepository(
             putJsonObject("input") { put("id", id) }
         })
         checkAccount(key)
+        cacheCommitGate.commitMutation {
+            runCatching { metadataCache?.removeNotification(key, id) }
+        }
     }
 
     suspend fun getUnreadSummary(): NotificationUnreadSummary {
@@ -86,6 +102,8 @@ class TwitchNotificationsRepository(
     fun clearAccountState() {
         accountKey = null
     }
+
+    fun currentUserId(): String? = context.tokenPrefs().getString(C.USER_ID, null)
 
     private fun webHeaders() = TwitchApiHelper.getWebGQLHeaders(context, includeToken = true)
     private fun networkLibrary() = context.prefs().getString(C.NETWORK_LIBRARY, C.OKHTTP)

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/WhispersRepository.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/WhispersRepository.kt
@@ -19,11 +19,16 @@ class WhispersRepository(
     private val context: Context,
     private val privateGqlClient: TwitchPrivateGqlClient,
     private val graphQLRepository: GraphQLRepository,
+    private val metadataCache: MetadataCache? = null,
 ) {
     private val secureRandom = SecureRandom()
+    private val cacheCommitGate = MetadataCacheCommitGate()
 
-    suspend fun getThreads(cursor: String? = null): WhisperThreadPage {
+    suspend fun getThreads(cursor: String? = null): WhisperThreadPage = fetchThreads(cursor, cacheResult = true)
+
+    private suspend fun fetchThreads(cursor: String?, cacheResult: Boolean): WhisperThreadPage {
         val key = requireAccount()
+        val generationAtStart = if (cacheResult) cacheCommitGate.generationAtStart() else null
         val variables = buildJsonObject { cursor?.let { put("cursor", it) } }
         val result = if (cursor == null) {
             try {
@@ -39,11 +44,20 @@ class WhispersRepository(
             privateGqlClient.executeDocument(networkLibrary(), webHeaders(), TwitchPrivateGqlOperations.whisperThreads.operationName, TwitchPrivateGqlDocuments.whisperThreads, variables)
         }
         checkAccount(key)
-        return parseWhisperThreadPage(result, key)
+        val page = parseWhisperThreadPage(result, key)
+        if (generationAtStart != null) {
+            cacheCommitGate.commitFetch(generationAtStart) {
+                runCatching { metadataCache?.writeWhisperThreads(key, page, replace = cursor == null) }
+            }
+        }
+        return page
     }
 
+    suspend fun getCachedThreads(): WhisperThreadPage? =
+        metadataCache?.readWhisperThreads(currentUserId())
+
     suspend fun getUnreadSummary(): WhisperUnreadSummary {
-        return scanWhisperUnreadPages(MAX_SUMMARY_THREAD_PAGES) { cursor -> getThreads(cursor) }
+        return scanWhisperUnreadPages(MAX_SUMMARY_THREAD_PAGES) { cursor -> fetchThreads(cursor, cacheResult = false) }
     }
 
     suspend fun getThread(threadId: String, cursor: String? = null): WhisperThreadDetails {
@@ -65,6 +79,9 @@ class WhispersRepository(
             }
         })
         checkAccount(key)
+        cacheCommitGate.commitMutation {
+            runCatching { metadataCache?.markWhisperThreadRead(key, threadId) }
+        }
     }
 
     fun createWhisperNonce(): String = generateWhisperNonce(secureRandom)
@@ -101,7 +118,7 @@ class WhispersRepository(
     suspend fun findThreadByPeer(peerId: String): String? {
         var cursor: String? = null
         repeat(20) {
-            val page = getThreads(cursor)
+            val page = fetchThreads(cursor, cacheResult = false)
             page.threads.firstOrNull { it.peer.id == peerId }?.let { return it.id }
             if (!page.hasNextPage || page.nextCursor == null || page.nextCursor == cursor) return null
             cursor = page.nextCursor
@@ -110,7 +127,7 @@ class WhispersRepository(
     }
 
     suspend fun findRecentThreadByPeer(peerId: String): String? =
-        getThreads().threads.firstOrNull { it.peer.id == peerId }?.id
+        fetchThreads(cursor = null, cacheResult = false).threads.firstOrNull { it.peer.id == peerId }?.id
 
     fun clearAccountState() = Unit
 

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/notifications/TwitchNotificationsViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/notifications/TwitchNotificationsViewModel.kt
@@ -28,6 +28,8 @@ class TwitchNotificationsViewModel(private val repository: TwitchNotificationsRe
     val uiState: StateFlow<NotificationsUiState> = _uiState.asStateFlow()
     private var loadJob: Job? = null
     private var nextCursor: String? = null
+    private val locallyReadIds = mutableSetOf<String>()
+    private val locallyDismissedIds = mutableSetOf<String>()
 
     init { loadInitial() }
 
@@ -35,9 +37,13 @@ class TwitchNotificationsViewModel(private val repository: TwitchNotificationsRe
         if (loadJob?.isActive == true || _uiState.value.markingAllAsSeen) return
         loadJob = viewModelScope.launch {
             _uiState.value = _uiState.value.copy(initialLoading = true, error = null)
+            runCatching { repository.getCachedNotifications() }.getOrNull()?.let { page ->
+                nextCursor = page.nextCursor
+                _uiState.value = _uiState.value.copy(items = applyLocalChanges(page.notifications), canLoadMore = page.hasNextPage)
+            }
             runCatching { repository.getNotifications() }.onSuccess { page ->
                 nextCursor = page.nextCursor
-                _uiState.value = NotificationsUiState(page.notifications, canLoadMore = page.hasNextPage)
+                _uiState.value = NotificationsUiState(applyLocalChanges(page.notifications), canLoadMore = page.hasNextPage)
                 runCatching { repository.markNotificationsViewed() }
             }.onFailure { error ->
                 _uiState.value = _uiState.value.copy(initialLoading = false, error = error.toInboxError())
@@ -51,7 +57,7 @@ class TwitchNotificationsViewModel(private val repository: TwitchNotificationsRe
             _uiState.value = _uiState.value.copy(refreshing = true, error = null)
             runCatching { repository.getNotifications() }.onSuccess { page ->
                 nextCursor = page.nextCursor
-                _uiState.value = NotificationsUiState(page.notifications, canLoadMore = page.hasNextPage)
+                _uiState.value = NotificationsUiState(applyLocalChanges(page.notifications), canLoadMore = page.hasNextPage)
                 runCatching { repository.markNotificationsViewed() }
             }.onFailure { error ->
                 _uiState.value = _uiState.value.copy(refreshing = false, error = error.toInboxError())
@@ -72,7 +78,7 @@ class TwitchNotificationsViewModel(private val repository: TwitchNotificationsRe
                     return@onSuccess
                 }
                 nextCursor = page.nextCursor
-                val merged = (_uiState.value.items + page.notifications).distinctBy { it.id }
+                val merged = applyLocalChanges((_uiState.value.items + page.notifications).distinctBy { it.id })
                 _uiState.value = _uiState.value.copy(items = merged, canLoadMore = page.hasNextPage, error = null)
             }.onFailure { error -> _uiState.value = _uiState.value.copy(error = error.toInboxError()) }
             _uiState.value = _uiState.value.copy(loadingNextPage = false)
@@ -81,10 +87,23 @@ class TwitchNotificationsViewModel(private val repository: TwitchNotificationsRe
 
     fun markRead(item: TwitchNotification, onSuccess: () -> Unit = {}) {
         if (!item.isUnread) return
-        _uiState.value = _uiState.value.copy(items = _uiState.value.items.map { if (it.id == item.id) it.copy(isUnread = false) else it })
+        locallyReadIds.add(item.id)
+        _uiState.value = _uiState.value.copy(items = applyLocalChanges(_uiState.value.items))
         viewModelScope.launch {
             runCatching { repository.markNotificationsRead(listOf(item.id)) }
-                .onSuccess { onSuccess() }
+                .onSuccess {
+                    _uiState.value = _uiState.value.copy(items = applyLocalChanges(_uiState.value.items))
+                    onSuccess()
+                }
+                .onFailure { error ->
+                    locallyReadIds.remove(item.id)
+                    _uiState.value = _uiState.value.copy(
+                        items = _uiState.value.items.map { current ->
+                            if (current.id == item.id) current.copy(isUnread = true) else current
+                        },
+                        error = error.toInboxError(),
+                    )
+                }
         }
     }
 
@@ -92,8 +111,10 @@ class TwitchNotificationsViewModel(private val repository: TwitchNotificationsRe
         val previous = _uiState.value
         if (previous.markingAllAsSeen || previous.initialLoading || previous.refreshing || previous.loadingNextPage || previous.items.isEmpty()) return
         val previousUnreadById = previous.items.associate { it.id to it.isUnread }
+        val locallyReadByThisOperation = previous.items.filter { it.isUnread }.mapTo(mutableSetOf(), TwitchNotification::id)
+        locallyReadIds.addAll(locallyReadByThisOperation)
         _uiState.value = previous.copy(
-            items = previous.items.map { it.copy(isUnread = false) },
+            items = applyLocalChanges(previous.items),
             markingAllAsSeen = true,
             error = null,
         )
@@ -101,12 +122,13 @@ class TwitchNotificationsViewModel(private val repository: TwitchNotificationsRe
             runCatching { repository.markAllNotificationsRead() }
                 .onSuccess {
                     _uiState.value = _uiState.value.copy(
-                        items = _uiState.value.items.map { it.copy(isUnread = false) },
+                        items = applyLocalChanges(_uiState.value.items),
                         markingAllAsSeen = false,
                     )
                     onSuccess()
                 }
                 .onFailure { error ->
+                    locallyReadIds.removeAll(locallyReadByThisOperation)
                     val current = _uiState.value
                     _uiState.value = current.copy(
                         items = current.items.map { item ->
@@ -121,13 +143,26 @@ class TwitchNotificationsViewModel(private val repository: TwitchNotificationsRe
 
     fun dismiss(item: TwitchNotification) {
         val previous = _uiState.value.items
-        _uiState.value = _uiState.value.copy(items = previous.filterNot { it.id == item.id })
+        locallyDismissedIds.add(item.id)
+        _uiState.value = _uiState.value.copy(items = applyLocalChanges(previous))
         viewModelScope.launch {
-            runCatching { repository.dismissNotification(item.id) }.onFailure { error ->
-                _uiState.value = _uiState.value.copy(items = previous, error = error.toInboxError())
-            }
+            runCatching { repository.dismissNotification(item.id) }
+                .onSuccess {
+                    _uiState.value = _uiState.value.copy(items = applyLocalChanges(_uiState.value.items))
+                }
+                .onFailure { error ->
+                    locallyDismissedIds.remove(item.id)
+                    val current = _uiState.value.items
+                    _uiState.value = _uiState.value.copy(
+                        items = if (current.any { it.id == item.id }) current else current + item,
+                        error = error.toInboxError(),
+                    )
+                }
         }
     }
+
+    private fun applyLocalChanges(items: List<TwitchNotification>): List<TwitchNotification> =
+        applyLocalNotificationChanges(items, locallyReadIds, locallyDismissedIds)
 
     companion object {
         fun factory(repository: TwitchNotificationsRepository) = object : ViewModelProvider.Factory {
@@ -138,3 +173,12 @@ class TwitchNotificationsViewModel(private val repository: TwitchNotificationsRe
 }
 
 private fun Throwable.toInboxError(): TwitchInboxError = (this as? TwitchInboxException)?.error ?: TwitchInboxError.Network
+
+internal fun applyLocalNotificationChanges(
+    items: List<TwitchNotification>,
+    locallyReadIds: Set<String>,
+    locallyDismissedIds: Set<String>,
+): List<TwitchNotification> = items.asSequence()
+    .filterNot { it.id in locallyDismissedIds }
+    .map { item -> if (item.id in locallyReadIds) item.copy(isUnread = false) else item }
+    .toList()

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/whispers/WhispersViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/whispers/WhispersViewModel.kt
@@ -42,6 +42,10 @@ class WhispersViewModel(private val repository: WhispersRepository) : ViewModel(
         if (loadJob?.isActive == true) return
         loadJob = viewModelScope.launch {
             _uiState.value = _uiState.value.copy(loading = true, error = null)
+            runCatching { repository.getCachedThreads() }.getOrNull()?.let { page ->
+                nextCursor = page.nextCursor
+                updateConversations(page.threads, page.hasNextPage)
+            }
             runCatching { repository.getThreads() }.onSuccess { page ->
                 nextCursor = page.nextCursor
                 updateConversations(page.threads, page.hasNextPage)

--- a/app/src/test/java/com/github/andreyasadchy/xtra/repository/MetadataCacheCommitGateTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/repository/MetadataCacheCommitGateTest.kt
@@ -1,0 +1,61 @@
+package com.github.andreyasadchy.xtra.repository
+
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MetadataCacheCommitGateTest {
+
+    @Test
+    fun staleNotificationFetchCannotUndoReadMutation() = runBlocking {
+        val gate = MetadataCacheCommitGate()
+        var isUnread = true
+
+        val fetchGeneration = gate.generationAtStart()
+        gate.commitMutation { isUnread = false }
+
+        val committed = gate.commitFetch(fetchGeneration) { isUnread = true }
+
+        assertFalse(committed)
+        assertFalse(isUnread)
+    }
+
+    @Test
+    fun staleNotificationFetchCannotUndoDismissMutation() = runBlocking {
+        val gate = MetadataCacheCommitGate()
+        var isPresent = true
+
+        val fetchGeneration = gate.generationAtStart()
+        gate.commitMutation { isPresent = false }
+
+        val committed = gate.commitFetch(fetchGeneration) { isPresent = true }
+
+        assertFalse(committed)
+        assertFalse(isPresent)
+    }
+
+    @Test
+    fun staleWhisperFetchCannotUndoReadMutation() = runBlocking {
+        val gate = MetadataCacheCommitGate()
+        var isUnread = true
+
+        val fetchGeneration = gate.generationAtStart()
+        gate.commitMutation { isUnread = false }
+
+        val committed = gate.commitFetch(fetchGeneration) { isUnread = true }
+
+        assertFalse(committed)
+        assertFalse(isUnread)
+    }
+
+    @Test
+    fun fetchCommitsWhenNoNewerMutationExists() = runBlocking {
+        val gate = MetadataCacheCommitGate()
+        var committedValue = false
+        val fetchGeneration = gate.generationAtStart()
+
+        assertTrue(gate.commitFetch(fetchGeneration) { committedValue = true })
+        assertTrue(committedValue)
+    }
+}

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/notifications/TwitchNotificationsViewModelTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/notifications/TwitchNotificationsViewModelTest.kt
@@ -1,0 +1,47 @@
+package com.github.andreyasadchy.xtra.ui.notifications
+
+import com.github.andreyasadchy.xtra.model.twitchinbox.TwitchNotification
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TwitchNotificationsViewModelTest {
+
+    @Test
+    fun backgroundRefreshPreservesLocalReadChange() {
+        val item = notification(isUnread = true)
+
+        val refreshed = applyLocalNotificationChanges(
+            items = listOf(item),
+            locallyReadIds = setOf(item.id),
+            locallyDismissedIds = emptySet(),
+        )
+
+        assertFalse(refreshed.single().isUnread)
+    }
+
+    @Test
+    fun backgroundRefreshPreservesLocalDismissal() {
+        val item = notification(isUnread = true)
+
+        val refreshed = applyLocalNotificationChanges(
+            items = listOf(item),
+            locallyReadIds = emptySet(),
+            locallyDismissedIds = setOf(item.id),
+        )
+
+        assertTrue(refreshed.isEmpty())
+    }
+
+    private fun notification(isUnread: Boolean) = TwitchNotification(
+        id = "notification-1",
+        type = "SUBSCRIPTION",
+        title = "A sub",
+        body = "Someone subscribed",
+        createdAt = null,
+        imageUrl = null,
+        isUnread = isUnread,
+        canDismiss = true,
+        action = null,
+    )
+}


### PR DESCRIPTION
Cache whisper threads and Twitch drop/sub notifications so the inbox screens render saved data immediately, then refresh in the background.