### PR TITLE
Fix multi-outcome prediction choices

### DIFF
--- a/.github/scripts/check-resources.py
+++ b/.github/scripts/check-resources.py
@@ -46,6 +46,7 @@ ARRAY_REFERENCE = re.compile(r"^@string/([A-Za-z0-9_]+)$")
 # prevents this policy from hiding missing translations elsewhere in the app.
 INTENTIONAL_FALLBACK_RESOURCES = {
     "automatic_updates",
+    "channel_points_prediction_outcome_description",
     "check_automatically",
     "copy_diagnostics",
     "diagnostics_copied",

--- a/app/src/main/java/com/github/andreyasadchy/xtra/model/chat/Prediction.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/model/chat/Prediction.kt
@@ -22,5 +22,8 @@ data class Prediction(
         val totalPoints: Int?,
         val totalUsers: Int?,
         val color: String? = null,
+        val badgeSetId: String? = null,
+        val badgeVersion: String? = null,
+        val badgeUrl: String? = null,
     )
 }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChannelPointsDialog.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChannelPointsDialog.kt
@@ -9,6 +9,7 @@ import android.graphics.drawable.GradientDrawable
 import android.os.Bundle
 import android.text.InputType
 import android.text.TextWatcher
+import android.util.Log
 import android.view.Gravity
 import android.view.View
 import android.view.WindowManager
@@ -32,6 +33,7 @@ import coil3.request.ImageRequest
 import coil3.request.CachePolicy
 import coil3.request.crossfade
 import coil3.request.target
+import com.github.andreyasadchy.xtra.BuildConfig
 import com.github.andreyasadchy.xtra.R
 import com.github.andreyasadchy.xtra.databinding.DialogChannelPointsBinding
 import com.github.andreyasadchy.xtra.model.chat.Emote
@@ -832,6 +834,14 @@ class ChannelPointsDialog : DialogFragment() {
         } else {
             binding.predictionBetChoices.removeAllViews()
         }
