### PR TITLE
Fix crash when scrolling chat history

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatAdapter.kt
@@ -656,11 +656,6 @@ class ChatAdapter(
         pendingAppends = publicationQueue.hasPendingAppends,
     )
 
-    internal fun shouldReconstructNewMessageDivider(
-        dividerPosition: Int?,
-        dividerConsumed: Boolean,
-    ): Boolean = shouldReconstructNewMessageDivider(dividerPosition, dividerConsumed)
-
     private fun promoteReadyRender(message: ChatMessage, configuration: ChatRenderConfiguration) {
         val key = createRenderKey(message, configuration)
         check(cachedRender(key) != null) { "Published chat message has no complete render" }


### PR DESCRIPTION
Scrolling chat to the oldest messages and back could crash the release app. This removes the recursive divider helper wrapper.