### PR TITLE
Wire live chat through chat-v2

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/XtraModule.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/XtraModule.kt
@@ -49,6 +49,22 @@ import com.github.andreyasadchy.xtra.repository.gamefeed.GameFeedRefreshCoordina
 import com.github.andreyasadchy.xtra.ui.common.StreamPreviewCoordinator
 import com.github.andreyasadchy.xtra.ui.player.PlaybackPersistence
 import com.github.andreyasadchy.xtra.ui.player.captions.LiveCaptionManager
+import com.github.andreyasadchy.xtra.ui.chat.v2.assets.ChatAssetLoader
+import com.github.andreyasadchy.xtra.ui.chat.v2.assets.ChatAssetRepository
+import com.github.andreyasadchy.xtra.ui.chat.v2.assets.CoilChatAssetLoader
+import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatCatalogRepository
+import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.TwitchChatCatalogCache
+import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.TwitchChatCatalogSource
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatEvent
+import com.github.andreyasadchy.xtra.ui.chat.v2.session.ChatSessionManager
+import com.github.andreyasadchy.xtra.ui.chat.v2.session.LiveChatSessionSpec
+import com.github.andreyasadchy.xtra.ui.chat.v2.transport.TwitchChatEventParser
+import com.github.andreyasadchy.xtra.ui.chat.v2.transport.TwitchChatTransport
+import com.github.andreyasadchy.xtra.ui.chat.v2.transport.TwitchChatTransportConfig
+import com.github.andreyasadchy.xtra.util.C
+import com.github.andreyasadchy.xtra.util.TwitchApiHelper
+import com.github.andreyasadchy.xtra.util.prefs
+import com.github.andreyasadchy.xtra.util.tokenPrefs
 import com.github.andreyasadchy.xtra.util.viewingstats.ViewingStatsRecorder
 import com.github.andreyasadchy.xtra.util.updater.ReleaseClient
 import com.github.andreyasadchy.xtra.util.updater.UpdateRepository
@@ -638,5 +654,96 @@ class XtraModule(application: Application) {
 
     val viewingStatsRecorder by lazy {
         ViewingStatsRecorder(viewingStatsRepository)
+    }
+
+    val chatAssetLoader: ChatAssetLoader by lazy {
+        CoilChatAssetLoader(application.applicationContext)
+    }
+
+    /** Process-owned, bounded asset state shared by disposable chat renderers. */
+    val chatAssetRepository by lazy {
+        ChatAssetRepository(
+            scope = (application as XtraApp).applicationScope,
+            loader = chatAssetLoader,
+        )
+    }
+
+    /** Process-owned live chat entry point. ChatFragment only observes its active handle. */
+    val chatSessionManager by lazy {
+        val appContext = application.applicationContext
+        ChatSessionManager(
+            parentScope = (application as XtraApp).applicationScope,
+            transportFactory = { spec: LiveChatSessionSpec ->
+                val scopes = appContext.tokenPrefs().getString(C.TOKEN_SCOPES, null)
+                    .orEmpty().split(Regex("\\s+")).filter(String::isNotBlank).toSet()
+                val accountId = appContext.tokenPrefs().getString(C.USER_ID, null)
+                val helixHeaders = TwitchApiHelper.getHelixHeaders(appContext)
+                val network = appContext.prefs().getString(C.NETWORK_LIBRARY, C.OKHTTP)
+                TwitchChatTransport(
+                    config = TwitchChatTransportConfig(
+                        channelId = spec.channelId,
+                        channelLogin = spec.channelLogin,
+                        useEventSub = !accountId.isNullOrBlank() &&
+                                "user:read:chat" in scopes && "user:write:chat" in scopes &&
+                                !helixHeaders[C.HEADER_TOKEN].isNullOrBlank(),
+                        accountId = accountId,
+                        helixHeaders = helixHeaders,
+                        networkLibrary = network,
+                    ),
+                    trustManager = trustManager,
+                    createSubscription = { headers, userId, type, sessionId ->
+                        helixRepository.createEventSubSubscription(
+                            network, headers, userId, spec.channelId, type, sessionId,
+                        )?.let { error("EventSub $type rejected: $it") }
+                    },
+                )
+            },
+            catalogFactory = { spec, scope ->
+                ChatCatalogRepository(
+                    scope = scope,
+                    source = TwitchChatCatalogSource(appContext, playerRepository, spec.channelId, spec.channelLogin),
+                    cache = TwitchChatCatalogCache(appContext, spec.channelId),
+                )
+            },
+            recentHistory = { spec ->
+                val url = spec.recentMessagesUrl ?: return@ChatSessionManager emptyList()
+                val network = appContext.prefs().getString(C.NETWORK_LIBRARY, C.OKHTTP)
+                playerRepository.loadRecentMessages(network, url, spec.channelLogin, "100")
+                    .messages.asSequence()
+                    .mapNotNull { raw ->
+                        TwitchChatEventParser.fromIrc(
+                            com.github.andreyasadchy.xtra.util.chat.ChatUtils.parseIRCMessage(raw),
+                            spec.channelId,
+                        )
+                    }
+                    .mapNotNull { (it as? com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatEvent.Message)?.message }
+                    .toList()
+            },
+            initialSettings = { spec ->
+                val userId = appContext.tokenPrefs().getString(C.USER_ID, null)
+                val headers = TwitchApiHelper.getHelixHeaders(appContext)
+                if (userId.isNullOrBlank() || headers[C.HEADER_TOKEN].isNullOrBlank()) {
+                    null
+                } else {
+                    helixRepository.getChatSettings(
+                        networkLibrary = appContext.prefs().getString(C.NETWORK_LIBRARY, C.OKHTTP),
+                        headers = headers,
+                        broadcasterId = spec.channelId,
+                        moderatorId = userId,
+                    )?.let { settings ->
+                        ChatEvent.SettingsUpdated(
+                            channelId = spec.channelId,
+                            slowModeSeconds = settings.slowModeWaitTime.takeIf { settings.slowMode },
+                            followerOnlyDurationMinutes = settings.followerModeDuration.takeIf { settings.followerMode },
+                            subscriberOnly = settings.subscriberMode,
+                            emoteOnly = settings.emoteMode,
+                            uniqueChatMode = settings.uniqueChatMode,
+                            eventId = null,
+                            receivedAtMs = System.currentTimeMillis(),
+                        )
+                    }
+                }
+            },
+        )
     }
 }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatFragment.kt
@@ -48,6 +48,7 @@ import coil3.request.target
 import coil3.request.transformations
 import coil3.transform.CircleCropTransformation
 import com.github.andreyasadchy.xtra.R
+import com.github.andreyasadchy.xtra.XtraApp
 import com.github.andreyasadchy.xtra.databinding.FragmentChatBinding
 import com.github.andreyasadchy.xtra.model.chat.Badge
 import com.github.andreyasadchy.xtra.model.chat.ChatMessage
@@ -69,6 +70,10 @@ import com.github.andreyasadchy.xtra.model.ui.WatchStreakShareResult
 import com.github.andreyasadchy.xtra.ui.channel.ChannelPagerFragmentDirections
 import com.github.andreyasadchy.xtra.ui.chat.ChatViewModel.Companion.ChatViewModelFactory
 import com.github.andreyasadchy.xtra.ui.common.BaseNetworkFragment
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessageId
+import com.github.andreyasadchy.xtra.ui.chat.v2.session.LiveChatSessionSpec
+import com.github.andreyasadchy.xtra.ui.chat.v2.ui.ChatV2RendererController
+import com.github.andreyasadchy.xtra.ui.chat.v2.ui.ChatViewportState
 import com.github.andreyasadchy.xtra.ui.main.MainActivity
 import com.github.andreyasadchy.xtra.ui.multiview.MultiviewFragment
 import com.github.andreyasadchy.xtra.ui.player.Media3PlayerFragment
@@ -113,6 +118,10 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
     private val binding get() = _binding!!
     private val viewModel: ChatViewModel by viewModels { ChatViewModelFactory }
     private var adapter: ChatAdapter? = null
+    private var chatV2Renderer: ChatV2RendererController? = null
+    private var chatV2ViewportState = ChatViewportState()
+    private var useChatV2 = false
+    private var chatV2RendererVisible = true
 
     var chatMessageListener: ((ChatMessage) -> Unit)? = null
     var chatHistoryListener: ((List<ChatMessage>) -> Unit)? = null
@@ -423,6 +432,8 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        chatV2ViewportState = restoreChatV2ViewportState(savedInstanceState)
+        useChatV2 = false
         seenPinnedMessageId = savedInstanceState?.getString(KEY_SEEN_PINNED_MESSAGE_ID)
         displayedPinnedMessageId = savedInstanceState?.getString(KEY_DISPLAYED_PINNED_MESSAGE_ID)
         pinnedMessageMinimized = savedInstanceState?.getBoolean(KEY_PINNED_MESSAGE_MINIMIZED) ?: false