+        if (BuildConfig.DEBUG) {
+            Log.d(
+                "PredictionRender",
+                "[DEBUG-PREDICTION] id=${prediction.id} modelOutcomes=${outcomes.size} " +
+                    "resultRows=${binding.predictionOutcomes.childCount} " +
+                    "betButtons=${binding.predictionBetChoices.childCount}",
+            )
+        }
     }
 
     private fun renderPredictionBetChoices(
@@ -842,17 +852,24 @@ class ChannelPointsDialog : DialogFragment() {
         val container = binding.predictionBetChoices
         container.removeAllViews()
         val outcomes = prediction.outcomes.orEmpty()
-        outcomes.forEach { outcome ->
-            val outcomeId = outcome.id ?: return@forEach
-            val buttonColor = when {
-                outcome.color.equals("PINK", true) -> PINK_PREDICTION_COLOR
-                outcome.color.equals("BLUE", true) -> BLUE_PREDICTION_COLOR
-                else -> BLUE_PREDICTION_COLOR
+        outcomes.forEachIndexed { index, outcome ->
+            val outcomeId = outcome.id ?: return@forEachIndexed
+            val buttonColor = if (outcomes.size > 2) {
+                BLUE_PREDICTION_COLOR
+            } else {
+                when {
+                    outcome.color.equals("PINK", true) -> PINK_PREDICTION_COLOR
+                    outcome.color.equals("BLUE", true) -> BLUE_PREDICTION_COLOR
+                    else -> BLUE_PREDICTION_COLOR
+                }
             }
+            val label = predictionOutcomeLabel(outcome, index, outcomes.size)
             val button = MaterialButton(requireContext()).apply {
-                text = outcome.title
+                text = label
                 tag = outcomeId
                 isEnabled = enabled
+                minHeight = dp(48)
+                contentDescription = outcomeDescription(outcome, index, outcomes.size)
                 stylePredictionButton(this, buttonColor)
                 setOnClickListener {
                     placePredictionBet(
@@ -899,11 +916,15 @@ class ChannelPointsDialog : DialogFragment() {
         viewerSelected: Boolean,
         viewerAmount: Int?,
     ) {
-        val color = when {
-            outcome.color.equals("PINK", true) -> PINK_PREDICTION_COLOR
-            outcome.color.equals("BLUE", true) -> BLUE_PREDICTION_COLOR
-            outcomeCount == 2 && index == 1 -> PINK_PREDICTION_COLOR
-            else -> BLUE_PREDICTION_COLOR
+        val color = if (outcomeCount > 2) {
+            BLUE_PREDICTION_COLOR
+        } else {
+            when {
+                outcome.color.equals("PINK", true) -> PINK_PREDICTION_COLOR
+                outcome.color.equals("BLUE", true) -> BLUE_PREDICTION_COLOR
+                outcomeCount == 2 && index == 1 -> PINK_PREDICTION_COLOR
+                else -> BLUE_PREDICTION_COLOR
+            }
         }
         val percent = if (totalPoints != null && totalPoints > 0 && outcome.totalPoints != null) {
             ((outcome.totalPoints.toLong() * 100.0) / totalPoints).roundToInt().coerceIn(0, 100)
@@ -931,15 +952,47 @@ class ChannelPointsDialog : DialogFragment() {
                 bottomMargin = dp(4)
             }
         }
-        content.addView(TextView(requireContext()).apply {
-            text = outcome.title
+        content.contentDescription = outcomeDescription(outcome, index, outcomeCount)
+        val titleRow = LinearLayout(requireContext()).apply {
+            orientation = LinearLayout.HORIZONTAL
+            gravity = Gravity.CENTER
+            layoutParams = LinearLayout.LayoutParams(
+                LinearLayout.LayoutParams.MATCH_PARENT,
+                LinearLayout.LayoutParams.WRAP_CONTENT,
+            )
+        }
+        if (outcomeCount > 2 && !outcome.badgeUrl.isNullOrBlank()) {
+            val badge = ImageView(requireContext()).apply {
+                layoutParams = LinearLayout.LayoutParams(dp(24), dp(24)).apply {
+                    rightMargin = dp(4)
+                }
+                scaleType = ImageView.ScaleType.CENTER_INSIDE
+                importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_NO
+            }
+            requireContext().imageLoader.enqueue(
+                ImageRequest.Builder(requireContext())
+                    .data(outcome.badgeUrl)
+                    .diskCachePolicy(CachePolicy.ENABLED)
+                    .crossfade(true)
+                    .target(badge)
+                    .build(),
+            )
+            titleRow.addView(badge)
+        }
+        titleRow.addView(TextView(requireContext()).apply {
+            text = predictionOutcomeLabel(outcome, index, outcomeCount)
             gravity = Gravity.CENTER
             maxLines = 2
-            ellipsize = android.text.TextUtils.TruncateAt.END
+            setHorizontallyScrolling(false)
             setTextColor(color)
             textSize = 16f
             setTypeface(typeface, android.graphics.Typeface.BOLD)
+            layoutParams = LinearLayout.LayoutParams(
+                0,
+                LinearLayout.LayoutParams.WRAP_CONTENT,
+            ).apply { weight = 1f }
         })
+        content.addView(titleRow)
         if (winner || tie) {
             content.addView(TextView(requireContext()).apply {
                 text = getString(if (winner) R.string.channel_points_prediction_winner else R.string.channel_points_prediction_tie)
@@ -1026,6 +1079,21 @@ class ChannelPointsDialog : DialogFragment() {
         button.isAllCaps = false
         button.maxLines = 2
         button.ellipsize = android.text.TextUtils.TruncateAt.END
+    }
+
+    private fun outcomeDescription(
+        outcome: Prediction.PredictionOutcome,
+        index: Int,
+        outcomeCount: Int,
+    ): String? = if (outcomeCount > 2) {
+        getString(
+            R.string.channel_points_prediction_outcome_description,
+            predictionOutcomeOrdinal(outcome, index),
+            outcomeCount,
+            outcome.title.orEmpty(),
+        )
+    } else {
+        null
     }
 
     private fun placePredictionBet(

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatViewModel.kt
@@ -14,6 +14,7 @@ import androidx.lifecycle.ViewModelProvider.AndroidViewModelFactory.Companion.AP
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
+import com.github.andreyasadchy.xtra.BuildConfig
 import com.github.andreyasadchy.xtra.R
 import com.github.andreyasadchy.xtra.XtraApp
 import com.github.andreyasadchy.xtra.model.chat.Badge
@@ -79,6 +80,8 @@ import com.github.andreyasadchy.xtra.util.chat.EventSubUtils
 import com.github.andreyasadchy.xtra.util.chat.EventSubWebSocket
 import com.github.andreyasadchy.xtra.util.chat.GqlPredictionParser
 import com.github.andreyasadchy.xtra.util.chat.GqlPredictionSnapshot
+import com.github.andreyasadchy.xtra.util.chat.chooseGqlPredictionSnapshot
+import com.github.andreyasadchy.xtra.util.chat.hasUsableOutcomeSet
 import com.github.andreyasadchy.xtra.util.chat.HermesWebSocket
 import com.github.andreyasadchy.xtra.util.chat.PollCache
 import com.github.andreyasadchy.xtra.util.chat.isHighlightedMessage
@@ -88,6 +91,7 @@ import com.github.andreyasadchy.xtra.util.chat.PredictionCache
 import com.github.andreyasadchy.xtra.util.chat.PredictionState
 import com.github.andreyasadchy.xtra.util.chat.PredictionStateStore
 import com.github.andreyasadchy.xtra.util.chat.PubSubUtils
+import com.github.andreyasadchy.xtra.util.chat.shouldLoadAnonymousPredictionSnapshot
 import com.github.andreyasadchy.xtra.util.chat.STVEventApiUtils
 import com.github.andreyasadchy.xtra.util.chat.STVEventApiWebSocket
 import com.github.andreyasadchy.xtra.util.chat.ViewerParticipationCache
@@ -3622,8 +3626,10 @@ class ChatViewModel(
                     ),
                     snapshotRequestedAt,
                 )
+                logPredictionSnapshot("gql-authenticated", authenticatedSnapshot)
                 var snapshot = authenticatedSnapshot
-                if ((authenticatedSnapshot == null || !authenticatedSnapshot.hasActiveOrLockedPrediction) &&
+                val shouldTryAnonymous = shouldLoadAnonymousPredictionSnapshot(authenticatedSnapshot)
+                if (shouldTryAnonymous &&
                     !authenticatedHeaders[C.HEADER_TOKEN].isNullOrBlank()
                 ) {
                     val anonymousSnapshot = GqlPredictionParser.parse(
@@ -3634,13 +3640,15 @@ class ChatViewModel(
                         ),
                         snapshotRequestedAt,
                     )
-                    snapshot = choosePredictionSnapshot(authenticatedSnapshot, anonymousSnapshot)
+                    logPredictionSnapshot("gql-anonymous", anonymousSnapshot)
+                    snapshot = chooseGqlPredictionSnapshot(authenticatedSnapshot, anonymousSnapshot)
                 }
+                logPredictionSnapshot("gql-selected", snapshot)
                 if (sessionToken != predictionSessionToken || activeChannelLogin != channelLogin || snapshot == null) {
                     return@launch
                 }
                 val prediction = snapshot.prediction
-                if (prediction != null) {
+                if (prediction != null && snapshot.hasUsableOutcomeSet()) {
                     updatePrediction(
                         prediction,
                         sourceChannelId = channelId,
@@ -3659,18 +3667,20 @@ class ChatViewModel(
         }
     }
 
-    private fun choosePredictionSnapshot(
-        authenticatedSnapshot: GqlPredictionSnapshot?,
-        anonymousSnapshot: GqlPredictionSnapshot?,
-    ): GqlPredictionSnapshot? = listOfNotNull(authenticatedSnapshot, anonymousSnapshot)
-        .maxByOrNull { snapshot ->
-            when {
-                snapshot.hasActiveOrLockedPrediction -> 3
-                snapshot.authoritative -> 2
-                snapshot.prediction != null -> 1
-                else -> 0
-            }
-        }
+    private fun logPredictionSnapshot(source: String, snapshot: GqlPredictionSnapshot?) {
+        if (!BuildConfig.DEBUG) return
+        val prediction = snapshot?.prediction
+        val outcomes = prediction?.outcomes
+        val outcomeDetails = outcomes?.joinToString(prefix = "[", postfix = "]") { outcome ->
+            "{id=${outcome.id},color=${outcome.color},badge=${outcome.badgeSetId}/${outcome.badgeVersion}}"
+        } ?: "unknown"
+        Log.d(
+            "PredictionSnapshot",
+            "[DEBUG-PREDICTION] source=$source id=${prediction?.id} status=${prediction?.status} " +
+                "outcomeCount=${outcomes?.size ?: "unknown"} authoritative=${snapshot?.authoritative} " +
+                "activeOrLocked=${snapshot?.hasActiveOrLockedPrediction} outcomes=$outcomeDetails",
+        )
+    }
 
     private fun clearStalePrediction(
         channelId: String?,
@@ -4014,6 +4024,13 @@ class ChatViewModel(
         override suspend fun onPredictionUpdate(message: JSONObject) {
             if (showPredictions && channelId == activeChannelId) {
                 PubSubUtils.onPredictionUpdate(message)?.let {
+                    if (BuildConfig.DEBUG) {
+                        Log.d(
+                            "PredictionHermes",
+                            "[DEBUG-PREDICTION] type=${message.optString("type")} id=${it.id} " +
+                                "status=${it.status} outcomeCount=${it.outcomes?.size ?: "unknown"}",
+                        )
+                    }
                     updatePrediction(
                         it,
                         sourceChannelId = channelId,

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/PredictionPresentation.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/PredictionPresentation.kt
@@ -1,0 +1,25 @@
+package com.github.andreyasadchy.xtra.ui.chat
+
+import com.github.andreyasadchy.xtra.model.chat.Prediction
+
+internal fun predictionOutcomeOrdinal(
+    outcome: Prediction.PredictionOutcome,
+    fallbackIndex: Int,
+): Int = outcome.badgeVersion
+    ?.substringAfterLast('-')
+    ?.toIntOrNull()
+    ?.takeIf { it in 1..10 }
+    ?: (fallbackIndex + 1)
+
+internal fun predictionOutcomeLabel(
+    outcome: Prediction.PredictionOutcome,
+    index: Int,
+    outcomeCount: Int,
+): String {
+    val title = outcome.title.orEmpty()
+    return if (outcomeCount > 2) {
+        "${predictionOutcomeOrdinal(outcome, index)}. $title"
+    } else {
+        title
+    }
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/chat/GqlPredictionParser.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/chat/GqlPredictionParser.kt
@@ -13,6 +13,35 @@ internal data class GqlPredictionSnapshot(
     val hasActiveOrLockedPrediction: Boolean,
 )
 
+internal fun GqlPredictionSnapshot.hasUsableOutcomeSet(): Boolean {
+    if (!hasActiveOrLockedPrediction) return true
+
+    val values = prediction?.outcomes ?: return false
+    return values.size in 2..10 && values.all { outcome ->
+        !outcome.id.isNullOrBlank() && !outcome.title.isNullOrBlank()
+    }
+}
+
+internal fun shouldLoadAnonymousPredictionSnapshot(
+    authenticatedSnapshot: GqlPredictionSnapshot?,
+): Boolean = authenticatedSnapshot == null ||
+    !authenticatedSnapshot.hasActiveOrLockedPrediction ||
+    !authenticatedSnapshot.hasUsableOutcomeSet()
+
+internal fun chooseGqlPredictionSnapshot(
+    authenticatedSnapshot: GqlPredictionSnapshot?,
+    anonymousSnapshot: GqlPredictionSnapshot?,
+): GqlPredictionSnapshot? = listOfNotNull(authenticatedSnapshot, anonymousSnapshot)
+    .maxByOrNull { snapshot ->
+        when {
+            snapshot.hasActiveOrLockedPrediction && snapshot.hasUsableOutcomeSet() -> 4
+            snapshot.hasActiveOrLockedPrediction -> 3
+            snapshot.authoritative -> 2
+            snapshot.prediction != null -> 1
+            else -> 0
+        }
+    }
+
 /**
  * Parser for the private ChannelPointsPredictionContext operation.
  *
@@ -23,21 +52,22 @@ internal data class GqlPredictionSnapshot(
 internal object GqlPredictionParser {
     fun parse(body: String, observedAt: Long = System.currentTimeMillis()): GqlPredictionSnapshot? {
         val root = runCatching { JSONObject(body) }.getOrNull() ?: return null
-        val channel = root.optJSONObject("data")
-            ?.optJSONObject("community")
+        val data = root.optJSONObject("data") ?: return null
+        val channel = data.optJSONObject("community")
             ?.optJSONObject("channel")
+            ?: data.optJSONObject("channel")
+            ?: data.optJSONObject("user")?.optJSONObject("channel")
             ?: return null
 
-        val activeEvents = channel.opt("activePredictionEvents")
-            .predictionObjects()
+        val activeObjects = channel.opt("activePredictionEvents").predictionObjectsOrNull()
+        val lockedObjects = channel.opt("lockedPredictionEvents").predictionObjectsOrNull()
+        val activeEvents = activeObjects.orEmpty()
             .mapNotNull { parsePrediction(it, "ACTIVE", observedAt) }
             .filter { prediction -> PredictionState.isOngoing(prediction) }
-        val lockedEvents = channel.opt("lockedPredictionEvents")
-            .predictionObjects()
+        val lockedEvents = lockedObjects.orEmpty()
             .mapNotNull { parsePrediction(it, "LOCKED", observedAt) }
             .filter { prediction -> PredictionState.isOngoing(prediction) }
-        val resolvedEvents = channel.opt("resolvedPredictionEvents")
-            .predictionObjects()
+        val resolvedEvents = channel.opt("resolvedPredictionEvents").predictionObjectsOrNull().orEmpty()
             .mapNotNull { parsePrediction(it, "RESOLVED", observedAt) }
             .filter { prediction ->
                 PredictionState.isFinal(prediction) && isRecentResolved(prediction, observedAt)
@@ -46,8 +76,7 @@ internal object GqlPredictionParser {
         return GqlPredictionSnapshot(
             prediction = (activeEvents + lockedEvents + resolvedEvents)
                 .firstOrNull { !it.id.isNullOrBlank() },
-            authoritative = channel.hasNonNullCollection("activePredictionEvents") &&
-                    channel.hasNonNullCollection("lockedPredictionEvents"),
+            authoritative = activeObjects != null && lockedObjects != null,
             hasActiveOrLockedPrediction = activeEvents.isNotEmpty() || lockedEvents.isNotEmpty(),
         )
     }
@@ -75,22 +104,7 @@ internal object GqlPredictionParser {
             null
         }
 
-        val outcomes = json.optJSONArray("outcomes")?.let { array ->
-            buildList {
-                for (index in 0 until array.length()) {
-                    val outcome = array.optJSONObject(index) ?: continue
-                    add(
-                        Prediction.PredictionOutcome(
-                            id = outcome.optionalString("id"),
-                            title = outcome.optionalString("title"),
-                            totalPoints = outcome.optionalInt("totalPoints", "total_points"),
-                            totalUsers = outcome.optionalInt("totalUsers", "total_users"),
-                            color = outcome.optionalString("color")?.uppercase(),
-                        ),
-                    )
-                }
-            }
-        }.orEmpty()
+        val outcomes = json.outcomeObjectsOrNull()?.map(::parseOutcome)
 
         val winningOutcomeId = json.optionalString("winning_outcome_id")
             ?: json.optJSONObject("winningOutcome")?.optionalString("id")
@@ -111,37 +125,64 @@ internal object GqlPredictionParser {
         )
     }
 
+    private fun parseOutcome(outcome: JSONObject): Prediction.PredictionOutcome {
+        val badge = outcome.optJSONObject("badge")
+        return Prediction.PredictionOutcome(
+            id = outcome.optionalString("id", "outcomeID", "outcomeId", "outcome_id"),
+            title = outcome.optionalString("title"),
+            totalPoints = outcome.optionalInt(
+                "totalPoints",
+                "total_points",
+                "channelPoints",
+                "channel_points",
+            ),
+            totalUsers = outcome.optionalInt("totalUsers", "total_users", "users"),
+            color = outcome.optionalString("color")?.uppercase(),
+            badgeSetId = badge?.optionalString("setID", "setId", "set_id"),
+            badgeVersion = badge?.optionalString("version"),
+            badgeUrl = badge?.optionalString("image4x", "image2x", "image1x"),
+        )
+    }
+
     private fun isRecentResolved(prediction: Prediction, observedAt: Long): Boolean {
         val endedAt = prediction.endedAt ?: return false
         val age = observedAt - endedAt
         return age in 0L..PredictionState.RESULT_DISPLAY_GRACE_MILLIS
     }
 
-    private fun Any?.predictionObjects(): List<JSONObject> = when (this) {
-        is JSONArray -> buildList {
-            for (index in 0 until length()) {
-                optJSONObject(index)?.let(::add)
-            }
+    private fun Any?.predictionObjectsOrNull(): List<JSONObject>? = when (this) {
+        null, JSONObject.NULL -> null
+        is JSONArray -> jsonObjects()
+        is JSONObject -> when {
+            optJSONArray("nodes") != null -> optJSONArray("nodes")!!.jsonObjects()
+            optJSONArray("edges") != null -> optJSONArray("edges")!!.jsonObjects()
+                .mapNotNull { it.optJSONObject("node") ?: it }
+            has("id") -> listOf(this)
+            else -> null
         }
-        is JSONObject -> {
-            val entries = optJSONArray("edges") ?: optJSONArray("nodes")
-            if (entries != null) {
-                buildList {
-                    for (index in 0 until entries.length()) {
-                        val entry = entries.optJSONObject(index) ?: continue
-                        (entry.optJSONObject("node") ?: entry).let(::add)
-                    }
-                }
-            } else if (has("id")) {
-                listOf(this)
-            } else {
-                emptyList()
-            }
-        }
-        else -> emptyList()
+        else -> null
     }
 
-    private fun JSONObject.hasNonNullCollection(key: String): Boolean = has(key) && !isNull(key)
+    private fun JSONObject.outcomeObjectsOrNull(key: String = "outcomes"): List<JSONObject>? {
+        if (!has(key) || isNull(key)) return null
+        val raw = opt(key)
+        return when {
+            raw is JSONArray -> raw.jsonObjects()
+            raw is JSONObject -> when {
+                raw.optJSONArray("nodes") != null -> raw.optJSONArray("nodes")!!.jsonObjects()
+                raw.optJSONArray("edges") != null -> raw.optJSONArray("edges")!!.jsonObjects()
+                    .mapNotNull { it.optJSONObject("node") ?: it }
+                else -> null
+            }
+            else -> null
+        }
+    }
+
+    private fun JSONArray.jsonObjects(): List<JSONObject> = buildList {
+        for (index in 0 until length()) {
+            optJSONObject(index)?.let(::add)
+        }
+    }
 
     private fun JSONObject.optionalString(vararg keys: String): String? = keys.firstNotNullOfOrNull { key ->
         if (!has(key) || isNull(key)) null else optString(key).takeIf { it.isNotBlank() }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/chat/PredictionCache.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/chat/PredictionCache.kt
@@ -114,6 +114,9 @@ object PredictionCache {
                     putNullable("total_points", outcome.totalPoints)
                     putNullable("total_users", outcome.totalUsers)
                     putNullable("color", outcome.color)
+                    putNullable("badge_set_id", outcome.badgeSetId)
+                    putNullable("badge_version", outcome.badgeVersion)
+                    putNullable("badge_url", outcome.badgeUrl)
                 })
             }
         })
@@ -132,6 +135,9 @@ object PredictionCache {
                             totalPoints = outcome.optionalInt("total_points"),
                             totalUsers = outcome.optionalInt("total_users"),
                             color = outcome.optionalString("color"),
+                            badgeSetId = outcome.optionalString("badge_set_id"),
+                            badgeVersion = outcome.optionalString("badge_version"),
+                            badgeUrl = outcome.optionalString("badge_url"),
                         ),
                     )
                 }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/chat/PredictionState.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/chat/PredictionState.kt
@@ -129,23 +129,30 @@ object PredictionState {
     ): List<Prediction.PredictionOutcome>? {
         if (current.isNullOrEmpty()) return incoming
         if (incoming.isNullOrEmpty()) return current
-        val currentByKey = current.associateBy { it.id ?: it.title }
-        val incomingKeys = incoming.map { it.id ?: it.title }.toSet()
-        val merged = incoming.map { outcome ->
-            val previous = currentByKey[outcome.id ?: outcome.title]
-            if (previous == null) {
-                outcome
-            } else {
-                outcome.copy(
-                    title = outcome.title ?: previous.title,
-                    totalPoints = max(previous.totalPoints, outcome.totalPoints),
-                    totalUsers = max(previous.totalUsers, outcome.totalUsers),
-                    color = outcome.color ?: previous.color,
-                )
-            }
+        fun key(outcome: Prediction.PredictionOutcome) = outcome.id ?: outcome.title
+
+        val incomingByKey = incoming.associateBy(::key)
+        val currentKeys = current.mapTo(mutableSetOf(), ::key)
+        val mergedExisting = current.map { previous ->
+            val update = incomingByKey[key(previous)] ?: return@map previous
+            mergePredictionOutcome(previous, update)
         }
-        return merged + current.filter { (it.id ?: it.title) !in incomingKeys }
+        val genuinelyNew = incoming.filter { key(it) !in currentKeys }
+        return mergedExisting + genuinelyNew
     }
+
+    private fun mergePredictionOutcome(
+        previous: Prediction.PredictionOutcome,
+        outcome: Prediction.PredictionOutcome,
+    ): Prediction.PredictionOutcome = outcome.copy(
+        title = outcome.title ?: previous.title,
+        totalPoints = max(previous.totalPoints, outcome.totalPoints),
+        totalUsers = max(previous.totalUsers, outcome.totalUsers),
+        color = outcome.color ?: previous.color,
+        badgeSetId = outcome.badgeSetId ?: previous.badgeSetId,
+        badgeVersion = outcome.badgeVersion ?: previous.badgeVersion,
+        badgeUrl = outcome.badgeUrl ?: previous.badgeUrl,
+    )
 
     private fun max(first: Long?, second: Long?): Long? = when {
         first == null -> second

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/chat/PubSubUtils.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/chat/PubSubUtils.kt
@@ -438,21 +438,27 @@ object PubSubUtils {
         val outcomes = prediction?.optJSONArray("outcomes")
         if (outcomes != null) {
             for (i in 0 until outcomes.length()) {
-                val outcome = outcomes.optJSONObject(i)
-                val title = outcome?.optionalString("title")
-                if (!title.isNullOrBlank()) {
-                    outcomesList.add(
-                        Prediction.PredictionOutcome(
-                            id = outcome?.optionalString("id"),
-                            title = title,
-                            totalPoints = outcome?.optionalInt("total_points")
-                                ?: outcome?.optionalInt("channel_points"),
-                            totalUsers = outcome?.optionalInt("total_users")
-                                ?: outcome?.optionalInt("users"),
-                            color = outcome?.optionalString("color")?.uppercase(),
-                        )
+                val outcome = outcomes.optJSONObject(i) ?: continue
+                val title = outcome.optionalString("title") ?: continue
+                val badge = outcome.optJSONObject("badge")
+                outcomesList.add(
+                    Prediction.PredictionOutcome(
+                        id = outcome.optionalString("id"),
+                        title = title,
+                        totalPoints = outcome.optionalInt("total_points")
+                            ?: outcome.optionalInt("channel_points"),
+                        totalUsers = outcome.optionalInt("total_users")
+                            ?: outcome.optionalInt("users"),
+                        color = outcome.optionalString("color")?.uppercase(),
+                        badgeSetId = badge?.optionalString("set_id")
+                            ?: badge?.optionalString("setID")
+                            ?: badge?.optionalString("setId"),
+                        badgeVersion = badge?.optionalString("version"),
+                        badgeUrl = badge?.optionalString("image4x")
+                            ?: badge?.optionalString("image2x")
+                            ?: badge?.optionalString("image1x"),
                     )
-                }
+                )
             }
         }
         return if (prediction != null) {
@@ -461,11 +467,15 @@ object PubSubUtils {
             val locksAt = prediction.timestamp("locks_at")
             val lockedAt = prediction.timestamp("locked_at")
             val endedAt = prediction.timestamp("ended_at")
-            val eventStatus = prediction.optString("status").takeIf { it.isNotBlank() }?.uppercase()
+            val eventName = eventType ?: message.optionalString("type")
+            val eventStatus = prediction.optionalString("status")?.uppercase()
             ?: when {
-                eventType?.endsWith(".begin") == true || eventType?.endsWith(".progress") == true -> "ACTIVE"
-                eventType?.endsWith(".lock") == true -> "LOCKED"
-                eventType?.endsWith(".end") == true -> "RESOLVED"
+                eventName == "event-created" -> "ACTIVE"
+                eventName == "event-updated" -> null
+                eventName?.endsWith(".begin") == true || eventName?.endsWith("_begin") == true -> "ACTIVE"
+                eventName?.endsWith(".progress") == true || eventName?.endsWith("_progress") == true -> "ACTIVE"
+                eventName?.endsWith(".lock") == true || eventName?.endsWith("_lock") == true -> "LOCKED"
+                eventName?.endsWith(".end") == true || eventName?.endsWith("_end") == true -> "RESOLVED"
                 else -> null
             }
             val predictionWindowSeconds = prediction.optionalInt("prediction_window_seconds")

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -927,6 +927,7 @@
     <string name="channel_points_prediction_closed">Prediction closed</string>
     <string name="channel_points_prediction_winner">Winner</string>
     <string name="channel_points_prediction_tie">Tie</string>
+    <string name="channel_points_prediction_outcome_description">Outcome %1$d of %2$d: %3$s</string>
     <string name="channel_points_prediction_total_points">%s points</string>
     <string name="channel_points_prediction_total_users">%s voters</string>
     <string name="channel_points_prediction_started">Started %s</string>

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/ChatRenderConfigurationTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/ChatRenderConfigurationTest.kt
@@ -1,5 +1,6 @@
 package com.github.andreyasadchy.xtra.ui.chat
 
+import com.github.andreyasadchy.xtra.model.chat.TwitchBadge
 import com.github.andreyasadchy.xtra.util.chat.ChatAdapterUtils
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertSame
@@ -57,5 +58,18 @@ class ChatRenderConfigurationTest {
 
         assertSame(catalogA, reverted.indexes)
         assertFalse(reverted.translateAllMessages)
+    }
+
+    @Test
+    fun genericChatBadgeLookupKeepsPredictionBadgeVersions() {
+        val blueThree = TwitchBadge("predictions", "blue-3", url4x = "https://example.invalid/3")
+        val blueTen = TwitchBadge("predictions", "blue-10", url4x = "https://example.invalid/10")
+        val indexes = ChatAdapterUtils.ChatCatalogIndexes.create(
+            emptyList(), emptyList(), listOf(blueThree, blueTen), emptyList(),
+            emptyList(), emptyList(), emptyList(), emptyMap(), emptyList(),
+        )
+
+        assertSame(blueThree, indexes.globalBadgesByKey["predictions:blue-3"])
+        assertSame(blueTen, indexes.globalBadgesByKey["predictions:blue-10"])
     }
 }

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/PredictionPresentationTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/PredictionPresentationTest.kt
@@ -1,0 +1,47 @@
+package com.github.andreyasadchy.xtra.ui.chat
+
+import com.github.andreyasadchy.xtra.model.chat.Prediction
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class PredictionPresentationTest {
+    @Test
+    fun keepsBinaryLabelsUnchanged() {
+        val outcomes = listOf(outcome("a", "Yes"), outcome("b", "No"))
+
+        assertEquals("Yes", predictionOutcomeLabel(outcomes[0], 0, outcomes.size))
+        assertEquals("No", predictionOutcomeLabel(outcomes[1], 1, outcomes.size))
+    }
+
+    @Test
+    fun numbersEveryMultiOutcomeLabel() {
+        val outcomes = listOf(
+            outcome("a", "One"),
+            outcome("b", "Two"),
+            outcome("c", "Three"),
+            outcome("d", "Four"),
+        )
+
+        assertEquals(
+            listOf("1. One", "2. Two", "3. Three", "4. Four"),
+            outcomes.mapIndexed { index, value -> predictionOutcomeLabel(value, index, outcomes.size) },
+        )
+    }
+
+    @Test
+    fun usesBadgeOrdinalAndFallsBackForInvalidVersions() {
+        assertEquals(7, predictionOutcomeOrdinal(outcome("g", "Seven", "blue-7"), 1))
+        assertEquals(2, predictionOutcomeOrdinal(outcome("b", "Two", "blue-invalid"), 1))
+        assertEquals("10. Ten", predictionOutcomeLabel(outcome("j", "Ten", "blue-10"), 9, 10))
+    }
+
+    private fun outcome(id: String, title: String, badgeVersion: String? = null) =
+        Prediction.PredictionOutcome(
+            id = id,
+            title = title,
+            totalPoints = null,
+            totalUsers = null,
+            color = "BLUE",
+            badgeVersion = badgeVersion,
+        )
+}

--- a/app/src/test/java/com/github/andreyasadchy/xtra/util/chat/GqlPredictionParserTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/util/chat/GqlPredictionParserTest.kt
@@ -1,0 +1,236 @@
+package com.github.andreyasadchy.xtra.util.chat
+
+import org.json.JSONArray
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class GqlPredictionParserTest {
+    @Test
+    fun parsesFourOutcomePredictionWithBlueBadgesInOrder() {
+        val snapshot = GqlPredictionParser.parse(fourOutcomeFixture(), observedAt = 1_000L)
+        val prediction = snapshot?.prediction
+        val outcomes = prediction?.outcomes
+
+        assertNotNull(snapshot)
+        assertNotNull(prediction)
+        assertEquals(4, outcomes?.size)
+        assertEquals(listOf("o1", "o2", "o3", "o4"), outcomes?.map { it.id })
+        assertEquals(listOf("One", "Two", "Three", "Four"), outcomes?.map { it.title })
+        assertEquals(listOf("BLUE", "BLUE", "BLUE", "BLUE"), outcomes?.map { it.color })
+        assertEquals(listOf(100, 200, 300, 400), outcomes?.map { it.totalPoints })
+        assertEquals(listOf(1, 2, 3, 4), outcomes?.map { it.totalUsers })
+        assertEquals("https://example.invalid/3", outcomes?.get(2)?.badgeUrl)
+        assertTrue(PredictionBetPolicy.isPredictionWagerable(outcomes.orEmpty().map { it.id }))
+        assertTrue(snapshot?.authoritative == true)
+        assertTrue(snapshot?.hasActiveOrLockedPrediction == true)
+        assertTrue(snapshot?.hasUsableOutcomeSet() == true)
+    }
+
+    @Test
+    fun parsesTenOutcomesAndKeepsTheTenthIdentity() {
+        val outcomes = JSONArray().apply {
+            (1..10).forEach { index ->
+                put(
+                    JSONObject()
+                        .put("id", "o$index")
+                        .put("title", "Outcome $index")
+                        .put("color", "BLUE")
+                        .put("badge", JSONObject().put("version", "blue-$index")),
+                )
+            }
+        }
+        val body = predictionBody(outcomes)
+
+        val snapshot = GqlPredictionParser.parse(body.toString(), observedAt = 1_000L)
+        val parsed = snapshot?.prediction?.outcomes
+
+        assertEquals(10, parsed?.size)
+        assertEquals((1..10).map { "o$it" }, parsed?.map { it.id })
+        assertEquals("o10", parsed?.get(9)?.id)
+        assertEquals("blue-10", parsed?.get(9)?.badgeVersion)
+        assertTrue(snapshot?.hasUsableOutcomeSet() == true)
+    }
+
+    @Test
+    fun acceptsRawChannelRootAndConnectionShapedOutcomes() {
+        val outcomeNodes = JSONArray().apply {
+            put(JSONObject().put("id", "o1").put("title", "One"))
+            put(JSONObject().put("id", "o2").put("title", "Two"))
+            put(JSONObject().put("id", "o3").put("title", "Three"))
+        }
+        val prediction = JSONObject()
+            .put("id", "p3")
+            .put("title", "Choose")
+            .put("status", "ACTIVE")
+            .put("outcomes", JSONObject().put("nodes", outcomeNodes))
+        val channel = JSONObject()
+            .put("activePredictionEvents", JSONArray().put(prediction))
+            .put("lockedPredictionEvents", JSONArray())
+        val body = JSONObject().put("data", JSONObject().put("channel", channel))
+
+        val snapshot = GqlPredictionParser.parse(body.toString(), observedAt = 1_000L)
+
+        assertEquals(listOf("o1", "o2", "o3"), snapshot?.prediction?.outcomes?.map { it.id })
+        assertTrue(snapshot?.authoritative == true)
+    }
+
+    @Test
+    fun acceptsEdgesAndUserChannelRoot() {
+        val prediction = JSONObject()
+            .put("id", "p3")
+            .put("title", "Choose")
+            .put("status", "ACTIVE")
+            .put(
+                "outcomes",
+                JSONObject().put(
+                    "edges",
+                    JSONArray()
+                        .put(JSONObject().put("node", JSONObject().put("id", "o1").put("title", "One")))
+                        .put(JSONObject().put("node", JSONObject().put("id", "o2").put("title", "Two")))
+                        .put(JSONObject().put("node", JSONObject().put("id", "o3").put("title", "Three"))),
+                ),
+            )
+        val channel = JSONObject()
+            .put("activePredictionEvents", JSONObject().put("edges", JSONArray().put(JSONObject().put("node", prediction))))
+            .put("lockedPredictionEvents", JSONObject().put("nodes", JSONArray()))
+        val body = JSONObject().put("data", JSONObject().put("user", JSONObject().put("channel", channel)))
+
+        val snapshot = GqlPredictionParser.parse(body.toString(), observedAt = 1_000L)
+
+        assertEquals(listOf("o1", "o2", "o3"), snapshot?.prediction?.outcomes?.map { it.id })
+        assertTrue(snapshot?.authoritative == true)
+    }
+
+    @Test
+    fun usableAnonymousSnapshotWinsOverIncompleteAuthenticatedSnapshot() {
+        val incomplete = GqlPredictionParser.parse(
+            predictionBody(JSONObject().put("unexpected", JSONArray())).toString(),
+            observedAt = 1_000L,
+        )
+        val complete = GqlPredictionParser.parse(fourOutcomeFixture(), observedAt = 1_000L)
+
+        assertFalse(incomplete?.hasUsableOutcomeSet() == true)
+        assertTrue(complete?.hasUsableOutcomeSet() == true)
+        assertSame(complete, chooseGqlPredictionSnapshot(incomplete, complete))
+    }
+
+    @Test
+    fun anonymousFallbackDecisionKeepsAllFourRecoveryCases() {
+        val malformedActive = GqlPredictionParser.parse(
+            predictionBody(JSONObject().put("unexpected", JSONArray())).toString(),
+            observedAt = 1_000L,
+        )
+        val validActive = GqlPredictionParser.parse(fourOutcomeFixture(), observedAt = 1_000L)
+        val authoritativeEmpty = GqlPredictionSnapshot(
+            prediction = null,
+            authoritative = true,
+            hasActiveOrLockedPrediction = false,
+        )
+
+        assertTrue(shouldLoadAnonymousPredictionSnapshot(null))
+        assertTrue(shouldLoadAnonymousPredictionSnapshot(authoritativeEmpty))
+        assertTrue(shouldLoadAnonymousPredictionSnapshot(malformedActive))
+        assertFalse(shouldLoadAnonymousPredictionSnapshot(validActive))
+    }
+
+    @Test
+    fun validAnonymousPredictionReplacesAuthoritativeEmptyAuthenticatedSnapshot() {
+        val authenticated = GqlPredictionSnapshot(
+            prediction = null,
+            authoritative = true,
+            hasActiveOrLockedPrediction = false,
+        )
+        val anonymous = GqlPredictionParser.parse(fourOutcomeFixture(), observedAt = 1_000L)
+
+        assertTrue(shouldLoadAnonymousPredictionSnapshot(authenticated))
+        assertSame(anonymous, chooseGqlPredictionSnapshot(authenticated, anonymous))
+    }
+
+    @Test
+    fun distinguishesUnknownOutcomeCollectionFromValidEmptyCollection() {
+        val unknown = GqlPredictionParser.parse(
+            predictionBody(JSONObject().put("unexpected", JSONArray())).toString(),
+            observedAt = 1_000L,
+        )
+        val empty = GqlPredictionParser.parse(
+            predictionBody(JSONArray()).toString(),
+            observedAt = 1_000L,
+        )
+
+        assertNull(unknown?.prediction?.outcomes)
+        assertFalse(unknown?.hasUsableOutcomeSet() == true)
+        assertNotNull(empty?.prediction?.outcomes)
+        assertTrue(empty?.prediction?.outcomes?.isEmpty() == true)
+        assertFalse(empty?.hasUsableOutcomeSet() == true)
+    }
+
+    @Test
+    fun unknownEventCollectionShapeIsNotAuthoritative() {
+        val channel = JSONObject()
+            .put("activePredictionEvents", JSONObject().put("unexpected", JSONArray()))
+            .put("lockedPredictionEvents", JSONArray())
+        val body = JSONObject().put(
+            "data",
+            JSONObject().put("community", JSONObject().put("channel", channel)),
+        )
+
+        val snapshot = GqlPredictionParser.parse(body.toString(), observedAt = 1_000L)
+
+        assertFalse(snapshot?.authoritative == true)
+        assertFalse(snapshot?.hasActiveOrLockedPrediction == true)
+    }
+
+    private fun fourOutcomeFixture(): String =
+        """
+        {
+          "data": {
+            "community": {
+              "channel": {
+                "activePredictionEvents": [
+                  {
+                    "id": "p4",
+                    "title": "Which one?",
+                    "status": "ACTIVE",
+                    "createdAt": "2026-09-01T08:00:00Z",
+                    "predictionWindowSeconds": 300,
+                    "outcomes": [
+                      {"id":"o1","title":"One","color":"BLUE","totalPoints":100,"totalUsers":1,"badge":{"image4x":"https://example.invalid/1"}},
+                      {"id":"o2","title":"Two","color":"BLUE","totalPoints":200,"totalUsers":2,"badge":{"image4x":"https://example.invalid/2"}},
+                      {"id":"o3","title":"Three","color":"BLUE","totalPoints":300,"totalUsers":3,"badge":{"image4x":"https://example.invalid/3"}},
+                      {"id":"o4","title":"Four","color":"BLUE","totalPoints":400,"totalUsers":4,"badge":{"image4x":"https://example.invalid/4"}}
+                    ]
+                  }
+                ],
+                "lockedPredictionEvents": []
+              }
+            }
+          }
+        }
+        """.trimIndent()
+
+    private fun predictionBody(outcomes: Any): JSONObject {
+        val prediction = JSONObject()
+            .put("id", "p-test")
+            .put("title", "Choose")
+            .put("status", "ACTIVE")
+            .put("outcomes", outcomes)
+        return JSONObject().put(
+            "data",
+            JSONObject().put(
+                "community",
+                JSONObject().put(
+                    "channel",
+                    JSONObject()
+                        .put("activePredictionEvents", JSONArray().put(prediction))
+                        .put("lockedPredictionEvents", JSONArray()),
+                ),
+            ),
+        )
+    }
+}

--- a/app/src/test/java/com/github/andreyasadchy/xtra/util/chat/PredictionBetPolicyTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/util/chat/PredictionBetPolicyTest.kt
@@ -19,6 +19,35 @@ class PredictionBetPolicyTest {
     }
 
     @Test
+    fun `third fourth and tenth outcome IDs stay candidate IDs`() {
+        val outcomeIds = (1..10).map { "outcome-$it" }
+
+        listOf("outcome-3", "outcome-4", "outcome-10").forEach { candidateId ->
+            assertTrue(
+                PredictionBetPolicy.canBetOutcome(
+                    selectedOutcomeId = null,
+                    candidateOutcomeId = candidateId,
+                    inFlight = false,
+                    confirmedAmount = 0,
+                    minimumPoints = 10,
+                    maximumPoints = 250_000,
+                ),
+            )
+            assertTrue(candidateId in outcomeIds)
+        }
+        assertFalse(
+            PredictionBetPolicy.canBetOutcome(
+                selectedOutcomeId = "outcome-3",
+                candidateOutcomeId = "outcome-4",
+                inFlight = false,
+                confirmedAmount = 10,
+                minimumPoints = 10,
+                maximumPoints = 250_000,
+            ),
+        )
+    }
+
+    @Test
     fun `invalid outcome sets are not wagerable`() {
         assertFalse(PredictionBetPolicy.isPredictionWagerable(listOf("a")))
         assertFalse(PredictionBetPolicy.isPredictionWagerable(listOf("a", null, "c")))

--- a/app/src/test/java/com/github/andreyasadchy/xtra/util/chat/PredictionStateTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/util/chat/PredictionStateTest.kt
@@ -336,6 +336,93 @@ class PredictionStateTest {
         }
     }
 
+    @Test
+    fun partialFourOutcomeUpdateKeepsExistingOrderAndMetadata() {
+        val currentOutcomes = (1..4).map { index ->
+            Prediction.PredictionOutcome(
+                id = "o$index",
+                title = "Outcome $index",
+                totalPoints = index * 10,
+                totalUsers = index,
+                color = "BLUE",
+                badgeSetId = "predictions",
+                badgeVersion = "blue-$index",
+                badgeUrl = "https://example.invalid/$index",
+            )
+        }
+        val incoming = Prediction(
+            id = "p4",
+            createdAt = 1_000L,
+            outcomes = listOf(
+                Prediction.PredictionOutcome(
+                    id = "o3",
+                    title = null,
+                    totalPoints = 99,
+                    totalUsers = null,
+                    color = null,
+                ),
+            ),
+            predictionWindowSeconds = null,
+            status = "ACTIVE",
+            title = "Title",
+            winningOutcomeId = null,
+            observedAt = 2_000L,
+        )
+        val current = Prediction(
+            id = "p4",
+            createdAt = 1_000L,
+            outcomes = currentOutcomes,
+            predictionWindowSeconds = null,
+            status = "ACTIVE",
+            title = "Title",
+            winningOutcomeId = null,
+            observedAt = 1_000L,
+        )
+
+        val merged = PredictionState.merge(current, incoming)
+
+        assertEquals(listOf("o1", "o2", "o3", "o4"), merged?.outcomes?.map { it.id })
+        assertEquals(99, merged?.outcomes?.get(2)?.totalPoints)
+        assertEquals("predictions", merged?.outcomes?.get(2)?.badgeSetId)
+        assertEquals("blue-4", merged?.outcomes?.get(3)?.badgeVersion)
+        assertEquals("https://example.invalid/1", merged?.outcomes?.first()?.badgeUrl)
+    }
+
+    @Test
+    fun fullFourOutcomeProgressRetainsAllUpdatedOutcomesInOrder() {
+        val current = predictionWithOutcomes("p4", points = 10)
+        val progress = PubSubUtils.onPredictionUpdate(
+            JSONObject(
+                """
+                {
+                  "type":"event-updated",
+                  "event":{"id":"p4","title":"Title","status":"ACTIVE","outcomes":[
+                    {"id":"o1","title":"One","total_points":11},
+                    {"id":"o2","title":"Two","total_points":22},
+                    {"id":"o3","title":"Three","total_points":33},
+                    {"id":"o4","title":"Four","total_points":44}
+                  ]}
+                }
+                """.trimIndent(),
+            ),
+            observedAt = 2_000L,
+        )
+
+        val merged = PredictionState.merge(current, progress)
+
+        assertEquals(listOf("o1", "o2", "o3", "o4"), merged?.outcomes?.map { it.id })
+        assertEquals(listOf(11, 22, 33, 44), merged?.outcomes?.map { it.totalPoints })
+    }
+
+    @Test
+    fun cacheRoundTripRetainsFourOutcomeBadgeMetadata() {
+        val source = predictionWithOutcomes("p4", points = 100)
+
+        val restored = PredictionCache.decode(PredictionCache.encode(source))
+
+        assertEquals(source, restored)
+    }
+
     private fun prediction(id: String, status: String, observedAt: Long, points: Int) = Prediction(
         id = id,
         createdAt = observedAt,
@@ -348,5 +435,27 @@ class PredictionStateTest {
         title = "Title",
         winningOutcomeId = null,
         observedAt = observedAt,
+    )
+
+    private fun predictionWithOutcomes(id: String, points: Int) = Prediction(
+        id = id,
+        createdAt = 1_000L,
+        outcomes = (1..4).map { index ->
+            Prediction.PredictionOutcome(
+                id = "o$index",
+                title = listOf("One", "Two", "Three", "Four")[index - 1],
+                totalPoints = points + index,
+                totalUsers = index,
+                color = "BLUE",
+                badgeSetId = "predictions",
+                badgeVersion = "blue-$index",
+                badgeUrl = "https://example.invalid/$index",
+            )
+        },
+        predictionWindowSeconds = null,
+        status = "ACTIVE",
+        title = "Title",
+        winningOutcomeId = null,
+        observedAt = 1_000L,
     )
 }

--- a/app/src/test/java/com/github/andreyasadchy/xtra/util/chat/PubSubUtilsTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/util/chat/PubSubUtilsTest.kt
@@ -3,6 +3,7 @@ package com.github.andreyasadchy.xtra.util.chat
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Test
 
 class PubSubUtilsTest {
@@ -107,5 +108,72 @@ class PubSubUtilsTest {
         assertEquals(2500, event?.absoluteBalance)
         assertEquals("CUSTOM_REWARD", event?.reasonCode)
         assertEquals("spend-1", event?.messageId)
+    }
+
+    @Test
+    fun parsesPrivatePredictionBadgesAndTopLevelEventType() {
+        val prediction = PubSubUtils.onPredictionUpdate(
+            JSONObject(
+                """
+                {
+                  "type": "event-created",
+                  "event": {
+                    "id": "p4",
+                    "title": "Which one?",
+                    "outcomes": [
+                      {"id":"o1","title":"One","color":"BLUE","total_points":100},
+                      {"id":"o2","title":"Two","color":"BLUE","total_points":200},
+                      {"id":"o3","title":"Three","color":"BLUE","total_points":300,
+                       "badge":{"version":"blue-3","set_id":"predictions"}},
+                      {"id":"o4","title":"Four","color":"BLUE","total_points":400}
+                    ]
+                  }
+                }
+                """.trimIndent(),
+            ),
+        )
+
+        assertEquals("ACTIVE", prediction?.status)
+        assertEquals(listOf("o1", "o2", "o3", "o4"), prediction?.outcomes?.map { it.id })
+        assertEquals("predictions", prediction?.outcomes?.get(2)?.badgeSetId)
+        assertEquals("blue-3", prediction?.outcomes?.get(2)?.badgeVersion)
+    }
+
+    @Test
+    fun eventUpdatedUsesEmbeddedStatusAndDoesNotInferActive() {
+        val locked = PubSubUtils.onPredictionUpdate(
+            JSONObject(
+                """
+                {
+                  "type": "event-updated",
+                  "data": {
+                    "event": {
+                      "id": "p4",
+                      "title": "Which one?",
+                      "status": "LOCKED",
+                      "outcomes": [
+                        {"id":"o1","title":"One"},
+                        {"id":"o2","title":"Two"},
+                        {"id":"o3","title":"Three"},
+                        {"id":"o4","title":"Four"}
+                      ]
+                    }
+                  }
+                }
+                """.trimIndent(),
+            ),
+        )
+
+        assertEquals("LOCKED", locked?.status)
+        assertEquals(4, locked?.outcomes?.size)
+    }
+
+    @Test
+    fun eventUpdatedWithoutEmbeddedStatusDoesNotGuessActive() {
+        val update = PubSubUtils.onPredictionUpdate(
+            JSONObject("""{"type":"event-updated","event":{"id":"p1","title":"Choose","outcomes":[]}}"""),
+        )
+
+        assertNull(update?.status)
     }
 }


### PR DESCRIPTION
## Summary

Keep all Twitch prediction choices visible and selectable when a prediction has more than two outcomes.

Preserve their order, labels, and selected choice through updates and reopening.