### PR TITLE
Improve update changelog presentation

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/update/UpdateDetailsBottomSheet.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/update/UpdateDetailsBottomSheet.kt
@@ -32,7 +32,6 @@ import com.github.andreyasadchy.xtra.util.updater.UpdateState
 import com.github.andreyasadchy.xtra.util.updater.UpdateVersionDisplay
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
-import io.noties.markwon.Markwon
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 
@@ -41,9 +40,7 @@ class UpdateDetailsBottomSheet : BottomSheetDialogFragment() {
     private val binding get() = _binding!!
     private val repository
         get() = (requireContext().applicationContext as XtraApp).xtraModule.updateRepository
-    private var fullNotesExpanded = false
     private var diagnosticsExpanded = false
-    private val markwon by lazy(LazyThreadSafetyMode.NONE) { Markwon.create(requireContext()) }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         _binding = SheetUpdateDetailsBinding.inflate(inflater, container, false)
@@ -57,10 +54,6 @@ class UpdateDetailsBottomSheet : BottomSheetDialogFragment() {
                 skipCollapsed = true
                 state = BottomSheetBehavior.STATE_EXPANDED
             }
-        }
-        binding.fullNotesButton.setOnClickListener {
-            fullNotesExpanded = !fullNotesExpanded
-            render(repository.state.value)
         }
         binding.diagnosticsButton.setOnClickListener {
             diagnosticsExpanded = !diagnosticsExpanded
@@ -119,9 +112,6 @@ class UpdateDetailsBottomSheet : BottomSheetDialogFragment() {
         binding.earlierChangesButton.visibility = View.GONE
         binding.earlierChangesContainer.visibility = View.GONE
         binding.earlierChangesContainer.removeAllViews()
-        binding.fullNotesButton.visibility = if (!release?.rawBody.isNullOrBlank()) View.VISIBLE else View.GONE
-        binding.fullNotesText.visibility = if (fullNotesExpanded && !release?.rawBody.isNullOrBlank()) View.VISIBLE else View.GONE
-        if (fullNotesExpanded) release?.rawBody?.let { markwon.setMarkdown(binding.fullNotesText, it) }
         binding.diagnosticsButton.visibility = if (model.showDiagnostics) View.VISIBLE else View.GONE
         binding.diagnosticsText.visibility = if (diagnosticsExpanded && model.showDiagnostics) View.VISIBLE else View.GONE
         binding.copyDiagnosticsButton.visibility = if (diagnosticsExpanded && model.showDiagnostics) View.VISIBLE else View.GONE

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/updater/ReleaseNotes.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/updater/ReleaseNotes.kt
@@ -24,6 +24,9 @@ object ReleaseNotes {
     private val conventionalPrefix = Regex("^(feat|feature|add|fix|fixed|perf|performance|improve|improved|update|refactor|chore|docs?)\\s*[:\\-]\\s*", RegexOption.IGNORE_CASE)
     private val whitespace = Regex("\\s+")
     private val generatedChangelog = Regex("^\\**full changelog\\**\\s*:", RegexOption.IGNORE_CASE)
+    private val markdownLink = Regex("\\[([^]]+)]\\(([^()]*(?:\\([^()]*\\)[^()]*)*)\\)")
+    private val asteriskEmphasis = Regex("(\\*{1,3})([^*\\n]+)\\1")
+    private val underscoreEmphasis = Regex("(?<![\\p{L}\\p{N}_])(_{1,3})([^_\\n]+)\\1(?![\\p{L}\\p{N}_])")
 
     fun structured(body: String?, commits: List<String> = emptyList()): StructuredReleaseNotes {
         val lines = body.orEmpty().lineSequence().toList()
@@ -40,7 +43,6 @@ object ReleaseNotes {
                 if (match != null) {
                     val headingText = clean(match.groupValues[1]) ?: return@forEach
                     val headingKind = kindForHeading(headingText)
-                    if (headingKind == ChangeKind.OTHER) items += ChangeItem(headingText, ChangeKind.OTHER)
                     kind = headingKind
                     return@forEach
                 }
@@ -92,6 +94,9 @@ object ReleaseNotes {
         val cleaned = description
             .replace(commitHash, "")
             .replace(Regex("\\s+by\\s+@[\\w-]+.*$", RegexOption.IGNORE_CASE), "")
+            .replace(markdownLink) { it.groupValues[1] }
+            .replace(asteriskEmphasis, "$2")
+            .replace(underscoreEmphasis, "$2")
             .let { value -> conventional?.let { value.removeRange(it.range) } ?: value }
             .trim(' ', '-', ':', '|')
             .replace(whitespace, " ")

--- a/app/src/main/res/layout/sheet_update_details.xml
+++ b/app/src/main/res/layout/sheet_update_details.xml
@@ -100,23 +100,6 @@
                 android:visibility="gone" />
 
             <com.google.android.material.button.MaterialButton
-                android:id="@+id/fullNotesButton"
-                style="@style/Widget.Material3.Button.TextButton"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="4dp"
-                android:text="@string/update_full_release_notes"
-                android:visibility="gone" />
-
-            <TextView
-                android:id="@+id/fullNotesText"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="4dp"
-                android:textAppearance="?attr/textAppearanceBodyMedium"
-                android:visibility="gone" />
-
-            <com.google.android.material.button.MaterialButton
                 android:id="@+id/diagnosticsButton"
                 style="@style/Widget.Material3.Button.TextButton"
                 android:layout_width="wrap_content"

--- a/app/src/test/java/com/github/andreyasadchy/xtra/util/updater/StructuredReleaseNotesTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/util/updater/StructuredReleaseNotesTest.kt
@@ -47,9 +47,7 @@ class StructuredReleaseNotesTest {
     @Test
     fun unknownHeadingsRemainAsOther() {
         val notes = ReleaseNotes.structured("## Notes\n- A note")
-        assertEquals(ChangeKind.OTHER, notes.items.first().kind)
-        assertEquals("Notes", notes.items.first().text)
-        assertEquals("A note", notes.items[1].text)
+        assertEquals(listOf(ChangeItem("A note", ChangeKind.OTHER)), notes.items)
     }
 
     @Test
@@ -84,5 +82,49 @@ class StructuredReleaseNotesTest {
         )
 
         assertEquals(listOf("A useful change"), notes.items.map(ChangeItem::text))
+    }
+
+    @Test
+    fun markdownFormattingAndNonSemanticHeadingsAreRemoved() {
+        val notes = ReleaseNotes.structured(
+            "## Notes\n- **Fixed** [chat rendering](https://example.test/chat)\n- Full Changelog: https://example.test/compare/old...new",
+        )
+
+        assertEquals(listOf("Fixed chat rendering"), notes.items.map(ChangeItem::text))
+        assertEquals(listOf(ChangeKind.FIXED), notes.items.map(ChangeItem::kind))
+    }
+
+    @Test
+    fun markdownEmphasisIsRemovedBeforeClassification() {
+        val notes = ReleaseNotes.structured(
+            "- _Fixed_ one\n- __Fixed__ two\n- *Fixed* three\n- **Fixed** four\n- ***Fixed*** five",
+        )
+
+        assertEquals(
+            listOf("Fixed one", "Fixed two", "Fixed three", "Fixed four", "Fixed five"),
+            notes.items.map(ChangeItem::text),
+        )
+        assertTrue(notes.items.all { it.kind == ChangeKind.FIXED })
+    }
+
+    @Test
+    fun intrawordUnderscoresAndMismatchedEmphasisArePreserved() {
+        val notes = ReleaseNotes.structured(
+            "- Fixed player_buffer_size\n- *foo_",
+        )
+
+        assertEquals(
+            listOf("Fixed player_buffer_size", "*foo_"),
+            notes.items.map(ChangeItem::text),
+        )
+    }
+
+    @Test
+    fun markdownLinksCanContainParentheses() {
+        val notes = ReleaseNotes.structured(
+            "- Read [the docs](https://example.com/foo_(bar))",
+        )
+
+        assertEquals(listOf("Read the docs"), notes.items.map(ChangeItem::text))
     }
 }


### PR DESCRIPTION
Show structured release notes without the raw full changelog view, and clean Markdown formatting and headings while parsing GitHub notes.