### PR TITLE
Fix automatic update prompt persistence ordering

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/updater/UpdateRepository.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/updater/UpdateRepository.kt
@@ -225,7 +225,6 @@ class UpdateRepository(
                                         }
                                         else -> current
                                     }
-                                    _state.value = finalState
                                     if (automatic && finalState is UpdateState.Available &&
                                         finalState.release.id == selectedRelease.id
                                     ) {
@@ -233,6 +232,11 @@ class UpdateRepository(
                                         preferences.edit()
                                             .putString(C.UPDATE_AUTOMATIC_PROMPT_VERSION, selectedRelease.id)
                                             .commit()
+                                    }
+                                    _state.value = finalState
+                                    if (automatic && finalState is UpdateState.Available &&
+                                        finalState.release.id == selectedRelease.id
+                                    ) {
                                         _automaticPromptEvents.tryEmit(selectedRelease)
                                         if (!foregroundChecker()) {
                                             postUpdateAvailableNotification(selectedRelease)


### PR DESCRIPTION
Persist the automatic update prompt marker before publishing the available state, so lifecycle observers cannot observe an update before its marker is durable.