### PR TITLE
Fix chat rendering backpressure

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatAdapter.kt
@@ -10,7 +10,6 @@ import android.text.SpannableStringBuilder
 import android.text.TextUtils
 import android.text.method.LinkMovementMethod
 import android.text.style.ImageSpan
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -292,10 +291,6 @@ class ChatAdapter(
         val bindGeneration = holder.beginBind(configuration.revision)
         val cachedResult = cachedRender(cacheKey)
         val result = selectRenderResultForBind(cachedResult) {
-            Log.w(
-                "ChatAdapter",
-                "Render cache miss during bind: position=$position revision=${configuration.revision}",
-            )
             ensureRenderScheduled(
                 chatMessage = chatMessage,
                 cacheKey = cacheKey,

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatFragment.kt
@@ -5,7 +5,9 @@ import android.content.res.ColorStateList
 import android.graphics.Color
 import android.os.Build
 import android.os.Bundle
+import android.os.SystemClock
 import android.text.format.DateUtils
+import android.util.Log
 import android.util.TypedValue
 import android.view.KeyEvent
 import android.view.LayoutInflater
@@ -150,6 +152,8 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
     private var chatSnapshotSyncPending = false
     private val pendingChatMutations = ArrayDeque<ChatViewModel.ChatMutation>()
     private var chatMutationRevision = 0L
+    private var chatMutationGapCount = 0L
+    private var chatSnapshotSyncCount = 0L
     private data class ChatViewportAnchor(val stableId: Long, val fallbackPosition: Int, val top: Int)
 
     private val chatAdapterUpdateRunnable = Runnable {
@@ -163,18 +167,14 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
         while (pendingChatMutations.isNotEmpty()) {
             when (val firstMutation = pendingChatMutations.removeFirst()) {
                 is ChatViewModel.ChatMutation.Append -> {
-                    val messages = ArrayList<ChatMessage>(firstMutation.messages.size)
-                    messages.addAll(firstMutation.messages)
-                    var trimCount = firstMutation.trimCount
-                    var revision = firstMutation.revision
+                    val appendMutations = ArrayList<ChatViewModel.ChatMutation.Append>()
+                    appendMutations += firstMutation
                     while (pendingChatMutations.firstOrNull() is ChatViewModel.ChatMutation.Append) {
-                        val next = pendingChatMutations.removeFirst() as ChatViewModel.ChatMutation.Append
-                        messages.addAll(next.messages)
-                        trimCount += next.trimCount
-                        revision = next.revision
+                        appendMutations += pendingChatMutations.removeFirst() as ChatViewModel.ChatMutation.Append
                     }
-                    currentAdapter.appendMessages(messages, trimCount)
-                    chatMutationRevision = revision
+                    val coalesced = coalesceChatAppendMutations(appendMutations)
+                    currentAdapter.appendMessages(coalesced.messages, coalesced.trimCount)
+                    chatMutationRevision = coalesced.revision
                     hasNewMessages = true
                 }
                 is ChatViewModel.ChatMutation.Prepend -> {
@@ -227,25 +227,60 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
         recyclerView.postOnAnimation(chatAdapterUpdateRunnable)
     }
 
+    private fun expectedChatMutationRevision(): Long =
+        pendingChatMutations.lastOrNull()?.revision ?: chatMutationRevision
+
+    private fun dispatchChatMutationSideEffects(mutation: ChatViewModel.ChatMutation) {
+        when (mutation) {
+            is ChatViewModel.ChatMutation.Append -> {
+                mutation.messages.forEach { message ->
+                    chatMessageListener?.invoke(message)
+                    messageDialog?.newMessage(message)
+                    replyDialog?.newMessage(message)
+                }
+            }
+            is ChatViewModel.ChatMutation.Prepend -> {
+                chatHistoryListener?.invoke(mutation.messages)
+                messageDialog?.addMessages(mutation.messages)
+                replyDialog?.addMessages(mutation.messages)
+            }
+            is ChatViewModel.ChatMutation.Clear -> Unit
+        }
+    }
+
     private suspend fun synchronizeChatAdapterToSnapshot() {
         val currentAdapter = adapter ?: return
         if (!chatAdapterReady) return
         val currentBinding = _binding ?: return
         val snapshot = viewModel.chatSnapshot()
-        if (!shouldSynchronizeChatSnapshot(chatMutationRevision, snapshot.revision)) return
+        if (!shouldSynchronizeChatSnapshot(
+                chatMutationRevision,
+                snapshot.revision,
+            )
+        ) {
+            return
+        }
 
         pendingChatMutations.clear()
-        currentAdapter.prepareForDisplay(snapshot.messages)
 
         if (_binding !== currentBinding || adapter !== currentAdapter) return
-        // Preparation suspends, so another synchronization may have advanced the UI.
-        // Never replace newer state with an older snapshot.
-        if (!shouldSynchronizeChatSnapshot(chatMutationRevision, snapshot.revision)) return
+        val syncStartedAt = SystemClock.elapsedRealtime()
         val recyclerView = currentBinding.recyclerView
         val followBottom = !recyclerView.canScrollVertically(1)
-        val anchor = if (followBottom) null else captureChatViewportAnchor(recyclerView, currentAdapter)
+        val anchor =
+            if (followBottom) null
+            else captureChatViewportAnchor(recyclerView, currentAdapter)
+
         currentAdapter.replaceMessages(snapshot.messages)
         chatMutationRevision = snapshot.revision
+        chatSnapshotSyncCount++
+        Log.d(
+            "ChatPerf",
+            "snapshot sync count=$chatSnapshotSyncCount " +
+                "revision=${snapshot.revision} " +
+                "messages=${snapshot.messages.size} " +
+                "durationMs=${SystemClock.elapsedRealtime() - syncStartedAt}",
+        )
         if (followBottom && currentAdapter.itemCount > 0) {
             recyclerView.scrollToPosition(currentAdapter.itemCount - 1)
         } else if (!followBottom) {
@@ -568,8 +603,15 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
                                     chatStatus.visibility = View.VISIBLE
                                     chatStatus.postDelayed({ chatStatus.visibility = View.GONE }, 5000)
                                 }
-                                if (newState == RecyclerView.SCROLL_STATE_IDLE && pendingChatMutations.isNotEmpty()) {
-                                    scheduleChatAdapterUpdate()
+                                if (newState == RecyclerView.SCROLL_STATE_IDLE) {
+                                    if (chatSnapshotSyncPending && chatAdapterReady) {
+                                        chatSnapshotSyncPending = false
+                                        viewLifecycleOwner.lifecycleScope.launch {
+                                            synchronizeChatAdapterToSnapshot()
+                                        }
+                                    } else if (pendingChatMutations.isNotEmpty()) {
+                                        scheduleChatAdapterUpdate()
+                                    }
                                 }
                             }
                         })
@@ -954,10 +996,25 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
                         repeatOnLifecycle(Lifecycle.State.STARTED) {
                             synchronizeChatAdapterToSnapshot()
                             viewModel.chatMutations.collect { mutation ->
-                                when (chatMutationAction(chatMutationRevision, mutation.revision)) {
+                                if (chatSnapshotSyncPending) {
+                                    dispatchChatMutationSideEffects(mutation)
+                                    return@collect
+                                }
+
+                                val expectedRevision = expectedChatMutationRevision()
+                                when (chatMutationAction(expectedRevision, mutation.revision)) {
                                     ChatMutationAction.IGNORE -> return@collect
                                     ChatMutationAction.SYNCHRONIZE_SNAPSHOT -> {
-                                        if (chatAdapterReady) {
+                                        chatMutationGapCount++
+                                        Log.d(
+                                            "ChatPerf",
+                                            "mutation gap count=$chatMutationGapCount " +
+                                                "displayed=$chatMutationRevision " +
+                                                "expected=$expectedRevision " +
+                                                "incoming=${mutation.revision}",
+                                        )
+                                        pendingChatMutations.clear()
+                                        if (chatAdapterReady && !isChatTouched) {
                                             synchronizeChatAdapterToSnapshot()
                                         } else {
                                             chatSnapshotSyncPending = true
@@ -966,31 +1023,16 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
                                     }
                                     ChatMutationAction.APPLY_INCREMENTAL -> Unit
                                 }
-                                // Complete render plans are prepared by ChatAdapter's bounded
-                                // background workers before this mutation can reach RecyclerView.
-                                val messagesToPrepare = when (mutation) {
-                                    is ChatViewModel.ChatMutation.Append -> mutation.messages
-                                    is ChatViewModel.ChatMutation.Prepend -> mutation.messages
-                                    is ChatViewModel.ChatMutation.Clear -> emptyList()
+                                dispatchChatMutationSideEffects(mutation)
+
+                                if (isChatTouched) {
+                                    pendingChatMutations.clear()
+                                    chatSnapshotSyncPending = true
+                                    return@collect
                                 }
-                                adapter?.prepareForDisplay(messagesToPrepare)
+
                                 pendingChatMutations.addLast(mutation)
-                                when (mutation) {
-                                    is ChatViewModel.ChatMutation.Append -> {
-                                        mutation.messages.forEach { message ->
-                                            chatMessageListener?.invoke(message)
-                                            messageDialog?.newMessage(message)
-                                            replyDialog?.newMessage(message)
-                                        }
-                                    }
-                                    is ChatViewModel.ChatMutation.Prepend -> {
-                                        chatHistoryListener?.invoke(mutation.messages)
-                                        messageDialog?.addMessages(mutation.messages)
-                                        replyDialog?.addMessages(mutation.messages)
-                                    }
-                                    is ChatViewModel.ChatMutation.Clear -> Unit
-                                }
-                                if (!isChatTouched) scheduleChatAdapterUpdate()
+                                scheduleChatAdapterUpdate()
                             }
                         }
                     }
@@ -2478,6 +2520,22 @@ internal enum class ChatMutationAction {
     IGNORE,
     APPLY_INCREMENTAL,
     SYNCHRONIZE_SNAPSHOT,
+}
+
+internal fun expectedChatMutationRevision(
+    displayedRevision: Long,
+    pendingRevision: Long?,
+): Long = pendingRevision ?: displayedRevision
+
+internal fun coalesceChatAppendMutations(
+    mutations: List<ChatViewModel.ChatMutation.Append>,
+): ChatViewModel.ChatMutation.Append {
+    require(mutations.isNotEmpty())
+    return ChatViewModel.ChatMutation.Append(
+        revision = mutations.last().revision,
+        messages = mutations.flatMap { it.messages },
+        trimCount = mutations.sumOf { it.trimCount },
+    )
 }
 
 internal fun chatMutationAction(displayedRevision: Long, mutationRevision: Long): ChatMutationAction =

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatViewModel.kt
@@ -168,6 +168,20 @@ data class DropsUiState(
                         it.requiredMinutesWatched > 0
                 }
                 .maxByOrNull { it.progressPercent }
+
+}
+
+internal fun appendChatMessageToHistory(
+    messages: MutableList<ChatMessage>,
+    message: ChatMessage,
+    messageLimit: Int,
+): Int {
+    messages.add(message)
+    val removeCount = (messages.size - messageLimit).coerceAtLeast(0)
+    if (removeCount > 0) {
+        messages.subList(0, removeCount).clear()
+    }
+    return removeCount
 }
 
 class ChatViewModel(
@@ -1409,13 +1423,7 @@ class ChatViewModel(
             )
         }
         synchronized(chatMessages) {
-            chatMessages.add(message)
-            val removeCount = if (chatMessages.size > messageLimit) {
-                chatMessages.size - messageLimit
-            } else 0
-            if (removeCount > 0) {
-                chatMessages.subList(0, removeCount).clear()
-            }
+            val removeCount = appendChatMessageToHistory(chatMessages, message, messageLimit)
             chatRevision++
             chatMutationEvents.trySend(
                 ChatMutation.Append(

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/chat/ChatReadWebSocket.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/chat/ChatReadWebSocket.kt
@@ -82,7 +82,7 @@ class ChatReadWebSocket(
             message.removeSuffix("\r\n").split("\r\n").forEach {
                 when {
                     it.startsWith("PING") -> {
-                        webSocket.write("PONG")
+                        webSocket.write("PONG${it.removePrefix("PING")}")
                     }
                     it.startsWith("PONG") -> {
                         pingTimer?.cancel()

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/ChatViewModelTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/ChatViewModelTest.kt
@@ -1,5 +1,6 @@
 package com.github.andreyasadchy.xtra.ui.chat
 
+import com.github.andreyasadchy.xtra.model.chat.ChatMessage
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -53,9 +54,73 @@ class ChatViewModelTest {
     }
 
     @Test
+    fun queuedMutationAdvancesExpectedRevisionBeforeFrameIsApplied() {
+        val expected = expectedChatMutationRevision(
+            displayedRevision = 100L,
+            pendingRevision = 101L,
+        )
+
+        assertEquals(101L, expected)
+        assertEquals(
+            ChatMutationAction.APPLY_INCREMENTAL,
+            chatMutationAction(expected, 102L),
+        )
+    }
+
+    @Test
+    fun canonicalChatHistoryStaysCappedAndOrdered() {
+        val history = ArrayList<ChatMessage>()
+
+        repeat(601) { index ->
+            appendChatMessageToHistory(
+                messages = history,
+                message = ChatMessage(message = "message-$index"),
+                messageLimit = 600,
+            )
+        }
+
+        assertEquals(600, history.size)
+        assertEquals("message-1", history.first().message)
+        assertEquals("message-600", history.last().message)
+    }
+
+    @Test
+    fun droppedIncrementalMutationsAreRecoverableFromCanonicalSnapshot() {
+        val history = ArrayList<ChatMessage>()
+        repeat(601) { index ->
+            appendChatMessageToHistory(history, ChatMessage(message = "message-$index"), 600)
+        }
+
+        // The incremental event for the latest message may be dropped, but the canonical
+        // history still contains it for the next snapshot recovery.
+        val snapshot = ChatViewModel.ChatSnapshot(revision = 601L, messages = history.toList())
+
+        assertEquals(601L, snapshot.revision)
+        assertEquals(600, snapshot.messages.size)
+        assertEquals("message-1", snapshot.messages.first().message)
+        assertEquals("message-600", snapshot.messages.last().message)
+    }
+
+    @Test
+    fun coalescedAppendsPreserveMessageOrder() {
+        val mutations = listOf(
+            ChatViewModel.ChatMutation.Append(101L, listOf(ChatMessage(message = "first")), 0),
+            ChatViewModel.ChatMutation.Append(102L, listOf(ChatMessage(message = "second")), 1),
+            ChatViewModel.ChatMutation.Append(103L, listOf(ChatMessage(message = "third")), 1),
+        )
+
+        val coalesced = coalesceChatAppendMutations(mutations)
+
+        assertEquals(103L, coalesced.revision)
+        assertEquals(2, coalesced.trimCount)
+        assertEquals(listOf("first", "second", "third"), coalesced.messages.map { it.message })
+    }
+
+    @Test
     fun revisionGapRequestsSnapshotRecovery() {
         assertEquals(ChatMutationAction.SYNCHRONIZE_SNAPSHOT, chatMutationAction(displayedRevision = 10, mutationRevision = 12))
         assertEquals(ChatMutationAction.SYNCHRONIZE_SNAPSHOT, chatMutationAction(displayedRevision = 10, mutationRevision = 138))
+        assertEquals(ChatMutationAction.SYNCHRONIZE_SNAPSHOT, chatMutationAction(displayedRevision = 100, mutationRevision = 103))
     }
 
     @Test


### PR DESCRIPTION
Fast live chat no longer waits for message rendering before updating the RecyclerView. Snapshot recovery is immediate, cache misses render asynchronously, and IRC PONG replies preserve the server payload.