### PR TITLE
Add recovery for stuck update downloads

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/settings/SettingsActivity.kt
@@ -1797,6 +1797,7 @@ class SettingsActivity : AppCompatActivity() {
             when (action) {
                 UpdateUiAction.Check -> repository.check(requireContext().prefs().getString(C.NETWORK_LIBRARY, C.OKHTTP), C.DEFAULT_UPDATE_URL)
                 UpdateUiAction.Download -> repository.downloadCurrent()
+                UpdateUiAction.RestartDownload -> repository.restartDownload()
                 UpdateUiAction.CancelDownload -> repository.cancelDownload()
                 UpdateUiAction.Retry -> repository.retry()
                 UpdateUiAction.NotNow -> (repository.state.value as? UpdateState.Available)?.release?.let(repository::defer)
@@ -1839,7 +1840,8 @@ class SettingsActivity : AppCompatActivity() {
             } else ""
             binding.statusMessage.text = when (model.status) {
                 UpdateUiStatus.CURRENT -> getString(R.string.update_checked_recently, UpdateTimeFormatter.format(requireContext(), repository.lastSuccessfulCheck))
-                UpdateUiStatus.DOWNLOADING -> UpdateStatusBinder.downloadStatusText(requireContext(), model.downloadManagerStatus, model.downloadManagerReason)
+                UpdateUiStatus.DOWNLOADING -> model.statusMessageRes?.let(::getString)
+                    ?: UpdateStatusBinder.downloadStatusText(requireContext(), model.downloadManagerStatus, model.downloadManagerReason)
                 else -> model.statusMessageRes?.let(::getString).orEmpty()
             }
             binding.downloadProgressView.root.visibility = if (model.status == UpdateUiStatus.DOWNLOADING) View.VISIBLE else View.GONE
@@ -1946,6 +1948,7 @@ class SettingsActivity : AppCompatActivity() {
             when (action) {
                 UpdateUiAction.Check -> R.string.check_for_updates
                 UpdateUiAction.Download -> R.string.download_update
+                UpdateUiAction.RestartDownload -> R.string.restart_download
                 UpdateUiAction.CancelDownload -> R.string.cancel
                 UpdateUiAction.Install -> R.string.install_update
                 UpdateUiAction.ContinueInstall -> R.string.continue_install

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/update/UpdateDetailsBottomSheet.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/update/UpdateDetailsBottomSheet.kt
@@ -165,6 +165,7 @@ class UpdateDetailsBottomSheet : BottomSheetDialogFragment() {
         when (action) {
             UpdateUiAction.Check -> repository.check(requireContext().prefs().getString(C.NETWORK_LIBRARY, C.OKHTTP), C.DEFAULT_UPDATE_URL)
             UpdateUiAction.Download -> repository.downloadCurrent()
+            UpdateUiAction.RestartDownload -> repository.restartDownload()
             UpdateUiAction.CancelDownload -> repository.cancelDownload()
             UpdateUiAction.Retry -> repository.retry()
             UpdateUiAction.NotNow -> (repository.state.value as? UpdateState.Available)?.release?.let(repository::defer)
@@ -222,7 +223,8 @@ class UpdateDetailsBottomSheet : BottomSheetDialogFragment() {
     }
 
     private fun statusText(model: UpdateUiModel): String = when (model.status) {
-        UpdateUiStatus.DOWNLOADING -> UpdateStatusBinder.downloadStatusText(requireContext(), model.downloadManagerStatus, model.downloadManagerReason)
+        UpdateUiStatus.DOWNLOADING -> model.statusMessageRes?.let(::getString)
+            ?: UpdateStatusBinder.downloadStatusText(requireContext(), model.downloadManagerStatus, model.downloadManagerReason)
         UpdateUiStatus.CURRENT -> getString(R.string.update_up_to_date)
         UpdateUiStatus.IDLE,
         UpdateUiStatus.AVAILABLE,
@@ -234,6 +236,7 @@ class UpdateDetailsBottomSheet : BottomSheetDialogFragment() {
         when (action) {
             UpdateUiAction.Check -> R.string.check_for_updates
             UpdateUiAction.Download -> R.string.download_update
+            UpdateUiAction.RestartDownload -> R.string.restart_download
             UpdateUiAction.CancelDownload -> R.string.cancel
             UpdateUiAction.Install -> R.string.install_update
             UpdateUiAction.ContinueInstall -> R.string.continue_install

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/update/UpdateUiModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/update/UpdateUiModel.kt
@@ -1,5 +1,6 @@
 package com.github.andreyasadchy.xtra.ui.update
 
+import android.app.DownloadManager
 import com.github.andreyasadchy.xtra.R
 import com.github.andreyasadchy.xtra.util.updater.DownloadProgress
 import com.github.andreyasadchy.xtra.util.updater.UpdateError
@@ -29,6 +30,7 @@ enum class UpdateUiStatus {
 sealed interface UpdateUiAction {
     data object Check : UpdateUiAction
     data object Download : UpdateUiAction
+    data object RestartDownload : UpdateUiAction
     data object CancelDownload : UpdateUiAction
     data object Install : UpdateUiAction
     data object ContinueInstall : UpdateUiAction
@@ -107,17 +109,24 @@ fun UpdateState.toUiModel(selectedAsset: UpdateSelectedAssetInfo? = null): Updat
         statusMessageRes = R.string.update_deferred,
         showReleaseNotes = true,
     )
-    is UpdateState.Downloading -> UpdateUiModel(
-        status = UpdateUiStatus.DOWNLOADING,
-        titleRes = R.string.downloading_update,
-        release = release,
-        progress = progress,
-        downloadManagerStatus = downloadManagerStatus,
-        downloadManagerReason = downloadManagerReason,
-        primaryAction = UpdateUiAction.CancelDownload,
-        showReleaseNotes = true,
-        showDiagnostics = true,
-    )
+    is UpdateState.Downloading -> {
+        val canRestart = progress?.stalled == true ||
+            downloadManagerStatus == DownloadManager.STATUS_PAUSED &&
+            downloadManagerReason == DownloadManager.PAUSED_WAITING_TO_RETRY
+        UpdateUiModel(
+            status = UpdateUiStatus.DOWNLOADING,
+            titleRes = R.string.downloading_update,
+            release = release,
+            progress = progress,
+            downloadManagerStatus = downloadManagerStatus,
+            downloadManagerReason = downloadManagerReason,
+            statusMessageRes = if (progress?.stalled == true) R.string.update_download_stalled else null,
+            primaryAction = if (canRestart) UpdateUiAction.RestartDownload else UpdateUiAction.CancelDownload,
+            secondaryAction = if (canRestart) UpdateUiAction.CancelDownload else null,
+            showReleaseNotes = true,
+            showDiagnostics = true,
+        )
+    }
     is UpdateState.Downloaded -> UpdateUiModel(
         status = UpdateUiStatus.READY,
         titleRes = R.string.update_ready_title,

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/updater/UpdateDownloadMonitor.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/updater/UpdateDownloadMonitor.kt
@@ -29,6 +29,7 @@ class UpdateDownloadMonitor(
     private val scope: CoroutineScope,
     private val nowMs: () -> Long = SystemClock::elapsedRealtime,
     private val pollMillis: Long = 400L,
+    private val pendingRestartAfterMs: Long = 15_000L,
 ) {
     private var job: Job? = null
     private var monitoredId: Long? = null
@@ -39,6 +40,7 @@ class UpdateDownloadMonitor(
         monitoredId = id
         job = scope.launch {
             val estimator = TransferRateEstimator()
+            var pendingSinceMs: Long? = null
             try {
                 while (isActive && monitoredId == id) {
                     val record = runCatching { store.query(id) }.getOrElse {
@@ -52,17 +54,21 @@ class UpdateDownloadMonitor(
                     when (record.status) {
                         DownloadManager.STATUS_PENDING -> {
                             estimator.reset()
+                            val observedAt = nowMs()
+                            val pendingSince = pendingSinceMs ?: observedAt.also { pendingSinceMs = it }
                             onEvent(
                                 UpdateDownloadEvent.Progress(
                                     record,
                                     DownloadProgress(
                                         downloadedBytes = record.downloadedBytes,
                                         totalBytes = record.totalBytes,
+                                        stalled = observedAt - pendingSince >= pendingRestartAfterMs,
                                     ),
                                 ),
                             )
                         }
                         DownloadManager.STATUS_RUNNING -> {
+                            pendingSinceMs = null
                             val rate = estimator.sample(record.downloadedBytes, nowMs())
                             onEvent(
                                 UpdateDownloadEvent.Progress(
@@ -84,6 +90,7 @@ class UpdateDownloadMonitor(
                             )
                         }
                         DownloadManager.STATUS_PAUSED -> {
+                            pendingSinceMs = null
                             estimator.reset()
                             onEvent(
                                 UpdateDownloadEvent.Progress(

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/updater/UpdateRepository.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/updater/UpdateRepository.kt
@@ -551,6 +551,20 @@ class UpdateRepository(
         }
     }
 
+    fun restartDownload() {
+        scope.launch {
+            ready.await()
+            downloadLock.withLock {
+                val current = _state.value as? UpdateState.Downloading ?: return@withLock
+                val oldDownloadId = activeDownloadId
+                clearDownloadReference()
+                removeDownload(oldDownloadId)
+                _state.value = UpdateState.Available(current.release)
+                downloadLocked(current.release)
+            }
+        }
+    }
+
     fun install() {
         scope.launch {
             ready.await()

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -1143,6 +1143,8 @@
     <string name="whats_new">ما الجديد</string>
     <string name="check_for_updates">التحقق من وجود تحديثات</string>
     <string name="download_update">تنزيل التحديث</string>
+    <string name="restart_download">إعادة تنزيل</string>
+    <string name="update_download_stalled">توقف التنزيل عن التقدم. أعد تشغيله لبدء تنزيل جديد.</string>
     <string name="install_update">تثبيت التحديث</string>
     <string name="retry_install">إعادة محاولة التثبيت</string>
     <string name="continue_install">متابعة التثبيت</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -973,6 +973,8 @@
     <string name="whats_new">Co je nového</string>
     <string name="check_for_updates">Kontrola aktualizací</string>
     <string name="download_update">Stáhnout aktualizaci</string>
+    <string name="restart_download">Restartovat stahování</string>
+    <string name="update_download_stalled">Stahování se zastavilo. Restartujte ho a začněte znovu.</string>
     <string name="install_update">Nainstalovat aktualizaci</string>
     <string name="retry_install">Opakovat instalaci</string>
     <string name="continue_install">Pokračovat v instalaci</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1143,6 +1143,8 @@
     <string name="whats_new">Was ist neu</string>
     <string name="check_for_updates">Nach Updates suchen</string>
     <string name="download_update">Update herunterladen</string>
+    <string name="restart_download">Download neu starten</string>
+    <string name="update_download_stalled">Der Download macht keine Fortschritte mehr. Starten Sie ihn neu, um von vorn zu beginnen.</string>
     <string name="install_update">Update installieren</string>
     <string name="retry_install">Installation erneut versuchen</string>
     <string name="continue_install">Installation fortsetzen</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1148,6 +1148,8 @@
     <string name="whats_new">Novedades</string>
     <string name="check_for_updates">Buscar actualizaciones</string>
     <string name="download_update">Descargar la actualización</string>
+    <string name="restart_download">Reiniciar descarga</string>
+    <string name="update_download_stalled">La descarga dejó de avanzar. Reiníciala para empezar una descarga nueva.</string>
     <string name="install_update">Instalar la actualización</string>
     <string name="retry_install">Reintentar la instalación</string>
     <string name="continue_install">Continuar la instalación</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1143,6 +1143,8 @@
     <string name="whats_new">Quoi de neuf</string>
     <string name="check_for_updates">Rechercher des mises à jour</string>
     <string name="download_update">Télécharger la mise à jour</string>
+    <string name="restart_download">Relancer le téléchargement</string>
+    <string name="update_download_stalled">Le téléchargement n’avance plus. Relancez-le pour recommencer.</string>
     <string name="install_update">Installer la mise à jour</string>
     <string name="retry_install">Réessayer l\'installation</string>
     <string name="continue_install">Poursuivre l\'installation</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -1143,6 +1143,8 @@
     <string name="whats_new">O que hai de novo</string>
     <string name="check_for_updates">Buscar actualizacións</string>
     <string name="download_update">Descargar actualización</string>
+    <string name="restart_download">Reiniciar descarga</string>
+    <string name="update_download_stalled">A descarga deixou de avanzar. Reiníciaa para comezar unha descarga nova.</string>
     <string name="install_update">Instalar actualización</string>
     <string name="retry_install">Reintenta a instalación</string>
     <string name="continue_install">Continuar a instalación</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -1144,6 +1144,8 @@
     <string name="whats_new">Apa yang baru</string>
     <string name="check_for_updates">Periksa pembaruan</string>
     <string name="download_update">Unduh pembaruan</string>
+    <string name="restart_download">Mulai ulang unduhan</string>
+    <string name="update_download_stalled">Unduhan berhenti berjalan. Mulai ulang untuk mengunduh dari awal.</string>
     <string name="install_update">Instal pembaruan</string>
     <string name="retry_install">Coba lagi instalasi</string>
     <string name="continue_install">Lanjutkan instalasi</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1143,6 +1143,8 @@
     <string name="whats_new">Novità</string>
     <string name="check_for_updates">Controlla aggiornamenti</string>
     <string name="download_update">Scarica aggiornamento</string>
+    <string name="restart_download">Riavvia download</string>
+    <string name="update_download_stalled">Il download non avanza più. Riavvialo per iniziare un nuovo download.</string>
     <string name="install_update">Installa aggiornamento</string>
     <string name="retry_install">Riprova installazione</string>
     <string name="continue_install">Continua installazione</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1143,6 +1143,8 @@
     <string name="whats_new">新機能</string>
     <string name="check_for_updates">アップデートのチェック</string>
     <string name="download_update">アップデートをダウンロード</string>
+    <string name="restart_download">ダウンロードを再開</string>
+    <string name="update_download_stalled">ダウンロードが進んでいません。再開すると新しくダウンロードし直します。</string>
     <string name="install_update">アップデートをインストール</string>
     <string name="retry_install">インストールを再試行</string>
     <string name="continue_install">インストールを続行</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -949,6 +949,8 @@
     <string name="whats_new">Co to jest nowość</string>
     <string name="check_for_updates">Sprawdź aktualizacje</string>
     <string name="download_update">Pobierz aktualizację</string>
+    <string name="restart_download">Uruchom ponownie pobieranie</string>
+    <string name="update_download_stalled">Pobieranie nie robi postępów. Uruchom je ponownie, aby zacząć od nowa.</string>
     <string name="install_update">Zainstaluj aktualizację</string>
     <string name="retry_install">Ponów instalację</string>
     <string name="continue_install">Kontynuuj instalację</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -1143,6 +1143,8 @@
     <string name="whats_new">Novidades</string>
     <string name="check_for_updates">Verifique se há atualizações</string>
     <string name="download_update">Baixar atualização</string>
+    <string name="restart_download">Reiniciar download</string>
+    <string name="update_download_stalled">O download parou de avançar. Reinicie para começar um novo download.</string>
     <string name="install_update">Instalar atualização</string>
     <string name="retry_install">Tentar instalação novamente</string>
     <string name="continue_install">Continuar instalação</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1143,6 +1143,8 @@
     <string name="whats_new">Что нового</string>
     <string name="check_for_updates">Проверить наличие обновлений</string>
     <string name="download_update">Загрузить обновление</string>
+    <string name="restart_download">Перезапустить загрузку</string>
+    <string name="update_download_stalled">Загрузка не продвигается. Перезапустите её, чтобы начать заново.</string>
     <string name="install_update">Установить обновление</string>
     <string name="retry_install">Повторить установку</string>
     <string name="continue_install">Продолжить установку</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -973,6 +973,8 @@
     <string name="whats_new">Čo je nové</string>
     <string name="check_for_updates">Skontrolujte aktualizácie</string>
     <string name="download_update">Stiahnite si aktualizáciu</string>
+    <string name="restart_download">Reštartovať sťahovanie</string>
+    <string name="update_download_stalled">Sťahovanie sa zastavilo. Reštartujte ho a začnite odznova.</string>
     <string name="install_update">Nainštalujte aktualizáciu</string>
     <string name="retry_install">Zopakujte inštaláciu</string>
     <string name="continue_install">Pokračujte v inštalácii</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -1144,6 +1144,8 @@
     <string name="whats_new">Yenilikler</string>
     <string name="check_for_updates">Güncellemeleri kontrol edin</string>
     <string name="download_update">Güncellemeyi indir</string>
+    <string name="restart_download">İndirmeyi yeniden başlat</string>
+    <string name="update_download_stalled">İndirme ilerlemiyor. Baştan indirmek için yeniden başlatın.</string>
     <string name="install_update">Güncellemeyi yükle</string>
     <string name="retry_install">Kurulumu yeniden dene</string>
     <string name="continue_install">Kuruluma devam et</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1143,6 +1143,8 @@
     <string name="whats_new">新功能</string>
     <string name="check_for_updates">检查更新</string>
     <string name="download_update">下载更新</string>
+    <string name="restart_download">重新下载</string>
+    <string name="update_download_stalled">下载没有进展。重新开始即可从头下载。</string>
     <string name="install_update">安装更新</string>
     <string name="retry_install">重试安装</string>
     <string name="continue_install">继续安装</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -1143,6 +1143,8 @@
     <string name="whats_new">什麼是新的</string>
     <string name="check_for_updates">檢查更新</string>
     <string name="download_update">下載更新</string>
+    <string name="restart_download">重新下載</string>
+    <string name="update_download_stalled">下載沒有進度。重新開始即可從頭下載。</string>
     <string name="install_update">安裝更新</string>
     <string name="retry_install">重試安裝</string>
     <string name="continue_install">繼續安裝</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1068,6 +1068,7 @@
     <string name="update_transfer_downloaded">%1$s downloaded</string>
     <string name="update_transfer_waiting">Waiting for download progress…</string>
     <string name="update_transfer_calculating_speed">Calculating speed…</string>
+    <string name="update_download_stalled">The download stopped making progress. Restart it to begin a fresh download.</string>
     <string name="update_transfer_speed_eta">%1$s · about %2$s left</string>
     <string name="update_transfer_speed">%s</string>
     <string name="update_download_starting">Starting download…</string>
@@ -1155,6 +1156,7 @@
     <string name="whats_new">What’s new</string>
     <string name="check_for_updates">Check for updates</string>
     <string name="download_update">Download update</string>
+    <string name="restart_download">Restart download</string>
     <string name="install_update">Install update</string>
     <string name="retry_install">Retry installation</string>
     <string name="continue_install">Continue installation</string>

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/update/UpdateUiMapperTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/update/UpdateUiMapperTest.kt
@@ -88,6 +88,31 @@ class UpdateUiMapperTest {
     }
 
     @Test
+    fun stalledDownloadOffersRestartWithoutRemovingCancel() {
+        val model = UpdateState.Downloading(
+            release,
+            DownloadProgress(1L, 2L, stalled = true),
+        ).toUiModel()
+
+        assertEquals(UpdateUiAction.RestartDownload, model.primaryAction)
+        assertEquals(UpdateUiAction.CancelDownload, model.secondaryAction)
+        assertEquals(com.github.andreyasadchy.xtra.R.string.update_download_stalled, model.statusMessageRes)
+    }
+
+    @Test
+    fun downloadManagerWaitingToRetryOffersRestart() {
+        val model = UpdateState.Downloading(
+            release,
+            DownloadProgress(1L, 2L),
+            downloadManagerStatus = android.app.DownloadManager.STATUS_PAUSED,
+            downloadManagerReason = android.app.DownloadManager.PAUSED_WAITING_TO_RETRY,
+        ).toUiModel()
+
+        assertEquals(UpdateUiAction.RestartDownload, model.primaryAction)
+        assertEquals(UpdateUiAction.CancelDownload, model.secondaryAction)
+    }
+
+    @Test
     fun errorPresentationKeepsCheckErrorsOutOfDownloadFallbacks() {
         val timeout = UpdateState.Error(UpdateStage.CHECK, UpdateError.Timeout, true, release).toUiModel()
         val rateLimited = UpdateState.Error(UpdateStage.CHECK, UpdateError.RateLimited, true, release).toUiModel()

--- a/app/src/test/java/com/github/andreyasadchy/xtra/util/updater/UpdateDownloadMonitorTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/util/updater/UpdateDownloadMonitorTest.kt
@@ -15,6 +15,45 @@ import java.util.concurrent.CopyOnWriteArrayList
 
 class UpdateDownloadMonitorTest {
     @Test
+    fun pendingDownloadEventuallyExposesRecovery() = runBlocking {
+        val records = ArrayDeque(
+            listOf(
+                record(DownloadManager.STATUS_PENDING, 0L),
+                record(DownloadManager.STATUS_PENDING, 0L),
+                record(DownloadManager.STATUS_PENDING, 0L),
+                record(DownloadManager.STATUS_SUCCESSFUL, 1L),
+            ),
+        )
+        val events = CopyOnWriteArrayList<UpdateDownloadEvent>()
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val monitor = UpdateDownloadMonitor(
+            store = SequenceStore(records),
+            scope = scope,
+            nowMs = object {
+                private var value = 0L
+                operator fun invoke(): Long = value.also { value += 1_000L }
+            }::invoke,
+            pollMillis = 1L,
+            pendingRestartAfterMs = 2_000L,
+        )
+
+        try {
+            monitor.start(1L) { events += it }
+            withTimeout(2_000L) {
+                while (events.none { it is UpdateDownloadEvent.Completed }) delay(5L)
+            }
+        } finally {
+            monitor.cancel()
+            scope.cancel()
+        }
+
+        assertEquals(
+            true,
+            events.filterIsInstance<UpdateDownloadEvent.Progress>().last().telemetry.stalled,
+        )
+    }
+
+    @Test
     fun pausingAndResumingClearsPreviousRateAndEta() = runBlocking {
         val records = ArrayDeque(
             listOf(


### PR DESCRIPTION
Stuck update downloads now explain what happened and offer a Restart download button. Restarting removes the old download and starts a fresh one, while Cancel remains available.