### PR TITLE
Fix chat profile badges and points icons

### DIFF
--- a/app/src/main/graphql/UserMessageClicked.graphql
+++ b/app/src/main/graphql/UserMessageClicked.graphql
@@ -11,7 +11,7 @@ fragment UserMessageClickedUser on User {
         version
         title
         description
-        imageURL(size: NORMAL)
+        imageURL(size: QUADRUPLE)
     }
     relationship(targetUserID: $targetId) {
         subscriptionBenefit {
@@ -44,7 +44,7 @@ query UserMessageClicked($id: ID, $login: String, $targetId: ID, $userLogin: Str
             version
             title
             description
-            imageURL(size: NORMAL)
+            imageURL(size: QUADRUPLE)
         }
     }
 }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChannelPointsDialog.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChannelPointsDialog.kt
@@ -355,7 +355,7 @@ class ChannelPointsDialog : DialogFragment() {
         val image = ImageView(requireContext()).apply {
             layoutParams = LinearLayout.LayoutParams(dp(42), dp(42))
             scaleType = ImageView.ScaleType.CENTER_INSIDE
-            setImageResource(R.drawable.ic_channel_points)
+            setImageResource(R.drawable.ic_channel_points_default)
             imageTintList = ColorStateList.valueOf(Color.WHITE)
         }
         reward.imageUrl?.let { imageUrl ->
@@ -559,7 +559,7 @@ class ChannelPointsDialog : DialogFragment() {
     }
 
     private fun setChannelPointsIcon(image: ImageView, imageUrl: String?, fallbackTint: Int) {
-        image.setImageResource(R.drawable.ic_channel_points)
+        image.setImageResource(R.drawable.ic_channel_points_default)
         image.imageTintList = ColorStateList.valueOf(fallbackTint)
         if (!imageUrl.isNullOrBlank()) {
             image.imageTintList = null

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatFragment.kt
@@ -1709,7 +1709,7 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
                     channelPointRewardSubtitle.text = state.reward.prompt
                         ?.takeIf { it.isNotBlank() }
                         ?: getString(R.string.channel_points_reward_message_overlay)
-                    updateComposerOverlayIcon(state.reward.imageUrl, R.drawable.ic_channel_points)
+                    updateComposerOverlayIcon(state.reward.imageUrl, R.drawable.ic_channel_points_default)
                 }
                 is ComposerOverlayState.StreakShare -> {
                     channelPointRewardTitle.text = getString(

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/MessageClickedDialog.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/MessageClickedDialog.kt
@@ -190,6 +190,10 @@ class MessageClickedDialog : BottomSheetDialogFragment() {
                                 }
                             }
                         } else {
+                            previewUserFromMessage(selectedMessage)?.let { previewUser ->
+                                userCardUser = previewUser
+                                updateUserLayout(previewUser)
+                            }
                             viewModel.loadUser(
                                 channelId = selectedMessage.userId,
                                 channelLogin = selectedMessage.userLogin,
@@ -256,6 +260,17 @@ class MessageClickedDialog : BottomSheetDialogFragment() {
                 }
             }
         }
+    }
+
+    private fun previewUserFromMessage(message: ChatMessage): User? {
+        if (message.userId.isNullOrBlank() && message.userLogin.isNullOrBlank() && message.userName.isNullOrBlank()) {
+            return null
+        }
+        return User(
+            id = message.userId,
+            login = message.userLogin,
+            name = message.userName,
+        )
     }
 
     private fun updateButtons(chatMessage: ChatMessage) {

--- a/app/src/main/res/layout/dialog_channel_points.xml
+++ b/app/src/main/res/layout/dialog_channel_points.xml
@@ -57,7 +57,7 @@
                 android:layout_width="18dp"
                 android:layout_height="18dp"
                 android:importantForAccessibility="no"
-                android:src="@drawable/ic_channel_points"
+                android:src="@drawable/ic_channel_points_default"
                 app:tint="?attr/colorControlNormal" />
 
             <TextView

--- a/app/src/main/res/layout/fragment_chat.xml
+++ b/app/src/main/res/layout/fragment_chat.xml
@@ -269,7 +269,7 @@
                     android:layout_height="34dp"
                     android:importantForAccessibility="no"
                     android:scaleType="centerInside"
-                    android:src="@drawable/ic_channel_points"
+                    android:src="@drawable/ic_channel_points_default"
                     app:tint="?attr/colorControlNormal" />
 
                 <LinearLayout


### PR DESCRIPTION
Improve badge quality in chat user profiles, show profile identity with the related messages, and use the current default channel-points icon throughout the chat points UI.