### PR TITLE
Fix complete updater changelog parsing

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/updater/ReleaseClient.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/updater/ReleaseClient.kt
@@ -42,7 +42,19 @@ class ReleaseClient(
 
     override suspend fun fetch(url: String, networkLibrary: String?): JsonObject {
         return try {
-            val release = fetchJson(url, networkLibrary)
+            var release = fetchJson(url, networkLibrary)
+            release.changelogApiUrl()?.let { changelogUrl ->
+                val changelog = try {
+                    fetchJson(changelogUrl, networkLibrary)
+                } catch (cancellation: CancellationException) {
+                    throw cancellation
+                } catch (_: Throwable) {
+                    null
+                }
+                changelog?.get("commits")?.let { commits ->
+                    release = JsonObject(release + ("commits" to commits))
+                }
+            }
             val metadataUrl = release.metadataUrl()
             if (metadataUrl == null) {
                 release
@@ -154,6 +166,16 @@ class ReleaseClient(
         return "$baseUrl${separator}per_page=$RELEASE_HISTORY_PAGE_SIZE&page=$page"
     }
 }
+
+private val githubChangelog = Regex(
+    "https://github\\.com/([^/]+/[^/]+)/compare/([^\\s)]+)",
+    RegexOption.IGNORE_CASE,
+)
+
+private fun JsonObject.changelogApiUrl(): String? =
+    this["body"]?.jsonPrimitive?.contentOrNull
+        ?.let(githubChangelog::find)
+        ?.let { match -> "https://api.github.com/repos/${match.groupValues[1]}/compare/${match.groupValues[2]}" }
 
 internal const val RELEASE_HISTORY_PAGE_SIZE = 100
 

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/updater/ReleaseNotes.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/updater/ReleaseNotes.kt
@@ -34,11 +34,11 @@ object ReleaseNotes {
             val candidate = it.replace(markdownPrefix, "")
             candidate.isNotBlank() && heading.matchEntire(it) == null && !isNoise(candidate)
         }
-        val source = if (hasUsefulBody) lines else commits
         var kind = ChangeKind.OTHER
         val items = mutableListOf<ChangeItem>()
         fun parseLines(sourceLines: List<String>) {
-            sourceLines.forEach { line ->
+            sourceLines.forEach { sourceLine ->
+                val line = sourceLine.substringBefore('\n')
                 val match = heading.matchEntire(line)
                 if (match != null) {
                     val headingText = clean(match.groupValues[1]) ?: return@forEach
@@ -51,8 +51,11 @@ object ReleaseNotes {
                 items += ChangeItem(parsed.text, finalKind)
             }
         }
-        parseLines(source)
-        if (items.isEmpty() && source !== commits && commits.isNotEmpty()) parseLines(commits)
+        if (hasUsefulBody) parseLines(lines)
+        if (commits.isNotEmpty()) {
+            kind = ChangeKind.OTHER
+            parseLines(commits)
+        }
         return StructuredReleaseNotes(
             items.asSequence()
                 .filterNot { isNoise(it.text) }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/updater/ReleaseParser.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/updater/ReleaseParser.kt
@@ -62,7 +62,12 @@ object ReleaseParser {
                 ?: return ReleaseParseResult.Failure(UpdateError.InvalidResponse)
         }
         val body = response.string("body").orEmpty()
-        val commits = response["commits"]?.asArrayOrNull()?.mapNotNull { it.asObjectString("message") } ?: emptyList()
+        val commits = response["commits"]?.asArrayOrNull()?.mapNotNull { element ->
+            val commit = runCatching { element.jsonObject }.getOrNull() ?: return@mapNotNull null
+            val message = commit["message"]?.jsonPrimitive?.contentOrNull
+                ?: commit["commit"]?.let { runCatching { it.jsonObject["message"]?.jsonPrimitive?.contentOrNull }.getOrNull() }
+            message?.substringBefore('\n')?.trim()?.takeIf { it.isNotBlank() }
+        } ?: emptyList()
         val structuredNotes = ReleaseNotes.structured(body, commits)
         val release = UpdateRelease(
             tagName = tagName,
@@ -105,5 +110,4 @@ object ReleaseParser {
         return entries.toMap()
     }
     private fun JsonElement.asArrayOrNull() = runCatching { jsonArray }.getOrNull()
-    private fun JsonElement.asObjectString(key: String): String? = runCatching { jsonObject[key]?.jsonPrimitive?.contentOrNull }.getOrNull()
 }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/updater/UpdateRepository.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/updater/UpdateRepository.kt
@@ -182,7 +182,7 @@ class UpdateRepository(
                         val release = (parsed as? ReleaseParseResult.Success)?.release
                             ?: throw UpdateException((parsed as ReleaseParseResult.Failure).error, stage = UpdateStage.PARSE)
                         when (val history = fetchReleaseHistory(url, networkLibrary, generation)) {
-                            is ReleaseHistoryResult.Complete -> updateReleaseHistory(history.releases + release)
+                            is ReleaseHistoryResult.Complete -> updateReleaseHistory(listOf(release) + history.releases)
                             is ReleaseHistoryResult.Partial,
                             ReleaseHistoryResult.Unavailable -> markReleaseHistoryIncomplete()
                         }

--- a/app/src/test/java/com/github/andreyasadchy/xtra/util/updater/UpdateDomainTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/util/updater/UpdateDomainTest.kt
@@ -291,6 +291,68 @@ class UpdateDomainTest {
     }
 
     @Test
+    fun githubCompareCommitMessagesUseSubjectsFromNestedCommitObjects() {
+        val response = JsonObject(
+            json.parseToJsonElement(response("v2.58.6", body = "## What's Changed")).jsonObject +
+                ("commits" to buildJsonArray {
+                    add(buildJsonObject {
+                        put("commit", buildJsonObject {
+                            put("message", "Fix player crash\n\nDetailed implementation notes")
+                        })
+                    })
+                }),
+        )
+
+        val result = ReleaseParser.parse(response, "https://example.test/releases/1")
+
+        assertEquals(
+            listOf("Fixed player crash"),
+            (result as ReleaseParseResult.Success).release.releaseNotes,
+        )
+    }
+
+    @Test
+    fun releaseBodyAndCompareSubjectsAreMergedWithoutDuplicateNotes() {
+        assertEquals(
+            listOf("Fixed player crash", "Improved playback recovery"),
+            ReleaseNotes.normalize(
+                body = "* Fix player crash",
+                commits = listOf(
+                    "Fix player crash\n\nDetailed implementation notes",
+                    "Improve playback recovery\n\nMore details",
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun enrichedReleaseWinsWhenPlacedBeforeRawHistoryDuplicate() {
+        val raw = parse("v2.58.6", body = "Fix release body")
+        val enriched = parse(
+            "v2.58.6",
+            body = "Fix release body",
+        ).copy(releaseNotes = listOf("Fixed release body", "Fixed compare-only detail"))
+
+        assertEquals(
+            listOf("Fixed release body", "Fixed compare-only detail"),
+            UpdateReleaseHistory.merge(listOf(enriched, raw))
+                .single()
+                .releaseNotes,
+        )
+    }
+
+    @Test
+    fun compareSubjectsDoNotInheritReleaseBodyHeading() {
+        val notes = ReleaseNotes.structured(
+            body = "## Fixed\n- Fix one bug",
+            commits = listOf("Add new player control"),
+        ).items
+
+        assertEquals(ChangeKind.FIXED, notes[0].kind)
+        assertEquals(ChangeKind.NEW, notes[1].kind)
+    }
+
+    @Test
     fun meaninglessReleaseBodyFallsBackToCommitDescriptions() {
         assertEquals(
             listOf("Fixed chat spacing"),


### PR DESCRIPTION
Show all useful update notes from GitHub releases and their full changelog, with clean commit subjects.