### PR TITLE
Use TextureView for emulator video output

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/ExoPlayerFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/ExoPlayerFragment.kt
@@ -13,6 +13,7 @@ import android.os.IBinder
 import android.text.format.DateUtils
 import android.util.Log
 import android.view.SurfaceView
+import android.view.TextureView
 import android.view.View
 import android.widget.FrameLayout
 import android.widget.HorizontalScrollView
@@ -77,10 +78,45 @@ class ExoPlayerFragment : PlayerFragment(), ClipEditorDialogFragment.Host {
     private var liveSurfaceRestoreTimeout: Runnable? = null
     private var clipEditorCoverTimeout: Runnable? = null
     private var videoOutputCover: View? = null
-    private val videoOutputOwner = VideoOutputOwner<Player, SurfaceView>(
-        attachTarget = { currentPlayer, target -> currentPlayer.setVideoSurfaceView(target) },
-        detachTarget = { currentPlayer, target -> currentPlayer.clearVideoSurfaceView(target) },
+    private val useTextureVideoOutput = shouldUseTextureViewForVideoOutput()
+    private val videoOutputOwner = VideoOutputOwner<Player, View>(
+        attachTarget = { currentPlayer, target ->
+            when (target) {
+                is SurfaceView -> currentPlayer.setVideoSurfaceView(target)
+                is TextureView -> currentPlayer.setVideoTextureView(target)
+                else -> error("Unsupported video output view: ${target.javaClass.name}")
+            }
+        },
+        detachTarget = { currentPlayer, target ->
+            when (target) {
+                is SurfaceView -> currentPlayer.clearVideoSurfaceView(target)
+                is TextureView -> currentPlayer.clearVideoTextureView(target)
+                else -> error("Unsupported video output view: ${target.javaClass.name}")
+            }
+        },
     )
+
+    private val videoOutputView: View
+        get() = if (useTextureVideoOutput) {
+            binding.playerTextureView
+        } else {
+            binding.playerSurface
+        }
+
+    private fun configureVideoOutputView() {
+        binding.playerTextureView.visibility =
+            if (useTextureVideoOutput) View.VISIBLE else View.GONE
+        binding.playerSurface.visibility =
+            if (useTextureVideoOutput) View.GONE else View.VISIBLE
+
+        if (!useTextureVideoOutput &&
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE
+        ) {
+            binding.playerSurface.setSurfaceLifecycle(
+                SurfaceView.SURFACE_LIFECYCLE_FOLLOWS_ATTACHMENT,
+            )
+        }
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -106,17 +142,16 @@ class ExoPlayerFragment : PlayerFragment(), ClipEditorDialogFragment.Host {
             importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_NO
         }
         videoOutputCover = outputCover
-        // Keep the SurfaceView renderer for lower composition overhead. The cover is a normal
-        // view above it and remains visible until the player confirms a new decoded frame.
+        // Keep the selected renderer covered until the player confirms a new decoded frame.
         binding.aspectRatioFrameLayout.addView(outputCover)
-        binding.playerTextureView.visibility = View.GONE
-        binding.playerSurface.visibility = View.VISIBLE
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
-            binding.playerSurface.setSurfaceLifecycle(
-                SurfaceView.SURFACE_LIFECYCLE_FOLLOWS_ATTACHMENT,
+        configureVideoOutputView()
+        if (BuildConfig.DEBUG) {
+            Log.d(
+                "VideoSurface",
+                "renderer=${videoOutputView.javaClass.simpleName} emulatorFallback=$useTextureVideoOutput",
             )
         }
-        logVideoSurfaceBinding("on_view_created", playbackService?.player, binding.playerSurface)
+        logVideoSurfaceBinding("on_view_created", playbackService?.player, videoOutputView)
         childFragmentManager.setFragmentResultListener(
             ClipEditorDialogFragment.RESULT_KEY,
             viewLifecycleOwner,
@@ -139,7 +174,7 @@ class ExoPlayerFragment : PlayerFragment(), ClipEditorDialogFragment.Host {
 
     override fun onStart() {
         super.onStart()
-        logVideoSurfaceBinding("on_start", playbackService?.player, binding.playerSurface)
+        logVideoSurfaceBinding("on_start", playbackService?.player, videoOutputView)
         val listener = object : Player.Listener {
             override fun onPlaybackStateChanged(playbackState: Int) {
                 if (playbackState == Player.STATE_ENDED) {
@@ -295,7 +330,7 @@ class ExoPlayerFragment : PlayerFragment(), ClipEditorDialogFragment.Host {
             }
 
             override fun onRenderedFirstFrame() {
-                logVideoSurfaceBinding("first_frame", playbackService?.player, binding.playerSurface)
+                logVideoSurfaceBinding("first_frame", playbackService?.player, videoOutputView)
                 hideVideoOutputCover()
             }
         }
@@ -394,7 +429,7 @@ class ExoPlayerFragment : PlayerFragment(), ClipEditorDialogFragment.Host {
                 if (view != null) {
                     val binder = service as ExoPlayerService.ServiceBinder
                     val connectedService = binder.getService()
-                    logVideoSurfaceBinding("service_connected", connectedService.player, binding.playerSurface)
+                    logVideoSurfaceBinding("service_connected", connectedService.player, videoOutputView)
                     val connectedServiceConnection = this
                     playbackService = connectedService
                     serviceSetupJob?.cancel()
@@ -726,9 +761,9 @@ class ExoPlayerFragment : PlayerFragment(), ClipEditorDialogFragment.Host {
         livePlayer?.pause()
         clipDebug("live player paused")
         setVideoOutputVisible(false)
-        clipDebug("live surface hidden parentVisible=${binding.playerSurface.visibility == View.VISIBLE}")
+        clipDebug("live surface hidden parentVisible=${videoOutputView.visibility == View.VISIBLE}")
         detachVideoOutput(livePlayer)
-        clipDebug("live surface cleared parentVisible=${binding.playerSurface.visibility == View.VISIBLE}")
+        clipDebug("live surface cleared parentVisible=${videoOutputView.visibility == View.VISIBLE}")
         binding.playerLayout.visibility = View.GONE
     }
 
@@ -838,7 +873,7 @@ class ExoPlayerFragment : PlayerFragment(), ClipEditorDialogFragment.Host {
         val resumePlayback = if (isVod) playbackBeforeClipEditor == true else livePlaybackBeforeClipEditor == true
         val firstFrameListener = object : Player.Listener {
             override fun onRenderedFirstFrame() {
-                logVideoSurfaceBinding("first_frame", livePlayer, binding.playerSurface)
+                logVideoSurfaceBinding("first_frame", livePlayer, videoOutputView)
                 finishLiveSurfaceRestore(livePlayer)
             }
         }
@@ -1030,7 +1065,7 @@ class ExoPlayerFragment : PlayerFragment(), ClipEditorDialogFragment.Host {
     }
 
     override fun onStop() {
-        logVideoSurfaceBinding("on_stop", playbackService?.player, view?.findViewById(R.id.playerSurface))
+        logVideoSurfaceBinding("on_stop", playbackService?.player, view?.let { videoOutputView })
         serviceSetupJob?.cancel()
         serviceSetupJob = null
         super.onStop()
@@ -1073,7 +1108,7 @@ class ExoPlayerFragment : PlayerFragment(), ClipEditorDialogFragment.Host {
     }
 
     override fun onDestroyView() {
-        logVideoSurfaceBinding("on_destroy_view", playbackService?.player, view?.findViewById(R.id.playerSurface))
+        logVideoSurfaceBinding("on_destroy_view", playbackService?.player, view?.let { videoOutputView })
         detachVideoOutput()
         clipDebug("parent editor view destroyed")
         serviceSetupJob?.cancel()
@@ -1092,20 +1127,21 @@ class ExoPlayerFragment : PlayerFragment(), ClipEditorDialogFragment.Host {
     }
 
     private fun attachVideoOutput(currentPlayer: Player) {
-        videoOutputOwner.attach(currentPlayer, binding.playerSurface)
-        logVideoSurfaceBinding("attach", currentPlayer, binding.playerSurface)
+        val target = videoOutputView
+        videoOutputOwner.attach(currentPlayer, target)
+        logVideoSurfaceBinding("attach", currentPlayer, target)
     }
 
     private fun detachVideoOutput(currentPlayer: Player? = videoOutputOwner.attachedPlayer()) {
         if (currentPlayer == null) return
         if (videoOutputOwner.attachedPlayer() === currentPlayer) {
-            logVideoSurfaceBinding("detach", currentPlayer, binding.playerSurface)
+            logVideoSurfaceBinding("detach", currentPlayer, videoOutputView)
             videoOutputOwner.clear()
         }
     }
 
     private fun setVideoOutputVisible(visible: Boolean) {
-        binding.playerSurface.visibility = if (visible) View.VISIBLE else View.GONE
+        videoOutputView.visibility = if (visible) View.VISIBLE else View.GONE
         if (!visible) {
             showVideoOutputCover()
         }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/Media3Fragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/Media3Fragment.kt
@@ -11,6 +11,7 @@ import android.os.Bundle
 import android.text.format.DateUtils
 import android.util.Log
 import android.view.SurfaceView
+import android.view.TextureView
 import android.view.View
 import android.widget.HorizontalScrollView
 import android.widget.TextView
@@ -35,6 +36,7 @@ import androidx.media3.session.MediaController
 import androidx.media3.session.SessionCommand
 import androidx.media3.session.SessionResult
 import androidx.media3.session.SessionToken
+import com.github.andreyasadchy.xtra.BuildConfig
 import com.github.andreyasadchy.xtra.R
 import com.github.andreyasadchy.xtra.model.VideoQuality
 import com.github.andreyasadchy.xtra.model.ui.Clip
@@ -83,22 +85,61 @@ class Media3Fragment : Media3PlayerFragment() {
     private var adAvoidanceJob: Job? = null
     private var primaryStreamRestoreJob: Job? = null
     private val updateProgressAction = Runnable { if (view != null) updateProgress() }
-    private val videoOutputOwner = VideoOutputOwner<Player, SurfaceView>(
-        attachTarget = { currentPlayer, target -> currentPlayer.setVideoSurfaceView(target) },
-        detachTarget = { currentPlayer, target -> currentPlayer.clearVideoSurfaceView(target) },
+    private val useTextureVideoOutput = shouldUseTextureViewForVideoOutput()
+    private val videoOutputOwner = VideoOutputOwner<Player, View>(
+        attachTarget = { currentPlayer, target ->
+            when (target) {
+                is SurfaceView -> currentPlayer.setVideoSurfaceView(target)
+                is TextureView -> currentPlayer.setVideoTextureView(target)
+                else -> error("Unsupported video output view: ${target.javaClass.name}")
+            }
+        },
+        detachTarget = { currentPlayer, target ->
+            when (target) {
+                is SurfaceView -> currentPlayer.clearVideoSurfaceView(target)
+                is TextureView -> currentPlayer.clearVideoTextureView(target)
+                else -> error("Unsupported video output view: ${target.javaClass.name}")
+            }
+        },
     )
 
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
+    private val videoOutputView: View
+        get() = if (useTextureVideoOutput) {
+            binding.playerTextureView
+        } else {
+            binding.playerSurface
+        }
 
-        binding.playerTextureView.visibility = View.GONE
-        binding.playerSurface.visibility = View.VISIBLE
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+    private fun configureVideoOutputView() {
+        binding.playerTextureView.visibility =
+            if (useTextureVideoOutput) View.VISIBLE else View.GONE
+        binding.playerSurface.visibility =
+            if (useTextureVideoOutput) View.GONE else View.VISIBLE
+
+        if (!useTextureVideoOutput &&
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE
+        ) {
             binding.playerSurface.setSurfaceLifecycle(
                 SurfaceView.SURFACE_LIFECYCLE_FOLLOWS_ATTACHMENT,
             )
         }
-        logVideoSurfaceBinding("on_view_created", player, binding.playerSurface)
+    }
+
+    private fun setVideoOutputVisible(visible: Boolean) {
+        videoOutputView.visibility = if (visible) View.VISIBLE else View.GONE
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        configureVideoOutputView()
+        if (BuildConfig.DEBUG) {
+            Log.d(
+                "VideoSurface",
+                "renderer=${videoOutputView.javaClass.simpleName} emulatorFallback=$useTextureVideoOutput",
+            )
+        }
+        logVideoSurfaceBinding("on_view_created", player, videoOutputView)
     }
 
     override fun onViewingMetadataChanged(title: String?, gameId: String?, gameName: String?) {
@@ -123,7 +164,7 @@ class Media3Fragment : Media3PlayerFragment() {
 
     override fun onStart() {
         super.onStart()
-        logVideoSurfaceBinding("on_start", player, binding.playerSurface)
+        logVideoSurfaceBinding("on_start", player, videoOutputView)
         controllerFuture?.let { MediaController.releaseFuture(it) }
         val future = MediaController.Builder(
             requireContext(),
@@ -143,7 +184,7 @@ class Media3Fragment : Media3PlayerFragment() {
                 MediaController.releaseFuture(future)
                 return@addListener
             }
-            logVideoSurfaceBinding("controller_connected", controller, binding.playerSurface)
+            logVideoSurfaceBinding("controller_connected", controller, videoOutputView)
             val listener = object : Player.Listener {
 
                 override fun onPlaybackStateChanged(playbackState: Int) {
@@ -497,11 +538,11 @@ class Media3Fragment : Media3PlayerFragment() {
                 }
 
                 override fun onRenderedFirstFrame() {
-                    logVideoSurfaceBinding("first_frame", controller, binding.playerSurface)
+                    logVideoSurfaceBinding("first_frame", controller, videoOutputView)
                 }
             }
             val restored = viewModel.videoOutputState.restoreIfNeeded {
-                binding.playerSurface.visibility = View.VISIBLE
+                setVideoOutputVisible(true)
                 attachVideoOutput(controller)
                 true
             }
@@ -632,7 +673,7 @@ class Media3Fragment : Media3PlayerFragment() {
                     player.trackSelectionParameters = player.trackSelectionParameters.buildUpon().apply {
                         setTrackTypeDisabled(androidx.media3.common.C.TRACK_TYPE_VIDEO, true)
                     }.build()
-                    binding.playerSurface.visibility = View.GONE
+                    setVideoOutputVisible(false)
                 }
                 player.volume = 0f
             }
@@ -648,7 +689,7 @@ class Media3Fragment : Media3PlayerFragment() {
                     player.trackSelectionParameters = player.trackSelectionParameters.buildUpon().apply {
                         setTrackTypeDisabled(androidx.media3.common.C.TRACK_TYPE_VIDEO, false)
                     }.build()
-                    binding.playerSurface.visibility = View.VISIBLE
+                    setVideoOutputVisible(true)
                 }
                 player.volume = requireContext().prefs().getInt(C.PLAYER_VOLUME, 100) / 100f
             }
@@ -830,7 +871,7 @@ class Media3Fragment : Media3PlayerFragment() {
             player.trackSelectionParameters = player.trackSelectionParameters.buildUpon().apply {
                 setTrackTypeDisabled(androidx.media3.common.C.TRACK_TYPE_VIDEO, false)
             }.build()
-            binding.playerSurface.visibility = View.VISIBLE
+            setVideoOutputVisible(true)
             player.sendCustomCommand(
                 SessionCommand(
                     PlaybackService.START_VIDEO, Bundle().apply {
@@ -857,12 +898,12 @@ class Media3Fragment : Media3PlayerFragment() {
                 player.trackSelectionParameters = player.trackSelectionParameters.buildUpon().apply {
                     setTrackTypeDisabled(androidx.media3.common.C.TRACK_TYPE_VIDEO, true)
                 }.build()
-                binding.playerSurface.visibility = View.GONE
+                setVideoOutputVisible(false)
             } else {
                 player.trackSelectionParameters = player.trackSelectionParameters.buildUpon().apply {
                     setTrackTypeDisabled(androidx.media3.common.C.TRACK_TYPE_VIDEO, false)
                 }.build()
-                binding.playerSurface.visibility = View.VISIBLE
+                setVideoOutputVisible(true)
             }
             player.sendCustomCommand(
                 SessionCommand(
@@ -889,12 +930,12 @@ class Media3Fragment : Media3PlayerFragment() {
                 player.trackSelectionParameters = player.trackSelectionParameters.buildUpon().apply {
                     setTrackTypeDisabled(androidx.media3.common.C.TRACK_TYPE_VIDEO, true)
                 }.build()
-                binding.playerSurface.visibility = View.GONE
+                setVideoOutputVisible(false)
             } else {
                 player.trackSelectionParameters = player.trackSelectionParameters.buildUpon().apply {
                     setTrackTypeDisabled(androidx.media3.common.C.TRACK_TYPE_VIDEO, false)
                 }.build()
-                binding.playerSurface.visibility = View.VISIBLE
+                setVideoOutputVisible(true)
             }
             player.sendCustomCommand(
                 SessionCommand(
@@ -1170,7 +1211,7 @@ class Media3Fragment : Media3PlayerFragment() {
                                 setTrackTypeDisabled(androidx.media3.common.C.TRACK_TYPE_VIDEO, false)
                                 clearOverridesOfType(androidx.media3.common.C.TRACK_TYPE_VIDEO)
                             }.build()
-                            binding.playerSurface.visibility = View.VISIBLE
+                            setVideoOutputVisible(true)
                         }
                         AUDIO_ONLY_QUALITY -> {
                             if (viewModel.usingProxy) {
@@ -1186,7 +1227,7 @@ class Media3Fragment : Media3PlayerFragment() {
                             player.trackSelectionParameters = player.trackSelectionParameters.buildUpon().apply {
                                 setTrackTypeDisabled(androidx.media3.common.C.TRACK_TYPE_VIDEO, true)
                             }.build()
-                            binding.playerSurface.visibility = View.GONE
+                            setVideoOutputVisible(false)
                             quality.url?.let {
                                 val position = player.currentPosition
                                 if (viewModel.qualities?.find { it.name == AUTO_QUALITY } != null) {
@@ -1223,7 +1264,7 @@ class Media3Fragment : Media3PlayerFragment() {
                                 } ?: player.prepare()
                                 player.trackSelectionParameters = player.trackSelectionParameters.buildUpon().apply {
                                     setTrackTypeDisabled(androidx.media3.common.C.TRACK_TYPE_VIDEO, false)
-                                    binding.playerSurface.visibility = View.VISIBLE
+                                    setVideoOutputVisible(true)
                                     if (!player.currentTracks.isEmpty) {
                                         player.currentTracks.groups.find { it.type == androidx.media3.common.C.TRACK_TYPE_VIDEO }?.let { trackGroup ->
                                             val selectedQuality = quality.name?.split("p")
@@ -1268,7 +1309,7 @@ class Media3Fragment : Media3PlayerFragment() {
                                 player.trackSelectionParameters = player.trackSelectionParameters.buildUpon().apply {
                                     setTrackTypeDisabled(androidx.media3.common.C.TRACK_TYPE_VIDEO, false)
                                 }.build()
-                                binding.playerSurface.visibility = View.VISIBLE
+                                setVideoOutputVisible(true)
                             }
                         }
                     }
@@ -1308,7 +1349,7 @@ class Media3Fragment : Media3PlayerFragment() {
                             player.trackSelectionParameters = player.trackSelectionParameters.buildUpon().apply {
                                 setTrackTypeDisabled(androidx.media3.common.C.TRACK_TYPE_VIDEO, true)
                             }.build()
-                            binding.playerSurface.visibility = View.GONE
+                            setVideoOutputVisible(false)
                         }
                     }
                 }
@@ -1394,7 +1435,7 @@ class Media3Fragment : Media3PlayerFragment() {
     }
 
     override fun onStop() {
-        logVideoSurfaceBinding("on_stop", player, view?.findViewById(R.id.playerSurface))
+        logVideoSurfaceBinding("on_stop", player, view?.let { videoOutputView })
         super.onStop()
         val isInPIPMode = when {
             Build.VERSION.SDK_INT >= Build.VERSION_CODES.R -> requireActivity().isInPictureInPictureMode
@@ -1418,7 +1459,7 @@ class Media3Fragment : Media3PlayerFragment() {
                     if (!isInPIPMode && player.playWhenReady && viewModel.quality?.name != AUDIO_ONLY_QUALITY) {
                         if (player.currentMediaItem != null) {
                             viewModel.videoOutputState.markDetachedForBackground()
-                            binding.playerSurface.visibility = View.GONE
+                            setVideoOutputVisible(false)
                         }
                     }
                 } else {
@@ -1465,19 +1506,20 @@ class Media3Fragment : Media3PlayerFragment() {
     }
 
     override fun onDestroyView() {
-        logVideoSurfaceBinding("on_destroy_view", player, view?.findViewById(R.id.playerSurface))
+        logVideoSurfaceBinding("on_destroy_view", player, view?.let { videoOutputView })
         detachVideoOutput()
         super.onDestroyView()
     }
 
     private fun attachVideoOutput(currentPlayer: Player) {
-        videoOutputOwner.attach(currentPlayer, binding.playerSurface)
-        logVideoSurfaceBinding("attach", currentPlayer, binding.playerSurface)
+        val target = videoOutputView
+        videoOutputOwner.attach(currentPlayer, target)
+        logVideoSurfaceBinding("attach", currentPlayer, target)
     }
 
     private fun detachVideoOutput() {
         val currentPlayer = videoOutputOwner.attachedPlayer() ?: return
-        logVideoSurfaceBinding("detach", currentPlayer, binding.playerSurface)
+        logVideoSurfaceBinding("detach", currentPlayer, videoOutputView)
         videoOutputOwner.clear()
     }
 

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/VideoOutputPlatform.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/VideoOutputPlatform.kt
@@ -1,0 +1,27 @@
+package com.github.andreyasadchy.xtra.ui.player
+
+import android.os.Build
+import java.util.Locale
+
+internal fun shouldUseTextureViewForVideoOutput(): Boolean {
+    val fingerprint = Build.FINGERPRINT.lowercase(Locale.ROOT)
+    val model = Build.MODEL.lowercase(Locale.ROOT)
+    val manufacturer = Build.MANUFACTURER.lowercase(Locale.ROOT)
+    val brand = Build.BRAND.lowercase(Locale.ROOT)
+    val device = Build.DEVICE.lowercase(Locale.ROOT)
+    val product = Build.PRODUCT.lowercase(Locale.ROOT)
+    val hardware = Build.HARDWARE.lowercase(Locale.ROOT)
+
+    return fingerprint.startsWith("generic") ||
+        fingerprint.contains("emulator") ||
+        model.contains("google_sdk") ||
+        model.contains("emulator") ||
+        model.contains("android sdk built for") ||
+        manufacturer.contains("genymotion") ||
+        hardware.contains("goldfish") ||
+        hardware.contains("ranchu") ||
+        product.contains("sdk_gphone") ||
+        product.contains("google_sdk") ||
+        product.contains("emulator") ||
+        (brand.startsWith("generic") && device.startsWith("generic"))
+}


### PR DESCRIPTION
Use TextureView only on Android emulators to avoid stale video compositor surfaces. Keep SurfaceView on physical devices.