### PR TITLE
Preserve settings scroll position

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/settings/MaterialPreferenceFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/settings/MaterialPreferenceFragment.kt
@@ -24,7 +24,7 @@ abstract class MaterialPreferenceFragment : PreferenceFragmentCompat() {
         }
         (requireActivity() as? SettingsActivity)?.getSelectedSearchItem()?.let { key ->
             listView.post { scrollToPreference(key) }
-        } ?: listView.post { listView.scrollToPosition(0) }
+        }
     }
 
     override fun onDisplayPreferenceDialog(preference: Preference) {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/settings/SettingsActivity.kt
@@ -483,7 +483,6 @@ class SettingsActivity : AppCompatActivity() {
             accountRow = ItemSettingsRowBinding.inflate(layoutInflater, binding.accountActions, false)
             binding.accountActions.addView(accountRow!!.root)
             renderAccountRow()
-            binding.scrollView.post { binding.scrollView.scrollTo(0, 0) }
             ViewCompat.setOnApplyWindowInsetsListener(view) { _, windowInsets ->
                 val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars())
                 view.updatePadding(bottom = resources.getDimensionPixelSize(R.dimen.settings_section_spacing) * 2 + insets.bottom)


### PR DESCRIPTION
Keep the current settings scroll position when navigating back within settings. A fresh settings visit still starts at the top.