### PR TITLE
Fix missing Discover tab and stale live recommendations

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/RecommendationsRepository.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/RecommendationsRepository.kt
@@ -9,6 +9,7 @@ import com.github.andreyasadchy.xtra.model.ui.Stream
 import com.github.andreyasadchy.xtra.repository.auth.AuthSessionStore
 import com.github.andreyasadchy.xtra.repository.auth.PrivateGqlCredential
 import com.github.andreyasadchy.xtra.repository.auth.PrivateGqlCredentialType
+import com.github.andreyasadchy.xtra.repository.streamfeed.StreamFeedFreshnessPolicy
 import com.github.andreyasadchy.xtra.util.C
 import com.github.andreyasadchy.xtra.util.TwitchApiHelper
 import com.github.andreyasadchy.xtra.util.prefs
@@ -52,7 +53,7 @@ class RecommendationsRepository(
         val accountKey = requestContext.accountKey
         cacheMutex.withLock {
             cache
-                ?.takeIf { it.accountKey == accountKey && it.expiresAt > now }
+                ?.takeIf { it.accountKey == accountKey && recommendationCacheIsFresh(now, it.expiresAt) }
                 ?.let { entry ->
                     lastSource = entry.source
                     return RecommendationResult(
@@ -262,9 +263,11 @@ class RecommendationsRepository(
 
     private companion object {
         const val LOG_TAG = "FollowingRecommendations"
-        const val RECOMMENDATIONS_CACHE_MILLIS = 5 * 60 * 1000L
+        const val RECOMMENDATIONS_CACHE_MILLIS = StreamFeedFreshnessPolicy.LIVE_STREAM_SOFT_TTL_MS
     }
 }
+
+internal fun recommendationCacheIsFresh(nowMs: Long, expiresAtMs: Long): Boolean = expiresAtMs > nowMs
 
 private data class RecommendationCache(
     val accountKey: RecommendationAccountKey,

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/discover/DiscoverFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/discover/DiscoverFragment.kt
@@ -209,7 +209,7 @@ class DiscoverFragment : BaseNetworkFragment(), Scrollable {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
                 launch {
                     while (isActive) {
-                        delay(90_000L)
+                        delay(30_000L)
                         if (lifecycle.currentState.isAtLeast(Lifecycle.State.RESUMED)) {
                             viewModel.refresh(RefreshReason.SCREEN_VISIBLE)
                         }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/discover/DiscoverViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/discover/DiscoverViewModel.kt
@@ -96,7 +96,6 @@ class DiscoverViewModel(
         DiscoverSectionState<List<Stream>>(emptyList(), refreshing = true),
     )
     private val recommendationsMutex = Mutex()
-    private var recommendationsLastAttemptAt = 0L
     private var currentTrendingSpec: StreamFeedSpec? = null
     private var lastVisibleRefreshAt = 0L
 
@@ -175,13 +174,14 @@ class DiscoverViewModel(
         ) {
             val now = System.currentTimeMillis()
             if (now - lastVisibleRefreshAt < StreamFeedFreshnessPolicy.VISIBLE_REVALIDATION_INTERVAL_MS) {
+                if (reason == RefreshReason.SCREEN_VISIBLE) refreshRecommendations()
                 return
             }
             lastVisibleRefreshAt = now
         }
         refreshTopStreams(reason, force)
         refreshTopGames(reason, force)
-        refreshRecommendations(force)
+        refreshRecommendations()
         currentTrendingSpec?.let { refreshTrending(it, reason, force) }
     }
 
@@ -221,10 +221,7 @@ class DiscoverViewModel(
         }
     }
 
-    private fun refreshRecommendations(force: Boolean) {
-        val now = System.currentTimeMillis()
-        if (!force && now - recommendationsLastAttemptAt < RECOMMENDATIONS_TTL_MS) return
-        recommendationsLastAttemptAt = now
+    private fun refreshRecommendations() {
         viewModelScope.launch {
             recommendationsMutex.withLock {
                 recommendationsSection.update { it.copy(refreshing = true) }
@@ -355,7 +352,6 @@ class DiscoverViewModel(
         const val KEY_CATEGORIES = "discover_categories"
         private const val STREAM_LIMIT = 12
         private const val CATEGORY_LIMIT = 12
-        private const val RECOMMENDATIONS_TTL_MS = 5 * 60_000L
 
         val Factory = viewModelFactory {
             initializer {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/settings/SettingsActivity.kt
@@ -2044,7 +2044,7 @@ class SettingsActivity : AppCompatActivity() {
                         }
                         list
                     } else defaultTabs
-                }.let(::limitNavigationVisibleItems)
+                }
                 val tabs = tabList.map {
                     val split = it.split(':')
                     SettingsDragListItem(

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/settings/SettingsTabCustomization.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/settings/SettingsTabCustomization.kt
@@ -52,9 +52,7 @@ internal fun maximumVisibleItemsForPreference(preferenceKey: String): Int? =
 internal fun limitNavigationVisibleItems(items: List<String>): List<String> {
     val result = items.toMutableList()
     while (result.count { it.split(':').getOrNull(2) != "0" } > MAX_NAVIGATION_VISIBLE_ITEMS) {
-        val index = result.indexOfLast { it.startsWith("4:") && it.split(':').getOrNull(2) != "0" }
-            .takeIf { it >= 0 }
-            ?: result.indexOfLast { it.split(':').getOrNull(2) != "0" }
+        val index = result.indexOfLast { it.split(':').getOrNull(2) != "0" }
         if (index < 0) break
         val parts = result[index].split(':')
         result[index] = "${parts[0]}:${parts.getOrElse(1) { "0" }}:0"

--- a/app/src/test/java/com/github/andreyasadchy/xtra/repository/RecommendationsAuthTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/repository/RecommendationsAuthTest.kt
@@ -3,6 +3,8 @@ package com.github.andreyasadchy.xtra.repository
 import com.github.andreyasadchy.xtra.repository.auth.PrivateGqlCredential
 import com.github.andreyasadchy.xtra.repository.auth.PrivateGqlCredentialType
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Assert.assertNull
 import org.junit.Test
 
@@ -63,5 +65,11 @@ class RecommendationsAuthTest {
             RecommendationSource.UNAVAILABLE,
             recommendationSourceFor(personalized = null, result = emptyList()),
         )
+    }
+
+    @Test
+    fun liveRecommendationCacheExpiresAtItsDeadline() {
+        assertTrue(recommendationCacheIsFresh(nowMs = 99L, expiresAtMs = 100L))
+        assertFalse(recommendationCacheIsFresh(nowMs = 100L, expiresAtMs = 100L))
     }
 }

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/settings/SettingsActivityTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/settings/SettingsActivityTest.kt
@@ -70,4 +70,23 @@ class SettingsActivityTest {
 
         assertEquals(1, items.count { it.enabled })
     }
+
+    @Test
+    fun navigationLimitKeepsConfiguredItemsInOrder() {
+        val items = listOf(
+            "0:0:1",
+            "4:0:1",
+            "1:1:1",
+            "2:0:1",
+            "3:0:1",
+            "5:0:1",
+            "6:0:1",
+        )
+
+        val limited = limitNavigationVisibleItems(items)
+
+        assertEquals(6, limited.count { it.endsWith(":1") })
+        assertTrue(limited.first { it.startsWith("4:") }.endsWith(":1"))
+        assertTrue(limited.last { it.startsWith("6:") }.endsWith(":0"))
+    }
 }


### PR DESCRIPTION
Keeps an enabled Discover tab visible within the six-item navigation limit and revalidates Discover recommendations on the live-feed cadence so ended streams are not kept as live.