@@ -448,7 +459,7 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
         viewLifecycleOwner.lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.connectionState.collectLatest { state ->
-                    val showConnectionStatus = state == ChatViewModel.ConnectionState.RECONNECTING
+                    val showConnectionStatus = !useChatV2 && state == ChatViewModel.ConnectionState.RECONNECTING
                     binding.connectionStatus.isVisible = showConnectionStatus
                     if (showConnectionStatus) {
                         binding.connectionStatusText.setText(R.string.chat_reconnecting)
@@ -525,6 +536,11 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
                 val channelId = args.getString(KEY_CHANNEL_ID)
                 val channelLogin = args.getString(KEY_CHANNEL_LOGIN)
                 val isLive = args.getBoolean(KEY_IS_LIVE)
+                useChatV2 = isLive &&
+                        !channelId.isNullOrBlank() &&
+                        !channelLogin.isNullOrBlank() &&
+                        parentFragment !is MultiviewFragment &&
+                        requireContext().prefs().getBoolean(C.CHAT_V2_ENABLED, true)
                 val accountLogin = requireContext().tokenPrefs().getString(C.USERNAME, null)
                 val isLoggedIn = !accountLogin.isNullOrBlank() &&
                         (!TwitchApiHelper.getGQLHeaders(requireContext(), true)[C.HEADER_TOKEN].isNullOrBlank() ||
@@ -536,8 +552,11 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
                             isLoggedIn
                     messagingEnabled = enableMessaging
                     val sizeModifier = (requireContext().prefs().getInt(C.CHAT_SIZE_MODIFIER, 100).toFloat() / 100f)
-                    val chatSnapshot = viewModel.chatSnapshot().also { chatMutationRevision = it.revision }
-                    val initialMessages = chatSnapshot.messages
+                    val initialMessages = if (useChatV2) {
+                        emptyList()
+                    } else {
+                        viewModel.chatSnapshot().also { chatMutationRevision = it.revision }.messages
+                    }
                     adapter = ChatAdapter(
                         // The initial snapshot is rendered off-main before the adapter is attached.
                         // This prevents RecyclerView from ever binding an uncached message.
@@ -618,12 +637,56 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
                         },
                     )
                     adapter?.onMessagesPublished = ::onChatMessagesPublished
+                    if (useChatV2) {
+                        val app = requireContext().applicationContext as XtraApp
+                        val chatBackground = MaterialColors.getColor(
+                            requireView(),
+                            com.google.android.material.R.attr.colorSurface,
+                        )
+                        val emoteHeight = TypedValue.applyDimension(
+                            TypedValue.COMPLEX_UNIT_DIP,
+                            (requireContext().prefs().getString(C.CHAT_EMOTE_SIZE, "29.5")?.toFloatOrNull() ?: 29.5f) * sizeModifier,
+                            resources.displayMetrics,
+                        ).toInt().coerceAtLeast(1)
+                        chatV2Renderer = ChatV2RendererController(
+                            recyclerView = recyclerView,
+                            manager = app.xtraModule.chatSessionManager,
+                            assets = app.xtraModule.chatAssetRepository,
+                            expectedChannelId = channelId!!,
+                            expectedChannelLogin = channelLogin!!,
+                            initialState = chatV2ViewportState,
+                            emoteHeightPx = emoteHeight,
+                            badgeHeightPx = TypedValue.applyDimension(
+                                TypedValue.COMPLEX_UNIT_DIP,
+                                chatBadgeSizeOrDefault(
+                                    requireContext().prefs().getString(
+                                        C.CHAT_BADGE_SIZE,
+                                        DEFAULT_CHAT_BADGE_SIZE_DP.toString(),
+                                    ),
+                                ) * sizeModifier,
+                                resources.displayMetrics,
+                            ).toInt().coerceAtLeast(1),
+                            showTimestamps = requireContext().prefs().getBoolean(C.CHAT_TIMESTAMPS, false),
+                            readableUsernameColors = requireContext().prefs().getBoolean(C.CHAT_THEME_ADAPTED_USERNAME_COLOR, true),
+                            backgroundColor = chatBackground,
+                            onStateChanged = { state ->
+                                btnDown.isVisible = state.followMode == com.github.andreyasadchy.xtra.ui.chat.v2.ui.FollowMode.USER_SCROLLED_UP
+                            },
+                        ).also {
+                            it.setVisible(chatV2RendererVisible)
+                            it.attach(viewLifecycleOwner)
+                        }
+                    }
                     recyclerView.let {
                         it.itemAnimator = null
                         it.layoutManager = LinearLayoutManager(context).apply { stackFromEnd = true }
                         it.addOnScrollListener(object : RecyclerView.OnScrollListener() {
                             override fun onScrollStateChanged(recyclerView: RecyclerView, newState: Int) {
                                 super.onScrollStateChanged(recyclerView, newState)
+                                if (useChatV2) {
+                                    chatV2Renderer?.onUserScroll()
+                                    return
+                                }
                                 if (newState == RecyclerView.SCROLL_STATE_DRAGGING) {
                                     // Programmatic scrolls caused by publication enter SETTLING,
                                     // not DRAGGING. Only a real user drag invalidates a staged
@@ -664,7 +727,7 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
                     }
                     val chatAdapter = adapter
                     viewLifecycleOwner.lifecycleScope.launch {
-                        if (_binding?.recyclerView === recyclerView && chatAdapter === adapter) {
+                        if (!useChatV2 && _binding?.recyclerView === recyclerView && chatAdapter === adapter) {
                             recyclerView.adapter = chatAdapter
                             chatAdapterReady = true
                             pendingChatPublicationFollowBottom = !recyclerView.canScrollVertically(1)
@@ -686,8 +749,12 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
                     }
                     btnDown.setOnClickListener {
                         view.post {
-                            val lastIndex = adapter?.itemCount?.minus(1) ?: RecyclerView.NO_POSITION
-                            recyclerView.scrollToPosition(lastIndex)
+                            if (useChatV2) {
+                                chatV2Renderer?.jumpToNewest()
+                            } else {
+                                val lastIndex = adapter?.itemCount?.minus(1) ?: RecyclerView.NO_POSITION
+                                recyclerView.scrollToPosition(lastIndex)
+                            }
                             it.visibility = View.GONE
                         }
                     }
@@ -1043,55 +1110,59 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
                             }
                         }
                     }
-                    viewLifecycleOwner.lifecycleScope.launch {
-                        repeatOnLifecycle(Lifecycle.State.STARTED) {
-                            synchronizeChatAdapterToSnapshot()
-                            viewModel.chatMutations.collect { mutation ->
-                                if (chatSnapshotSyncPending) {
-                                    dispatchChatMutationSideEffects(mutation)
-                                    return@collect
-                                }
-
-                                val expectedRevision = expectedChatMutationRevision()
-                                when (chatMutationAction(expectedRevision, mutation.revision)) {
-                                    ChatMutationAction.IGNORE -> return@collect
-                                    ChatMutationAction.SYNCHRONIZE_SNAPSHOT -> {
-                                        chatMutationGapCount++
-                                        Log.d(
-                                            "ChatPerf",
-                                            "mutation gap count=$chatMutationGapCount " +
-                                                "displayed=$chatMutationRevision " +
-                                                "expected=$expectedRevision " +
-                                                "incoming=${mutation.revision}",
-                                        )
-                                        pendingChatMutations.clear()
-                                        if (chatAdapterReady && !isChatTouched) {
-                                            synchronizeChatAdapterToSnapshot()
-                                        } else {
-                                            chatSnapshotSyncPending = true
-                                        }
+                    if (!useChatV2) {
+                        viewLifecycleOwner.lifecycleScope.launch {
+                            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                                synchronizeChatAdapterToSnapshot()
+                                viewModel.chatMutations.collect { mutation ->
+                                    if (chatSnapshotSyncPending) {
+                                        dispatchChatMutationSideEffects(mutation)
                                         return@collect
                                     }
-                                    ChatMutationAction.APPLY_INCREMENTAL -> Unit
-                                }
-                                dispatchChatMutationSideEffects(mutation)
 
-                                if (isChatTouched) {
-                                    pendingChatMutations.clear()
-                                    chatSnapshotSyncPending = true
-                                    return@collect
-                                }
+                                    val expectedRevision = expectedChatMutationRevision()
+                                    when (chatMutationAction(expectedRevision, mutation.revision)) {
+                                        ChatMutationAction.IGNORE -> return@collect
+                                        ChatMutationAction.SYNCHRONIZE_SNAPSHOT -> {
+                                            chatMutationGapCount++
+                                            Log.d(
+                                                "ChatPerf",
+                                                "mutation gap count=$chatMutationGapCount " +
+                                                    "displayed=$chatMutationRevision " +
+                                                    "expected=$expectedRevision " +
+                                                    "incoming=${mutation.revision}",
+                                            )
+                                            pendingChatMutations.clear()
+                                            if (chatAdapterReady && !isChatTouched) {
+                                                synchronizeChatAdapterToSnapshot()
+                                            } else {
+                                                chatSnapshotSyncPending = true
+                                            }
+                                            return@collect
+                                        }
+                                        ChatMutationAction.APPLY_INCREMENTAL -> Unit
+                                    }
+                                    dispatchChatMutationSideEffects(mutation)
 
-                                pendingChatMutations.addLast(mutation)
-                                scheduleChatAdapterUpdate()
+                                    if (isChatTouched) {
+                                        pendingChatMutations.clear()
+                                        chatSnapshotSyncPending = true
+                                        return@collect
+                                    }
+
+                                    pendingChatMutations.addLast(mutation)
+                                    scheduleChatAdapterUpdate()
+                                }
                             }
                         }
                     }
                     viewLifecycleOwner.lifecycleScope.launch {
                         repeatOnLifecycle(Lifecycle.State.STARTED) {
                             viewModel.updateUserMessages.collectLatest { userId ->
-                                adapter?.let { adapter ->
-                                    adapter.notifyUserMessages(userId)
+                                if (!useChatV2) {
+                                    adapter?.let { adapter ->
+                                        adapter.notifyUserMessages(userId)
+                                    }
                                 }
                                 messageDialog?.updateUserMessages(userId)
                                 replyDialog?.updateUserMessages(userId)
@@ -1252,6 +1323,24 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
     private fun currentLiveStreamId(): String? =
         resolveCurrentLiveStreamId(viewModel.streamId, requireArguments().getString(KEY_STREAM_ID))
 
+    /** Requests a process/playback-owned session; this Fragment never owns its lifetime. */
+    private fun startChatV2Session(channelId: String, channelLogin: String) {
+        val app = requireContext().applicationContext as XtraApp
+        app.applicationScope.launch {
+            runCatching {
+                app.xtraModule.chatSessionManager.start(
+                    LiveChatSessionSpec(
+                        channelId = channelId,
+                        channelLogin = channelLogin,
+                        recentMessagesUrl = "https://recent-messages.robotty.de/api/v2/recent-messages/\$channel",
+                    ),
+                )
+            }.onFailure { error ->
+                Log.e("ChatV2", "Unable to start live v2 chat", error)
+            }
+        }
+    }
+
     override fun initialize() {
         if (requireContext().prefs().isChatEnabled()) {
             val args = requireArguments()
@@ -1259,6 +1348,9 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
             val channelLogin = args.getString(KEY_CHANNEL_LOGIN)
             when (val mode = viewModel.activeChatMode) {
                 ChatViewModel.ActiveChatMode.Live -> if (args.getBoolean(KEY_IS_LIVE)) {
+                    if (useChatV2 && channelId != null && channelLogin != null) {
+                        startChatV2Session(channelId, channelLogin)
+                    }
                     viewModel.startLive(
                         requireContext().prefs().getString(C.NETWORK_LIBRARY, C.OKHTTP),
                         "https://recent-messages.robotty.de/api/v2/recent-messages/\$channel",
@@ -1266,6 +1358,7 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
                         channelLogin,
                         args.getString(KEY_CHANNEL_NAME),
                         currentLiveStreamId(),
+                        useChatV2 = useChatV2,
                     )
                 }
                 is ChatViewModel.ActiveChatMode.VideoReplay -> {
@@ -1299,6 +1392,7 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
 
     override fun onResume() {
         super.onResume()
+        if (useChatV2 && chatV2RendererVisible) chatV2Renderer?.setVisible(true)
         val args = requireArguments()
         val channelId = args.getString(KEY_CHANNEL_ID)
         val channelLogin = args.getString(KEY_CHANNEL_LOGIN)
@@ -1348,11 +1442,42 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
     }
 
     fun isActive(): Boolean? {
+        if (useChatV2) {
+            val app = requireContext().applicationContext as XtraApp
+            return app.xtraModule.chatSessionManager.active.value?.let { active ->
+                active.spec.channelId == requireArguments().getString(KEY_CHANNEL_ID) && active.session.isActive
+            }
+        }
         return viewModel.isActive()
     }
 
     fun disconnect() {
-        viewModel.disconnect()
+        if (useChatV2) {
+            val app = requireContext().applicationContext as XtraApp
+            val active = app.xtraModule.chatSessionManager.active.value
+                ?.takeIf { it.spec.channelId == requireArguments().getString(KEY_CHANNEL_ID) }
+            active?.let { matching ->
+                app.applicationScope.launch {
+                    app.xtraModule.chatSessionManager.stop(matching.key)
+                    // v2 owns message ingress, but this ViewModel still owns ancillary live
+                    // features during the migration. Stop those only when playback explicitly
+                    // closes; Fragment/view disappearance must not reach this branch.
+                    viewModel.stopLiveChat()
+                }
+            }
+        } else {
+            viewModel.disconnect()
+        }
+    }
+
+    override fun onPause() {
+        if (useChatV2) chatV2Renderer?.setVisible(false)
+        super.onPause()
+    }
+
+    fun setV2RendererVisible(visible: Boolean) {
+        chatV2RendererVisible = visible
+        if (useChatV2) chatV2Renderer?.setVisible(visible)
     }
 
     fun reconnect() {
@@ -1371,23 +1496,34 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
             return
         }
         if (channelLogin != null) {
-            viewModel.startLive(
-                networkLibrary = requireContext().prefs().getString(C.NETWORK_LIBRARY, C.OKHTTP),
-                recentMessagesUrl = "https://recent-messages.robotty.de/api/v2/recent-messages/\$channel",
-                channelId = requireArguments().getString(KEY_CHANNEL_ID),
-                channelLogin = channelLogin,
-                channelName = requireArguments().getString(KEY_CHANNEL_NAME),
-                streamId = currentLiveStreamId(),
-            )
+            if (useChatV2) {
+                requireArguments().getString(KEY_CHANNEL_ID)?.let { channelId ->
+                    startChatV2Session(channelId, channelLogin)
+                }
+            } else {
+                viewModel.startLive(
+                    networkLibrary = requireContext().prefs().getString(C.NETWORK_LIBRARY, C.OKHTTP),
+                    recentMessagesUrl = "https://recent-messages.robotty.de/api/v2/recent-messages/\$channel",
+                    channelId = requireArguments().getString(KEY_CHANNEL_ID),
+                    channelLogin = channelLogin,
+                    channelName = requireArguments().getString(KEY_CHANNEL_NAME),
+                    streamId = currentLiveStreamId(),
+                )
+            }
         }
         viewModel.autoReconnect = true
     }
 
     fun reloadEmotes() {
-        viewModel.reloadEmotes(
-            requireArguments().getString(KEY_CHANNEL_ID),
-            requireArguments().getString(KEY_CHANNEL_LOGIN)
-        )
+        if (useChatV2) {
+            val app = requireContext().applicationContext as XtraApp
+            app.xtraModule.chatSessionManager.active.value?.catalog?.refresh()
+        } else {
+            viewModel.reloadEmotes(
+                requireArguments().getString(KEY_CHANNEL_ID),
+                requireArguments().getString(KEY_CHANNEL_LOGIN)
+            )
+        }
     }
 
     fun startReplayChatLoad() {
@@ -2318,13 +2454,18 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
     override fun onStop() {
         chatIdentityPopup?.dismiss()
         super.onStop()
-        if (!requireArguments().getBoolean(KEY_IS_LIVE) || !requireContext().prefs().getBoolean(C.PLAYER_KEEP_CHAT_OPEN, false)) {
+        if (!useChatV2 && (!requireArguments().getBoolean(KEY_IS_LIVE) || !requireContext().prefs().getBoolean(C.PLAYER_KEEP_CHAT_OPEN, false))) {
             viewModel.stopLiveChat()
             viewModel.stopReplayChat()
         }
     }
 
     override fun onSaveInstanceState(outState: Bundle) {
+        chatV2ViewportState = chatV2Renderer?.state ?: chatV2ViewportState
+        outState.putString(KEY_V2_FOLLOW_MODE, chatV2ViewportState.followMode.name)
+        outState.putInt(KEY_V2_NEW_MESSAGE_COUNT, chatV2ViewportState.newMessageCount)
+        outState.putString(KEY_V2_ANCHOR_ID, chatV2ViewportState.anchor?.messageId?.value)
+        outState.putInt(KEY_V2_ANCHOR_OFFSET, chatV2ViewportState.anchor?.topOffsetPx ?: 0)
         outState.putString(KEY_COMPOSER_DRAFT, _binding?.editText?.text?.toString())
         outState.putString(KEY_SEEN_PINNED_MESSAGE_ID, seenPinnedMessageId)
         outState.putString(KEY_DISPLAYED_PINNED_MESSAGE_ID, displayedPinnedMessageId)
@@ -2333,6 +2474,9 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
     }
 
     override fun onDestroyView() {
+        chatV2ViewportState = chatV2Renderer?.state ?: chatV2ViewportState
+        chatV2Renderer?.detach()
+        chatV2Renderer = null
         chatIdentityPopup?.dismiss()
         chatIdentityPopup = null
         chatIdentityBadgeRequest?.dispose()
@@ -2470,6 +2614,26 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
         }
     }
 
+    private fun restoreChatV2ViewportState(savedState: Bundle?): ChatViewportState {
+        if (savedState == null) return ChatViewportState()
+        val followMode = runCatching {
+            com.github.andreyasadchy.xtra.ui.chat.v2.ui.FollowMode.valueOf(
+                savedState.getString(KEY_V2_FOLLOW_MODE).orEmpty(),
+            )
+        }.getOrDefault(com.github.andreyasadchy.xtra.ui.chat.v2.ui.FollowMode.FOLLOWING_BOTTOM)
+        val anchorId = savedState.getString(KEY_V2_ANCHOR_ID)?.takeIf { it.isNotBlank() }
+        return ChatViewportState(
+            followMode = followMode,
+            newMessageCount = savedState.getInt(KEY_V2_NEW_MESSAGE_COUNT, 0),
+            anchor = anchorId?.let {
+                com.github.andreyasadchy.xtra.ui.chat.v2.ui.ChatViewportAnchor(
+                    messageId = ChatMessageId(it),
+                    topOffsetPx = savedState.getInt(KEY_V2_ANCHOR_OFFSET, 0),
+                )
+            },
+        )
+    }
+
     companion object {
         private const val KEY_IS_LIVE = "isLive"
         private const val KEY_CHANNEL_ID = "channel_id"
@@ -2484,6 +2648,10 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
         private const val KEY_SEEN_PINNED_MESSAGE_ID = "seenPinnedMessageId"
         private const val KEY_DISPLAYED_PINNED_MESSAGE_ID = "displayedPinnedMessageId"
         private const val KEY_PINNED_MESSAGE_MINIMIZED = "pinnedMessageMinimized"
+        private const val KEY_V2_FOLLOW_MODE = "chatV2FollowMode"
+        private const val KEY_V2_NEW_MESSAGE_COUNT = "chatV2NewMessageCount"
+        private const val KEY_V2_ANCHOR_ID = "chatV2AnchorId"
+        private const val KEY_V2_ANCHOR_OFFSET = "chatV2AnchorOffset"
 
         fun newInstance(
             channelId: String?,

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatViewModel.kt
@@ -298,6 +298,10 @@ class ChatViewModel(
     private var liveChatInitialized = false
     private var activeChannelId: String? = null
     private var activeChannelLogin: String? = null
+    // v2 owns the message transport and canonical timeline. This marker keeps
+    // ancillary live-chat services from being restarted on every view reattach.
+    private var v2LiveChannelId: String? = null
+    private var v2LiveChannelLogin: String? = null
     private var loggedInUserId: String? = null
     private var loggedInUserLogin: String? = null
     private val chatIdentityCache = mutableMapOf<String, CachedChatIdentity>()
@@ -658,22 +662,30 @@ class ChatViewModel(
         channelName: String?,
         streamId: String?,
         readOnly: Boolean = false,
+        useChatV2: Boolean = false,
     ) {
         activeChatMode = ActiveChatMode.Live
         if (chatReadIRCSocket == null && chatReadWebSocket == null && eventSub == null && channelLogin != null) {
+            if (useChatV2 && channelId.isNullOrBlank()) return
+            if (useChatV2 && v2LiveChannelId == channelId && v2LiveChannelLogin == channelLogin && started) return
             messageLimit = 600
             this.streamId = streamId
-            startLiveChat(channelId, channelLogin, readOnly = readOnly)
-            addChatter(channelName)
-            loadEmotes(channelId, channelLogin)
-            if (applicationContext.prefs().getBoolean(C.CHAT_RECENT, true)) {
-                loadRecentMessages(networkLibrary, recentMessagesUrl, channelLogin)
-            }
-            val isLoggedIn = !applicationContext.tokenPrefs().getString(C.USERNAME, null).isNullOrBlank() &&
-                    (!TwitchApiHelper.getGQLHeaders(applicationContext, true)[C.HEADER_TOKEN].isNullOrBlank() ||
-                            !TwitchApiHelper.getHelixHeaders(applicationContext)[C.HEADER_TOKEN].isNullOrBlank())
-            if (isLoggedIn) {
-                loadUserEmotes(channelId)
+            startLiveChat(channelId, channelLogin, readOnly = readOnly, startMessageTransport = !useChatV2)
+            if (useChatV2) {
+                v2LiveChannelId = channelId
+                v2LiveChannelLogin = channelLogin
+            } else {
+                addChatter(channelName)
+                loadEmotes(channelId, channelLogin)
+                if (applicationContext.prefs().getBoolean(C.CHAT_RECENT, true)) {
+                    loadRecentMessages(networkLibrary, recentMessagesUrl, channelLogin)
+                }
+                val isLoggedIn = !applicationContext.tokenPrefs().getString(C.USERNAME, null).isNullOrBlank() &&
+                        (!TwitchApiHelper.getGQLHeaders(applicationContext, true)[C.HEADER_TOKEN].isNullOrBlank() ||
+                                !TwitchApiHelper.getHelixHeaders(applicationContext)[C.HEADER_TOKEN].isNullOrBlank())
+                if (isLoggedIn) {
+                    loadUserEmotes(channelId)
+                }
             }
         }
     }
@@ -693,12 +705,14 @@ class ChatViewModel(
 
     fun resumeLive(channelId: String?, channelLogin: String?) {
         val login = channelLogin ?: return
+        if (v2LiveChannelId == channelId && v2LiveChannelLogin == login) return
         if (shouldResumeLiveChat(liveChatInitialized, chatReadJob?.isActive, login, autoReconnect)) {
             startLiveChat(channelId, login, readOnly = liveChatReadOnly)
         }
     }
 
     fun retryLiveChat() {
+        if (v2LiveChannelId != null) return
         val channelId = activeChannelId
         val channelLogin = activeChannelLogin
         if (!channelLogin.isNullOrBlank()) {
@@ -2533,6 +2547,7 @@ class ChatViewModel(
         channelId: String?,
         channelLogin: String,
         readOnly: Boolean = liveChatReadOnly,
+        startMessageTransport: Boolean = true,
     ) {
         liveChatInitialized = true
         stopLiveChat()
@@ -2616,23 +2631,25 @@ class ChatViewModel(
             loadWatchStreak(networkLibrary, gqlHeaders, channelId)
             startWatchStreakRefresh(networkLibrary, gqlHeaders, channelId)
         }
-        if (applicationContext.prefs().getBoolean(C.DEBUG_EVENT_SUB_CHAT, false) && !helixHeaders[C.HEADER_TOKEN].isNullOrBlank()) {
-            eventSub = EventSubWebSocket(trustManager, EventSubListener(helixHeaders, gqlHeaders, channelLogin, showUserNotice, showClearChat, usePubSub, networkLibrary, isLoggedIn, accountId, channelId))
-            chatReadJob = eventSub?.connect(viewModelScope)
-        } else {
-            val gqlToken = gqlHeaders[C.HEADER_TOKEN]?.removePrefix("OAuth ")
-            val helixToken = helixHeaders[C.HEADER_TOKEN]?.removePrefix("Bearer ")
-            chatReadWebSocket = ChatReadWebSocket(channelLogin, trustManager, ChatReadListener(channelLogin, nameDisplay, showUserNotice, showClearMsg, showClearChat, usePubSub, networkLibrary, gqlHeaders, isLoggedIn, accountId, channelId))
-            chatReadJob = chatReadWebSocket?.connect(viewModelScope)
-            if (!readOnly && isLoggedIn && (!gqlToken.isNullOrBlank() || !helixHeaders[C.HEADER_TOKEN].isNullOrBlank() && !useApiChatMessages)) {
-                chatWriteWebSocket = ChatWriteWebSocket(
-                    userLogin = accountLogin,
-                    userToken = gqlToken?.takeIf { it.isNotBlank() } ?: helixToken,
-                    channelLogin = channelLogin,
-                    trustManager = trustManager,
-                    listener = ChatWriteListener(channelId, showWebSocketDebugInfo)
-                )
-                chatWriteJob = chatWriteWebSocket?.connect(viewModelScope)
+        if (startMessageTransport) {
+            if (applicationContext.prefs().getBoolean(C.DEBUG_EVENT_SUB_CHAT, false) && !helixHeaders[C.HEADER_TOKEN].isNullOrBlank()) {
+                eventSub = EventSubWebSocket(trustManager, EventSubListener(helixHeaders, gqlHeaders, channelLogin, showUserNotice, showClearChat, usePubSub, networkLibrary, isLoggedIn, accountId, channelId))
+                chatReadJob = eventSub?.connect(viewModelScope)
+            } else {
+                val gqlToken = gqlHeaders[C.HEADER_TOKEN]?.removePrefix("OAuth ")
+                val helixToken = helixHeaders[C.HEADER_TOKEN]?.removePrefix("Bearer ")
+                chatReadWebSocket = ChatReadWebSocket(channelLogin, trustManager, ChatReadListener(channelLogin, nameDisplay, showUserNotice, showClearMsg, showClearChat, usePubSub, networkLibrary, gqlHeaders, isLoggedIn, accountId, channelId))
+                chatReadJob = chatReadWebSocket?.connect(viewModelScope)
+                if (!readOnly && isLoggedIn && (!gqlToken.isNullOrBlank() || !helixHeaders[C.HEADER_TOKEN].isNullOrBlank() && !useApiChatMessages)) {
+                    chatWriteWebSocket = ChatWriteWebSocket(
+                        userLogin = accountLogin,
+                        userToken = gqlToken?.takeIf { it.isNotBlank() } ?: helixToken,
+                        channelLogin = channelLogin,
+                        trustManager = trustManager,
+                        listener = ChatWriteListener(channelId, showWebSocketDebugInfo)
+                    )
+                    chatWriteJob = chatWriteWebSocket?.connect(viewModelScope)
+                }
             }
         }
         if (usePubSub && !channelId.isNullOrBlank()) {
@@ -2902,6 +2919,8 @@ class ChatViewModel(
         lastWatchStreakReconciliationElapsedRealtime = null
         activeChannelId = null
         activeChannelLogin = null
+        v2LiveChannelId = null
+        v2LiveChannelLogin = null
         pinnedChatRefreshJob?.cancel()
         pinnedChatRefreshJob = null
         _pinnedChatMessage.value = null

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/assets/ChatAssetRepository.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/assets/ChatAssetRepository.kt
@@ -81,7 +81,9 @@ class ChatAssetRepository(
                 loaded?.let(ChatAssetState::Ready)
                     ?: ChatAssetState.Failed(completedAt + retryDelay(attempt), attempt)
             } catch (e: CancellationException) {
-                if (repositoryJob?.isActive != true) throw e
+                // A loader-local timeout is retryable while the repository is alive. Only
+                // cancellation of the repository's own scope should terminate the attempt.
+                if (repositoryJob?.isActive == false) throw e
                 completedAt = nowMs()
                 ChatAssetState.Failed(completedAt + retryDelay(attempt), attempt)
             } catch (e: ChatAssetLoadException) {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/assets/CoilChatAssetLoader.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/assets/CoilChatAssetLoader.kt
@@ -1,0 +1,32 @@
+package com.github.andreyasadchy.xtra.ui.chat.v2.assets
+
+import android.content.Context
+import coil3.ImageLoader
+import coil3.asDrawable
+import coil3.imageLoader
+import coil3.request.ImageRequest
+import coil3.request.SuccessResult
+import coil3.request.crossfade
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatAssetKey
+
+/** One Coil-backed loader for v2 chat assets. */
+class CoilChatAssetLoader(
+    context: Context,
+    private val imageLoader: ImageLoader = context.imageLoader,
+) : ChatAssetLoader {
+    private val context = context.applicationContext
+
+    override suspend fun load(key: ChatAssetKey): ChatImageHandle? {
+        val result = imageLoader.execute(
+            ImageRequest.Builder(context)
+                .data(key.value)
+                .crossfade(false)
+                .build(),
+        ) as? SuccessResult ?: return null
+        // Keep the decoded image handle, not a mutable Drawable. Every bound TextView asks
+        // Coil for its own Drawable instance, which is required for animated assets.
+        return ChatImageHandle {
+            result.image.asDrawable(context.resources).mutate()
+        }
+    }
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/catalog/TwitchChatCatalogSource.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/catalog/TwitchChatCatalogSource.kt
@@ -1,0 +1,262 @@
+package com.github.andreyasadchy.xtra.ui.chat.v2.catalog
+
+import android.content.Context
+import com.github.andreyasadchy.xtra.model.chat.Emote
+import com.github.andreyasadchy.xtra.model.chat.TwitchBadge
+import com.github.andreyasadchy.xtra.repository.PlayerRepository
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatAssetKey
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatAssetSpec
+import com.github.andreyasadchy.xtra.util.C
+import com.github.andreyasadchy.xtra.util.TwitchApiHelper
+import com.github.andreyasadchy.xtra.util.prefs
+import com.github.andreyasadchy.xtra.util.tokenPrefs
+import kotlinx.coroutines.CancellationException
+import org.json.JSONArray
+import org.json.JSONObject
+import java.io.File
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/**
+ * Bridges the already-used catalog endpoints into the immutable v2 catalog.
+ * Each provider is independently best-effort: a failed provider is omitted
+ * from the result so ChatCatalogRepository keeps its last-good map.
+ */
+class TwitchChatCatalogSource(
+    context: Context,
+    private val playerRepository: PlayerRepository,
+    private val channelId: String,
+    private val channelLogin: String,
+) : ChatCatalogSource {
+    private val context = context.applicationContext
+
+    override suspend fun load(): ChatCatalogLoadResult = withContext(Dispatchers.IO) {
+        val network = context.prefs().getString(C.NETWORK_LIBRARY, C.OKHTTP)
+        val helix = TwitchApiHelper.getHelixHeaders(context)
+        val gql = TwitchApiHelper.getGQLHeaders(context, true)
+        val useWebp = true
+        ChatCatalogLoadResult(
+            twitch = ChatCatalogProviderUpdate(emptyMap()),
+            sevenTv = provider { loadSevenTv(network, useWebp) },
+            bttv = provider { loadBttv(network, useWebp) },
+            ffz = provider { loadFfz(network, useWebp) },
+            badges = provider {
+                val global = playerRepository.loadGlobalBadges(network, helix, gql, "4")
+                val channel = playerRepository.loadChannelBadges(network, helix, gql, channelId, channelLogin, "4")
+                (global + channel).associateBy { "${it.setId}:${it.version}" }.mapValues { (_, badge) -> badge.toCatalog() }
+            },
+        )
+    }
+
+    private suspend fun loadSevenTv(network: String?, useWebp: Boolean): Map<String, ChatCatalogEmote> {
+        val global = playerRepository.loadSTVEmoteSet(
+            playerRepository.loadGlobalSTVEmoteSetResponse(network), useWebp, true,
+        ).second
+        // A channel failure must fail the provider as a whole. Returning only the global set
+        // would silently erase the last-good channel aliases on the next refresh.
+        val user = playerRepository.loadSTVUser(playerRepository.loadSTVUserResponse(network, channelId), useWebp)
+        val channel = user.second ?: if (!user.first.isNullOrBlank()) {
+            playerRepository.loadSTVEmoteSet(
+                playerRepository.loadSTVEmoteSetResponse(network, user.first!!), useWebp, false,
+            ).second
+        } else emptyList()
+        return emoteMap(global + channel, ChatAssetProvider.SEVEN_TV)
+    }
+
+    private suspend fun loadBttv(network: String?, useWebp: Boolean): Map<String, ChatCatalogEmote> {
+        val global = playerRepository.loadBTTVEmotes(
+            playerRepository.loadGlobalBTTVEmotesResponse(network), useWebp,
+        )
+        val channel = playerRepository.loadBTTVEmotes(
+            playerRepository.loadBTTVEmotesResponse(network, channelId), useWebp,
+        )
+        return emoteMap(global + channel, ChatAssetProvider.BTTV)
+    }
+
+    private suspend fun loadFfz(network: String?, useWebp: Boolean): Map<String, ChatCatalogEmote> {
+        val global = playerRepository.loadGlobalFFZEmotes(
+            playerRepository.loadGlobalFFZEmotesResponse(network), useWebp,
+        )
+        val channel = playerRepository.loadFFZEmotes(
+            playerRepository.loadFFZEmotesResponse(network, channelId), useWebp,
+        )
+        return emoteMap(global + channel, ChatAssetProvider.FFZ)
+    }
+
+    private fun emoteMap(emotes: List<Emote>, provider: ChatAssetProvider): Map<String, ChatCatalogEmote> = buildMap {
+        // Provider response order is stable; first alias wins within a provider.
+        emotes.forEach { emote ->
+            val name = emote.name?.takeIf { it.isNotBlank() } ?: return@forEach
+            if (name in this) return@forEach
+            val url = emote.url4x ?: emote.url3x ?: emote.url2x ?: emote.url1x ?: return@forEach
+            val width = emote.width?.takeIf { it > 0 } ?: 56
+            val height = emote.height?.takeIf { it > 0 } ?: 56
+            put(name, ChatCatalogEmote(
+                name = name,
+                asset = ChatAssetSpec(
+                    key = ChatAssetKey(url),
+                    sourceWidth = width,
+                    sourceHeight = height,
+                    targetHeight = 28,
+                ),
+                provider = provider,
+                animated = emote.isAnimated,
+                zeroWidth = emote.isOverlayEmote,
+            ))
+        }
+    }
+
+    private fun TwitchBadge.toCatalog(): ChatCatalogBadge {
+        val url = url4x ?: url3x ?: url2x ?: url1x
+        return ChatCatalogBadge(
+            name = "$setId:$version",
+            asset = ChatAssetSpec(
+                key = ChatAssetKey(url ?: "twitch-badge:$setId:$version"),
+                sourceWidth = 18,
+                sourceHeight = 18,
+                targetHeight = 18,
+            ),
+            provider = ChatAssetProvider.TWITCH,
+            setId = setId,
+            versionId = version,
+            info = title,
+        )
+    }
+
+    private suspend fun <T> provider(block: suspend () -> T): ChatCatalogProviderUpdate<T>? = try {
+        ChatCatalogProviderUpdate(block())
+    } catch (e: CancellationException) {
+        throw e
+    } catch (_: Throwable) {
+        null
+    }
+}
+
+/** Structured, versioned last-good catalog storage for one playback channel. */
+class TwitchChatCatalogCache(
+    context: Context,
+    channelId: String,
+) : ChatCatalogCache {
+    private val file = File(
+        File(context.applicationContext.filesDir, "chat-v2/catalog"),
+        channelId.replace(Regex("[^A-Za-z0-9._-]"), "_") + ".json",
+    )
+
+    override suspend fun read(): ChatCatalogSnapshot? = withContext(Dispatchers.IO) {
+        if (!file.isFile) return@withContext null
+        runCatching { decode(JSONObject(file.readText())) }.getOrNull()
+    }
+
+    override suspend fun write(snapshot: ChatCatalogSnapshot) = withContext(Dispatchers.IO) {
+        file.parentFile?.mkdirs()
+        val temp = File(file.parentFile, "${file.name}.tmp")
+        temp.writeText(encode(snapshot).toString())
+        if (!temp.renameTo(file)) {
+            file.delete()
+            check(temp.renameTo(file)) { "Unable to publish chat catalog cache" }
+        }
+    }
+
+    private fun encode(snapshot: ChatCatalogSnapshot): JSONObject = JSONObject().apply {
+        put("schemaVersion", 1)
+        put("revision", snapshot.revision)
+        put("provider", "combined")
+        put("fetchedAt", System.currentTimeMillis())
+        put("twitch", encodeEmotes(snapshot.twitch))
+        put("sevenTv", encodeEmotes(snapshot.sevenTv))
+        put("bttv", encodeEmotes(snapshot.bttv))
+        put("ffz", encodeEmotes(snapshot.ffz))
+        put("badges", encodeBadges(snapshot.badges))
+    }
+
+    private fun encodeEmotes(map: Map<String, ChatCatalogEmote>) = JSONArray().apply {
+        map.values.forEach { emote ->
+            put(JSONObject().apply {
+                put("name", emote.name)
+                put("provider", emote.provider.name)
+                put("animated", emote.animated)
+                put("zeroWidth", emote.zeroWidth)
+                put("asset", encodeSpec(emote.asset))
+            })
+        }
+    }
+
+    private fun encodeBadges(map: Map<String, ChatCatalogBadge>) = JSONArray().apply {
+        map.values.forEach { badge ->
+            put(JSONObject().apply {
+                put("name", badge.name)
+                put("provider", badge.provider.name)
+                put("setId", badge.setId)
+                put("versionId", badge.versionId)
+                putOpt("info", badge.info)
+                put("asset", encodeSpec(badge.asset))
+            })
+        }
+    }
+
+    private fun encodeSpec(spec: ChatAssetSpec): JSONObject = JSONObject().apply {
+        put("key", spec.key.value)
+        put("sourceWidth", spec.sourceWidth)
+        put("sourceHeight", spec.sourceHeight)
+        put("targetHeight", spec.targetHeight)
+        val encodedOverlays = JSONArray()
+        spec.overlays.forEach { overlay -> encodedOverlays.put(encodeSpec(overlay)) }
+        put("overlays", encodedOverlays)
+    }
+
+    private fun decode(root: JSONObject): ChatCatalogSnapshot {
+        check(root.optInt("schemaVersion") == 1)
+        fun emotes(name: String): Map<String, ChatCatalogEmote> = buildMap {
+            val array = root.optJSONArray(name) ?: return@buildMap
+            for (i in 0 until array.length()) {
+                val item = array.optJSONObject(i) ?: continue
+                val emoteName = item.optString("name").takeIf { it.isNotBlank() } ?: continue
+                val provider = runCatching { ChatAssetProvider.valueOf(item.optString("provider")) }.getOrNull() ?: continue
+                put(emoteName, ChatCatalogEmote(
+                    emoteName,
+                    decodeSpec(item.optJSONObject("asset")),
+                    provider,
+                    item.optBoolean("animated"),
+                    item.optBoolean("zeroWidth"),
+                ))
+            }
+        }
+        val badges = buildMap {
+            val array = root.optJSONArray("badges") ?: JSONArray()
+            for (i in 0 until array.length()) {
+                val item = array.optJSONObject(i) ?: continue
+                val key = "${item.optString("setId")}:${item.optString("versionId")}"
+                put(key, ChatCatalogBadge(
+                    item.optString("name"),
+                    decodeSpec(item.optJSONObject("asset")),
+                    ChatAssetProvider.TWITCH,
+                    item.optString("setId"),
+                    item.optString("versionId"),
+                    item.optString("info").takeIf { it.isNotBlank() },
+                ))
+            }
+        }
+        return ChatCatalogSnapshot(
+            revision = root.optLong("revision", 0L),
+            twitch = emotes("twitch"),
+            sevenTv = emotes("sevenTv"),
+            bttv = emotes("bttv"),
+            ffz = emotes("ffz"),
+            badges = badges,
+        )
+    }
+
+    private fun decodeSpec(value: JSONObject?): ChatAssetSpec {
+        requireNotNull(value)
+        val overlays = value.optJSONArray("overlays")?.let { array ->
+            (0 until array.length()).mapNotNull { array.optJSONObject(it)?.let(::decodeSpec) }
+        }.orEmpty()
+        return ChatAssetSpec(
+            key = ChatAssetKey(value.optString("key")),
+            sourceWidth = value.optInt("sourceWidth", 56),
+            sourceHeight = value.optInt("sourceHeight", 56),
+            targetHeight = value.optInt("targetHeight", 28),
+            overlays = overlays,
+        )
+    }
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/domain/ChatEvent.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/domain/ChatEvent.kt
@@ -23,4 +23,10 @@ sealed interface ChatEvent {
         override val receivedAtMs: Long,
     ) : ChatEvent
     data class Notice(val message: ChatMessage, override val eventId: String?, override val receivedAtMs: Long) : ChatEvent
+    /** Transport lifecycle is not a timeline item. It lets the session reconcile after a gap. */
+    data class TransportDisconnected(
+        val reason: String? = null,
+        override val eventId: String? = null,
+        override val receivedAtMs: Long = System.currentTimeMillis(),
+    ) : ChatEvent
 }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/domain/ChatMessage.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/domain/ChatMessage.kt
@@ -105,4 +105,6 @@ data class ChatMessage(
     val rewardId: String? = null,
     val bits: Int? = null,
     val twitchType: TwitchChatMessageType = TwitchChatMessageType.Text,
+    val systemText: String? = null,
+    val noticeType: String? = null,
 )

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/presentation/ChatRowCompiler.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/presentation/ChatRowCompiler.kt
@@ -4,6 +4,7 @@ import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessage
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatAssetKey
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatAssetSpec
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatBadgeRef
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessageKind
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatSegment
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.TwitchChatMessageType
 import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatCatalogEmote
@@ -12,15 +13,25 @@ import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatCatalogSnapshot
 class ChatRowCompiler(
     private val colors: ChatColorResolver = ChatColorResolver(),
     private val emoteHeightPx: Int = 28,
+    private val badgeHeightPx: Int = 18,
     private val timestampText: (Long) -> String? = { null },
     private val background: (ChatMessage) -> Int = { 0 },
 ) {
     fun compile(message: ChatMessage, catalog: ChatCatalogSnapshot = ChatCatalogSnapshot(0)): ChatRowUiModel {
         val targetHeight = emoteHeightPx * if (message.twitchType == TwitchChatMessageType.GigantifiedEmote) 2 else 1
         val rowBackground = background(message)
+        val hasSemanticBody = message.segments.any {
+            it !is ChatSegment.Text || it.text.isNotBlank()
+        }
+        val noticeBody = message.systemText?.takeIf { message.kind == ChatMessageKind.NOTICE && it.isNotBlank() }
+        val resolvedSegments = if (noticeBody != null && !hasSemanticBody) {
+            listOf(ChatSegment.Text(noticeBody))
+        } else {
+            resolveSegments(message.segments, catalog)
+        }
         val pieces = buildList {
             message.badges.forEach { badge -> add(ChatPiece.Badge(badgeSpec(badge, catalog))) }
-            message.user?.let { user ->
+            message.user?.takeIf { noticeBody == null || hasSemanticBody }?.let { user ->
                 val name = user.displayName ?: user.login
                 name?.let {
                     add(ChatPiece.Username(
@@ -29,7 +40,7 @@ class ChatRowCompiler(
                     ))
                 }
             }
-            resolveSegments(message.segments, catalog).forEach { segment ->
+            resolvedSegments.forEach { segment ->
                 when (segment) {
                     is ChatSegment.Text -> add(ChatPiece.Text(segment.text))
                     is ChatSegment.Mention -> add(ChatPiece.Mention(segment.text, segment.userId, segment.login))
@@ -50,8 +61,10 @@ class ChatRowCompiler(
             isAction = message.kind == com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessageKind.ACTION,
             twitchType = message.twitchType,
             accessibilityText = buildString {
-                message.user?.let { user -> (user.displayName ?: user.login)?.let { append(it).append(": ") } }
-                message.segments.forEach { segment ->
+                message.user?.takeIf { noticeBody == null || hasSemanticBody }?.let { user ->
+                    (user.displayName ?: user.login)?.let { append(it).append(": ") }
+                }
+                resolvedSegments.forEach { segment ->
                     when (segment) {
                         is ChatSegment.Text -> append(segment.text)
                         is ChatSegment.Mention -> append(segment.text)
@@ -65,7 +78,7 @@ class ChatRowCompiler(
     }
 
     private fun badgeSpec(badge: ChatBadgeRef, catalog: ChatCatalogSnapshot): ChatAssetSpec =
-        catalog.badges[badge.catalogKey]?.asset ?: badge.asset
+        (catalog.badges[badge.catalogKey]?.asset ?: badge.asset).scaledTo(badgeHeightPx)
 
     private fun resolveSegments(segments: List<ChatSegment>, catalog: ChatCatalogSnapshot): List<ChatSegment> {
         val resolved = ArrayList<ChatSegment>()

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/session/ChatEventProcessor.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/session/ChatEventProcessor.kt
@@ -46,8 +46,8 @@ class ChatEventProcessor(scope: CoroutineScope, private val store: ChatTimelineS
                     is Command.Event -> {
                         if (command.value.key != activeKey) continue
                         val event = command.value.event
-                        val id = event.eventId
-                        if (id != null && !seen.add(id)) continue
+                        val dedupeKey = eventDedupeKey(event)
+                        if (dedupeKey != null && !seen.add(dedupeKey)) continue
                         if (seen.size > 4096) seen.remove(seen.first())
                         store.accept(event)
                     }
@@ -64,6 +64,22 @@ class ChatEventProcessor(scope: CoroutineScope, private val store: ChatTimelineS
         processorJob.invokeOnCompletion {
             events.close()
         }
+    }
+
+    /**
+     * Protocol event IDs are not one global namespace. A message ID can also be the target of
+     * its delete event, while a clear-user payload commonly contains only the user ID. Clear-user
+     * is idempotent, so it deliberately has no dedupe key until a transport supplies a distinct
+     * protocol delivery ID.
+     */
+    private fun eventDedupeKey(event: ChatEvent): String? = when (event) {
+        is ChatEvent.Message -> event.eventId?.let { "message:$it" }
+        is ChatEvent.Notice -> event.eventId?.let { "notice:$it" }
+        is ChatEvent.Delete -> "delete:${event.eventId ?: event.messageId.value}"
+        is ChatEvent.ClearUser -> null
+        is ChatEvent.Clear -> event.eventId?.let { "clear:$it" }
+        is ChatEvent.SettingsUpdated -> event.eventId?.let { "settings:$it" }
+        is ChatEvent.TransportDisconnected -> null
     }
 
     val isActive: Boolean

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/session/ChatSession.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/session/ChatSession.kt
@@ -1,6 +1,7 @@
 package com.github.andreyasadchy.xtra.ui.chat.v2.session
 
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatSessionKey
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatEvent
 import com.github.andreyasadchy.xtra.ui.chat.v2.transport.ChatTransport
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
@@ -17,6 +18,7 @@ class ChatSession(
     parentScope: CoroutineScope,
     private val transport: ChatTransport,
     maxTimelineSize: Int = 600,
+    private val onTransportDisconnected: suspend (ChatSessionKey, String?) -> Unit = { _, _ -> },
 ) {
     private val job = SupervisorJob(parentScope.coroutineContext[Job])
     private val scope = CoroutineScope(parentScope.coroutineContext + job)
@@ -28,6 +30,9 @@ class ChatSession(
     private var highestAcceptedGeneration = Long.MIN_VALUE
     private var highestAcceptedKey: ChatSessionKey? = null
     private var closed = false
+
+    val isActive: Boolean
+        get() = job.isActive && !closed
 
     suspend fun start(key: ChatSessionKey) {
         transitionMutex.withLock {
@@ -46,7 +51,19 @@ class ChatSession(
             processor.activate(key)
             if (desiredKey == key) {
                 transportJob = scope.launch(start = CoroutineStart.UNDISPATCHED) {
-                    transport.events(key).collect { processor.submit(key, it) }
+                    try {
+                        transport.events(key).collect { event ->
+                            if (event is ChatEvent.TransportDisconnected) {
+                                launch { onTransportDisconnected(key, event.reason) }
+                            } else {
+                                processor.submit(key, event)
+                            }
+                        }
+                    } catch (e: kotlinx.coroutines.CancellationException) {
+                        throw e
+                    } catch (e: Throwable) {
+                        onTransportDisconnected(key, e.message)
+                    }
                 }
             }
         }
@@ -68,6 +85,9 @@ class ChatSession(
     fun attachUi() = ChatUiBatcher(timeline.versions, timeline::versionedSnapshot, VersionedTimelineSnapshot::version).flow()
 
     suspend fun reconcile(key: ChatSessionKey, recent: List<com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessage>) = processor.reconcile(key, recent)
+
+    /** Injects non-message session state through the same generation-aware writer. */
+    suspend fun submit(key: ChatSessionKey, event: ChatEvent) = processor.submit(key, event)
 
     suspend fun close() {
         transitionMutex.withLock {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/session/ChatSessionManager.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/session/ChatSessionManager.kt
@@ -1,0 +1,121 @@
+package com.github.andreyasadchy.xtra.ui.chat.v2.session
+
+import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatCatalogRepository
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatEvent
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessage
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatSessionKey
+import com.github.andreyasadchy.xtra.ui.chat.v2.transport.ChatTransport
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+data class LiveChatSessionSpec(
+    val channelId: String,
+    val channelLogin: String,
+    val recentMessagesUrl: String? = null,
+)
+
+data class ActiveChatSession(
+    val spec: LiveChatSessionSpec,
+    val key: ChatSessionKey,
+    val session: ChatSession,
+    val catalog: ChatCatalogRepository,
+)
+
+/**
+ * Playback-owned live chat coordinator. Its parent is the application/playback
+ * scope, never a Fragment or a Fragment view lifecycle.
+ */
+class ChatSessionManager(
+    parentScope: CoroutineScope,
+    private val transportFactory: (LiveChatSessionSpec) -> ChatTransport,
+    private val catalogFactory: (LiveChatSessionSpec, CoroutineScope) -> ChatCatalogRepository,
+    private val recentHistory: suspend (LiveChatSessionSpec) -> List<ChatMessage> = { emptyList() },
+    private val initialSettings: suspend (LiveChatSessionSpec) -> ChatEvent.SettingsUpdated? = { null },
+    private val maxTimelineSize: Int = 600,
+) {
+    private val managerJob = SupervisorJob(parentScope.coroutineContext[Job])
+    private val scope = CoroutineScope(parentScope.coroutineContext + managerJob)
+    private val transitionMutex = Mutex()
+    private val _active = MutableStateFlow<ActiveChatSession?>(null)
+    val active: StateFlow<ActiveChatSession?> = _active.asStateFlow()
+    private var generation = 0L
+    private var closed = false
+
+    suspend fun start(spec: LiveChatSessionSpec): ActiveChatSession = transitionMutex.withLock {
+        check(!closed) { "ChatSessionManager is closed" }
+        val current = _active.value
+        if (current?.spec == spec && current.session.isActive) return@withLock current
+
+        current?.let {
+            it.session.close()
+            it.catalog.close()
+        }
+        val key = ChatSessionKey(spec.channelId, ++generation)
+        val session = ChatSession(
+            parentScope = scope,
+            transport = transportFactory(spec),
+            maxTimelineSize = maxTimelineSize,
+            onTransportDisconnected = { disconnectedKey, _ ->
+                _active.value
+                    ?.takeIf { it.key == disconnectedKey }
+                    ?.let(::scheduleRecentHistory)
+            },
+        )
+        val catalog = catalogFactory(spec, scope)
+        session.start(key)
+        val active = ActiveChatSession(spec, key, session, catalog)
+        _active.value = active
+        catalog.refresh()
+        // Reconcile startup/reconstruction history independently of transport startup. Live
+        // events can arrive while this request is in flight; ChatEventProcessor serializes the
+        // atomic merge with those events and rejects the work if this generation is no longer
+        // active.
+        scheduleRecentHistory(active)
+        scope.launch {
+            val settings = runCatching { initialSettings(spec) }.getOrNull() ?: return@launch
+            val stillActive = _active.value?.key == key
+            if (stillActive) session.submit(key, settings)
+        }
+        active
+    }
+
+    suspend fun stop(key: ChatSessionKey? = null) = transitionMutex.withLock {
+        val active = _active.value ?: return@withLock
+        if (key != null && key != active.key) return@withLock
+        _active.value = null
+        active.session.close()
+        active.catalog.close()
+    }
+
+    private fun scheduleRecentHistory(active: ActiveChatSession) {
+        scope.launch {
+            val recent = try {
+                recentHistory(active.spec)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (_: Throwable) {
+                emptyList()
+            }
+            if (_active.value?.key != active.key) return@launch
+            active.session.reconcile(active.key, recent)
+        }
+    }
+
+    suspend fun close() = transitionMutex.withLock {
+        if (closed) return@withLock
+        closed = true
+        val active = _active.value
+        _active.value = null
+        active?.session?.close()
+        active?.catalog?.close()
+        managerJob.cancel()
+    }
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/session/ChatTimelineStore.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/session/ChatTimelineStore.kt
@@ -14,9 +14,9 @@ import kotlinx.coroutines.CoroutineScope
 sealed interface TimelineOperation {
     data class Append(val items: List<ChatMessage>) : TimelineOperation
     data class Prepend(val items: List<ChatMessage>) : TimelineOperation
-    data class Delete(val id: ChatMessageId) : TimelineOperation
-    data class ClearUser(val userId: String) : TimelineOperation
-    data object Clear : TimelineOperation
+    data class Delete(val id: ChatMessageId, val atMs: Long) : TimelineOperation
+    data class ClearUser(val userId: String, val atMs: Long) : TimelineOperation
+    data class Clear(val atMs: Long) : TimelineOperation
     data class Replace(val items: List<ChatMessage>) : TimelineOperation
     class RequestSnapshot(val result: CompletableDeferred<List<ChatMessage>>) : TimelineOperation
     class RequestVersionedSnapshot(val result: CompletableDeferred<VersionedTimelineSnapshot>) : TimelineOperation
@@ -38,6 +38,11 @@ class ChatTimelineStore(
         scope.launch {
             val items = ArrayDeque<ChatMessage>(maxSize)
             val ids = HashSet<com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessageId>(maxSize * 2)
+            // These tombstones belong to the active generation. Replace(emptyList()) is the
+            // processor's generation boundary and resets them before a new channel is accepted.
+            val deletedMessageIds = LinkedHashSet<ChatMessageId>(MODERATION_TOMBSTONE_LIMIT)
+            val clearedUsersAt = LinkedHashMap<String, Long>(MODERATION_TOMBSTONE_LIMIT, 0.75f, true)
+            var globallyClearedAt: Long? = null
             for (operation in operations) {
                 when (operation) {
                     is TimelineOperation.RequestSnapshot -> {
@@ -49,24 +54,48 @@ class ChatTimelineStore(
                         continue
                     }
                     is TimelineOperation.Append -> operation.items.forEach { item ->
+                        if (isSuppressed(item, deletedMessageIds, clearedUsersAt, globallyClearedAt)) continue
                         if (ids.add(item.id)) items.addLast(item)
                     }
                     is TimelineOperation.Prepend -> operation.items.asReversed().forEach { item ->
+                        if (isSuppressed(item, deletedMessageIds, clearedUsersAt, globallyClearedAt)) continue
                         if (ids.add(item.id)) items.addFirst(item)
                     }
-                    is TimelineOperation.Delete -> if (ids.remove(operation.id)) items.removeIf { it.id == operation.id }
-                    is TimelineOperation.ClearUser -> items.removeIf { item ->
-                        val removed = item.user?.id == operation.userId
-                        if (removed) ids.remove(item.id)
-                        removed
+                    is TimelineOperation.Delete -> {
+                        deletedMessageIds.add(operation.id)
+                        trimModerationTombstones(deletedMessageIds, clearedUsersAt)
+                        if (ids.remove(operation.id)) items.removeIf { it.id == operation.id }
                     }
-                    TimelineOperation.Clear -> { items.clear(); ids.clear() }
+                    is TimelineOperation.ClearUser -> {
+                        val previous = clearedUsersAt[operation.userId]
+                        if (previous == null || operation.atMs > previous) {
+                            clearedUsersAt[operation.userId] = operation.atMs
+                        }
+                        trimModerationTombstones(deletedMessageIds, clearedUsersAt)
+                        items.removeIf { item ->
+                            val removed = item.user?.id == operation.userId
+                            if (removed) ids.remove(item.id)
+                            removed
+                        }
+                    }
+                    is TimelineOperation.Clear -> {
+                        val previous = globallyClearedAt
+                        if (previous == null || operation.atMs > previous) {
+                            globallyClearedAt = operation.atMs
+                        }
+                        items.clear(); ids.clear()
+                    }
                     is TimelineOperation.Replace -> {
                         items.clear(); ids.clear()
+                        deletedMessageIds.clear()
+                        clearedUsersAt.clear()
+                        globallyClearedAt = null
                         operation.items.takeLast(maxSize).forEach { if (ids.add(it.id)) items.addLast(it) }
                     }
                     is TimelineOperation.Reconcile -> {
-                        val merged = (items.toList() + operation.recent)
+                        val merged = (items.toList() + operation.recent.filterNot {
+                            isSuppressed(it, deletedMessageIds, clearedUsersAt, globallyClearedAt)
+                        })
                             .distinctBy { it.id }
                             .sortedBy { it.timestampMs }
                         items.clear(); ids.clear()
@@ -77,6 +106,34 @@ class ChatTimelineStore(
                 _version.value++
             }
         }
+    }
+
+    private fun isSuppressed(
+        message: ChatMessage,
+        deletedMessageIds: Set<ChatMessageId>,
+        clearedUsersAt: Map<String, Long>,
+        globallyClearedAt: Long?,
+    ): Boolean {
+        if (message.id in deletedMessageIds) return true
+        if (globallyClearedAt?.let { message.timestampMs <= it } == true) return true
+        val userId = message.user?.id ?: return false
+        return clearedUsersAt[userId]?.let { message.timestampMs <= it } == true
+    }
+
+    private fun trimModerationTombstones(
+        deletedMessageIds: LinkedHashSet<ChatMessageId>,
+        clearedUsersAt: LinkedHashMap<String, Long>,
+    ) {
+        while (deletedMessageIds.size > MODERATION_TOMBSTONE_LIMIT) {
+            deletedMessageIds.remove(deletedMessageIds.first())
+        }
+        while (clearedUsersAt.size > MODERATION_TOMBSTONE_LIMIT) {
+            clearedUsersAt.remove(clearedUsersAt.entries.iterator().next().key)
+        }
+    }
+
+    private companion object {
+        const val MODERATION_TOMBSTONE_LIMIT = 4096
     }
 
     suspend fun apply(operation: TimelineOperation) = operations.send(operation)
@@ -97,10 +154,11 @@ class ChatTimelineStore(
         when (event) {
             is ChatEvent.Message -> apply(TimelineOperation.Append(listOf(event.message)))
             is ChatEvent.Notice -> apply(TimelineOperation.Append(listOf(event.message)))
-            is ChatEvent.Delete -> apply(TimelineOperation.Delete(event.messageId))
-            is ChatEvent.ClearUser -> apply(TimelineOperation.ClearUser(event.userId))
-            is ChatEvent.Clear -> apply(TimelineOperation.Clear)
+            is ChatEvent.Delete -> apply(TimelineOperation.Delete(event.messageId, event.receivedAtMs))
+            is ChatEvent.ClearUser -> apply(TimelineOperation.ClearUser(event.userId, event.receivedAtMs))
+            is ChatEvent.Clear -> apply(TimelineOperation.Clear(event.receivedAtMs))
             is ChatEvent.SettingsUpdated -> Unit
+            is ChatEvent.TransportDisconnected -> Unit
         }
     }
 }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/transport/TwitchChatEventParser.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/transport/TwitchChatEventParser.kt
@@ -1,0 +1,317 @@
+package com.github.andreyasadchy.xtra.ui.chat.v2.transport
+
+import com.github.andreyasadchy.xtra.model.chat.ChatMessage as LegacyChatMessage
+import com.github.andreyasadchy.xtra.model.chat.Reply as LegacyReply
+import com.github.andreyasadchy.xtra.model.chat.TwitchEmote
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatAssetKey
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatAssetSpec
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatBadgeRef
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatEvent
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessage
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessageId
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessageKind
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatReply
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatSegment
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatUser
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.SharedChatSource
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.TwitchChatMessageType
+import com.github.andreyasadchy.xtra.util.chat.ChatUtils
+import org.json.JSONArray
+import org.json.JSONObject
+import kotlin.time.Instant
+
+/**
+ * Protocol-to-domain normalization for the production transport bridge.
+ *
+ * EventSub fragments are consumed as structured values. IRC emote offsets are
+ * converted once at ingress and ordinary text is intentionally left intact for
+ * current-catalog presentation resolution.
+ */
+object TwitchChatEventParser {
+    fun fromIrc(message: ChatUtils.IRCMessage, channelId: String): ChatEvent? = when (message.command) {
+        "PRIVMSG", "USERNOTICE" -> ChatEvent.Message(fromLegacy(ChatUtils.parseChatMessage(message), channelId))
+        "CLEARMSG" -> ChatEvent.Delete(
+            messageId = ChatMessageId(message.tags["target-msg-id"] ?: return null),
+            eventId = message.tags["target-msg-id"],
+            receivedAtMs = timestamp(message.tags["tmi-sent-ts"]),
+        )
+        "CLEARCHAT" -> {
+            val userId = message.tags["target-user-id"]
+            if (!userId.isNullOrBlank()) {
+                ChatEvent.ClearUser(userId, message.tags["target-user-id"], timestamp(message.tags["tmi-sent-ts"]))
+            } else {
+                ChatEvent.Clear(message.tags["id"], timestamp(message.tags["tmi-sent-ts"]))
+            }
+        }
+        "NOTICE" -> ChatEvent.Notice(
+            fromLegacy(ChatUtils.parseNotice(message), channelId),
+            message.tags["id"],
+            timestamp(message.tags["tmi-sent-ts"]),
+        )
+        "ROOMSTATE" -> ChatEvent.SettingsUpdated(
+            channelId = channelId,
+            slowModeSeconds = message.tags["slow"]?.toIntOrNull()?.takeIf { it >= 0 },
+            followerOnlyDurationMinutes = message.tags["followers-only"]?.toIntOrNull()?.takeIf { it >= 0 },
+            subscriberOnly = message.tags["subs-only"] == "1",
+            emoteOnly = message.tags["emote-only"] == "1",
+            uniqueChatMode = message.tags["r9k"] == "1",
+            eventId = message.tags["id"],
+            receivedAtMs = timestamp(message.tags["tmi-sent-ts"]),
+        )
+        else -> null
+    }
+
+    fun fromEventSub(event: JSONObject, timestamp: String?, notice: Boolean = false): ChatEvent.Message {
+        val message = eventMessage(event, timestamp, notice)
+        return ChatEvent.Message(message, eventId = message.id.value, receivedAtMs = System.currentTimeMillis())
+    }
+
+    fun fromEventSubClear(event: JSONObject, timestamp: String?): ChatEvent {
+        val receivedAt = parseTimestamp(timestamp)
+        val messageId = event.optString("message_id").takeIf { it.isNotBlank() }
+        val userId = event.optString("target_user_id").takeIf { it.isNotBlank() }
+        return when {
+            messageId != null -> ChatEvent.Delete(ChatMessageId(messageId), messageId, receivedAt)
+            userId != null -> ChatEvent.ClearUser(userId, userId, receivedAt)
+            else -> ChatEvent.Clear(null, receivedAt)
+        }
+    }
+
+    fun fromEventSubSettings(event: JSONObject, timestamp: String?, channelId: String): ChatEvent.SettingsUpdated =
+        ChatEvent.SettingsUpdated(
+            channelId = channelId,
+            slowModeSeconds = event.optIntOrNull("slow_mode_wait_time_seconds"),
+            followerOnlyDurationMinutes = event.optIntOrNull("follower_mode_duration_minutes"),
+            subscriberOnly = event.optBoolean("subscriber_mode", false),
+            emoteOnly = event.optBoolean("emote_mode", false),
+            uniqueChatMode = event.optBoolean("unique_chat_mode", false),
+            eventId = null,
+            receivedAtMs = parseTimestamp(timestamp),
+        )
+
+    private fun eventMessage(event: JSONObject, timestamp: String?, notice: Boolean): ChatMessage {
+        val messageObject = event.optJSONObject("message")
+        val fragments = messageObject?.optJSONArray("fragments")
+        val segments = if (fragments != null) parseFragments(fragments) else listOfNotNull(
+            messageObject?.optString("text")?.takeIf { it.isNotEmpty() }?.let(ChatSegment::Text),
+        )
+        val rawType = event.optString("message_type").takeIf { it.isNotBlank() } ?: "text"
+        val type = parseMessageType(rawType)
+        val fullText = segments.joinToString(separator = "") { segment ->
+            when (segment) {
+                is ChatSegment.Text -> segment.text
+                is ChatSegment.Mention -> segment.text
+                is ChatSegment.Emote -> segment.fallbackText
+                is ChatSegment.Gif -> segment.fallbackText
+                is ChatSegment.Cheermote -> segment.text
+            }
+        }
+        val userName = event.optString("chatter_user_name").takeIf { it.isNotBlank() }
+        val userLogin = event.optString("chatter_user_login").takeIf { it.isNotBlank() }
+        val id = event.optString("message_id").takeIf { it.isNotBlank() }
+            ?: "eventsub-${event.hashCode()}-${parseTimestamp(timestamp)}"
+        return ChatMessage(
+            id = ChatMessageId(id),
+            channelId = event.optString("broadcaster_user_id").takeIf { it.isNotBlank() }.orEmpty(),
+            timestampMs = parseTimestamp(timestamp),
+            user = ChatUser(
+                id = event.optString("chatter_user_id").takeIf { it.isNotBlank() },
+                login = userLogin,
+                displayName = userName,
+                color = parseColor(event.optString("color").takeIf { it.isNotBlank() }),
+            ),
+            badges = parseBadges(event.optJSONArray("badges")),
+            segments = segments,
+            kind = when {
+                notice -> ChatMessageKind.NOTICE
+                fullText.startsWith(ChatUtils.ACTION) -> ChatMessageKind.ACTION
+                type == TwitchChatMessageType.Highlighted -> ChatMessageKind.REWARD
+                else -> ChatMessageKind.CHAT
+            },
+            reply = parseReply(event.optJSONObject("reply")),
+            source = parseSource(event),
+            rewardId = event.optString("channel_points_custom_reward_id").takeIf { it.isNotBlank() },
+            bits = event.optJSONObject("cheer")?.optInt("bits")?.takeIf { it > 0 },
+            twitchType = type,
+            systemText = event.optString("system_message").takeIf { it.isNotBlank() },
+            noticeType = event.optString("notice_type").takeIf { it.isNotBlank() },
+        )
+    }
+
+    private fun parseFragments(fragments: JSONArray): List<ChatSegment> = buildList {
+        for (index in 0 until fragments.length()) {
+            val fragment = fragments.optJSONObject(index) ?: continue
+            val text = fragment.optString("text")
+            when (fragment.optString("type")) {
+                "emote" -> {
+                    val emote = fragment.optJSONObject("emote")
+                    val id = emote?.optString("id")?.takeIf { it.isNotBlank() }
+                    if (id == null) add(ChatSegment.Text(text)) else add(
+                        ChatSegment.Emote(
+                            asset = nativeSpec("twitch-emote:$id", 56, 56),
+                            fallbackText = text,
+                            animated = emote.optJSONArray("format")?.let { formats ->
+                                (0 until formats.length()).any { formats.optString(it) == "animated" }
+                            } == true,
+                        ),
+                    )
+                }
+                "cheermote" -> {
+                    val cheer = fragment.optJSONObject("cheermote")
+                    val prefix = cheer?.optString("prefix").orEmpty()
+                    val bits = cheer?.optInt("bits") ?: parseCheerAmount(text)
+                    val tier = cheer?.optInt("tier") ?: 1
+                    add(ChatSegment.Cheermote(nativeSpec("twitch-cheer:$prefix:$tier", 28, 28), text, bits, null))
+                }
+                "mention" -> {
+                    val mention = fragment.optJSONObject("mention")
+                    add(ChatSegment.Mention(
+                        text = text,
+                        userId = mention?.optString("user_id")?.takeIf { it.isNotBlank() },
+                        login = mention?.optString("user_login")?.takeIf { it.isNotBlank() },
+                    ))
+                }
+                "gif" -> {
+                    val gif = fragment.optJSONObject("gif")
+                    val gifId = gif?.optString("id")?.takeIf { it.isNotBlank() }
+                    val url = gif?.optString("url")?.takeIf { it.isNotBlank() }
+                    if (gifId == null || url == null) add(ChatSegment.Text(text)) else add(ChatSegment.Gif(gifId, url, text))
+                }
+                else -> add(ChatSegment.Text(text))
+            }
+        }
+    }
+
+    private fun parseBadges(array: JSONArray?): List<ChatBadgeRef> = buildList {
+        if (array == null) return@buildList
+        for (index in 0 until array.length()) {
+            val badge = array.optJSONObject(index) ?: continue
+            val setId = badge.optString("set_id").takeIf { it.isNotBlank() } ?: continue
+            val versionId = badge.optString("id").takeIf { it.isNotBlank() } ?: continue
+            add(ChatBadgeRef(setId, versionId, badge.optString("info").takeIf { it.isNotBlank() }))
+        }
+    }
+
+    private fun parseReply(reply: JSONObject?): ChatReply? {
+        if (reply == null) return null
+        val parent = reply.optString("parent_message_id").takeIf { it.isNotBlank() } ?: return null
+        return ChatReply(
+            parentMessageId = ChatMessageId(parent),
+            parentMessageBody = reply.optString("parent_message_body").takeIf { it.isNotBlank() },
+            parentUserId = reply.optString("parent_user_id").takeIf { it.isNotBlank() },
+            parentUserName = reply.optString("parent_user_name").takeIf { it.isNotBlank() },
+            parentUserLogin = reply.optString("parent_user_login").takeIf { it.isNotBlank() },
+            threadMessageId = reply.optString("thread_message_id").takeIf { it.isNotBlank() }?.let(::ChatMessageId),
+            threadUserId = reply.optString("thread_user_id").takeIf { it.isNotBlank() },
+            threadUserName = reply.optString("thread_user_name").takeIf { it.isNotBlank() },
+            threadUserLogin = reply.optString("thread_user_login").takeIf { it.isNotBlank() },
+        )
+    }
+
+    private fun parseSource(event: JSONObject): SharedChatSource? {
+        val id = event.optString("source_broadcaster_user_id").takeIf { it.isNotBlank() } ?: return null
+        return SharedChatSource(
+            broadcasterId = id,
+            broadcasterLogin = event.optString("source_broadcaster_user_login").takeIf { it.isNotBlank() },
+            broadcasterName = event.optString("source_broadcaster_user_name").takeIf { it.isNotBlank() },
+            messageId = event.optString("source_message_id").takeIf { it.isNotBlank() }?.let(::ChatMessageId),
+            badges = parseBadges(event.optJSONArray("source_badges")),
+            sourceOnly = event.optBoolean("is_source_only", false),
+        )
+    }
+
+    private fun fromLegacy(message: LegacyChatMessage, channelId: String): ChatMessage {
+        val raw = message.message.orEmpty()
+        val segments = legacySegments(raw, message.emotes.orEmpty())
+        val legacyReply = message.reply
+        return ChatMessage(
+            id = ChatMessageId(message.id ?: "irc-${message.hashCode()}-${message.timestamp ?: System.currentTimeMillis()}"),
+            channelId = channelId,
+            timestampMs = message.timestamp ?: System.currentTimeMillis(),
+            user = ChatUser(message.userId, message.userLogin, message.userName, parseColor(message.color)),
+            badges = message.badges.orEmpty().map { ChatBadgeRef(it.setId, it.version) },
+            segments = segments,
+            kind = when {
+                message.isAction -> ChatMessageKind.ACTION
+                message.type == LegacyChatMessage.NOTICE_MESSAGE -> ChatMessageKind.NOTICE
+                else -> ChatMessageKind.CHAT
+            },
+            reply = legacyReply?.toChatReply(),
+            source = message.sourceMsgId?.let { SharedChatSource(channelId, null, null, ChatMessageId(it), emptyList(), false) },
+            rewardId = message.reward?.id,
+            bits = message.bits,
+            twitchType = message.msgId?.let(::parseMessageType) ?: TwitchChatMessageType.Text,
+            systemText = message.systemMsg,
+            noticeType = message.msgId,
+        )
+    }
+
+    private fun legacySegments(text: String, emotes: List<TwitchEmote>): List<ChatSegment> {
+        if (text.isEmpty() || emotes.isEmpty()) return listOf(ChatSegment.Text(text))
+        val byStart = emotes.filter { it.id != null && it.begin >= 0 && it.end >= it.begin }
+            .sortedBy { it.begin }
+        val result = ArrayList<ChatSegment>()
+        var cursor = 0
+        byStart.forEach { emote ->
+            val start = emote.begin.coerceIn(cursor, text.length)
+            val endExclusive = (emote.end + 1).coerceIn(start, text.length)
+            if (start > cursor) result += ChatSegment.Text(text.substring(cursor, start))
+            val token = text.substring(start, endExclusive)
+            result += ChatSegment.Emote(nativeSpec("twitch-emote:${emote.id}", 56, 56), token, emote.isAnimated)
+            cursor = endExclusive
+        }
+        if (cursor < text.length) result += ChatSegment.Text(text.substring(cursor))
+        return result
+    }
+
+    private fun LegacyReply.toChatReply(): ChatReply? {
+        val parentId = threadParentId ?: return null
+        return ChatReply(
+        parentMessageId = ChatMessageId(parentId),
+        parentMessageBody = message,
+        parentUserId = null,
+        parentUserName = userName,
+        parentUserLogin = userLogin,
+        threadMessageId = null,
+        threadUserId = null,
+        threadUserName = null,
+        threadUserLogin = null,
+        )
+    }
+
+    private fun nativeSpec(key: String, width: Int, height: Int): ChatAssetSpec =
+        ChatAssetSpec(
+            key = ChatAssetKey(
+                if (key.startsWith("twitch-emote:")) {
+                    val id = key.substringAfter("twitch-emote:")
+                    "https://static-cdn.jtvnw.net/emoticons/v2/$id/default/dark/3.0"
+                } else {
+                    key
+                },
+            ),
+            sourceWidth = width,
+            sourceHeight = height,
+            targetHeight = 28,
+        )
+
+    private fun parseMessageType(raw: String): TwitchChatMessageType = when (raw.lowercase()) {
+        "text" -> TwitchChatMessageType.Text
+        "channel_points_highlighted" -> TwitchChatMessageType.Highlighted
+        "channel_points_sub_only" -> TwitchChatMessageType.SubscriberOnly
+        "user_intro" -> TwitchChatMessageType.UserIntro
+        "power_ups_message_effect" -> TwitchChatMessageType.MessageEffect
+        "power_ups_gigantified_emote" -> TwitchChatMessageType.GigantifiedEmote
+        else -> TwitchChatMessageType.Unknown(raw)
+    }
+
+    private fun parseColor(raw: String?): Int? {
+        val value = raw?.trim()?.takeIf { it.matches(Regex("#[0-9a-fA-F]{6}")) } ?: return null
+        return runCatching { (value.substring(1).toLong(16).toInt() or 0xFF000000.toInt()) }.getOrNull()
+    }
+
+    private fun parseCheerAmount(text: String): Int = Regex("\\d+").find(text)?.value?.toIntOrNull() ?: 0
+    private fun parseTimestamp(raw: String?): Long = raw?.let { runCatching { Instant.parse(it).toEpochMilliseconds() }.getOrNull() }
+        ?: System.currentTimeMillis()
+    private fun timestamp(raw: String?): Long = raw?.toLongOrNull() ?: System.currentTimeMillis()
+    private fun JSONObject.optIntOrNull(name: String): Int? = if (isNull(name)) null else optInt(name).takeIf { it >= 0 }
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/transport/TwitchChatTransport.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/transport/TwitchChatTransport.kt
@@ -1,0 +1,144 @@
+package com.github.andreyasadchy.xtra.ui.chat.v2.transport
+
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatEvent
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatSessionKey
+import com.github.andreyasadchy.xtra.util.chat.ChatReadWebSocket
+import com.github.andreyasadchy.xtra.util.chat.ChatUtils
+import com.github.andreyasadchy.xtra.util.chat.EventSubWebSocket
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.buffer
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.launch
+import javax.net.ssl.X509TrustManager
+
+data class TwitchChatTransportConfig(
+    val channelId: String,
+    val channelLogin: String,
+    val useEventSub: Boolean,
+    val accountId: String? = null,
+    val helixHeaders: Map<String, String> = emptyMap(),
+    val networkLibrary: String? = null,
+)
+
+/**
+ * Adapts the existing protocol sockets to the lossless v2 ingress contract.
+ * Protocol callbacks only normalize and suspend-send an event; no catalog,
+ * image, RecyclerView, or presentation work is performed here.
+ */
+class TwitchChatTransport(
+    private val config: TwitchChatTransportConfig,
+    private val trustManager: Lazy<X509TrustManager>,
+    private val createSubscription: suspend (Map<String, String>, String?, String, String?) -> Unit = { _, _, _, _ -> },
+) : com.github.andreyasadchy.xtra.ui.chat.v2.transport.ChatTransport {
+    override fun events(session: ChatSessionKey): Flow<ChatEvent> = if (config.useEventSub) {
+        eventSubEvents(session).catch { error ->
+            // EventSub chat subscriptions are capability-gated per channel. A token can have
+            // the scopes but still be unable to subscribe to a channel it does not moderate.
+            // Keep the v2 session live by falling back to the same normalized IRC stream.
+            if (error is CancellationException) throw error
+            emitAll(ircEvents(session))
+        }
+    } else {
+        ircEvents(session)
+    }
+
+    private fun ircEvents(session: ChatSessionKey): Flow<ChatEvent> = callbackFlow {
+        val flowScope = this
+        val socket = ChatReadWebSocket(
+            channelLogin = config.channelLogin,
+            trustManager = trustManager,
+            listener = object : ChatReadWebSocket.Listener {
+                override suspend fun onChatMessage(message: ChatUtils.IRCMessage, userNotice: Boolean) {
+                    TwitchChatEventParser.fromIrc(message, config.channelId)?.let { event -> send(event) }
+                }
+
+                override suspend fun onClearMessage(message: ChatUtils.IRCMessage) {
+                    TwitchChatEventParser.fromIrc(message, config.channelId)?.let { event -> send(event) }
+                }
+
+                override suspend fun onClearChat(message: ChatUtils.IRCMessage) {
+                    TwitchChatEventParser.fromIrc(message, config.channelId)?.let { event -> send(event) }
+                }
+
+                override suspend fun onNotice(message: ChatUtils.IRCMessage) {
+                    TwitchChatEventParser.fromIrc(message, config.channelId)?.let { event -> send(event) }
+                }
+
+                override suspend fun onRoomState(message: ChatUtils.IRCMessage) {
+                    TwitchChatEventParser.fromIrc(message, config.channelId)?.let { event -> send(event) }
+                }
+
+                override suspend fun onDisconnect(message: String, fullMsg: String?) {
+                    flowScope.send(ChatEvent.TransportDisconnected(message))
+                }
+            },
+        )
+        val connectionJob = socket.connect(this)
+        awaitClose {
+            flowScope.launch { socket.disconnect(connectionJob) }
+        }
+    }.buffer(4096, kotlinx.coroutines.channels.BufferOverflow.SUSPEND)
+
+    private fun eventSubEvents(session: ChatSessionKey): Flow<ChatEvent> = callbackFlow {
+        val flowScope = this
+        val socket = EventSubWebSocket(
+            trustManager = trustManager,
+            listener = object : EventSubWebSocket.Listener {
+                override suspend fun onWelcomeMessage(sessionId: String) {
+                    flowScope.launch {
+                        EVENTSUB_CHAT_SUBSCRIPTIONS.forEach { type ->
+                            createSubscription(config.helixHeaders, config.accountId, type, sessionId)
+                        }
+                    }
+                }
+
+                override suspend fun onChatMessage(event: org.json.JSONObject, timestamp: String?) {
+                    flowScope.send(TwitchChatEventParser.fromEventSub(event, timestamp))
+                }
+
+                override suspend fun onUserNotice(event: org.json.JSONObject, timestamp: String?) {
+                    flowScope.send(TwitchChatEventParser.fromEventSub(event, timestamp, notice = true))
+                }
+
+                override suspend fun onClearChat(event: org.json.JSONObject, timestamp: String?) {
+                    flowScope.send(TwitchChatEventParser.fromEventSubClear(event, timestamp))
+                }
+
+                override suspend fun onClearUserMessages(event: org.json.JSONObject, timestamp: String?) {
+                    flowScope.send(TwitchChatEventParser.fromEventSubClear(event, timestamp))
+                }
+
+                override suspend fun onMessageDelete(event: org.json.JSONObject, timestamp: String?) {
+                    flowScope.send(TwitchChatEventParser.fromEventSubClear(event, timestamp))
+                }
+
+                override suspend fun onRoomState(event: org.json.JSONObject, timestamp: String?) {
+                    flowScope.send(TwitchChatEventParser.fromEventSubSettings(event, timestamp, config.channelId))
+                }
+
+                override suspend fun onDisconnect(message: String, fullMsg: String?) {
+                    flowScope.send(ChatEvent.TransportDisconnected(message))
+                }
+            },
+        )
+        val connectionJob = socket.connect(this)
+        awaitClose {
+            flowScope.launch { socket.disconnect(connectionJob) }
+        }
+    }.buffer(4096, kotlinx.coroutines.channels.BufferOverflow.SUSPEND)
+
+    private companion object {
+        val EVENTSUB_CHAT_SUBSCRIPTIONS = listOf(
+            "channel.chat.message",
+            "channel.chat.notification",
+            "channel.chat.clear",
+            "channel.chat.clear_user_messages",
+            "channel.chat.message_delete",
+            "channel.chat_settings.update",
+        )
+    }
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatMessageTextView.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatMessageTextView.kt
@@ -25,6 +25,7 @@ open class ChatMessageTextView(context: Context, private val assets: ChatAssetRe
     private val drawables = HashMap<ChatAssetKey, Drawable>()
     private val drawableHandles = HashMap<ChatAssetKey, Any>()
     private val invalidator: () -> Unit = { postInvalidateOnAnimation() }
+    private var renderingActive = true
 
     fun bind(row: ChatRowUiModel) {
         keys.forEach { assets.removeObserver(it, invalidator) }
@@ -114,6 +115,24 @@ open class ChatMessageTextView(context: Context, private val assets: ChatAssetRe
         text = null
     }
 
+    /** Stops asset callbacks while the containing chat surface is hidden. */
+    fun setRenderingActive(active: Boolean) {
+        if (renderingActive == active) return
+        renderingActive = active
+        if (active) {
+            if (isAttachedToWindow) keys.forEach { assets.observe(it, invalidator) }
+            if (isAttachedToWindow) {
+                drawables.values.forEach { drawable ->
+                    drawable.callback = this
+                    drawable.startIfNeeded()
+                }
+            }
+        } else {
+            keys.forEach { assets.removeObserver(it, invalidator) }
+            drawables.values.forEach { drawable -> drawable.stopIfNeeded(); drawable.callback = null }
+        }
+    }
+
     override fun onDetachedFromWindow() {
         keys.forEach { assets.removeObserver(it, invalidator) }
         drawables.values.forEach { it.stopIfNeeded(); it.callback = null }
@@ -122,8 +141,10 @@ open class ChatMessageTextView(context: Context, private val assets: ChatAssetRe
 
     override fun onAttachedToWindow() {
         super.onAttachedToWindow()
-        keys.forEach { assets.observe(it, invalidator) }
-        drawables.values.forEach { drawable -> drawable.callback = this; drawable.startIfNeeded() }
+        if (renderingActive) {
+            keys.forEach { assets.observe(it, invalidator) }
+            drawables.values.forEach { drawable -> drawable.callback = this; drawable.startIfNeeded() }
+        }
     }
 
     override fun verifyDrawable(who: Drawable): Boolean =

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatV2RendererController.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatV2RendererController.kt
@@ -1,0 +1,184 @@
+package com.github.andreyasadchy.xtra.ui.chat.v2.ui
+
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import com.github.andreyasadchy.xtra.ui.chat.v2.assets.ChatAssetRepository
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessageId
+import com.github.andreyasadchy.xtra.ui.chat.v2.presentation.ChatColorResolver
+import com.github.andreyasadchy.xtra.ui.chat.v2.presentation.ChatPresentationResolver
+import com.github.andreyasadchy.xtra.ui.chat.v2.presentation.ChatRowCompiler
+import com.github.andreyasadchy.xtra.ui.chat.v2.presentation.ChatRowUiModel
+import com.github.andreyasadchy.xtra.ui.chat.v2.session.ActiveChatSession
+import com.github.andreyasadchy.xtra.ui.chat.v2.session.ChatSessionManager
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.text.DateFormat
+import java.util.Date
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+
+/**
+ * Bridges a playback-owned v2 session to one disposable RecyclerView renderer.
+ *
+ * The collector is lifecycle-owned by the Fragment view. The session, timeline,
+ * and asset repository are not. When the view is absent this class has no active
+ * collection, no snapshot materialization, and no drawable callbacks.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class ChatV2RendererController(
+    private val recyclerView: RecyclerView,
+    private val manager: ChatSessionManager,
+    private val assets: ChatAssetRepository,
+    private val expectedChannelId: String,
+    private val expectedChannelLogin: String,
+    private val initialState: ChatViewportState = ChatViewportState(),
+    emoteHeightPx: Int = 28,
+    badgeHeightPx: Int = 18,
+    showTimestamps: Boolean = false,
+    readableUsernameColors: Boolean = true,
+    backgroundColor: Int = 0xFF101010.toInt(),
+    private val onStateChanged: (ChatViewportState) -> Unit = {},
+) {
+    private val adapter = ChatTimelineAdapter(assets)
+    private val viewport = ChatViewportController(recyclerView, initialState)
+    private val presentation = ChatPresentationResolver(
+        ChatRowCompiler(
+            colors = ChatColorResolver(
+                readable = readableUsernameColors,
+                background = backgroundColor,
+            ),
+            emoteHeightPx = emoteHeightPx,
+            badgeHeightPx = badgeHeightPx,
+            timestampText = if (showTimestamps) {
+                { timestamp -> DateFormat.getTimeInstance(DateFormat.SHORT).format(Date(timestamp)) }
+            } else {
+                { null }
+            },
+            background = { backgroundColor },
+        ),
+    )
+    private var collectionJob: Job? = null
+    private var currentKey: com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatSessionKey? = null
+    private var previousIds: Set<ChatMessageId>? = null
+    private var latestRows: List<ChatRowUiModel> = emptyList()
+    private val rendererVisible = MutableStateFlow(true)
+
+    init {
+        recyclerView.itemAnimator = null
+        recyclerView.layoutManager = LinearLayoutManager(recyclerView.context).apply {
+            stackFromEnd = true
+        }
+        recyclerView.adapter = adapter
+    }
+
+    val state: ChatViewportState
+        get() = viewport.state
+
+    fun attach(owner: LifecycleOwner) {
+        collectionJob?.cancel()
+        collectionJob = owner.lifecycleScope.launch {
+            owner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                rendererVisible
+                    .flatMapLatest { visible ->
+                        if (!visible) {
+                            emptyFlow()
+                        } else {
+                            manager.active.flatMapLatest { active ->
+                                if (active == null ||
+                                    active.spec.channelId != expectedChannelId ||
+                                    !active.spec.channelLogin.equals(expectedChannelLogin, ignoreCase = true)
+                                ) {
+                                    emptyFlow()
+                                } else {
+                                    active.presentationFlow()
+                                }
+                            }
+                        }
+                    }
+                    .collect { publication -> publish(publication) }
+            }
+        }
+    }
+
+    /** Hides only rendering; the playback-owned session and canonical timeline continue. */
+    fun setVisible(visible: Boolean) {
+        if (rendererVisible.value == visible) return
+        rendererVisible.value = visible
+        for (index in 0 until recyclerView.childCount) {
+            (recyclerView.getChildAt(index) as? ChatMessageTextView)?.setRenderingActive(visible)
+        }
+    }
+
+    fun detach() {
+        collectionJob?.cancel()
+        collectionJob = null
+        rendererVisible.value = false
+        for (index in 0 until recyclerView.childCount) {
+            (recyclerView.getChildAt(index) as? ChatMessageTextView)?.setRenderingActive(false)
+        }
+        recyclerView.adapter = null
+        adapter.submitList(emptyList())
+        latestRows = emptyList()
+        previousIds = null
+        currentKey = null
+    }
+
+    fun onUserScroll() {
+        viewport.onUserScroll()
+        onStateChanged(viewport.state)
+    }
+
+    fun jumpToNewest() {
+        viewport.jumpToNewest(latestRows)
+        onStateChanged(viewport.state)
+    }
+
+    private suspend fun publish(publication: PresentationPublication) {
+        val rows = withContext(Dispatchers.Default) {
+            publication.messages.map { presentation.resolve(it, publication.catalog) }
+        }
+        if (!rendererVisible.value) return
+        withContext(Dispatchers.Main.immediate) {
+            if (!rendererVisible.value) return@withContext
+            if (currentKey != publication.key) {
+                if (currentKey != null) viewport.resetForNewSession()
+                currentKey = publication.key
+                previousIds = null
+            }
+            val oldIds = previousIds
+            val previousAnchor = if (oldIds == null) null else viewport.captureAnchor(adapter)
+            val appendedCount = oldIds?.let { ids -> rows.count { it.id !in ids } } ?: 0
+            previousIds = rows.asSequence().map(ChatRowUiModel::id).toSet()
+            latestRows = rows
+            adapter.submitList(rows.toList()) {
+                viewport.onSnapshotCommitted(previousAnchor, rows, appendedCount)
+                onStateChanged(viewport.state)
+            }
+        }
+    }
+
+    private fun ActiveChatSession.presentationFlow() =
+        combine(
+            session.attachUi(),
+            catalog.state,
+        ) { snapshot, catalogState ->
+            if (!catalogState.hydrated) null else PresentationPublication(key, snapshot.messages, catalogState.snapshot)
+        }.filter { it != null }.map { it!! }
+
+    private data class PresentationPublication(
+        val key: com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatSessionKey,
+        val messages: List<com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessage>,
+        val catalog: com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatCatalogSnapshot,
+    )
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatViewportController.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatViewportController.kt
@@ -25,6 +25,11 @@ class ChatViewportController(
 
     fun restore(savedState: ChatViewportState) { state = savedState }
 
+    /** Channel/session changes start at the newest tail; an old anchor is not meaningful. */
+    fun resetForNewSession() {
+        state = ChatViewportState()
+    }
+
     fun captureAnchor(adapter: RecyclerView.Adapter<*>): ChatViewportAnchor? {
         val layout = recyclerView.layoutManager as? LinearLayoutManager ?: return null
         val position = layout.findFirstVisibleItemPosition()

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/ExoPlayerFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/ExoPlayerFragment.kt
@@ -1020,6 +1020,7 @@ class ExoPlayerFragment : PlayerFragment(), ClipEditorDialogFragment.Host {
     }
 
     override fun close(deleteStates: Boolean) {
+        releaseV2ChatSession()
         detachVideoOutput()
         playbackService?.cancelLiveClipPreparation()
         playbackService?.clearVodClipSource()

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/Media3Fragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/Media3Fragment.kt
@@ -1382,6 +1382,7 @@ class Media3Fragment : Media3PlayerFragment() {
     }
 
     override fun close() {
+        releaseV2ChatSession()
         savePosition()
         val controller = player
         controller?.pause()

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/Media3PlayerFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/Media3PlayerFragment.kt
@@ -1504,9 +1504,9 @@ abstract class Media3PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFr
                     gravity = Gravity.BOTTOM
                 }
                 if (isMaximized) {
-                    chatLayout.visibility = View.VISIBLE
+                    setChatLayoutVisibility(View.VISIBLE)
                 } else {
-                    chatLayout.visibility = View.GONE
+                    setChatLayoutVisibility(View.GONE)
                     val (minimizedScaleX, minimizedScaleY) = getScaleValues()
                     slidingLayout.scaleX = minimizedScaleX
                     slidingLayout.scaleY = minimizedScaleY
@@ -1577,14 +1577,14 @@ abstract class Media3PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFr
                         }
                     }
                     if (isChatOpen) {
-                        chatLayout.visibility = View.VISIBLE
+                        setChatLayoutVisibility(View.VISIBLE)
                         if (requireView().findViewById<Button>(R.id.btnDown)?.isVisible == false) {
                             requireView().findViewById<RecyclerView>(R.id.recyclerView)?.let { recyclerView ->
                                 recyclerView.adapter?.itemCount?.let { recyclerView.scrollToPosition(it - 1) }
                             }
                         }
                     } else {
-                        chatLayout.visibility = View.GONE
+                        setChatLayoutVisibility(View.GONE)
                     }
                 } else {
                     showStatusBar()
@@ -1598,7 +1598,7 @@ abstract class Media3PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFr
                         height = ViewGroup.LayoutParams.MATCH_PARENT
                         gravity = Gravity.END
                     }
-                    chatLayout.visibility = View.GONE
+                    setChatLayoutVisibility(View.GONE)
                     val (minimizedScaleX, minimizedScaleY) = getScaleValues()
                     slidingLayout.scaleX = minimizedScaleX
                     slidingLayout.scaleY = minimizedScaleY
@@ -1894,11 +1894,16 @@ abstract class Media3PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFr
             }
             (requireContext().getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager).hideSoftInputFromWindow(chatLayout.windowToken, 0)
             chatLayout.clearFocus()
-            chatLayout.visibility = View.GONE
+            setChatLayoutVisibility(View.GONE)
             if (requireContext().isTelevision()) {
                 applyTvChatPresentation(chatLayout, playerLayout, slidingLayout, false)
             }
         }
+    }
+
+    private fun setChatLayoutVisibility(visibility: Int) {
+        binding.chatLayout.visibility = visibility
+        chatFragment?.setV2RendererVisible(visibility == View.VISIBLE)
     }
 
     private fun showChatLayout() {
@@ -1914,7 +1919,7 @@ abstract class Media3PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFr
                 height = ViewGroup.LayoutParams.MATCH_PARENT
                 gravity = Gravity.END
             }
-            chatLayout.visibility = View.VISIBLE
+            setChatLayoutVisibility(View.VISIBLE)
             if (requireContext().isTelevision()) {
                 applyTvChatPresentation(chatLayout, playerLayout, slidingLayout, true)
             }
@@ -2507,6 +2512,11 @@ abstract class Media3PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFr
 
     fun disconnect() = chatFragment?.disconnect()
 
+    /** Explicit playback end, distinct from the Fragment/view becoming hidden. */
+    protected fun releaseV2ChatSession() {
+        chatFragment?.disconnect()
+    }
+
     fun reconnect() = chatFragment?.reconnect()
 
     fun secondViewIsHidden() = !binding.chatLayout.isVisible && isMaximized
@@ -2595,7 +2605,7 @@ abstract class Media3PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFr
         }
         if (isInPIPMode) {
             if (isPortrait) {
-                binding.chatLayout.visibility = View.GONE
+                setChatLayoutVisibility(View.GONE)
             } else {
                 hideChatLayout()
             }
@@ -3269,7 +3279,7 @@ abstract class Media3PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFr
                     slidingLayout.scaleY = 1f
                 }
                 if (isPortrait) {
-                    chatLayout.visibility = View.GONE
+                    setChatLayoutVisibility(View.GONE)
                 } else {
                     hideChatLayout()
                 }
@@ -3381,7 +3391,7 @@ abstract class Media3PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFr
                 }
             }
             if (isPortrait) {
-                chatLayout.visibility = View.GONE
+                setChatLayoutVisibility(View.GONE)
                 slidingLayout.doOnLayout {
                     animate()
                 }
@@ -3417,7 +3427,7 @@ abstract class Media3PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFr
                 updateProgress()
             }
             if (isPortrait) {
-                chatLayout.visibility = View.VISIBLE
+                setChatLayoutVisibility(View.VISIBLE)
             } else {
                 hideStatusBar()
                 if (isChatOpen) {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/MediaPlayerFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/MediaPlayerFragment.kt
@@ -442,6 +442,7 @@ class MediaPlayerFragment : PlayerFragment() {
     }
 
     override fun close(deleteStates: Boolean) {
+        releaseV2ChatSession()
         playbackService?.player?.pause()
         playbackService?.updatePlayingState()
         updatePlayingState()

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/PlayerFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/PlayerFragment.kt
@@ -2093,9 +2093,9 @@ abstract class PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFragment
                     gravity = Gravity.BOTTOM
                 }
                 if (isMaximized) {
-                    chatLayout.visibility = View.VISIBLE
+                    setChatLayoutVisibility(View.VISIBLE)
                 } else {
-                    chatLayout.visibility = View.GONE
+                    setChatLayoutVisibility(View.GONE)
                     val (minimizedScaleX, minimizedScaleY) = getScaleValues()
                     slidingLayout.scaleX = minimizedScaleX
                     slidingLayout.scaleY = minimizedScaleY
@@ -2166,14 +2166,14 @@ abstract class PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFragment
                         }
                     }
                     if (isChatOpen) {
-                        chatLayout.visibility = View.VISIBLE
+                        setChatLayoutVisibility(View.VISIBLE)
                         if (requireView().findViewById<Button>(R.id.btnDown)?.isVisible == false) {
                             requireView().findViewById<RecyclerView>(R.id.recyclerView)?.let { recyclerView ->
                                 recyclerView.adapter?.itemCount?.let { recyclerView.scrollToPosition(it - 1) }
                             }
                         }
                     } else {
-                        chatLayout.visibility = View.GONE
+                        setChatLayoutVisibility(View.GONE)
                     }
                 } else {
                     showStatusBar()
@@ -2187,7 +2187,7 @@ abstract class PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFragment
                         height = ViewGroup.LayoutParams.MATCH_PARENT
                         gravity = Gravity.END
                     }
-                    chatLayout.visibility = View.GONE
+                    setChatLayoutVisibility(View.GONE)
                     val (minimizedScaleX, minimizedScaleY) = getScaleValues()
                     slidingLayout.scaleX = minimizedScaleX
                     slidingLayout.scaleY = minimizedScaleY
@@ -2507,11 +2507,16 @@ abstract class PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFragment
             }
             (requireContext().getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager).hideSoftInputFromWindow(chatLayout.windowToken, 0)
             chatLayout.clearFocus()
-            chatLayout.visibility = View.GONE
+            setChatLayoutVisibility(View.GONE)
             if (requireContext().isTelevision()) {
                 applyTvChatPresentation(chatLayout, playerLayout, slidingLayout, false)
             }
         }
+    }
+
+    private fun setChatLayoutVisibility(visibility: Int) {
+        binding.chatLayout.visibility = visibility
+        chatFragment?.setV2RendererVisible(visibility == View.VISIBLE)
     }
 
     private fun showChatLayout() {
@@ -2527,7 +2532,7 @@ abstract class PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFragment
                 height = ViewGroup.LayoutParams.MATCH_PARENT
                 gravity = Gravity.END
             }
-            chatLayout.visibility = View.VISIBLE
+            setChatLayoutVisibility(View.VISIBLE)
             if (requireContext().isTelevision()) {
                 applyTvChatPresentation(chatLayout, playerLayout, slidingLayout, true)
             }
@@ -3160,6 +3165,11 @@ abstract class PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFragment
 
     fun disconnect() = chatFragment?.disconnect()
 
+    /** Explicit playback end, distinct from the Fragment/view becoming hidden. */
+    protected fun releaseV2ChatSession() {
+        chatFragment?.disconnect()
+    }
+
     fun reconnect() = chatFragment?.reconnect()
 
     fun secondViewIsHidden() = !binding.chatLayout.isVisible && isMaximized
@@ -3244,7 +3254,7 @@ abstract class PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFragment
         }
         if (isInPIPMode) {
             if (isPortrait) {
-                binding.chatLayout.visibility = View.GONE
+                setChatLayoutVisibility(View.GONE)
             } else {
                 hideChatLayout()
             }
@@ -3307,7 +3317,7 @@ abstract class PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFragment
                     slidingLayout.scaleY = 1f
                 }
                 if (isPortrait) {
-                    chatLayout.visibility = View.GONE
+                    setChatLayoutVisibility(View.GONE)
                 } else {
                     hideChatLayout()
                 }
@@ -3416,7 +3426,7 @@ abstract class PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFragment
                 }
             }
             if (isPortrait) {
-                chatLayout.visibility = View.GONE
+                setChatLayoutVisibility(View.GONE)
                 slidingLayout.doOnLayout {
                     animate()
                 }
@@ -3455,7 +3465,7 @@ abstract class PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFragment
                 updateProgress()
             }
             if (isPortrait) {
-                chatLayout.visibility = View.VISIBLE
+                setChatLayoutVisibility(View.VISIBLE)
             } else {
                 hideStatusBar()
                 if (isChatOpen) {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/C.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/C.kt
@@ -406,5 +406,6 @@ object C {
     const val DEBUG_WEBSOCKET_INFO = "debug_websocket_info"
     const val DEBUG_USE_CUSTOM_PLAYBACK_SERVICE = "debug_use_custom_playback_service_v2"
     const val DEBUG_EVENT_SUB_CHAT = "debug_eventsub_chat"
+    const val CHAT_V2_ENABLED = "chat_v2_enabled"
     const val DEBUG_PLAYER_MENU_PLAYLIST_TAGS = "debug_player_menu_playlist_tags"
 }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/chat/EventSubWebSocket.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/chat/EventSubWebSocket.kt
@@ -332,6 +332,8 @@ class EventSubWebSocket(
         suspend fun onChatMessage(event: JSONObject, timestamp: String?) {}
         suspend fun onUserNotice(event: JSONObject, timestamp: String?) {}
         suspend fun onClearChat(event: JSONObject, timestamp: String?) {}
+        suspend fun onClearUserMessages(event: JSONObject, timestamp: String?) {}
+        suspend fun onMessageDelete(event: JSONObject, timestamp: String?) {}
         suspend fun onRoomState(event: JSONObject, timestamp: String?) {}
         suspend fun onStreamOnline(event: JSONObject, timestamp: String?) {}
         suspend fun onDisconnect(message: String, fullMsg: String?) {}
@@ -375,6 +377,8 @@ class EventSubWebSocket(
                                     "channel.chat.message" -> listener.onChatMessage(event, timestamp)
                                     "channel.chat.notification" -> listener.onUserNotice(event, timestamp)
                                     "channel.chat.clear" -> listener.onClearChat(event, timestamp)
+                                    "channel.chat.clear_user_messages" -> listener.onClearUserMessages(event, timestamp)
+                                    "channel.chat.message_delete" -> listener.onMessageDelete(event, timestamp)
                                     "channel.chat_settings.update" -> listener.onRoomState(event, timestamp)
                                     "stream.online" -> listener.onStreamOnline(event, timestamp)
                                 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1632,6 +1632,7 @@
     <string name="statistics_reset_done">Viewing statistics reset</string>
     <string name="statistics_multiview_note">Watch time counts every actively playing stream, including each Multiview tile.</string>
     <string name="use_eventsub_chat_experimental">Use EventSub chat (experimental)</string>
+    <string name="use_chat_v2_renderer" translatable="false">Use the new chat renderer</string>
     <string name="settings_section_support">Support</string>
     <string name="settings_download_wifi_only_summary">Only start downloads while connected to Wi-Fi.</string>
     <string name="settings_download_single_file_summary">Store downloaded videos as one media file instead of Xtra\'s segmented format.</string>

--- a/app/src/main/res/xml/developer_preferences.xml
+++ b/app/src/main/res/xml/developer_preferences.xml
@@ -8,6 +8,7 @@
     <SwitchPreferenceCompat android:defaultValue="false" android:key="debug_api_chat_messages" android:title="@string/use_api_chat_messages" app:iconSpaceReserved="false" />
     <SwitchPreferenceCompat android:defaultValue="false" android:key="debug_websocket_info" android:title="@string/show_more_websocket_info" app:iconSpaceReserved="false" />
     <SwitchPreferenceCompat android:defaultValue="false" android:key="debug_eventsub_chat" android:title="@string/use_eventsub_chat_experimental" app:iconSpaceReserved="false" />
+    <SwitchPreferenceCompat android:defaultValue="true" android:key="chat_v2_enabled" android:title="@string/use_chat_v2_renderer" app:iconSpaceReserved="false" />
     <PreferenceCategory android:title="@string/settings_playback_diagnostics" app:iconSpaceReserved="false" />
     <SwitchPreferenceCompat android:defaultValue="true" android:key="debug_use_custom_playback_service_v2" android:summary="@string/use_legacy_exoplayer_service_summary" android:title="@string/use_legacy_exoplayer_service" app:iconSpaceReserved="false" />
     <ListPreference android:defaultValue="ExoPlayer" android:entries="@array/playerEntries" android:entryValues="@array/playerEntryValues" android:key="player" android:summary="%s" android:title="@string/legacy_playback_engine" app:iconSpaceReserved="false" />

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatSessionManagerIntegrationTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatSessionManagerIntegrationTest.kt
@@ -1,0 +1,252 @@
+package com.github.andreyasadchy.xtra.ui.chat.v2
+
+import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatCatalogProviderUpdate
+import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatCatalogRepository
+import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatCatalogSource
+import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatCatalogLoadResult
+import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatCatalogEmote
+import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatCatalogBadge
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatEvent
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessage
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessageId
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessageKind
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatSessionKey
+import com.github.andreyasadchy.xtra.ui.chat.v2.session.ChatSessionManager
+import com.github.andreyasadchy.xtra.ui.chat.v2.session.LiveChatSessionSpec
+import com.github.andreyasadchy.xtra.ui.chat.v2.transport.ChatTransport
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.atomic.AtomicInteger
+
+class ChatSessionManagerIntegrationTest {
+    @Test
+    fun initialHistoryReconcilesLiveMessagesWithoutDuplicates() = runBlocking {
+        val parent = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val transport = FakeTransport()
+        val historyStarted = CompletableDeferred<Unit>()
+        val releaseHistory = CompletableDeferred<List<ChatMessage>>()
+        val manager = ChatSessionManager(
+            parentScope = parent,
+            transportFactory = { transport },
+            catalogFactory = { _, scope -> ChatCatalogRepository(scope, EMPTY_CATALOG_SOURCE) },
+            recentHistory = {
+                historyStarted.complete(Unit)
+                releaseHistory.await()
+            },
+            maxTimelineSize = 200,
+        )
+
+        val active = manager.start(LiveChatSessionSpec("channel-id", "channel-login"))
+        withTimeout(1_000) { historyStarted.await() }
+        withTimeout(1_000) { while (transport.activeCollectors != 1) delay(1) }
+
+        transport.send(active.key, message(101))
+        transport.send(active.key, message(102))
+        awaitLast(active.session, "102")
+
+        releaseHistory.complete((1..101).map(::message))
+        val final = withTimeout(2_000) {
+            var result: List<ChatMessage>? = null
+            while (result == null) {
+                val current = active.session.snapshot()
+                if (current.lastOrNull()?.id?.value == "102" && current.size == 102) result = current
+                else delay(1)
+            }
+            result
+        }
+
+        assertEquals((1..102).map(Int::toString), final.map { it.id.value })
+        assertEquals(1, final.count { it.id.value == "101" })
+
+        manager.close()
+        parent.cancel()
+    }
+
+    @Test
+    fun failedInitialHistoryDoesNotStopLiveTransport() = runBlocking {
+        val parent = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val transport = FakeTransport()
+        val manager = ChatSessionManager(
+            parentScope = parent,
+            transportFactory = { transport },
+            catalogFactory = { _, scope -> ChatCatalogRepository(scope, EMPTY_CATALOG_SOURCE) },
+            recentHistory = { error("history unavailable") },
+        )
+
+        val active = manager.start(LiveChatSessionSpec("channel-id", "channel-login"))
+        withTimeout(1_000) { while (transport.activeCollectors != 1) delay(1) }
+        transport.send(active.key, message(1))
+
+        assertEquals(listOf("1"), awaitLast(active.session, "1").map { it.id.value })
+        manager.close()
+        parent.cancel()
+    }
+
+    @Test
+    fun lateInitialHistoryCannotContaminateNewChannel() = runBlocking {
+        val parent = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val transport = FakeTransport()
+        val oldHistoryStarted = CompletableDeferred<Unit>()
+        val releaseOldHistory = CompletableDeferred<List<ChatMessage>>()
+        val oldHistoryFinished = CompletableDeferred<Unit>()
+        val manager = ChatSessionManager(
+            parentScope = parent,
+            transportFactory = { transport },
+            catalogFactory = { _, scope -> ChatCatalogRepository(scope, EMPTY_CATALOG_SOURCE) },
+            recentHistory = { spec ->
+                if (spec.channelId == "old") {
+                    oldHistoryStarted.complete(Unit)
+                    try {
+                        releaseOldHistory.await()
+                    } finally {
+                        oldHistoryFinished.complete(Unit)
+                    }
+                } else {
+                    emptyList()
+                }
+            },
+        )
+
+        val old = manager.start(LiveChatSessionSpec("old", "old"))
+        withTimeout(1_000) { oldHistoryStarted.await() }
+        val current = manager.start(LiveChatSessionSpec("new", "new"))
+        withTimeout(1_000) { while (transport.activeCollectors != 1) delay(1) }
+        transport.send(current.key, message(2))
+        awaitLast(current.session, "2")
+
+        releaseOldHistory.complete(listOf(message(1)))
+        withTimeout(1_000) { oldHistoryFinished.await() }
+
+        assertEquals(listOf("2"), current.session.snapshot().map { it.id.value })
+        manager.close()
+        parent.cancel()
+    }
+
+    @Test
+    fun playbackOwnedSessionKeepsCurrentTailWhileUiIsDetached() = runBlocking {
+        val parent = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val transport = FakeTransport()
+        val manager = ChatSessionManager(
+            parentScope = parent,
+            transportFactory = { transport },
+            catalogFactory = { _, scope -> ChatCatalogRepository(scope, EMPTY_CATALOG_SOURCE) },
+            maxTimelineSize = 600,
+        )
+        val spec = LiveChatSessionSpec("channel-id", "channel-login")
+        val active = manager.start(spec)
+
+        withTimeout(1_000) { while (transport.activeCollectors != 1) delay(1) }
+        repeat(500) { transport.send(active.key, message(it)) }
+
+        val snapshot = withTimeout(2_000) {
+            active.session.attachUi().first { it.messages.lastOrNull()?.id?.value == "499" }
+        }
+        assertEquals((0 until 500).map(Int::toString), snapshot.messages.map { it.id.value })
+        assertEquals(1, transport.activeCollectors)
+
+        manager.close()
+        withTimeout(1_000) { while (transport.activeCollectors != 0) delay(1) }
+        parent.cancel()
+    }
+
+    @Test
+    fun switchingPlaybackSessionsLeavesOnlyNewestChannelInManager() = runBlocking {
+        val parent = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val transport = FakeTransport()
+        val manager = ChatSessionManager(
+            parentScope = parent,
+            transportFactory = { transport },
+            catalogFactory = { _, scope -> ChatCatalogRepository(scope, EMPTY_CATALOG_SOURCE) },
+        )
+
+        val first = manager.start(LiveChatSessionSpec("first-id", "first"))
+        withTimeout(1_000) { while (transport.activeCollectors != 1) delay(1) }
+        transport.send(first.key, message(1))
+        awaitLast(first.session, "1")
+
+        val second = manager.start(LiveChatSessionSpec("second-id", "second"))
+        withTimeout(1_000) { while (transport.activeCollectors != 1) delay(1) }
+        transport.send(first.key, message(2))
+        transport.send(second.key, message(3))
+        assertEquals(listOf("3"), awaitLast(second.session, "3").map { it.id.value })
+        assertEquals(second.key, manager.active.value?.key)
+
+        manager.close()
+        withTimeout(1_000) { while (transport.activeCollectors != 0) delay(1) }
+        parent.cancel()
+    }
+
+    private suspend fun awaitLast(session: com.github.andreyasadchy.xtra.ui.chat.v2.session.ChatSession, id: String): List<ChatMessage> =
+        withTimeout(2_000) {
+            var result: List<ChatMessage>? = null
+            while (true) {
+                val current = session.snapshot()
+                if (current.lastOrNull()?.id?.value == id) {
+                    result = current
+                    break
+                }
+                delay(1)
+            }
+            checkNotNull(result)
+        }
+
+    private fun message(index: Int) = ChatMessage(
+        id = ChatMessageId(index.toString()),
+        channelId = "channel",
+        timestampMs = index.toLong(),
+        user = null,
+        badges = emptyList(),
+        segments = emptyList(),
+        kind = ChatMessageKind.CHAT,
+    )
+
+    private class FakeTransport : ChatTransport {
+        private val feeds = ConcurrentHashMap<ChatSessionKey, MutableSharedFlow<ChatEvent>>()
+        private val active = AtomicInteger()
+        val activeCollectors: Int get() = active.get()
+        val requested = CopyOnWriteArrayList<ChatSessionKey>()
+
+        override fun events(session: ChatSessionKey): Flow<ChatEvent> = flow {
+            requested += session
+            active.incrementAndGet()
+            try {
+                feeds.computeIfAbsent(session) { MutableSharedFlow(extraBufferCapacity = 1_024) }
+                    .collect { emit(it) }
+            } finally {
+                active.decrementAndGet()
+            }
+        }
+
+        suspend fun send(key: ChatSessionKey, message: ChatMessage) {
+            feeds.computeIfAbsent(key) { MutableSharedFlow(extraBufferCapacity = 1_024) }
+                .emit(ChatEvent.Message(message))
+        }
+    }
+
+    private companion object {
+        val EMPTY_CATALOG_SOURCE = ChatCatalogSource {
+            ChatCatalogLoadResult(
+                twitch = ChatCatalogProviderUpdate<Map<String, ChatCatalogEmote>>(emptyMap()),
+                sevenTv = ChatCatalogProviderUpdate<Map<String, ChatCatalogEmote>>(emptyMap()),
+                bttv = ChatCatalogProviderUpdate<Map<String, ChatCatalogEmote>>(emptyMap()),
+                ffz = ChatCatalogProviderUpdate<Map<String, ChatCatalogEmote>>(emptyMap()),
+                badges = ChatCatalogProviderUpdate<Map<String, ChatCatalogBadge>>(emptyMap()),
+            )
+        }
+    }
+}

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatTimelineArchitectureTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatTimelineArchitectureTest.kt
@@ -89,8 +89,97 @@ class ChatTimelineArchitectureTest {
         val scope = CoroutineScope(Dispatchers.Default)
         val store = ChatTimelineStore(scope, maxSize = 600)
         store.apply(com.github.andreyasadchy.xtra.ui.chat.v2.session.TimelineOperation.Append(listOf(message(1, "u1"), message(2, "u2"), message(3, "u1"))))
-        store.apply(com.github.andreyasadchy.xtra.ui.chat.v2.session.TimelineOperation.Delete(ChatMessageId("2")))
-        store.apply(com.github.andreyasadchy.xtra.ui.chat.v2.session.TimelineOperation.ClearUser("u1"))
+        store.apply(com.github.andreyasadchy.xtra.ui.chat.v2.session.TimelineOperation.Delete(ChatMessageId("2"), atMs = 4))
+        store.apply(com.github.andreyasadchy.xtra.ui.chat.v2.session.TimelineOperation.ClearUser("u1", atMs = 4))
+        assertEquals(emptyList<String>(), store.snapshot().map { it.id.value })
+        scope.cancel()
+    }
+
+    @Test
+    fun deletingASeenMessageIsNotFilteredAsADuplicate() = runBlocking {
+        val scope = CoroutineScope(Dispatchers.Default)
+        val store = ChatTimelineStore(scope, maxSize = 600)
+        val processor = ChatEventProcessor(scope, store)
+        val key = com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatSessionKey("channel", 1)
+        processor.activate(key)
+        processor.submit(key, ChatEvent.Message(message(1), eventId = "1", receivedAtMs = 1))
+        awaitSnapshot(store) { it.lastOrNull()?.id?.value == "1" }
+
+        processor.submit(key, ChatEvent.Delete(ChatMessageId("1"), eventId = "1", receivedAtMs = 2))
+        assertEquals(emptyList<String>(), awaitSnapshot(store) { it.isEmpty() }.map { it.id.value })
+        scope.cancel()
+    }
+
+    @Test
+    fun repeatedClearUserEventsAreBothApplied() = runBlocking {
+        val scope = CoroutineScope(Dispatchers.Default)
+        val store = ChatTimelineStore(scope, maxSize = 600)
+        val processor = ChatEventProcessor(scope, store)
+        val key = com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatSessionKey("channel", 1)
+        processor.activate(key)
+        processor.submit(key, ChatEvent.Message(message(1, "u1"), receivedAtMs = 1))
+        awaitSnapshot(store) { it.lastOrNull()?.id?.value == "1" }
+
+        processor.submit(key, ChatEvent.ClearUser("u1", eventId = "u1", receivedAtMs = 2))
+        awaitSnapshot(store) { it.isEmpty() }
+        processor.submit(key, ChatEvent.Message(message(3, "u1"), receivedAtMs = 3))
+        awaitSnapshot(store) { it.lastOrNull()?.id?.value == "3" }
+
+        processor.submit(key, ChatEvent.ClearUser("u1", eventId = "u1", receivedAtMs = 4))
+        assertEquals(emptyList<String>(), awaitSnapshot(store) { it.isEmpty() }.map { it.id.value })
+        scope.cancel()
+    }
+
+    @Test
+    fun deletedMessageDoesNotReturnFromStaleReconciliation() = runBlocking {
+        val scope = CoroutineScope(Dispatchers.Default)
+        val store = ChatTimelineStore(scope, maxSize = 600)
+        val processor = ChatEventProcessor(scope, store)
+        val key = com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatSessionKey("channel", 1)
+        processor.activate(key)
+        val deleted = message(1)
+        processor.submit(key, ChatEvent.Message(deleted, receivedAtMs = 1))
+        awaitSnapshot(store) { it.lastOrNull()?.id?.value == "1" }
+        processor.submit(key, ChatEvent.Delete(deleted.id, eventId = "1", receivedAtMs = 2))
+        awaitSnapshot(store) { it.isEmpty() }
+
+        processor.reconcile(key, listOf(deleted))
+        assertEquals(emptyList<String>(), store.snapshot().map { it.id.value })
+        scope.cancel()
+    }
+
+    @Test
+    fun clearedUserMessagesDoNotReturnFromStaleReconciliation() = runBlocking {
+        val scope = CoroutineScope(Dispatchers.Default)
+        val store = ChatTimelineStore(scope, maxSize = 600)
+        val processor = ChatEventProcessor(scope, store)
+        val key = com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatSessionKey("channel", 1)
+        processor.activate(key)
+        val oldMessages = listOf(message(1, "u1"), message(2, "u1"))
+        oldMessages.forEach { processor.submit(key, ChatEvent.Message(it, receivedAtMs = it.timestampMs)) }
+        awaitSnapshot(store) { it.size == 2 }
+        processor.submit(key, ChatEvent.ClearUser("u1", eventId = "u1", receivedAtMs = 3))
+        awaitSnapshot(store) { it.isEmpty() }
+
+        processor.reconcile(key, oldMessages)
+        assertEquals(emptyList<String>(), store.snapshot().map { it.id.value })
+        scope.cancel()
+    }
+
+    @Test
+    fun messagesBeforeGlobalClearDoNotReturnFromStaleReconciliation() = runBlocking {
+        val scope = CoroutineScope(Dispatchers.Default)
+        val store = ChatTimelineStore(scope, maxSize = 600)
+        val processor = ChatEventProcessor(scope, store)
+        val key = com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatSessionKey("channel", 1)
+        processor.activate(key)
+        val oldMessages = listOf(message(1), message(2))
+        oldMessages.forEach { processor.submit(key, ChatEvent.Message(it, receivedAtMs = it.timestampMs)) }
+        awaitSnapshot(store) { it.size == 2 }
+        processor.submit(key, ChatEvent.Clear(eventId = "clear", receivedAtMs = 3))
+        awaitSnapshot(store) { it.isEmpty() }
+
+        processor.reconcile(key, oldMessages)
         assertEquals(emptyList<String>(), store.snapshot().map { it.id.value })
         scope.cancel()
     }
@@ -149,5 +238,17 @@ class ChatTimelineArchitectureTest {
             }
             checkNotNull(result)
         }
+    }
+
+    private suspend fun awaitSnapshot(
+        store: ChatTimelineStore,
+        predicate: (List<ChatMessage>) -> Boolean,
+    ): List<ChatMessage> = withTimeout(5_000) {
+        var result: List<ChatMessage>? = null
+        while (result == null) {
+            val snapshot = store.snapshot()
+            if (predicate(snapshot)) result = snapshot else delay(1)
+        }
+        checkNotNull(result)
     }
 }

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/TwitchChatEventParserTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/TwitchChatEventParserTest.kt
@@ -1,0 +1,97 @@
+package com.github.andreyasadchy.xtra.ui.chat.v2
+
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatEvent
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatSegment
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.TwitchChatMessageType
+import com.github.andreyasadchy.xtra.ui.chat.v2.transport.TwitchChatEventParser
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TwitchChatEventParserTest {
+    @Test
+    fun eventSubKeepsStructuredFragmentsAndCurrentMessageMetadata() {
+        val gifUrl = "https://clips-media-assets2.twitch.tv/gif?token=keep-exactly"
+        val event = JSONObject(
+            """
+            {
+              "broadcaster_user_id":"broadcaster",
+              "chatter_user_id":"chatter",
+              "chatter_user_login":"viewer_login",
+              "chatter_user_name":"Viewer",
+              "color":"#123456",
+              "message_id":"message-1",
+              "message_type":"power_ups_gigantified_emote",
+              "badges":[{"set_id":"subscriber","id":"12","info":"Tier 1"}],
+              "reply":{
+                "parent_message_id":"parent",
+                "parent_message_body":"parent body",
+                "parent_user_id":"parent-user",
+                "parent_user_name":"Parent",
+                "parent_user_login":"parent_login",
+                "thread_message_id":"thread",
+                "thread_user_id":"thread-user",
+                "thread_user_name":"Thread",
+                "thread_user_login":"thread_login"
+              },
+              "source_broadcaster_user_id":"source",
+              "source_broadcaster_user_login":"source_login",
+              "source_broadcaster_user_name":"Source",
+              "source_message_id":"source-message",
+              "source_badges":[{"set_id":"moderator","id":"1","info":"Mod"}],
+              "is_source_only":true,
+              "message":{
+                "text":"Kappa @friend Cheer100 party",
+                "fragments":[
+                  {"type":"emote","text":"Kappa","emote":{"id":"25","emote_set_id":"set","owner_id":"owner","format":["static","animated"]}},
+                  {"type":"text","text":" "},
+                  {"type":"mention","text":"@friend","mention":{"user_id":"mentioned","user_login":"friend","user_name":"Friend"}},
+                  {"type":"text","text":" "},
+                  {"type":"cheermote","text":"Cheer100","cheermote":{"prefix":"Cheer","bits":100,"tier":1}},
+                  {"type":"text","text":" party"},
+                  {"type":"gif","text":"party","gif":{"id":"gif-1","url":"%s"}}
+                ]
+              }
+            }
+            """.trimIndent().format(gifUrl),
+        )
+
+        val message = (TwitchChatEventParser.fromEventSub(event, "2026-09-01T12:00:00Z") as ChatEvent.Message).message
+        assertEquals("message-1", message.id.value)
+        assertEquals(TwitchChatMessageType.GigantifiedEmote, message.twitchType)
+        assertEquals("#123456", "#%06X".format(message.user!!.color!! and 0xFFFFFF))
+        assertEquals("subscriber", message.badges.single().setId)
+        assertEquals("12", message.badges.single().versionId)
+        assertEquals("parent", message.reply!!.parentMessageId.value)
+        assertEquals("parent body", message.reply.parentMessageBody)
+        assertEquals("thread_login", message.reply.threadUserLogin)
+        assertEquals("source-message", message.source!!.messageId!!.value)
+        assertTrue(message.source.sourceOnly)
+
+        assertTrue(message.segments[0] is ChatSegment.Emote)
+        assertEquals("mentioned", (message.segments[2] as ChatSegment.Mention).userId)
+        assertEquals(100, (message.segments[4] as ChatSegment.Cheermote).bits)
+        val gif = message.segments.last() as ChatSegment.Gif
+        assertEquals("gif-1", gif.gifId)
+        assertEquals(gifUrl, gif.url)
+    }
+
+    @Test
+    fun unknownMessageTypeAndUnknownFragmentAreNonFatal() {
+        val event = JSONObject(
+            """
+            {
+              "broadcaster_user_id":"broadcaster",
+              "message_id":"message-2",
+              "message_type":"future_type",
+              "message":{"fragments":[{"type":"future_fragment","text":"future text"}]}
+            }
+            """.trimIndent(),
+        )
+
+        val message = (TwitchChatEventParser.fromEventSub(event, null) as ChatEvent.Message).message
+        assertEquals(TwitchChatMessageType.Unknown("future_type"), message.twitchType)
+        assertEquals(ChatSegment.Text("future text"), message.segments.single())
+    }
+}


### PR DESCRIPTION
Wire live single-channel Twitch chat through the chat-v2 timeline and renderer while keeping the legacy path available during migration.\n\nThis adds EventSub with IRC fallback, a playback-owned session manager, normalized Twitch events, persistent hydrated catalogs, asynchronous Coil assets, atomic reconnect history, and lifecycle-aware renderer attachment. Scrolling, minimize, and view recreation no longer pause or replay canonical chat. Multiview remains on the legacy path in this PR.\n\nVerified locally with JVM tests, release APK assembly, v2 renderer instrumentation, and the full connected instrumentation suite.