### PR TITLE
Fix chat-v2 sizing and emote picker

### DIFF
--- a/.github/scripts/check-resources.py
+++ b/.github/scripts/check-resources.py
@@ -151,6 +151,7 @@ INTENTIONAL_FALLBACK_RESOURCES = {
     "third_party_emotes_loading",
     "third_party_emotes_empty",
     "third_party_emotes_error",
+    "user_card_subscribed",
 }
 
 

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -56,6 +56,8 @@ jobs:
           ./gradlew --no-daemon :app:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.github.andreyasadchy.xtra.repository.streamfeed.StreamFeedCacheTest
           ./gradlew --no-daemon :app:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.github.andreyasadchy.xtra.ui.view.CenteredImageSpanTest
           ./gradlew --no-daemon :app:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.github.andreyasadchy.xtra.ui.chat.v2.ChatMessageTextViewTest
+          ./gradlew --no-daemon :app:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.github.andreyasadchy.xtra.ui.chat.v2.TwitchChatCatalogCacheTest
+          ./gradlew --no-daemon :app:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.github.andreyasadchy.xtra.ui.chat.v2.ChatCatalogCacheMigrationTest
 
   build:
     runs-on: ubuntu-latest

--- a/app/src/androidTest/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatMessageTextViewTest.kt
+++ b/app/src/androidTest/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatMessageTextViewTest.kt
@@ -9,19 +9,29 @@ import android.graphics.PixelFormat
 import android.graphics.drawable.Animatable
 import android.graphics.drawable.Drawable
 import android.text.Spanned
+import android.text.style.ClickableSpan
 import android.text.style.ForegroundColorSpan
 import android.text.style.ReplacementSpan
 import android.view.View
+import android.view.ViewGroup
+import android.view.MotionEvent
+import android.view.ViewConfiguration
+import android.widget.FrameLayout
 import com.github.andreyasadchy.xtra.ui.chat.v2.assets.ChatAssetLoader
 import com.github.andreyasadchy.xtra.ui.chat.v2.assets.ChatAssetRepository
 import com.github.andreyasadchy.xtra.ui.chat.v2.assets.ChatAssetState
 import com.github.andreyasadchy.xtra.ui.chat.v2.assets.ChatImageHandle
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatAssetKey
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatAssetSpec
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatEmoteInteraction
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatGifInteraction
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessageId
 import com.github.andreyasadchy.xtra.ui.chat.v2.presentation.ChatPiece
 import com.github.andreyasadchy.xtra.ui.chat.v2.presentation.ChatRowUiModel
 import com.github.andreyasadchy.xtra.ui.chat.v2.ui.ChatMessageTextView
+import com.github.andreyasadchy.xtra.ui.chat.v2.ui.ChatTimelineAdapter
+import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatAssetProvider
+import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatEmoteScope
 import com.github.andreyasadchy.xtra.ui.chat.resolveChatSizing
 import com.github.andreyasadchy.xtra.util.C
 import com.github.andreyasadchy.xtra.util.prefs
@@ -34,6 +44,8 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNotNull
@@ -133,7 +145,7 @@ class ChatMessageTextViewTest {
     }
 
     @Test
-    fun animationPreferenceCanDisableAnAlreadyBoundRow() {
+    fun disabledAnimationStaysStoppedAcrossHideAndWindowLifecycle() {
         val context = InstrumentationRegistry.getInstrumentation().targetContext
         val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
         lateinit var animated: RecordingAnimatedDrawable
@@ -143,21 +155,218 @@ class ChatMessageTextViewTest {
         val view = TestTextView(context, repository)
         val spec = ChatAssetSpec(ChatAssetKey("disabled-animation"), 20, 20, 28)
         runOnMain {
+            view.setAnimateGifs(false)
             view.bind(row(spec))
             val spanned = view.text as Spanned
             val span = spanned.getSpans(0, spanned.length, ReplacementSpan::class.java).single()
             draw(span, spanned, Paint.FontMetricsInt())
             view.attachedForTest()
-            assertTrue(animated.startCount > 0)
-            val startsBeforeDisable = animated.startCount
-            view.setAnimateGifs(false)
-            assertTrue(animated.stopCount > 0)
             view.setRenderingActive(false)
             view.setRenderingActive(true)
             view.detachedForTest()
             view.attachedForTest()
-            assertEquals(startsBeforeDisable, animated.startCount)
+            assertEquals(0, animated.startCount)
         }
+        scope.cancel()
+    }
+
+    @Test
+    fun adapterAppliesRuntimeAnimationSettingToReboundRows() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+        val repository = ChatAssetRepository(scope, ChatAssetLoader { null })
+        val adapter = ChatTimelineAdapter(repository, textSizeSp = 14f, animateGifs = true)
+        val row = row(ChatAssetSpec(ChatAssetKey("plain"), 16, 16, 24))
+        lateinit var holder: ChatTimelineAdapter.Holder
+        val submitted = CountDownLatch(1)
+
+        runOnMain {
+            holder = adapter.onCreateViewHolder(FrameLayout(context), 0)
+            adapter.submitList(listOf(row)) { submitted.countDown() }
+        }
+        assertTrue(submitted.await(1, TimeUnit.SECONDS))
+
+        fun boundAnimationState(): Boolean {
+            runOnMain { adapter.onBindViewHolder(holder, 0) }
+            val field = ChatMessageTextView::class.java.getDeclaredField("animateGifs")
+            field.isAccessible = true
+            return field.getBoolean(holder.view)
+        }
+
+        assertTrue(boundAnimationState())
+        runOnMain { adapter.setAnimateGifs(false) }
+        assertTrue(!boundAnimationState())
+        runOnMain { adapter.setAnimateGifs(true) }
+        assertTrue(boundAnimationState())
+        scope.cancel()
+    }
+
+    @Test
+    fun emoteSpanInvokesOnlyEmoteCallbackAndLongPressInvokesMessageCallback() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+        val repository = ChatAssetRepository(scope, ChatAssetLoader { null })
+        val view = TestTextView(context, repository)
+        val interaction = ChatEmoteInteraction(
+            id = "emote-id",
+            name = "Party",
+            url = "https://cdn.example.test/party.webp",
+            animated = false,
+            provider = ChatAssetProvider.BTTV,
+            scope = ChatEmoteScope.CHANNEL,
+        )
+        var messageClicks = 0
+        var emoteClicks = 0
+        var clickedInteraction: ChatEmoteInteraction? = null
+
+        runOnMain {
+            view.setInteractionCallbacks(
+                onMessageLongClick = { messageClicks++ },
+                onEmoteClick = {
+                    emoteClicks++
+                    clickedInteraction = it
+                },
+            )
+            view.bind(row(ChatAssetSpec(ChatAssetKey("party"), 16, 16, 24), interaction = interaction))
+            val spanned = view.text as Spanned
+            val clickables = spanned.getSpans(0, spanned.length, ClickableSpan::class.java)
+            assertEquals(1, clickables.size)
+            clickables.single().onClick(view)
+            assertEquals(1, emoteClicks)
+            assertEquals(interaction, clickedInteraction)
+            assertEquals(0, messageClicks)
+
+            assertTrue(view.performLongClick())
+            assertEquals(1, messageClicks)
+            assertEquals(1, emoteClicks)
+        }
+        scope.cancel()
+    }
+
+    @Test
+    fun realLongPressOnEmoteSuppressesSpanActionUp() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+        val repository = ChatAssetRepository(scope, ChatAssetLoader { null })
+        val view = TestTextView(context, repository)
+        val interaction = ChatEmoteInteraction(
+            id = "gesture-emote",
+            name = "Gesture",
+            url = "https://cdn.example.test/gesture.webp",
+            animated = false,
+            provider = ChatAssetProvider.SEVEN_TV,
+            scope = ChatEmoteScope.CHANNEL,
+        )
+        var messageClicks = 0
+        var emoteClicks = 0
+        runOnMain {
+            view.layoutParams = ViewGroup.LayoutParams(200, 80)
+            view.setInteractionCallbacks({ messageClicks++ }, { emoteClicks++ })
+            view.bind(row(ChatAssetSpec(ChatAssetKey("gesture"), 16, 16, 24), interaction = interaction))
+            view.measure(
+                View.MeasureSpec.makeMeasureSpec(200, View.MeasureSpec.EXACTLY),
+                View.MeasureSpec.makeMeasureSpec(80, View.MeasureSpec.EXACTLY),
+            )
+            view.layout(0, 0, 200, 80)
+            val now = android.os.SystemClock.uptimeMillis()
+            view.dispatchTouchEvent(MotionEvent.obtain(now, now, MotionEvent.ACTION_DOWN, 8f, 40f, 0))
+        }
+        Thread.sleep((ViewConfiguration.getLongPressTimeout() + 150).toLong())
+        runOnMain {
+            val now = android.os.SystemClock.uptimeMillis()
+            view.dispatchTouchEvent(MotionEvent.obtain(now, now, MotionEvent.ACTION_UP, 8f, 40f, 0))
+        }
+        assertEquals(1, messageClicks)
+        assertEquals(0, emoteClicks)
+        scope.cancel()
+    }
+
+    @Test
+    fun ordinaryTextHasNoEmoteHitTarget() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+        val repository = ChatAssetRepository(scope, ChatAssetLoader { null })
+        val view = TestTextView(context, repository)
+        var emoteClicks = 0
+
+        runOnMain {
+            view.setInteractionCallbacks(null, { emoteClicks++ })
+            view.bind(textRow("ordinary text"))
+            val spanned = view.text as Spanned
+            assertEquals(0, spanned.getSpans(0, spanned.length, ClickableSpan::class.java).size)
+            assertEquals(0, emoteClicks)
+        }
+        scope.cancel()
+    }
+
+    @Test
+    fun gifSpanInvokesGifCallbackWithItsDescriptionAndUrl() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+        val repository = ChatAssetRepository(scope, ChatAssetLoader { null })
+        val view = TestTextView(context, repository)
+        val interaction = ChatGifInteraction(
+            id = "gif-id",
+            description = "Joe Biden Vote GIF by Creative Courage",
+            url = "https://media.example.test/joe.gif?token=a%26b&format=gif",
+        )
+        var clicked: ChatGifInteraction? = null
+
+        runOnMain {
+            view.setInteractionCallbacks(null, null) { clicked = it }
+            view.bind(
+                ChatRowUiModel(
+                    id = ChatMessageId("gif-row"), channelId = "channel", timestampText = null,
+                    pieces = listOf(
+                        ChatPiece.Gif(
+                            asset = ChatAssetSpec(ChatAssetKey("gif"), 16, 9, 180),
+                            url = interaction.url,
+                            fallback = interaction.description,
+                            interaction = interaction,
+                        ),
+                    ),
+                    background = 0xff101010.toInt(), accessibilityText = interaction.description,
+                    reply = null, source = null, isAction = false,
+                ),
+            )
+            val spanned = view.text as Spanned
+            val clickable = spanned.getSpans(0, spanned.length, ClickableSpan::class.java).single()
+            clickable.onClick(view)
+        }
+
+        assertEquals(interaction, clicked)
+        scope.cancel()
+    }
+
+    @Test
+    fun recycledHolderCallbacksUseTheNewlyBoundMessageId() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+        val repository = ChatAssetRepository(scope, ChatAssetLoader { null })
+        val clickedIds = mutableListOf<ChatMessageId>()
+        val adapter = ChatTimelineAdapter(
+            repository,
+            textSizeSp = 14f,
+            animateGifs = true,
+            onMessageLongClick = { clickedIds += it },
+        )
+        lateinit var holder: ChatTimelineAdapter.Holder
+        runOnMain {
+            holder = adapter.onCreateViewHolder(FrameLayout(context), 0)
+            adapter.submitList(listOf(textRow("first", ChatMessageId("first"))))
+            adapter.onBindViewHolder(holder, 0)
+            assertTrue(holder.view.performLongClick())
+        }
+        val committed = CountDownLatch(1)
+        runOnMain {
+            adapter.submitList(listOf(textRow("second", ChatMessageId("second")))) { committed.countDown() }
+        }
+        assertTrue(committed.await(1, TimeUnit.SECONDS))
+        runOnMain {
+            adapter.onBindViewHolder(holder, 0)
+            assertTrue(holder.view.performLongClick())
+        }
+        assertEquals(listOf(ChatMessageId("first"), ChatMessageId("second")), clickedIds)
         scope.cancel()
     }
 
@@ -241,13 +450,24 @@ class ChatMessageTextViewTest {
         scope.cancel()
     }
 
-    private fun row(spec: ChatAssetSpec, username: String? = null) = ChatRowUiModel(
+    private fun row(
+        spec: ChatAssetSpec,
+        username: String? = null,
+        interaction: ChatEmoteInteraction? = null,
+    ) = ChatRowUiModel(
         id = ChatMessageId("row"), channelId = "channel", timestampText = null,
         pieces = buildList {
             username?.let { add(ChatPiece.Username(it, 0xffff8a80.toInt())) }
-            add(ChatPiece.Emote(spec, ":asset:"))
+            add(ChatPiece.Emote(spec, ":asset:", interaction = interaction))
         },
         background = 0xff101010.toInt(), accessibilityText = "row", reply = null,
+        source = null, isAction = false,
+    )
+
+    private fun textRow(value: String, id: ChatMessageId = ChatMessageId("text")) = ChatRowUiModel(
+        id = id, channelId = "channel", timestampText = null,
+        pieces = listOf(ChatPiece.Text(value)),
+        background = 0xff101010.toInt(), accessibilityText = value, reply = null,
         source = null, isAction = false,
     )
 

--- a/app/src/androidTest/java/com/github/andreyasadchy/xtra/ui/chat/v2/TwitchChatCatalogCacheTest.kt
+++ b/app/src/androidTest/java/com/github/andreyasadchy/xtra/ui/chat/v2/TwitchChatCatalogCacheTest.kt
@@ -1,0 +1,56 @@
+package com.github.andreyasadchy.xtra.ui.chat.v2
+
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatAssetProvider
+import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatCatalogEmote
+import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatCatalogSnapshot
+import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatEmoteScope
+import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ScopedEmoteCatalog
+import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.TwitchChatCatalogCache
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatAssetKey
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatAssetSpec
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.File
+
+@RunWith(AndroidJUnit4::class)
+class TwitchChatCatalogCacheTest {
+    @Test
+    fun cacheRoundTripPreservesShadowedProviderScopes() = runBlocking {
+        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+        val channelId = "scope-cache-regression"
+        val cache = TwitchChatCatalogCache(context, channelId)
+        val file = File(File(context.filesDir, "chat-v2/catalog"), "$channelId.json")
+        val global = emote("global", ChatEmoteScope.GLOBAL).copy(name = "same")
+        val channel = emote("channel", ChatEmoteScope.CHANNEL).copy(name = "same")
+        val snapshot = ChatCatalogSnapshot(
+            revision = 4,
+            sevenTv = ScopedEmoteCatalog(
+                global = mapOf("same" to global),
+                channel = mapOf("same" to channel),
+            ),
+        )
+
+        try {
+            cache.write(snapshot)
+            val restored = checkNotNull(cache.read())
+            assertEquals(global, restored.sevenTv.global["same"])
+            assertEquals(channel, restored.sevenTv.channel["same"])
+            assertEquals(channel, restored.sevenTv["same"])
+        } finally {
+            file.delete()
+        }
+    }
+
+    private fun emote(name: String, scope: ChatEmoteScope) = ChatCatalogEmote(
+        name = name,
+        asset = ChatAssetSpec(ChatAssetKey(name), 28, 28, 28),
+        provider = ChatAssetProvider.SEVEN_TV,
+        animated = false,
+        id = name,
+        scope = scope,
+    )
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/XtraModule.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/XtraModule.kt
@@ -683,12 +683,22 @@ class XtraModule(application: Application) {
                     config = TwitchChatTransportConfig(
                         channelId = spec.channelId,
                         channelLogin = spec.channelLogin,
-                        useEventSub = !accountId.isNullOrBlank() &&
-                                "user:read:chat" in scopes && "user:write:chat" in scopes &&
-                                !helixHeaders[C.HEADER_TOKEN].isNullOrBlank(),
+                        // EventSub is required for structured Twitch chat fragments such as
+                        // GIFs. Keep the developer switch useful for v2 as well; a failed
+                        // subscription still falls back to IRC in TwitchChatTransport.
+                        useEventSub = !helixHeaders[C.HEADER_TOKEN].isNullOrBlank() &&
+                                (appContext.prefs().getBoolean(C.DEBUG_EVENT_SUB_CHAT, false) ||
+                                        (!accountId.isNullOrBlank() &&
+                                                "user:read:chat" in scopes)),
                         accountId = accountId,
                         helixHeaders = helixHeaders,
                         networkLibrary = network,
+                        showUserNotices = appContext.prefs().getBoolean(C.CHAT_SHOW_USER_NOTICE, true),
+                        showClearMessages = appContext.prefs().getBoolean(C.CHAT_SHOW_CLEAR_MSG, true),
+                        showClearChat = appContext.prefs().getBoolean(C.CHAT_SHOW_CLEAR_CHAT, true),
+                        joinedMessage = appContext.getString(R.string.chat_join).format(spec.channelLogin),
+                        messageDeletedMessage = appContext.getString(R.string.chat_message_deleted),
+                        chatClearedMessage = appContext.getString(R.string.chat_clear),
                     ),
                     trustManager = trustManager,
                     createSubscription = { headers, userId, type, sessionId ->

--- a/app/src/main/java/com/github/andreyasadchy/xtra/model/misc/STVEmoteSetResponse.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/model/misc/STVEmoteSetResponse.kt
@@ -19,6 +19,7 @@ class STVEmoteSetResponse(
     class Data(
         val host: Host? = null,
         val animated: Boolean? = null,
+        val state: List<String> = emptyList(),
     )
 
     @Serializable

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/PlayerRepository.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/PlayerRepository.kt
@@ -70,6 +70,7 @@ import okhttp3.Credentials
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.MediaType.Companion.toMediaType
 import okio.buffer
 import okio.source
 import org.chromium.net.CronetEngine
@@ -89,6 +90,23 @@ import kotlin.uuid.Uuid
 
 private const val MAX_VIDEO_HISTORY_ITEMS = 100
 private const val AD_TAG = "XtraAd"
+
+internal fun parseSTVEntitledEmoteSetIds(response: String): List<String> {
+    val root = JSONObject(response)
+    check(!root.has("errors")) { "7TV entitlement query failed" }
+    val sets = root.optJSONObject("data")
+        ?.optJSONObject("userByConnection")
+        ?.optJSONArray("emote_sets")
+        ?: return emptyList()
+    return buildList {
+        for (index in 0 until sets.length()) {
+            sets.optJSONObject(index)
+                ?.optString("id")
+                ?.takeIf { it.isNotBlank() }
+                ?.let(::add)
+        }
+    }
+}
 
 @OptIn(UnstableApi::class)
 class PlayerRepository(
@@ -1185,6 +1203,40 @@ class PlayerRepository(
     suspend fun loadSTVEmoteSet(response: String, useWebp: Boolean, global: Boolean): Pair<String?, List<Emote>> = withContext(Dispatchers.IO) {
         val response = json.decodeFromString<STVEmoteSetResponse>(response)
         Pair(response.id, parseSTVEmotes(response.emotes, useWebp, if (global) Emote.GLOBAL_STV else Emote.CHANNEL_STV))
+    }
+
+    suspend fun loadSTVPersonalEmotes(response: String, useWebp: Boolean): Pair<String?, List<Emote>> = withContext(Dispatchers.IO) {
+        val response = json.decodeFromString<STVEmoteSetResponse>(response)
+        Pair(
+            response.id,
+            parseSTVEmotes(
+                response.emotes.filter { emote -> "PERSONAL" in emote.data?.state.orEmpty() },
+                useWebp,
+                Emote.PERSONAL_STV,
+            ),
+        )
+    }
+
+    suspend fun loadSTVEntitledEmoteSetIds(networkLibrary: String?, userId: String): List<String> = withContext(Dispatchers.IO) {
+        val query = """
+            query {
+              userByConnection(id: ${JSONObject.quote(userId)}, platform: TWITCH) {
+                emote_sets(entitled: true) { id }
+              }
+            }
+        """.trimIndent()
+        val body = JSONObject()
+            .put("query", query)
+            .toString()
+            .toRequestBody("application/json".toMediaType())
+        val request = Request.Builder()
+            .url("https://7tv.io/v3/gql")
+            .header("User-Agent", "Xtra/" + BuildConfig.VERSION_NAME)
+            .post(body)
+            .build()
+        okHttpClient.value.newCall(request).executeAsync(throwOnHttpError = true).use { response ->
+            parseSTVEntitledEmoteSetIds(response.body.string())
+        }
     }
 
     suspend fun loadSTVUserResponse(

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatAdapter.kt
@@ -35,6 +35,10 @@ import com.github.andreyasadchy.xtra.model.chat.STVUser
 import com.github.andreyasadchy.xtra.model.chat.TwitchBadge
 import com.github.andreyasadchy.xtra.model.chat.TwitchEmote
 import com.github.andreyasadchy.xtra.ui.view.NamePaintImageSpan
+import com.github.andreyasadchy.xtra.ui.chat.v2.assets.ChatAssetRepository
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatEmoteInteraction
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatGifInteraction
+import com.github.andreyasadchy.xtra.ui.chat.v2.presentation.ChatRowUiModel
 import com.github.andreyasadchy.xtra.util.chat.ChatAdapterUtils
 import com.github.andreyasadchy.xtra.util.chat.displayName
 import com.github.andreyasadchy.xtra.util.chat.isHighlightedMessage
@@ -729,16 +733,24 @@ class ChatAdapter(
         }
     }
 
-    fun createMessageClickedChatAdapter(): MessageClickedChatAdapter {
+    fun createMessageClickedChatAdapter(
+        sourceMessages: List<ChatMessage>? = null,
+        selectedMessageOverride: ChatMessage? = selectedMessage,
+        v2Rows: List<ChatRowUiModel>? = null,
+        v2Assets: ChatAssetRepository? = null,
+        v2EmoteClick: ((ChatEmoteInteraction) -> Unit)? = null,
+        v2GifClick: ((ChatGifInteraction) -> Unit)? = null,
+    ): MessageClickedChatAdapter {
         return MessageClickedChatAdapter(
-            messages, localTwitchEmotes, thirdPartyEmotes, globalBadges, channelBadges, cheerEmotes, namePaints, stvBadges, personalEmoteSets,
+            sourceMessages ?: messages, localTwitchEmotes, thirdPartyEmotes, globalBadges, channelBadges, cheerEmotes, namePaints, stvBadges, personalEmoteSets,
             stvUsers, enableTimestamps, timestampFormat, firstMsgVisibility, firstChatMsg, redeemedChatMsg, redeemedNoMsg, replyMessage,
             { chatMessage -> selectedMessage = chatMessage; replyClickListener?.invoke() },
             { url, name, format, isAnimated, source, thirdParty, emoteId -> imageClickListener?.invoke(url, name, format, isAnimated, source, thirdParty, emoteId) },
             useRandomColors, useReadableColors, isLightTheme, nameDisplay, useBoldNames, showNamePaints, showBadges, showSTVBadges, showPersonalEmotes,
             showSystemMessageEmotes, chatUrl, fragment, dialogBackgroundColor, imageLibrary, messageTextSize, emoteSize, badgeSize, inlineIconSize,
             emoteQuality, animateGifs, enableOverlayEmotes, translateAllMessages, translateMessage, showLanguageDownloadDialog, random, userColors,
-            savedColors, savedLocalTwitchEmotes, savedLocalBadges, savedLocalCheerEmotes, savedLocalEmotes, loggedInUser, selectedMessage
+            savedColors, savedLocalTwitchEmotes, savedLocalBadges, savedLocalCheerEmotes, savedLocalEmotes, loggedInUser, selectedMessageOverride,
+            v2Rows, v2Assets, v2EmoteClick, v2GifClick,
         )
     }
 

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatFragment.kt
@@ -71,9 +71,16 @@ import com.github.andreyasadchy.xtra.ui.channel.ChannelPagerFragmentDirections
 import com.github.andreyasadchy.xtra.ui.chat.ChatViewModel.Companion.ChatViewModelFactory
 import com.github.andreyasadchy.xtra.ui.common.BaseNetworkFragment
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessageId
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessage as V2ChatMessage
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatEmoteInteraction
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatGifInteraction
+import com.github.andreyasadchy.xtra.ui.chat.v2.presentation.ChatRowUiModel
+import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatAssetProvider
+import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatEmoteScope
 import com.github.andreyasadchy.xtra.ui.chat.v2.session.LiveChatSessionSpec
 import com.github.andreyasadchy.xtra.ui.chat.v2.ui.ChatV2RendererController
 import com.github.andreyasadchy.xtra.ui.chat.v2.ui.ChatViewportState
+import com.github.andreyasadchy.xtra.ui.chat.v2.presentation.ChatPresentationLabels
 import com.github.andreyasadchy.xtra.ui.main.MainActivity
 import com.github.andreyasadchy.xtra.ui.multiview.MultiviewFragment
 import com.github.andreyasadchy.xtra.ui.player.Media3PlayerFragment
@@ -107,6 +114,89 @@ import kotlinx.coroutines.launch
 import java.util.Locale
 import kotlin.math.max
 
+internal fun shouldShowChatComposer(
+    messagingEnabled: Boolean,
+    isSlidingPlayerLayout: Boolean,
+    chatBarVisible: Boolean,
+): Boolean = messagingEnabled && (!isSlidingPlayerLayout || chatBarVisible)
+
+internal fun matchesV2MessageUser(
+    message: V2ChatMessage,
+    selected: V2ChatMessage,
+): Boolean {
+    val selectedUser = selected.user ?: return false
+    fun matches(userId: String?, login: String?): Boolean {
+        val selectedId = selectedUser.id
+        return if (!selectedId.isNullOrBlank()) {
+            userId == selectedId
+        } else {
+            val selectedLogin = selectedUser.login
+            !selectedLogin.isNullOrBlank() && login.equals(selectedLogin, ignoreCase = true)
+        }
+    }
+    return matches(message.user?.id, message.user?.login) ||
+            message.reply?.let { reply -> matches(reply.parentUserId, reply.parentUserLogin) } == true
+}
+
+internal data class ComposerOverlaySnapshot<Overlay, RestoreState>(
+    val overlay: Overlay,
+    val input: String,
+    val restoreState: RestoreState,
+    val submissionPending: Boolean,
+)
+
+internal fun <Overlay, RestoreState> captureComposerOverlaySnapshot(
+    overlay: Overlay?,
+    existing: ComposerOverlaySnapshot<Overlay, RestoreState>?,
+    pendingRestoreState: RestoreState?,
+    pendingInput: String?,
+    currentInput: String?,
+    submissionPending: Boolean,
+): ComposerOverlaySnapshot<Overlay, RestoreState>? {
+    val retainedOverlay = overlay ?: existing?.overlay ?: return null
+    val restoreState = pendingRestoreState ?: existing?.restoreState ?: return null
+    val input = if (submissionPending) {
+        pendingInput ?: existing?.input.orEmpty()
+    } else {
+        currentInput ?: existing?.input.orEmpty()
+    }
+    return ComposerOverlaySnapshot(
+        overlay = retainedOverlay,
+        input = input,
+        restoreState = restoreState,
+        submissionPending = submissionPending,
+    )
+}
+
+internal class ComposerOverlayStateStore<Overlay, RestoreState> {
+    var active: ComposerOverlaySnapshot<Overlay, RestoreState>? = null
+        private set
+
+    fun open(overlay: Overlay, restoreState: RestoreState) {
+        active = ComposerOverlaySnapshot(overlay, "", restoreState, submissionPending = false)
+    }
+
+    fun submit(input: String): ComposerOverlaySnapshot<Overlay, RestoreState>? {
+        active = active?.copy(input = input, submissionPending = true)
+        return active
+    }
+
+    fun markFailed(input: String): ComposerOverlaySnapshot<Overlay, RestoreState>? {
+        active = active?.copy(input = input, submissionPending = false)
+        return active
+    }
+
+    fun set(snapshot: ComposerOverlaySnapshot<Overlay, RestoreState>) {
+        active = snapshot
+    }
+
+    fun clear(): RestoreState? {
+        val restoreState = active?.restoreState
+        active = null
+        return restoreState
+    }
+}
+
 class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickListener, ReplyClickedDialog.OnButtonClickListener, ChannelPointsDialog.Listener {
 
     private sealed interface ComposerOverlayState {
@@ -122,6 +212,10 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
     private var chatV2ViewportState = ChatViewportState()
     private var useChatV2 = false
     private var chatV2RendererVisible = true
+    private var selectedV2Message: V2ChatMessage? = null
+
+    internal val isUsingChatV2: Boolean
+        get() = useChatV2
 
     var chatMessageListener: ((ChatMessage) -> Unit)? = null
     var chatHistoryListener: ((List<ChatMessage>) -> Unit)? = null
@@ -130,7 +224,6 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
     private var showChatStatus = false
     private var messagingEnabled = false
     private var messageViewWasVisibleBeforeReplay: Boolean? = null
-    private var messagingEnabledBeforeReplay = false
     private var channelPointsIconUrl: String? = null
     private var channelPointsIconRequest: Disposable? = null
     private var channelPointsIconRequestGeneration = 0
@@ -143,9 +236,36 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
     private var composerOverlayState: ComposerOverlayState? = null
     private var pendingComposerText: String? = null
     private var composerSubmissionInProgress = false
-    private var composerTextBeforeOverlay: String? = null
-    private var composerSelectionBeforeOverlay: Int? = null
-    private var messageViewWasVisibleBeforeOverlay: Boolean? = null
+    private var pendingChatSendResult: ChatSendResult? = null
+
+    private data class ComposerRestoreState(
+        val text: String,
+        val selection: Int?,
+        val reply: ReplyComposerState?,
+    )
+
+    private data class PendingOverlaySubmission(
+        val state: ComposerOverlayState,
+        val text: String,
+        val restoreState: ComposerRestoreState,
+    )
+
+    private data class PendingChatSubmission(
+        val text: String,
+        val replyId: String?,
+    )
+
+    private data class ReplyComposerState(
+        val replyId: String,
+        val userLogin: String?,
+        val userName: String?,
+        val message: String?,
+    )
+
+    private var pendingChatSubmission: PendingChatSubmission? = null
+    private var pendingOverlaySubmission: PendingOverlaySubmission? = null
+    private val overlayStateStore = ComposerOverlayStateStore<ComposerOverlayState, ComposerRestoreState>()
+    private var replyComposerState: ReplyComposerState? = null
     private var seenPinnedMessageId: String? = null
     private var displayedPinnedMessageId: String? = null
     private var pinnedMessageMinimized = false
@@ -548,9 +668,14 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
                                 !TwitchApiHelper.getHelixHeaders(requireContext())[C.HEADER_TOKEN].isNullOrBlank())
                 val chatUrl = args.getString(KEY_CHAT_URL)
                 if (isLive || (args.getString(KEY_VIDEO_ID) != null && args.getInt(KEY_START_TIME) != -1) || chatUrl != null) {
-                    val enableMessaging = isLive &&
-                            viewModel.activeChatMode is ChatViewModel.ActiveChatMode.Live &&
-                            isLoggedIn
+                    // The ViewModel is switched to Live by initialize(), which runs from
+                    // BaseNetworkFragment.onResume(). Set up the live composer before that
+                    // point as well; otherwise a v2 view can keep the XML-gone composer for
+                    // its entire lifetime.
+                    // Authentication controls capability, not structural setup. The
+                    // account can become available after this view is created.
+                    val enableMessaging = isLive && isLoggedIn &&
+                            viewModel.activeChatMode is ChatViewModel.ActiveChatMode.Live
                     messagingEnabled = enableMessaging
                     val chatStyle = resolveChatRenderStyle(requireContext())
                     val chatSizing = ChatSizing(
@@ -622,7 +747,7 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
                             (requireContext().getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager).hideSoftInputFromWindow(editText.windowToken, 0)
                             editText.clearFocus()
                             MessageClickedDialog.newInstance(
-                                messagingEnabled = enableMessaging,
+                                messagingEnabled = messagingEnabled,
                                 channelId = channelId,
                                 channelLogin = channelLogin,
                             ).show(this@ChatFragment.childFragmentManager, "messageDialog")
@@ -630,7 +755,7 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
                         replyClickListener = {
                             (requireContext().getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager).hideSoftInputFromWindow(editText.windowToken, 0)
                             editText.clearFocus()
-                            ReplyClickedDialog.newInstance(enableMessaging).show(this@ChatFragment.childFragmentManager, "replyDialog")
+                            ReplyClickedDialog.newInstance(messagingEnabled).show(this@ChatFragment.childFragmentManager, "replyDialog")
                         },
                         imageClickListener = { url, name, format, isAnimated, source, thirdParty, emoteId ->
                             (requireContext().getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager).hideSoftInputFromWindow(editText.windowToken, 0)
@@ -658,13 +783,28 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
                             animateGifs = chatStyle.animateGifs,
                             showBadges = chatStyle.showBadges,
                             enableOverlayEmotes = chatStyle.enableOverlayEmotes,
+                            firstMessageVisibility = chatStyle.firstMessageVisibility,
+                            boldNames = chatStyle.boldNames,
                             timestampFormat = chatStyle.timestampFormat,
                             showTimestamps = chatStyle.showTimestamps,
                             readableUsernameColors = requireContext().prefs().getBoolean(C.CHAT_THEME_ADAPTED_USERNAME_COLOR, true),
                             backgroundColor = chatBackground,
+                            presentationLabels = ChatPresentationLabels(
+                                firstChatter = getString(R.string.chat_first),
+                                redeemed = { reward -> getString(R.string.redeemed, reward) },
+                                highlightTitle = getString(R.string.chat_highlight_title),
+                                highlightRedeemed = { title -> getString(R.string.chat_highlight_redeemed, title) },
+                                watchStreakReached = getString(R.string.chat_watch_streak_reached),
+                                watchStreakStatus = { user, count -> getString(R.string.chat_watch_streak_status, user, count) },
+                                reply = { user, message -> getString(R.string.replying_to_message, user, message) },
+                            ),
                             onStateChanged = { state ->
                                 btnDown.isVisible = state.followMode == com.github.andreyasadchy.xtra.ui.chat.v2.ui.FollowMode.USER_SCROLLED_UP
                             },
+                            onMessageLongClick = ::onV2MessageLongClick,
+                            onEmoteClick = ::onV2EmoteClick,
+                            onGifClick = ::onV2GifClick,
+                            onPublicationChanged = ::onV2PublicationChanged,
                         ).also {
                             it.setVisible(chatV2RendererVisible)
                             it.attach(viewLifecycleOwner)
@@ -757,7 +897,7 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
                             it.visibility = View.GONE
                         }
                     }
-                    if (enableMessaging) {
+                    if (isLive) {
                         val identityGqlHeaders = TwitchApiHelper.getGQLHeaders(requireContext(), true)
                         val chatIdentityEnabled = !channelId.isNullOrBlank() &&
                                 !channelLogin.isNullOrBlank() &&
@@ -829,6 +969,19 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
                                 setNotifyOnChange(hasFocus)
                             }
                         }
+                        if (useChatV2) {
+                            viewLifecycleOwner.lifecycleScope.launch {
+                                repeatOnLifecycle(Lifecycle.State.STARTED) {
+                                    viewModel.pickerCatalogFor(channelId, channelLogin, useV2 = true)
+                                        .collectLatest { catalog ->
+                                            if (catalog != null) {
+                                                viewModel.refreshV2AutoCompleteList(catalog)
+                                                autoCompleteAdapter?.notifyDataSetChanged()
+                                            }
+                                        }
+                                }
+                            }
+                        }
                         editText.addTextChangedListener(onTextChanged = { text, _, _, _ ->
                             updateComposerButtons()
                         })
@@ -862,11 +1015,12 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
                         }
                         replyView.visibility = View.GONE
                         send.setOnClickListener { sendMessage() }
-                        if ((view.parent?.parent?.parent?.parent as? View)?.id == R.id.slidingLayout && !requireContext().prefs().getBoolean(C.KEY_CHAT_BAR_VISIBLE, true)) {
-                            messageView.visibility = View.GONE
-                        } else {
-                            messageView.visibility = View.VISIBLE
-                        }
+                        messageView.isVisible = shouldShowChatComposer(
+                            messagingEnabled = messagingEnabled,
+                            isSlidingPlayerLayout = isInSlidingPlayerLayout(binding.root),
+                            chatBarVisible = requireContext().prefs().getBoolean(C.KEY_CHAT_BAR_VISIBLE, true),
+                        )
+                        editText.isEnabled = enableMessaging && !composerSubmissionInProgress
                         updateSlowModeIndicator(viewModel.slowModeState.value)
                         messageView.addOnLayoutChangeListener { _, _, _, _, _, _, _, _, _ ->
                             updateComposerDensity()
@@ -1206,11 +1360,52 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
                 }
             }
         }
-        savedInstanceState?.getString(KEY_COMPOSER_DRAFT)?.takeIf { it.isNotEmpty() }?.let { draft ->
-            binding.editText.setText(draft)
+        val pendingSubmission = pendingChatSubmission
+        val draft = if (overlayStateStore.active == null && pendingOverlaySubmission == null) {
+            pendingSubmission?.text ?: savedInstanceState?.getString(KEY_COMPOSER_DRAFT)
+        } else {
+            null
+        }
+        draft?.takeIf { it.isNotEmpty() }?.let {
+            binding.editText.setText(it)
             binding.editText.setSelection(binding.editText.length())
             updateComposerButtons()
         }
+        if (pendingSubmission != null) {
+            binding.editText.isEnabled = false
+            pendingChatSendResult?.let { result ->
+                pendingChatSendResult = null
+                handleChatSendResult(result, pendingSubmission.text, pendingSubmission.replyId)
+            }
+        }
+        val retainedOverlay = overlayStateStore.active ?: pendingOverlaySubmission?.let { pending ->
+            ComposerOverlaySnapshot(
+                overlay = pending.state,
+                input = pending.text,
+                restoreState = pending.restoreState,
+                submissionPending = true,
+            )
+        }
+        retainedOverlay?.let { overlay ->
+            composerOverlayState = overlay.overlay
+            if (overlayStateStore.active == null) {
+                overlayStateStore.set(overlay)
+            }
+            if (overlay.submissionPending) {
+                composerSubmissionInProgress = true
+                pendingOverlaySubmission = PendingOverlaySubmission(
+                    state = overlay.overlay,
+                    text = overlay.input,
+                    restoreState = overlay.restoreState,
+                )
+            }
+            renderComposerOverlay(overlay.overlay)
+            binding.editText.setText(overlay.input)
+            binding.editText.setSelection(binding.editText.length())
+            binding.editText.isEnabled = !overlay.submissionPending
+            updateComposerButtons()
+        }
+        replyComposerState?.let(::configureReplyComposer)
     }
 
     private fun isInsideInsetAwareContainer(view: View): Boolean {
@@ -1386,6 +1581,10 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
                     )
                 }
             }
+            // BaseNetworkFragment may invoke initialize() after this Fragment's onResume()
+            // when network state arrives asynchronously. Refresh here as well so the live
+            // composer is enabled once the ViewModel has actually entered Live mode.
+            if (_binding != null) refreshMessagingEnabled()
         }
     }
 
@@ -1426,6 +1625,7 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
                 getCurrentSpeed = if (parentFragment is Media3PlayerFragment) (parentFragment as Media3PlayerFragment)::getCurrentSpeed else (parentFragment as PlayerFragment)::getCurrentSpeed
             )
         }
+        refreshMessagingEnabled()
     }
 
     private fun currentPositionProvider(): () -> Long? = {
@@ -1502,6 +1702,15 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
             if (useChatV2) {
                 requireArguments().getString(KEY_CHANNEL_ID)?.let { channelId ->
                     startChatV2Session(channelId, channelLogin)
+                    viewModel.startLive(
+                        networkLibrary = requireContext().prefs().getString(C.NETWORK_LIBRARY, C.OKHTTP),
+                        recentMessagesUrl = "https://recent-messages.robotty.de/api/v2/recent-messages/\$channel",
+                        channelId = channelId,
+                        channelLogin = channelLogin,
+                        channelName = requireArguments().getString(KEY_CHANNEL_NAME),
+                        streamId = currentLiveStreamId(),
+                        useChatV2 = true,
+                    )
                 }
             } else {
                 viewModel.startLive(
@@ -1551,7 +1760,6 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
         _binding?.let {
             if (!alreadyInReplay) {
                 messageViewWasVisibleBeforeReplay = it.messageView.isVisible
-                messagingEnabledBeforeReplay = messagingEnabled
             }
             it.messageView.isVisible = false
             it.editText.clearFocus()
@@ -1577,12 +1785,19 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
             channelLogin = args.getString(KEY_CHANNEL_LOGIN),
             channelName = args.getString(KEY_CHANNEL_NAME),
             streamId = currentLiveStreamId(),
+            useChatV2 = useChatV2,
         )
+        if (useChatV2) {
+            val channelId = args.getString(KEY_CHANNEL_ID)
+            val channelLogin = args.getString(KEY_CHANNEL_LOGIN)
+            if (!channelId.isNullOrBlank() && !channelLogin.isNullOrBlank()) {
+                startChatV2Session(channelId, channelLogin)
+            }
+        }
         _binding?.let {
-            messagingEnabled = messagingEnabledBeforeReplay
             messageViewWasVisibleBeforeReplay?.let { wasVisible -> it.messageView.isVisible = wasVisible }
             messageViewWasVisibleBeforeReplay = null
-            updateComposerButtons()
+            refreshMessagingEnabled()
         }
     }
 
@@ -1702,6 +1917,7 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
     }
 
     private fun resetMessageComposerAction() {
+        replyComposerState = null
         with(binding) {
             replyView.visibility = View.GONE
             send.setOnClickListener { sendMessage() }
@@ -1735,6 +1951,28 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
         binding.send.isEnabled = !blockedBySlowMode
         binding.clear.isVisible = !composerSubmissionInProgress && hasText
     }
+
+    private fun refreshMessagingEnabled() {
+        val args = arguments ?: return
+        val accountLogin = requireContext().tokenPrefs().getString(C.USERNAME, null)
+        val isLoggedIn = !accountLogin.isNullOrBlank() &&
+                (!TwitchApiHelper.getGQLHeaders(requireContext(), true)[C.HEADER_TOKEN].isNullOrBlank() ||
+                        !TwitchApiHelper.getHelixHeaders(requireContext())[C.HEADER_TOKEN].isNullOrBlank())
+        messagingEnabled = args.getBoolean(KEY_IS_LIVE) &&
+                viewModel.activeChatMode is ChatViewModel.ActiveChatMode.Live &&
+                isLoggedIn
+        binding.messageView.isVisible = shouldShowChatComposer(
+            messagingEnabled = messagingEnabled,
+            isSlidingPlayerLayout = isInSlidingPlayerLayout(binding.root),
+            chatBarVisible = requireContext().prefs().getBoolean(C.KEY_CHAT_BAR_VISIBLE, true),
+        )
+        binding.editText.isEnabled = messagingEnabled && !composerSubmissionInProgress
+        updateComposerButtons()
+        updateSlowModeIndicator(viewModel.slowModeState.value)
+    }
+
+    private fun isInSlidingPlayerLayout(root: View): Boolean =
+        (root.parent?.parent?.parent?.parent as? View)?.id == R.id.slidingLayout
 
     private fun updateSlowModeIndicator(state: SlowModeState) {
         if (_binding == null) return
@@ -1872,7 +2110,25 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
     private fun updateComposerDensity() {
         if (_binding == null || binding.messageView.width <= 0) return
         val compactWidth = (320 * resources.displayMetrics.density).toInt()
-        binding.channelPointsText.isVisible = binding.channelPoints.isVisible && binding.messageView.width >= compactWidth
+        val compact = binding.messageView.width < compactWidth
+        val controlSize = TypedValue.applyDimension(
+            TypedValue.COMPLEX_UNIT_DIP,
+            if (compact) 40f else 48f,
+            resources.displayMetrics,
+        ).toInt()
+        listOf(binding.chatIdentity, binding.clear, binding.emotes, binding.send).forEach { control ->
+            control.updateLayoutParams<LinearLayout.LayoutParams> {
+                width = controlSize
+                height = ViewGroup.LayoutParams.MATCH_PARENT
+            }
+            control.minimumWidth = controlSize
+        }
+        binding.channelPointsText.isVisible = binding.channelPoints.isVisible && !compact
+        binding.channelPoints.updateLayoutParams<LinearLayout.LayoutParams> {
+            width = if (compact) controlSize else ViewGroup.LayoutParams.WRAP_CONTENT
+            height = ViewGroup.LayoutParams.MATCH_PARENT
+        }
+        binding.channelPoints.minimumWidth = controlSize
     }
 
     private fun setupEmotePickerSizing() {
@@ -1940,14 +2196,26 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
     }
 
     private fun showComposerOverlay(state: ComposerOverlayState) {
+        if (composerSubmissionInProgress) return
         if (composerOverlayState == null) {
-            composerTextBeforeOverlay = binding.editText.text.toString()
-            composerSelectionBeforeOverlay = binding.editText.selectionStart.takeIf { it >= 0 }
-            messageViewWasVisibleBeforeOverlay = binding.messageView.isVisible
+            val restoreState = ComposerRestoreState(
+                text = binding.editText.text.toString(),
+                selection = binding.editText.selectionStart.takeIf { it >= 0 },
+                reply = replyComposerState,
+            )
+            overlayStateStore.open(state, restoreState)
+        } else if (overlayStateStore.active == null) {
+            overlayStateStore.open(
+                overlay = state,
+                restoreState = ComposerRestoreState("", null, null),
+            )
         }
         composerOverlayState = state
         pendingComposerText = null
-        composerSubmissionInProgress = false
+        renderComposerOverlay(state)
+    }
+
+    private fun renderComposerOverlay(state: ComposerOverlayState) {
         with(binding) {
             resetMessageComposerAction()
             toggleEmoteMenu(false)
@@ -2001,42 +2269,70 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
         }
     }
 
-    private fun cancelComposerOverlay() {
-        val textBeforeOverlay = composerTextBeforeOverlay
-        val selectionBeforeOverlay = composerSelectionBeforeOverlay
-        val messageViewWasVisible = messageViewWasVisibleBeforeOverlay
+    private fun cancelComposerOverlay(force: Boolean = false) {
+        if (composerSubmissionInProgress && !force) return
+        val restoreState = pendingOverlaySubmission?.restoreState ?: overlayStateStore.active?.restoreState
         composerOverlayState = null
         pendingComposerText = null
+        pendingOverlaySubmission = null
         composerSubmissionInProgress = false
-        composerTextBeforeOverlay = null
-        composerSelectionBeforeOverlay = null
-        messageViewWasVisibleBeforeOverlay = null
+        overlayStateStore.clear()
         binding.channelPointRewardOverlay.isGone = true
-        textBeforeOverlay?.let { text ->
-            binding.editText.setText(text)
-            binding.editText.setSelection(
-                (selectionBeforeOverlay ?: binding.editText.length()).coerceIn(0, binding.editText.length()),
-            )
-        }
-        messageViewWasVisible?.let { binding.messageView.isVisible = it }
+        refreshMessagingEnabled()
+        restoreState?.let(::restoreComposerState)
         updateComposerButtons()
     }
 
     private fun restorePendingComposerText() {
-        pendingComposerText?.let { text ->
+        val pending = pendingOverlaySubmission
+        pending?.let {
+            composerOverlayState = pending.state
+            overlayStateStore.markFailed(pending.text)
+            renderComposerOverlay(pending.state)
+        }
+        (pending?.text ?: pendingComposerText)?.let { text ->
             binding.editText.setText(text)
             binding.editText.setSelection(binding.editText.length())
         }
         pendingComposerText = null
+        pendingOverlaySubmission = null
         composerSubmissionInProgress = false
+        binding.editText.isEnabled = messagingEnabled && !composerSubmissionInProgress
         updateComposerButtons()
     }
 
+    private fun restoreComposerState(state: ComposerRestoreState) {
+        replyComposerState = state.reply
+        state.reply?.let(::configureReplyComposer)
+        binding.editText.setText(state.text)
+        binding.editText.setSelection(
+            (state.selection ?: binding.editText.length()).coerceIn(0, binding.editText.length()),
+        )
+    }
+
+    private fun captureActiveOverlayState() {
+        val existing = overlayStateStore.active
+        val overlay = composerOverlayState ?: existing?.overlay ?: return
+        val pending = pendingOverlaySubmission
+        captureComposerOverlaySnapshot(
+            overlay = overlay,
+            existing = existing,
+            pendingRestoreState = pending?.restoreState,
+            pendingInput = pending?.text,
+            currentInput = _binding?.editText?.text?.toString(),
+            submissionPending = composerSubmissionInProgress || pending != null,
+        )?.let(overlayStateStore::set)
+    }
+
     private fun handleChannelPointRedemption(result: ChannelPointRedemptionResult) {
-        val overlay = composerOverlayState
-        if (overlay is ComposerOverlayState.Reward && overlay.reward.id == result.rewardId) {
+        val pending = pendingOverlaySubmission
+        val overlay = pending?.state
+        val matchesSubmission = overlay is ComposerOverlayState.Reward &&
+            (overlay.reward.id == result.rewardId ||
+                (result.rewardId == null && overlay.reward.title == result.rewardTitle))
+        if (matchesSubmission) {
             if (result.success) {
-                cancelComposerOverlay()
+                cancelComposerOverlay(force = true)
             } else {
                 restorePendingComposerText()
             }
@@ -2050,10 +2346,14 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
     }
 
     private fun handleWatchStreakShare(result: WatchStreakShareResult) {
-        val overlay = composerOverlayState
-        if (overlay is ComposerOverlayState.StreakShare && overlay.streak.milestoneId == result.milestoneId) {
+        val pending = pendingOverlaySubmission
+        val overlay = pending?.state
+        val matchesSubmission = overlay is ComposerOverlayState.StreakShare &&
+            (overlay.streak.milestoneId == result.milestoneId ||
+                (result.milestoneId == null && overlay.streak.milestoneId == null))
+        if (matchesSubmission) {
             if (result.success) {
-                cancelComposerOverlay()
+                cancelComposerOverlay(force = true)
             } else {
                 restorePendingComposerText()
             }
@@ -2176,19 +2476,29 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
         "${drop.id}:${drop.isClaimable}"
 
     private fun sendMessage(replyId: String? = null): Boolean {
-        if (!messagingEnabled) return false
+        if (!messagingEnabled || composerSubmissionInProgress) return false
         with(binding) {
             val overlay = composerOverlayState
             if (overlay != null) {
-                if (composerSubmissionInProgress) {
-                    return false
-                }
                 val text = editText.text.trim().toString()
                 if (overlay is ComposerOverlayState.Reward && text.isBlank()) {
                     return false
                 }
                 pendingComposerText = text
+                val restoreState = overlayStateStore.active?.restoreState ?: ComposerRestoreState(
+                    text = "",
+                    selection = null,
+                    reply = null,
+                )
+                overlayStateStore.open(overlay, restoreState)
+                overlayStateStore.submit(text)
+                pendingOverlaySubmission = PendingOverlaySubmission(
+                    state = overlay,
+                    text = text,
+                    restoreState = restoreState,
+                )
                 composerSubmissionInProgress = true
+                editText.isEnabled = false
                 editText.text.clear()
                 (requireContext().getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager)
                     .hideSoftInputFromWindow(editText.windowToken, 0)
@@ -2207,10 +2517,11 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
             (requireContext().getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager).hideSoftInputFromWindow(editText.windowToken, 0)
             editText.clearFocus()
             toggleEmoteMenu(false)
-            resetMessageComposerAction()
-            val text = editText.text.trim()
-            editText.text.clear()
+            val text = editText.text.trim().toString()
             return if (text.isNotEmpty()) {
+                pendingChatSubmission = PendingChatSubmission(text = text, replyId = replyId)
+                composerSubmissionInProgress = true
+                editText.isEnabled = false
                 viewModel.send(
                     message = text,
                     replyId = replyId,
@@ -2222,11 +2533,9 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
                     channelLogin = requireArguments().getString(KEY_CHANNEL_LOGIN),
                     useApiCommands = requireContext().prefs().getBoolean(C.DEBUG_API_COMMANDS, true),
                     useApiChatMessages = requireContext().prefs().getBoolean(C.DEBUG_API_CHAT_MESSAGES, true),
+                    onResult = { result -> handleChatSendResult(result, text, replyId) },
                 )
-                val lastIndex = synchronized(viewModel.chatMessages) {
-                    viewModel.chatMessages.lastIndex
-                }
-                recyclerView.scrollToPosition(lastIndex)
+                updateComposerButtons()
                 true
             } else {
                 false
@@ -2234,8 +2543,190 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
         }
     }
 
+    private fun hideChatInputForDialog() {
+        (requireContext().getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager)
+            .hideSoftInputFromWindow(binding.editText.windowToken, 0)
+        binding.editText.clearFocus()
+    }
+
+    private fun onV2MessageLongClick(message: V2ChatMessage) {
+        selectedV2Message = message
+        hideChatInputForDialog()
+        MessageClickedDialog.newInstance(
+            messagingEnabled = messagingEnabled,
+            channelId = message.channelId,
+            channelLogin = requireArguments().getString(KEY_CHANNEL_LOGIN),
+        ).show(childFragmentManager, "messageDialog")
+    }
+
+    private fun onV2PublicationChanged(
+        messages: List<V2ChatMessage>,
+        rows: List<ChatRowUiModel>,
+    ) {
+        if (selectedV2Message != null) {
+            messageDialog?.updateV2Messages(messages.map(::v2MessageToLegacy), rows)
+        }
+    }
+
+    private fun handleChatSendResult(result: ChatSendResult, submittedText: String, submittedReplyId: String?) {
+        val pending = pendingChatSubmission
+        if (pending == null || pending.text != submittedText || pending.replyId != submittedReplyId) return
+        val currentBinding = _binding
+        if (currentBinding == null) {
+            pendingChatSendResult = result
+            return
+        }
+        pendingChatSubmission = null
+        composerSubmissionInProgress = false
+        when (result) {
+            is ChatSendResult.Success -> {
+                currentBinding.editText.text.clear()
+                currentBinding.editText.isEnabled = messagingEnabled
+                resetMessageComposerAction()
+                (requireContext().getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager)
+                    .hideSoftInputFromWindow(currentBinding.editText.windowToken, 0)
+                currentBinding.editText.clearFocus()
+                toggleEmoteMenu(false)
+                if (useChatV2) {
+                    chatV2Renderer?.jumpToNewest()
+                } else {
+                    val lastIndex = synchronized(viewModel.chatMessages) { viewModel.chatMessages.lastIndex }
+                    if (lastIndex >= 0) currentBinding.recyclerView.scrollToPosition(lastIndex)
+                }
+            }
+            is ChatSendResult.Failure -> {
+                if (currentBinding.editText.text.isBlank()) {
+                    currentBinding.editText.setText(submittedText)
+                    currentBinding.editText.setSelection(currentBinding.editText.length())
+                }
+                currentBinding.editText.isEnabled = messagingEnabled
+                if (messagingEnabled) currentBinding.editText.requestFocus()
+                val safeMessage = result.message
+                    .takeIf { it.length <= 120 }
+                    ?.takeUnless {
+                        it.contains('{') || it.contains('}') ||
+                                it.contains("OAuth", ignoreCase = true) ||
+                                it.contains("Bearer", ignoreCase = true)
+                    }
+                    ?: getString(R.string.connection_error)
+                Snackbar.make(currentBinding.root, getString(R.string.chat_send_msg_error, safeMessage), Snackbar.LENGTH_LONG).show()
+            }
+        }
+        updateComposerButtons()
+    }
+
+    private fun onV2EmoteClick(interaction: ChatEmoteInteraction) {
+        hideChatInputForDialog()
+        val source = when (interaction.provider) {
+            ChatAssetProvider.TWITCH -> null
+            ChatAssetProvider.SEVEN_TV -> when (interaction.scope) {
+                ChatEmoteScope.PERSONAL -> Emote.PERSONAL_STV
+                ChatEmoteScope.CHANNEL -> Emote.CHANNEL_STV
+                ChatEmoteScope.GLOBAL -> Emote.GLOBAL_STV
+                ChatEmoteScope.LEGACY_COMBINED, null -> null
+            }
+            ChatAssetProvider.BTTV -> when (interaction.scope) {
+                ChatEmoteScope.CHANNEL -> Emote.CHANNEL_BTTV
+                ChatEmoteScope.GLOBAL -> Emote.GLOBAL_BTTV
+                ChatEmoteScope.PERSONAL, ChatEmoteScope.LEGACY_COMBINED, null -> null
+            }
+            ChatAssetProvider.FFZ -> when (interaction.scope) {
+                ChatEmoteScope.CHANNEL -> Emote.CHANNEL_FFZ
+                ChatEmoteScope.GLOBAL -> Emote.GLOBAL_FFZ
+                ChatEmoteScope.PERSONAL, ChatEmoteScope.LEGACY_COMBINED, null -> null
+            }
+        }
+        val url = interaction.url
+        ImageClickedDialog.newInstance(
+            url = url,
+            name = interaction.name,
+            format = url?.substringAfterLast('.', "webp"),
+            isAnimated = interaction.animated,
+            source = source,
+            thirdParty = interaction.provider != ChatAssetProvider.TWITCH,
+            emoteId = interaction.id.takeIf { interaction.provider == ChatAssetProvider.TWITCH },
+        ).show(childFragmentManager, "imageDialog")
+    }
+
+    private fun onV2GifClick(interaction: ChatGifInteraction) {
+        hideChatInputForDialog()
+        ImageClickedDialog.newGifInstance(
+            url = interaction.url,
+            description = interaction.description,
+        ).show(childFragmentManager, "imageDialog")
+    }
+
+    private fun v2MessageToLegacy(message: V2ChatMessage): ChatMessage {
+        val text = message.rawText ?: message.segments.joinToString(separator = "") { segment ->
+            when (segment) {
+                is com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatSegment.Text -> segment.text
+                is com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatSegment.Mention -> segment.text
+                is com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatSegment.Emote -> segment.fallbackText
+                is com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatSegment.Gif -> segment.fallbackText
+                is com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatSegment.Cheermote -> segment.text
+            }
+        }
+        val reply = message.reply?.let {
+            com.github.andreyasadchy.xtra.model.chat.Reply(
+                threadParentId = it.parentMessageId.value,
+                userLogin = it.parentUserLogin,
+                userName = it.parentUserName,
+                message = it.parentMessageBody,
+            )
+        }
+        val replyParent = message.reply?.let {
+            ChatMessage(
+                type = ChatMessage.USER_MESSAGE,
+                id = it.parentMessageId.value,
+                userId = it.parentUserId,
+                userLogin = it.parentUserLogin,
+                userName = it.parentUserName,
+                message = it.parentMessageBody,
+            )
+        }
+        return ChatMessage(
+            type = if (message.user != null) ChatMessage.USER_MESSAGE else ChatMessage.SYSTEM_MESSAGE,
+            id = message.id.value,
+            userId = message.user?.id,
+            userLogin = message.user?.login,
+            userName = message.user?.displayName,
+            message = text.takeIf { it.isNotEmpty() },
+            isAction = message.kind == com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessageKind.ACTION,
+            bits = message.bits,
+            badges = message.badges.map { badge ->
+                com.github.andreyasadchy.xtra.model.chat.Badge(badge.setId, badge.versionId)
+            },
+            systemMsg = message.systemText,
+            msgId = message.noticeType,
+            sourceMsgId = message.source?.messageId?.value,
+            reply = reply,
+            replyParent = replyParent,
+            timestamp = message.timestampMs,
+        )
+    }
+
     override fun onCreateMessageClickedChatAdapter(): MessageClickedChatAdapter? {
-        return adapter?.createMessageClickedChatAdapter()
+        val clicked = selectedV2Message
+        if (!useChatV2 || clicked == null) return adapter?.createMessageClickedChatAdapter()
+        val canonicalMessages = chatV2Renderer?.currentMessages().orEmpty()
+        val history = if (clicked.user != null) {
+            canonicalMessages.filter { matchesV2MessageUser(it, clicked) }
+        } else {
+            canonicalMessages
+        }
+        val messages = history.map(::v2MessageToLegacy)
+        val selected = messages.firstOrNull { it.id == clicked.id.value } ?: v2MessageToLegacy(clicked)
+        val historyIds = history.mapTo(HashSet()) { it.id }
+        val rows = chatV2Renderer?.currentRows().orEmpty().filter { it.id in historyIds }
+        val app = requireContext().applicationContext as XtraApp
+        return adapter?.createMessageClickedChatAdapter(
+            sourceMessages = messages,
+            selectedMessageOverride = selected,
+            v2Rows = rows,
+            v2Assets = app.xtraModule.chatAssetRepository,
+            v2EmoteClick = ::onV2EmoteClick,
+            v2GifClick = ::onV2GifClick,
+        )
     }
 
     override fun onCreateReplyClickedChatAdapter(): ReplyClickedChatAdapter? {
@@ -2243,50 +2734,53 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
     }
 
     override fun onReplyClicked(replyId: String?, userLogin: String?, userName: String?, message: String?) {
+        if (replyId.isNullOrBlank()) return
+        cancelComposerOverlay()
+        messageDialog?.dismiss()
+        replyComposerState = ReplyComposerState(replyId, userLogin, userName, message)
+        configureReplyComposer(replyComposerState!!)
+    }
+
+    private fun configureReplyComposer(state: ReplyComposerState) {
         with(binding) {
-            if (!replyId.isNullOrBlank()) {
-                cancelComposerOverlay()
-                messageDialog?.dismiss()
-                replyView.visibility = View.VISIBLE
-                replyText.text = message?.let {
-                    val name = if (userName != null && userLogin != null && !userLogin.equals(userName, true)) {
-                        when (requireContext().prefs().getString(C.UI_NAME_DISPLAY, "0")) {
-                            "0" -> "${userName}(${userLogin})"
-                            "1" -> userName
-                            else -> userLogin
-                        }
-                    } else {
-                        userName ?: userLogin
+            replyView.visibility = View.VISIBLE
+            replyText.text = state.message?.let { message ->
+                val name = if (state.userName != null && state.userLogin != null &&
+                    !state.userLogin.equals(state.userName, true)
+                ) {
+                    when (requireContext().prefs().getString(C.UI_NAME_DISPLAY, "0")) {
+                        "0" -> "${state.userName}(${state.userLogin})"
+                        "1" -> state.userName
+                        else -> state.userLogin
                     }
-                    getString(R.string.replying_to_message, name, message)
+                } else {
+                    state.userName ?: state.userLogin
                 }
-                replyClose.setOnClickListener {
-                    resetMessageComposerAction()
-                }
-                send.setOnClickListener { sendMessage(replyId) }
-                editText.setOnKeyListener { _, keyCode, event ->
-                    if (event.action == KeyEvent.ACTION_DOWN && keyCode == KeyEvent.KEYCODE_ENTER) {
-                        val sent = sendMessage(replyId)
-                        sent || viewModel.isSlowModeBlocked()
-                    } else {
-                        false
-                    }
-                }
-                editText.setOnEditorActionListener { _, actionId, event ->
-                    if (actionId == EditorInfo.IME_ACTION_SEND ||
-                        event?.keyCode == KeyEvent.KEYCODE_ENTER && event.action == KeyEvent.ACTION_DOWN
-                    ) {
-                        val sent = sendMessage(replyId)
-                        sent || viewModel.isSlowModeBlocked()
-                    } else {
-                        false
-                    }
+                getString(R.string.replying_to_message, name, message)
+            }
+            replyClose.setOnClickListener { resetMessageComposerAction() }
+            send.setOnClickListener { sendMessage(state.replyId) }
+            editText.setOnKeyListener { _, keyCode, event ->
+                if (event.action == KeyEvent.ACTION_DOWN && keyCode == KeyEvent.KEYCODE_ENTER) {
+                    val sent = sendMessage(state.replyId)
+                    sent || viewModel.isSlowModeBlocked()
+                } else {
+                    false
                 }
             }
-            editText.apply {
-                requestFocus()
-                WindowCompat.getInsetsController(this@ChatFragment.requireActivity().window, this).show(WindowInsetsCompat.Type.ime())
+            editText.setOnEditorActionListener { _, actionId, event ->
+                if (actionId == EditorInfo.IME_ACTION_SEND ||
+                    event?.keyCode == KeyEvent.KEYCODE_ENTER && event.action == KeyEvent.ACTION_DOWN
+                ) {
+                    val sent = sendMessage(state.replyId)
+                    sent || viewModel.isSlowModeBlocked()
+                } else {
+                    false
+                }
             }
+            editText.requestFocus()
+            WindowCompat.getInsetsController(this@ChatFragment.requireActivity().window, editText)
+                .show(WindowInsetsCompat.Type.ime())
         }
     }
 
@@ -2464,12 +2958,15 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
     }
 
     override fun onSaveInstanceState(outState: Bundle) {
+        captureActiveOverlayState()
         chatV2ViewportState = chatV2Renderer?.state ?: chatV2ViewportState
         outState.putString(KEY_V2_FOLLOW_MODE, chatV2ViewportState.followMode.name)
         outState.putInt(KEY_V2_NEW_MESSAGE_COUNT, chatV2ViewportState.newMessageCount)
         outState.putString(KEY_V2_ANCHOR_ID, chatV2ViewportState.anchor?.messageId?.value)
         outState.putInt(KEY_V2_ANCHOR_OFFSET, chatV2ViewportState.anchor?.topOffsetPx ?: 0)
-        outState.putString(KEY_COMPOSER_DRAFT, _binding?.editText?.text?.toString())
+        if (overlayStateStore.active == null) {
+            outState.putString(KEY_COMPOSER_DRAFT, _binding?.editText?.text?.toString())
+        }
         outState.putString(KEY_SEEN_PINNED_MESSAGE_ID, seenPinnedMessageId)
         outState.putString(KEY_DISPLAYED_PINNED_MESSAGE_ID, displayedPinnedMessageId)
         outState.putBoolean(KEY_PINNED_MESSAGE_MINIMIZED, pinnedMessageMinimized)
@@ -2477,6 +2974,7 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
     }
 
     override fun onDestroyView() {
+        captureActiveOverlayState()
         chatV2ViewportState = chatV2Renderer?.state ?: chatV2ViewportState
         chatV2Renderer?.detach()
         chatV2Renderer = null
@@ -2499,10 +2997,6 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
         channelPointsIconForeground = null
         composerOverlayState = null
         pendingComposerText = null
-        composerSubmissionInProgress = false
-        composerTextBeforeOverlay = null
-        composerSelectionBeforeOverlay = null
-        messageViewWasVisibleBeforeOverlay = null
         lastSlowModeUiState = SlowModeState()
         dropCalloutView = null
         dropImageView = null

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatSizing.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatSizing.kt
@@ -21,6 +21,8 @@ internal data class ChatRenderStyle(
     val animateGifs: Boolean,
     val showBadges: Boolean,
     val enableOverlayEmotes: Boolean,
+    val firstMessageVisibility: Int,
+    val boldNames: Boolean,
     val showTimestamps: Boolean,
     val timestampFormat: String?,
 )
@@ -51,6 +53,8 @@ internal fun resolveChatRenderStyle(context: Context): ChatRenderStyle {
         animateGifs = prefs.getBoolean(C.ANIMATED_EMOTES, true),
         showBadges = prefs.getBoolean(C.CHAT_SHOW_BADGES, true),
         enableOverlayEmotes = prefs.getBoolean(C.CHAT_ZERO_WIDTH, true),
+        firstMessageVisibility = prefs.getString(C.CHAT_FIRST_MSG_VISIBILITY, "0")?.toIntOrNull() ?: 0,
+        boldNames = prefs.getBoolean(C.CHAT_BOLD_NAMES, false),
         showTimestamps = prefs.getBoolean(C.CHAT_TIMESTAMPS, false),
         timestampFormat = prefs.getString(C.CHAT_TIMESTAMP_FORMAT, "0"),
     )

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatViewModel.kt
@@ -118,6 +118,8 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.merge
+import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.isActive
@@ -159,6 +161,11 @@ internal fun shouldResumeLiveChat(
 internal fun resolveCurrentLiveStreamId(currentStreamId: String?, initialStreamId: String?): String? =
     currentStreamId ?: initialStreamId
 
+sealed interface ChatSendResult {
+    data class Success(val messageId: String? = null) : ChatSendResult
+    data class Failure(val message: String) : ChatSendResult
+}
+
 internal fun matchesV2PickerSession(
     active: com.github.andreyasadchy.xtra.ui.chat.v2.session.LiveChatSessionSpec?,
     expectedChannelId: String?,
@@ -166,6 +173,32 @@ internal fun matchesV2PickerSession(
 ): Boolean = active != null &&
         active.channelId == expectedChannelId &&
         active.channelLogin.equals(expectedChannelLogin, ignoreCase = true)
+
+internal fun mergePickerThirdPartyEmotes(
+    personalEmotes: List<Emote>,
+    catalogEmotes: List<Emote>,
+): List<Emote> = FavoriteEmoteCatalog.deduplicate(personalEmotes + catalogEmotes)
+
+internal fun personalSevenTvEmotesForPicker(
+    setId: String?,
+    emotes: List<Emote>?,
+): List<Emote> = if (setId.isNullOrBlank()) emptyList() else emotes.orEmpty().map { emote ->
+    Emote(
+        name = emote.name,
+        localData = emote.localData,
+        url1x = emote.url1x,
+        url2x = emote.url2x,
+        url3x = emote.url3x,
+        url4x = emote.url4x,
+        format = emote.format,
+        isAnimated = emote.isAnimated,
+        isOverlayEmote = emote.isOverlayEmote,
+        source = Emote.PERSONAL_STV,
+        id = emote.id,
+        width = emote.width,
+        height = emote.height,
+    )
+}
 
 data class DropsUiState(
     val drops: List<TwitchDrop> = emptyList(),
@@ -200,6 +233,21 @@ internal fun appendChatMessageToHistory(
     return removeCount
 }
 
+internal fun shouldStartLegacyChatWriteTransport(
+    startMessageTransport: Boolean,
+    startWriteTransport: Boolean,
+    readOnly: Boolean,
+    isLoggedIn: Boolean,
+    useEventSubChat: Boolean,
+    hasGqlToken: Boolean,
+    hasHelixToken: Boolean,
+    useApiChatMessages: Boolean,
+): Boolean = startWriteTransport &&
+        !readOnly &&
+        isLoggedIn &&
+        !(startMessageTransport && useEventSubChat) &&
+        (hasGqlToken || hasHelixToken && !useApiChatMessages)
+
 @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
 class ChatViewModel(
     private val applicationContext: Context,
@@ -219,17 +267,54 @@ class ChatViewModel(
         data class Error(val retry: () -> Unit) : ThirdPartyPickerState
     }
 
+    data class PickerCatalog(
+        val twitch: List<Emote>,
+        val thirdParty: List<Emote>,
+    ) {
+        val all: List<Emote> by lazy {
+            FavoriteEmoteCatalog.deduplicate(twitch + thirdParty)
+                .filter { !it.name.isNullOrBlank() }
+        }
+    }
+
+    fun pickerCatalogFor(
+        expectedChannelId: String?,
+        expectedChannelLogin: String?,
+        useV2: Boolean = true,
+    ): Flow<PickerCatalog?> = if (!useV2) {
+        flowOf(null)
+    } else {
+        chatSessionManager.active.flatMapLatest { active ->
+            val session = active ?: return@flatMapLatest flowOf(null)
+            if (!matchesV2PickerSession(session.spec, expectedChannelId, expectedChannelLogin)) {
+                flowOf(null)
+            } else {
+                combine(
+                    session.catalog.state,
+                    merge(userEmotesUpdated, thirdPartyEmotesUpdated).onStart { emit(Unit) },
+                ) { state, _ ->
+                    if (!state.hydrated) PickerCatalog(emptyList(), emptyList())
+                    else pickerCatalogFor(state.snapshot)
+                }
+            }
+        }
+    }
+
     fun thirdPartyPickerStateFor(
         expectedChannelId: String?,
         expectedChannelLogin: String?,
-    ): Flow<ThirdPartyPickerState?> = chatSessionManager.active.flatMapLatest { active ->
+        useV2: Boolean = true,
+    ): Flow<ThirdPartyPickerState?> = if (!useV2) flowOf(null) else chatSessionManager.active.flatMapLatest { active ->
         val session = active ?: return@flatMapLatest flowOf(null)
         if (!matchesV2PickerSession(session.spec, expectedChannelId, expectedChannelLogin)) {
             flowOf(null)
         } else {
-            session.catalog.state.map { state ->
+            combine(
+                session.catalog.state,
+                thirdPartyEmotesUpdated.onStart { emit(Unit) },
+            ) { state, _ ->
                 if (!state.hydrated) ThirdPartyPickerState.Loading
-                else thirdPartyPickerStateFor(state.snapshot, state.refreshFailed) { session.catalog.refresh() }
+                else thirdPartyPickerStateFor(state.snapshot, state.thirdPartyRefreshFailed) { session.catalog.refresh() }
             }
         }
     }
@@ -239,11 +324,12 @@ class ChatViewModel(
         refreshFailed: Boolean,
         retry: () -> Unit,
     ): ThirdPartyPickerState {
-        val emotes = FavoriteEmoteCatalog.deduplicate(
-            snapshot.sevenTv.values.map(::toPickerEmote) +
-                    snapshot.bttv.values.map(::toPickerEmote) +
-                    snapshot.ffz.values.map(::toPickerEmote),
-        ).filter { it.name?.isNotBlank() == true }
+        val emotes = mergePickerThirdPartyEmotes(
+            personalPickerEmotes(),
+            snapshot.sevenTv.effectiveValues().map(::toPickerEmote) +
+                    snapshot.bttv.effectiveValues().map(::toPickerEmote) +
+                    snapshot.ffz.effectiveValues().map(::toPickerEmote),
+        ).filter { it.name?.isNotBlank() == true && isPickerProviderEnabled(it) }
         return if (emotes.isEmpty() && refreshFailed) ThirdPartyPickerState.Error(retry)
         else if (emotes.isEmpty()) ThirdPartyPickerState.Empty
         else ThirdPartyPickerState.Ready(emotes.sortedBy { it.name.orEmpty().lowercase() })
@@ -457,8 +543,15 @@ class ChatViewModel(
     val stvUsers = mutableListOf<STVUser>()
     var channelSTVEmoteSetId: String? = null
     var userSTVEmoteSetId: String? = null
+    private val personalSTVEmoteSetIds = mutableSetOf<String>()
 
     private val pickerCatalogRevision = MutableStateFlow(0L)
+    private val pickerCatalogUpdates: Flow<Unit> = merge(
+        pickerCatalogRevision.map { Unit },
+        chatSessionManager.active.flatMapLatest { active ->
+            active?.catalog?.state?.map { Unit } ?: flowOf(Unit)
+        },
+    )
     val recentEmotes: StateFlow<List<RecentEmote>> = playerRepository.loadRecentEmotesFlow().stateIn(
         viewModelScope,
         SharingStarted.Eagerly,
@@ -481,7 +574,7 @@ class ChatViewModel(
         SharingStarted.Eagerly,
         emptySet(),
     )
-    val availableFavoriteEmotes: StateFlow<List<Emote>> = combine(favoriteEmotes, pickerCatalogRevision) { favorites, _ ->
+    val availableFavoriteEmotes: StateFlow<List<Emote>> = combine(favoriteEmotes, pickerCatalogUpdates.onStart { emit(Unit) }) { favorites, _ ->
         FavoriteEmoteCatalog.availableFavorites(favorites, currentPickerEmotes())
     }.stateIn(
         viewModelScope,
@@ -751,21 +844,31 @@ class ChatViewModel(
             if (useChatV2 && v2LiveChannelId == channelId && v2LiveChannelLogin == channelLogin && started) return
             messageLimit = 600
             this.streamId = streamId
-            startLiveChat(channelId, channelLogin, readOnly = readOnly, startMessageTransport = !useChatV2)
+            val useApiChatMessages = applicationContext.prefs().getBoolean(C.DEBUG_API_CHAT_MESSAGES, true)
+            startLiveChat(
+                channelId,
+                channelLogin,
+                readOnly = readOnly,
+                startMessageTransport = !useChatV2,
+                startWriteTransport = !useChatV2 || !useApiChatMessages,
+            )
+            val isLoggedIn = !applicationContext.tokenPrefs().getString(C.USERNAME, null).isNullOrBlank() &&
+                    (!TwitchApiHelper.getGQLHeaders(applicationContext, true)[C.HEADER_TOKEN].isNullOrBlank() ||
+                            !TwitchApiHelper.getHelixHeaders(applicationContext)[C.HEADER_TOKEN].isNullOrBlank())
+            if (isLoggedIn) {
+                // v2 owns third-party loading, but Twitch subscriber/user emotes are still
+                // needed by the Twitch picker and autocomplete.
+                loadUserEmotes(channelId)
+            }
             if (useChatV2) {
                 v2LiveChannelId = channelId
                 v2LiveChannelLogin = channelLogin
+                markPickerCatalogChanged()
             } else {
                 addChatter(channelName)
                 loadEmotes(channelId, channelLogin)
                 if (applicationContext.prefs().getBoolean(C.CHAT_RECENT, true)) {
                     loadRecentMessages(networkLibrary, recentMessagesUrl, channelLogin)
-                }
-                val isLoggedIn = !applicationContext.tokenPrefs().getString(C.USERNAME, null).isNullOrBlank() &&
-                        (!TwitchApiHelper.getGQLHeaders(applicationContext, true)[C.HEADER_TOKEN].isNullOrBlank() ||
-                                !TwitchApiHelper.getHelixHeaders(applicationContext)[C.HEADER_TOKEN].isNullOrBlank())
-                if (isLoggedIn) {
-                    loadUserEmotes(channelId)
                 }
             }
         }
@@ -2557,18 +2660,109 @@ class ChatViewModel(
     }
 
     fun thirdPartyPickerEmotes(): List<Emote> {
-        val personalEmotes = userSTVEmoteSetId?.let { setId ->
-            synchronized(personalEmoteSets) { personalEmoteSets[setId].orEmpty() }
-        }.orEmpty()
+        currentV2PickerCatalog()?.let { return it.thirdParty }
+        val personalEmotes = personalPickerEmotes()
         return FavoriteEmoteCatalog.deduplicate(personalEmotes +
                 synchronized(thirdPartyEmotes) { thirdPartyEmotes.toList() })
             .filter { !it.name.isNullOrBlank() && isPickerProviderEnabled(it) }
     }
 
     fun currentPickerEmotes(): List<Emote> {
+        currentV2PickerCatalog()?.let { return it.all }
         return FavoriteEmoteCatalog.deduplicate(synchronized(userEmotes) { userEmotes.toList() } +
                 thirdPartyPickerEmotes())
             .filter { !it.name.isNullOrBlank() && isPickerProviderEnabled(it) }
+    }
+
+    fun twitchPickerEmotes(): List<Emote> = synchronized(userEmotes) {
+        userEmotes.toList()
+    }.filter { !it.name.isNullOrBlank() }
+
+    fun availableFavoriteEmotesFor(catalog: PickerCatalog?): List<Emote> =
+        FavoriteEmoteCatalog.availableFavorites(
+            favoriteEmotes.value,
+            catalog?.all ?: currentPickerEmotes(),
+        )
+
+    fun refreshV2AutoCompleteList(catalog: PickerCatalog) {
+        synchronized(autoCompleteList) {
+            val nonEmotes = autoCompleteList.filterNot { it is Emote }
+            autoCompleteList.clear()
+            autoCompleteList.addAll(nonEmotes)
+            autoCompleteList.addAll(catalog.all)
+        }
+    }
+
+    private fun currentV2PickerCatalog(): PickerCatalog? {
+        val session = chatSessionManager.active.value ?: return null
+        if (v2LiveChannelId != session.spec.channelId ||
+            !v2LiveChannelLogin.equals(session.spec.channelLogin, ignoreCase = true)
+        ) return null
+        val state = session.catalog.state.value
+        return state.snapshot.takeIf { state.hydrated }?.let(::pickerCatalogFor)
+    }
+
+    private fun pickerCatalogFor(
+        snapshot: com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatCatalogSnapshot,
+    ): PickerCatalog {
+        val thirdParty = mergePickerThirdPartyEmotes(
+            personalPickerEmotes(),
+            snapshot.sevenTv.effectiveValues().map(::toPickerEmote) +
+                    snapshot.bttv.effectiveValues().map(::toPickerEmote) +
+                    snapshot.ffz.effectiveValues().map(::toPickerEmote),
+        ).filter { it.name?.isNotBlank() == true && isPickerProviderEnabled(it) }
+            .sortedBy { it.name.orEmpty().lowercase() }
+        return PickerCatalog(
+            twitch = twitchPickerEmotes(),
+            thirdParty = thirdParty,
+        )
+    }
+
+    private fun personalPickerEmotes(): List<Emote> {
+        val setIds = synchronized(personalSTVEmoteSetIds) {
+            personalSTVEmoteSetIds.toList()
+        }.ifEmpty { listOfNotNull(userSTVEmoteSetId) }
+        return synchronized(personalEmoteSets) {
+            setIds.flatMap { personalEmoteSets[it].orEmpty() }
+        }
+    }
+
+    private fun hydratePersonalSevenTvEmotes(networkLibrary: String?, accountId: String) {
+        viewModelScope.launch {
+            try {
+                val entitledSetIds = playerRepository.loadSTVEntitledEmoteSetIds(networkLibrary, accountId)
+                val hydratedSets = entitledSetIds.mapNotNull { setId ->
+                    try {
+                        val response = playerRepository.loadSTVEmoteSetResponse(
+                            networkLibrary,
+                            setId,
+                            throwOnHttpError = true,
+                        )
+                        setId to playerRepository.loadSTVPersonalEmotes(response, true).second
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (_: Exception) {
+                        null
+                    }
+                }
+                if (hydratedSets.isEmpty()) return@launch
+                synchronized(personalSTVEmoteSetIds) {
+                    personalSTVEmoteSetIds.clear()
+                    personalSTVEmoteSetIds.addAll(hydratedSets.map { it.first })
+                }
+                userSTVEmoteSetId = hydratedSets.first().first
+                synchronized(personalEmoteSets) {
+                    hydratedSets.forEach { (setId, emotes) ->
+                        personalEmoteSets[setId] = personalSevenTvEmotesForPicker(setId, emotes)
+                    }
+                }
+                emitThirdPartyEmotesUpdated()
+            } catch (e: CancellationException) {
+                throw e
+            } catch (_: Exception) {
+                // Personal emotes are optional; the EventAPI can hydrate them later.
+            }
+        }
     }
 
     private fun isPickerProviderEnabled(emote: Emote): Boolean {
@@ -2629,9 +2823,17 @@ class ChatViewModel(
         channelLogin: String,
         readOnly: Boolean = liveChatReadOnly,
         startMessageTransport: Boolean = true,
+        startWriteTransport: Boolean = startMessageTransport,
     ) {
         liveChatInitialized = true
+        val channelChanged = activeChannelId != channelId ||
+                !activeChannelLogin.equals(channelLogin, ignoreCase = true)
         stopLiveChat()
+        if (channelChanged) {
+            synchronized(userEmotes) { userEmotes.clear() }
+            loadedUserEmotes = false
+            viewModelScope.launch { emitUserEmotesUpdated() }
+        }
         liveChatReadOnly = readOnly
         val sessionToken = predictionSessionToken
         started = true
@@ -2712,26 +2914,38 @@ class ChatViewModel(
             loadWatchStreak(networkLibrary, gqlHeaders, channelId)
             startWatchStreakRefresh(networkLibrary, gqlHeaders, channelId)
         }
+        val gqlToken = gqlHeaders[C.HEADER_TOKEN]?.removePrefix("OAuth ")
+        val helixToken = helixHeaders[C.HEADER_TOKEN]?.removePrefix("Bearer ")
+        val useEventSubChat = applicationContext.prefs().getBoolean(C.DEBUG_EVENT_SUB_CHAT, false) &&
+                !helixHeaders[C.HEADER_TOKEN].isNullOrBlank()
         if (startMessageTransport) {
-            if (applicationContext.prefs().getBoolean(C.DEBUG_EVENT_SUB_CHAT, false) && !helixHeaders[C.HEADER_TOKEN].isNullOrBlank()) {
+            if (useEventSubChat) {
                 eventSub = EventSubWebSocket(trustManager, EventSubListener(helixHeaders, gqlHeaders, channelLogin, showUserNotice, showClearChat, usePubSub, networkLibrary, isLoggedIn, accountId, channelId))
                 chatReadJob = eventSub?.connect(viewModelScope)
             } else {
-                val gqlToken = gqlHeaders[C.HEADER_TOKEN]?.removePrefix("OAuth ")
-                val helixToken = helixHeaders[C.HEADER_TOKEN]?.removePrefix("Bearer ")
                 chatReadWebSocket = ChatReadWebSocket(channelLogin, trustManager, ChatReadListener(channelLogin, nameDisplay, showUserNotice, showClearMsg, showClearChat, usePubSub, networkLibrary, gqlHeaders, isLoggedIn, accountId, channelId))
                 chatReadJob = chatReadWebSocket?.connect(viewModelScope)
-                if (!readOnly && isLoggedIn && (!gqlToken.isNullOrBlank() || !helixHeaders[C.HEADER_TOKEN].isNullOrBlank() && !useApiChatMessages)) {
-                    chatWriteWebSocket = ChatWriteWebSocket(
-                        userLogin = accountLogin,
-                        userToken = gqlToken?.takeIf { it.isNotBlank() } ?: helixToken,
-                        channelLogin = channelLogin,
-                        trustManager = trustManager,
-                        listener = ChatWriteListener(channelId, showWebSocketDebugInfo)
-                    )
-                    chatWriteJob = chatWriteWebSocket?.connect(viewModelScope)
-                }
             }
+        }
+        if (shouldStartLegacyChatWriteTransport(
+                startMessageTransport = startMessageTransport,
+                startWriteTransport = startWriteTransport,
+                readOnly = readOnly,
+                isLoggedIn = isLoggedIn,
+                useEventSubChat = useEventSubChat,
+                hasGqlToken = !gqlToken.isNullOrBlank(),
+                hasHelixToken = !helixHeaders[C.HEADER_TOKEN].isNullOrBlank(),
+                useApiChatMessages = useApiChatMessages,
+            )
+        ) {
+            chatWriteWebSocket = ChatWriteWebSocket(
+                userLogin = accountLogin,
+                userToken = gqlToken?.takeIf { it.isNotBlank() } ?: helixToken,
+                channelLogin = channelLogin,
+                trustManager = trustManager,
+                listener = ChatWriteListener(channelId, showWebSocketDebugInfo)
+            )
+            chatWriteJob = chatWriteWebSocket?.connect(viewModelScope)
         }
         if (usePubSub && !channelId.isNullOrBlank()) {
             val collectPoints = applicationContext.prefs().getBoolean(C.CHAT_POINTS_COLLECT, true)
@@ -2786,9 +3000,14 @@ class ChatViewModel(
                 viewModelScope.launch {
                     try {
                         stvUserId = playerRepository.getSTVUser(networkLibrary, accountId).takeIf { !it.isNullOrBlank() }
-                    } catch (e: Exception) {
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (_: Exception) {
 
                     }
+                }
+                if (showPersonalEmotes) {
+                    hydratePersonalSevenTvEmotes(networkLibrary, accountId)
                 }
             }
         }
@@ -4295,6 +4514,9 @@ class ChatViewModel(
                                 }
                             }
                             if (isLoggedIn && !accountId.isNullOrBlank() && result.userId == accountId) {
+                                synchronized(personalSTVEmoteSetIds) {
+                                    personalSTVEmoteSetIds.add(result.setId)
+                                }
                                 userSTVEmoteSetId = result.setId
                                 viewModelScope.launch {
                                     emitThirdPartyEmotesUpdated()
@@ -4712,74 +4934,143 @@ class ChatViewModel(
         clearPollPresentation()
     }
 
-    fun send(message: CharSequence, replyId: String?, networkLibrary: String?, gqlHeaders: Map<String, String>, helixHeaders: Map<String, String>, accountId: String?, channelId: String?, channelLogin: String?, useApiCommands: Boolean, useApiChatMessages: Boolean) {
+    fun send(
+        message: CharSequence,
+        replyId: String?,
+        networkLibrary: String?,
+        gqlHeaders: Map<String, String>,
+        helixHeaders: Map<String, String>,
+        accountId: String?,
+        channelId: String?,
+        channelLogin: String?,
+        useApiCommands: Boolean,
+        useApiChatMessages: Boolean,
+        onResult: (ChatSendResult) -> Unit = {},
+    ) {
         if (replyId != null) {
-            sendMessage(message, networkLibrary, gqlHeaders, helixHeaders, accountId, channelId, useApiChatMessages, replyId = replyId)
+            sendMessage(message, networkLibrary, gqlHeaders, helixHeaders, accountId, channelId, useApiChatMessages, replyId = replyId, onResult = onResult)
         } else {
             if (useApiCommands) {
                 if (message.toString().startsWith("/")) {
-                    try {
-                        sendCommand(message, networkLibrary, gqlHeaders, helixHeaders, accountId, channelId, channelLogin, useApiChatMessages)
-                    } catch (e: Exception) {
-
+                    viewModelScope.launch {
+                        try {
+                            onResult(
+                                sendCommand(
+                                    message,
+                                    networkLibrary,
+                                    gqlHeaders,
+                                    helixHeaders,
+                                    accountId,
+                                    channelId,
+                                    channelLogin,
+                                    useApiChatMessages,
+                                ),
+                            )
+                        } catch (e: CancellationException) {
+                            throw e
+                        } catch (e: Exception) {
+                            onResult(ChatSendResult.Failure(e.message ?: "Unable to send command"))
+                        }
                     }
                 } else {
-                    sendMessage(message, networkLibrary, gqlHeaders, helixHeaders, accountId, channelId, useApiChatMessages)
+                    sendMessage(message, networkLibrary, gqlHeaders, helixHeaders, accountId, channelId, useApiChatMessages, onResult = onResult)
                 }
             } else {
                 if (message.toString() == "/dc" || message.toString() == "/disconnect") {
                     disconnect()
+                    onResult(ChatSendResult.Success())
                 } else {
-                    sendMessage(message, networkLibrary, gqlHeaders, helixHeaders, accountId, channelId, useApiChatMessages)
+                    sendMessage(message, networkLibrary, gqlHeaders, helixHeaders, accountId, channelId, useApiChatMessages, onResult = onResult)
                 }
             }
         }
     }
 
-    private fun sendMessage(message: CharSequence, networkLibrary: String?, gqlHeaders: Map<String, String>, helixHeaders: Map<String, String>, accountId: String?, channelId: String?, useApiChatMessages: Boolean, replyId: String? = null) {
-        try {
-            viewModelScope.launch {
+    private fun sendMessage(
+        message: CharSequence,
+        networkLibrary: String?,
+        gqlHeaders: Map<String, String>,
+        helixHeaders: Map<String, String>,
+        accountId: String?,
+        channelId: String?,
+        useApiChatMessages: Boolean,
+        replyId: String? = null,
+        onResult: (ChatSendResult) -> Unit = {},
+    ) {
+        viewModelScope.launch {
+            val result = try {
                 if (useApiChatMessages) {
-                    if (!gqlHeaders[C.HEADER_TOKEN].isNullOrBlank()) {
-                        val response = graphQLRepository.sendMessage(networkLibrary, gqlHeaders, channelId, message.toString(), replyId).also { response ->
-                        }
-                        if (response.errors.isNullOrEmpty()) {
-                            onAcceptedOwnChatMessage(
-                                SlowModeMessageIdentity(message = message.toString(), replyId = replyId),
+                    when {
+                        !gqlHeaders[C.HEADER_TOKEN].isNullOrBlank() -> {
+                            val response = graphQLRepository.sendMessage(
+                                networkLibrary,
+                                gqlHeaders,
+                                channelId,
+                                message.toString(),
+                                replyId,
                             )
-                            null
-                        } else {
-                            response.toString()
+                            if (response.errors.isNullOrEmpty()) {
+                                onAcceptedOwnChatMessage(
+                                    SlowModeMessageIdentity(message = message.toString(), replyId = replyId),
+                                )
+                                ChatSendResult.Success()
+                            } else {
+                                ChatSendResult.Failure(
+                                    response.errors?.firstOrNull()?.message ?: "Twitch rejected the message",
+                                )
+                            }
                         }
-                    } else {
-                        if (!helixHeaders[C.HEADER_TOKEN].isNullOrBlank()) {
-                            helixRepository.sendMessage(networkLibrary, helixHeaders, accountId, channelId, message.toString(), replyId).also { response ->
-                                if (response.isSent) {
-                                    onAcceptedOwnChatMessage(
-                                        SlowModeMessageIdentity(
-                                            messageId = response.messageId,
-                                            message = message.toString(),
-                                            replyId = replyId,
-                                        ),
-                                    )
-                                }
-                            }.errorMessage
-                        } else null
-                    }?.let {
-                        onMessage(ChatMessage(systemMsg = it))
+                        !helixHeaders[C.HEADER_TOKEN].isNullOrBlank() -> {
+                            val response = helixRepository.sendMessage(
+                                networkLibrary,
+                                helixHeaders,
+                                accountId,
+                                channelId,
+                                message.toString(),
+                                replyId,
+                            )
+                            if (response.isSent) {
+                                onAcceptedOwnChatMessage(
+                                    SlowModeMessageIdentity(
+                                        messageId = response.messageId,
+                                        message = message.toString(),
+                                        replyId = replyId,
+                                    ),
+                                )
+                                ChatSendResult.Success(response.messageId)
+                            } else {
+                                ChatSendResult.Failure(response.errorMessage ?: "Twitch rejected the message")
+                            }
+                        }
+                        else -> ChatSendResult.Failure("Login required to send chat messages")
                     }
                 } else {
-                    chatWriteIRCSocket?.send(message, replyId) ?: chatWriteWebSocket?.send(message, replyId)
+                    val sent = when {
+                        chatWriteIRCSocket != null -> chatWriteIRCSocket!!.send(message, replyId)
+                        chatWriteWebSocket != null -> chatWriteWebSocket!!.send(message, replyId)
+                        else -> false
+                    }
+                    if (sent) ChatSendResult.Success() else ChatSendResult.Failure("Chat write transport is unavailable")
                 }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                ChatSendResult.Failure(e.message ?: "Unable to send chat message")
             }
-        } catch (e: Exception) {
-
+            if (result is ChatSendResult.Success) recordRecentEmotes(message)
+            onResult(result)
         }
+    }
+
+    private fun recordRecentEmotes(message: CharSequence) {
         val usedEmotes = hashSetOf<RecentEmote>()
         val currentTime = System.currentTimeMillis()
+        val pickerEmoteNames = currentPickerEmotes().mapNotNull { it.name }.toSet()
         synchronized(allEmotes) {
             message.split(' ').forEach { word ->
-                allEmotes.find { it == word }?.let { usedEmotes.add(RecentEmote(word, currentTime)) }
+                if (word in pickerEmoteNames || allEmotes.any { it == word }) {
+                    usedEmotes.add(RecentEmote(word, currentTime))
+                }
             }
         }
         if (usedEmotes.isNotEmpty()) {
@@ -4789,8 +5080,84 @@ class ChatViewModel(
         }
     }
 
-    private fun sendCommand(message: CharSequence, networkLibrary: String?, gqlHeaders: Map<String, String>, helixHeaders: Map<String, String>, accountId: String?, channelId: String?, channelLogin: String?, useApiChatMessages: Boolean) {
+    private suspend fun sendCommand(
+        message: CharSequence,
+        networkLibrary: String?,
+        gqlHeaders: Map<String, String>,
+        helixHeaders: Map<String, String>,
+        accountId: String?,
+        channelId: String?,
+        channelLogin: String?,
+        useApiChatMessages: Boolean,
+    ): ChatSendResult {
+        val result = kotlinx.coroutines.CompletableDeferred<ChatSendResult>()
+        sendCommandAsync(
+            message,
+            networkLibrary,
+            gqlHeaders,
+            helixHeaders,
+            accountId,
+            channelId,
+            channelLogin,
+            useApiChatMessages,
+        ) { result.complete(it) }
+        return result.await()
+    }
+
+    private fun sendCommandAsync(
+        message: CharSequence,
+        networkLibrary: String?,
+        gqlHeaders: Map<String, String>,
+        helixHeaders: Map<String, String>,
+        accountId: String?,
+        channelId: String?,
+        channelLogin: String?,
+        useApiChatMessages: Boolean,
+        onResult: (ChatSendResult) -> Unit,
+    ) {
         val command = message.toString().substringBefore(" ")
+        var completed = false
+        fun complete(result: ChatSendResult) {
+            if (!completed) {
+                completed = true
+                onResult(result)
+            }
+        }
+        suspend fun onMessage(chatMessage: ChatMessage) {
+            this@ChatViewModel.onMessage(chatMessage)
+            chatMessage.systemMsg?.let { complete(ChatSendResult.Failure(it)) }
+        }
+        var started = false
+        val viewModelScope = object {
+            fun launch(block: suspend kotlinx.coroutines.CoroutineScope.() -> Unit) {
+                started = true
+                this@ChatViewModel.viewModelScope.launch {
+                    try {
+                        block(this)
+                        complete(ChatSendResult.Success())
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (e: Exception) {
+                        complete(ChatSendResult.Failure(e.message ?: "Unable to send command"))
+                    }
+                }
+            }
+        }
+        val trimmedMessage = message.toString().trim()
+        val commandsRequiringArgument = setOf(
+            "/announce", "/ban", "/unban", "/commercial", "/delete", "/mod", "/unmod",
+            "/raid", "/timeout", "/untimeout", "/vip", "/unvip", "/w", "/me",
+        )
+        if (command.lowercase() in commandsRequiringArgument && trimmedMessage == command) {
+            complete(ChatSendResult.Failure("Command requires an argument"))
+            return
+        }
+        if (command.equals("/color", true) && trimmedMessage == command &&
+            helixHeaders[C.HEADER_TOKEN].isNullOrBlank()
+        ) {
+            complete(ChatSendResult.Failure("Checking chat color requires a Helix token"))
+            return
+        }
         when {
             command.startsWith("/announce", true) -> {
                 val splits = message.split(" ", limit = 2)
@@ -4866,30 +5233,40 @@ class ChatViewModel(
                     }
                 } else {
                     if (!gqlHeaders[C.HEADER_TOKEN].isNullOrBlank()) {
-                        sendMessage(message, networkLibrary, gqlHeaders, helixHeaders, accountId, channelId, useApiChatMessages)
+                        started = true
+                        sendMessage(message, networkLibrary, gqlHeaders, helixHeaders, accountId, channelId, useApiChatMessages, onResult = ::complete)
                     }
                 }
             }
             command.equals("/color", true) -> {
                 val splits = message.split(" ")
+                started = true
                 viewModelScope.launch {
                     if (splits.size >= 2) {
-                        if (!gqlHeaders[C.HEADER_TOKEN].isNullOrBlank()) {
+                        val error = if (!gqlHeaders[C.HEADER_TOKEN].isNullOrBlank()) {
                             graphQLRepository.updateChatColor(networkLibrary, gqlHeaders, splits[1]).also { response ->
                             }.takeIf { !it.errors.isNullOrEmpty() }?.toString()
+                        } else if (!helixHeaders[C.HEADER_TOKEN].isNullOrBlank()) {
+                            helixRepository.updateChatColor(networkLibrary, helixHeaders, accountId, splits[1])
+                            null
                         } else {
-                            if (!helixHeaders[C.HEADER_TOKEN].isNullOrBlank()) {
-                                helixRepository.updateChatColor(networkLibrary, helixHeaders, accountId, splits[1])
-                            } else null
+                            "Setting chat color requires a usable token"
+                        }
+                        if (error.isNullOrBlank()) {
+                            complete(ChatSendResult.Success())
+                        } else {
+                            complete(ChatSendResult.Failure(error))
                         }
                     } else {
                         if (!helixHeaders[C.HEADER_TOKEN].isNullOrBlank()) {
-                            runCatching {
-                                helixRepository.getChatColor(networkLibrary, helixHeaders, accountId)
-                            }.getOrElse { it.message }
-                        } else null
-                    }?.let {
-                        onMessage(ChatMessage(systemMsg = it))
+                            val color = helixRepository.getChatColor(networkLibrary, helixHeaders, accountId)
+                            color?.let { value ->
+                                this@ChatViewModel.onMessage(ChatMessage(systemMsg = value))
+                            }
+                            complete(ChatSendResult.Success())
+                        } else {
+                            complete(ChatSendResult.Failure("Checking chat color requires a Helix token"))
+                        }
                     }
                 }
             }
@@ -4905,7 +5282,8 @@ class ChatViewModel(
                     }
                 } else {
                     if (!gqlHeaders[C.HEADER_TOKEN].isNullOrBlank()) {
-                        sendMessage(message, networkLibrary, gqlHeaders, helixHeaders, accountId, channelId, useApiChatMessages)
+                        started = true
+                        sendMessage(message, networkLibrary, gqlHeaders, helixHeaders, accountId, channelId, useApiChatMessages, onResult = ::complete)
                     }
                 }
             }
@@ -4921,11 +5299,15 @@ class ChatViewModel(
                     }
                 } else {
                     if (!gqlHeaders[C.HEADER_TOKEN].isNullOrBlank()) {
-                        sendMessage(message, networkLibrary, gqlHeaders, helixHeaders, accountId, channelId, useApiChatMessages)
+                        started = true
+                        sendMessage(message, networkLibrary, gqlHeaders, helixHeaders, accountId, channelId, useApiChatMessages, onResult = ::complete)
                     }
                 }
             }
-            command.equals("/disconnect", true) -> disconnect()
+            command.equals("/disconnect", true) -> {
+                disconnect()
+                complete(ChatSendResult.Success())
+            }
             command.equals("/emoteonly", true) -> {
                 viewModelScope.launch {
                     if (!gqlHeaders[C.HEADER_TOKEN].isNullOrBlank()) {
@@ -5050,7 +5432,7 @@ class ChatViewModel(
                 viewModelScope.launch {
                     graphQLRepository.getModerators(networkLibrary, gqlHeaders, channelLogin).also { response ->
                     }.let {
-                        onMessage(ChatMessage(systemMsg = it.data?.user?.mods?.edges?.map { it.node.login }?.toString() ?: it.toString()))
+                        this@ChatViewModel.onMessage(ChatMessage(systemMsg = it.data?.user?.mods?.edges?.map { it.node.login }?.toString() ?: it.toString()))
                     }
                 }
             }
@@ -5142,7 +5524,8 @@ class ChatViewModel(
                     }
                 } else {
                     if (!gqlHeaders[C.HEADER_TOKEN].isNullOrBlank()) {
-                        sendMessage(message, networkLibrary, gqlHeaders, helixHeaders, accountId, channelId, useApiChatMessages)
+                        started = true
+                        sendMessage(message, networkLibrary, gqlHeaders, helixHeaders, accountId, channelId, useApiChatMessages, onResult = ::complete)
                     }
                 }
             }
@@ -5155,7 +5538,8 @@ class ChatViewModel(
                     }
                 } else {
                     if (!gqlHeaders[C.HEADER_TOKEN].isNullOrBlank()) {
-                        sendMessage(message, networkLibrary, gqlHeaders, helixHeaders, accountId, channelId, useApiChatMessages)
+                        started = true
+                        sendMessage(message, networkLibrary, gqlHeaders, helixHeaders, accountId, channelId, useApiChatMessages, onResult = ::complete)
                     }
                 }
             }
@@ -5218,7 +5602,8 @@ class ChatViewModel(
                     }
                 } else {
                     if (!gqlHeaders[C.HEADER_TOKEN].isNullOrBlank()) {
-                        sendMessage(message, networkLibrary, gqlHeaders, helixHeaders, accountId, channelId, useApiChatMessages)
+                        started = true
+                        sendMessage(message, networkLibrary, gqlHeaders, helixHeaders, accountId, channelId, useApiChatMessages, onResult = ::complete)
                     }
                 }
             }
@@ -5231,7 +5616,8 @@ class ChatViewModel(
                     }
                 } else {
                     if (!gqlHeaders[C.HEADER_TOKEN].isNullOrBlank()) {
-                        sendMessage(message, networkLibrary, gqlHeaders, helixHeaders, accountId, channelId, useApiChatMessages)
+                        started = true
+                        sendMessage(message, networkLibrary, gqlHeaders, helixHeaders, accountId, channelId, useApiChatMessages, onResult = ::complete)
                     }
                 }
             }
@@ -5283,7 +5669,7 @@ class ChatViewModel(
                 viewModelScope.launch {
                     graphQLRepository.getVips(networkLibrary, gqlHeaders, channelLogin).also { response ->
                     }.let {
-                        onMessage(ChatMessage(systemMsg = it.data?.user?.vips?.edges?.map { it.node.login }?.toString() ?: it.toString()))
+                        this@ChatViewModel.onMessage(ChatMessage(systemMsg = it.data?.user?.vips?.edges?.map { it.node.login }?.toString() ?: it.toString()))
                     }
                 }
             }
@@ -5304,7 +5690,15 @@ class ChatViewModel(
                     }
                 }
             }
-            else -> sendMessage(message, networkLibrary, gqlHeaders, helixHeaders, accountId, channelId, useApiChatMessages)
+            else -> if (command.equals("/me", true)) {
+                started = true
+                sendMessage(message, networkLibrary, gqlHeaders, helixHeaders, accountId, channelId, useApiChatMessages, onResult = ::complete)
+            } else {
+                complete(ChatSendResult.Failure("Unknown chat command"))
+            }
+        }
+        if (!completed && !started) {
+            complete(ChatSendResult.Failure("No usable transport for chat command"))
         }
     }
 
@@ -5372,6 +5766,7 @@ class ChatViewModel(
         channelLogin: String?,
         channelName: String?,
         streamId: String?,
+        useChatV2: Boolean = false,
     ) {
         activeChatMode = ActiveChatMode.Live
         stopReplayChat()
@@ -5384,6 +5779,7 @@ class ChatViewModel(
             channelName = channelName,
             streamId = streamId,
             readOnly = liveChatReadOnly,
+            useChatV2 = useChatV2,
         )
     }
 

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/EmotesFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/EmotesFragment.kt
@@ -58,6 +58,7 @@ class EmotesFragment : Fragment() {
     private var favoriteEditMode = false
     private var pendingFavoriteItems: List<Emote>? = null
     private var thirdPartyPickerState: ChatViewModel.ThirdPartyPickerState? = null
+    private var pickerCatalog: ChatViewModel.PickerCatalog? = null
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         _binding = FragmentEmotesBinding.inflate(inflater, container, false)
@@ -72,6 +73,7 @@ class EmotesFragment : Fragment() {
         val chatFragment = parentFragment as? ChatFragment
         val expectedChannelId = chatFragment?.arguments?.getString(ChatFragment.KEY_CHANNEL_ID)
         val expectedChannelLogin = chatFragment?.arguments?.getString(ChatFragment.KEY_CHANNEL_LOGIN)
+        val usesV2 = chatFragment?.isUsingChatV2 == true
         binding.emptyState.setOnClickListener {
             (thirdPartyPickerState as? ChatViewModel.ThirdPartyPickerState.Error)?.retry?.invoke()
         }
@@ -164,8 +166,14 @@ class EmotesFragment : Fragment() {
                     }
                 }
                 launch {
-                    viewModel.thirdPartyPickerStateFor(expectedChannelId, expectedChannelLogin).collectLatest {
+                    viewModel.thirdPartyPickerStateFor(expectedChannelId, expectedChannelLogin, usesV2).collectLatest {
                         thirdPartyPickerState = it
+                        updateList(section, adapter)
+                    }
+                }
+                launch {
+                    viewModel.pickerCatalogFor(expectedChannelId, expectedChannelLogin, usesV2).collectLatest {
+                        pickerCatalog = it
                         updateList(section, adapter)
                     }
                 }
@@ -192,14 +200,13 @@ class EmotesFragment : Fragment() {
 
     private fun updateList(section: EmotePickerSection, adapter: EmotesAdapter) {
         val list = when (section) {
-            EmotePickerSection.FAVORITES -> viewModel.availableFavoriteEmotes.value
+            EmotePickerSection.FAVORITES -> pickerCatalog?.let(viewModel::availableFavoriteEmotesFor)
+                ?: viewModel.availableFavoriteEmotes.value
             EmotePickerSection.RECENTS -> {
-                val current = viewModel.currentPickerEmotes()
+                val current = pickerCatalog?.all ?: viewModel.currentPickerEmotes()
                 recentEmotes.mapNotNull { recent -> current.find { it.name == recent.name } }
             }
-            EmotePickerSection.TWITCH -> synchronized(viewModel.userEmotes) {
-                viewModel.userEmotes.toList()
-            }
+            EmotePickerSection.TWITCH -> pickerCatalog?.twitch ?: viewModel.twitchPickerEmotes()
             EmotePickerSection.THIRD_PARTY -> when (val state = thirdPartyPickerState) {
                 is ChatViewModel.ThirdPartyPickerState.Ready -> state.emotes
                 null -> viewModel.thirdPartyPickerEmotes()

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ImageClickedDialog.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ImageClickedDialog.kt
@@ -1,7 +1,9 @@
 package com.github.andreyasadchy.xtra.ui.chat
 
+import android.content.Intent
 import android.graphics.drawable.Animatable
 import android.graphics.drawable.Drawable
+import android.net.Uri
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -44,6 +46,7 @@ class ImageClickedDialog : BottomSheetDialogFragment() {
         private const val IMAGE_SOURCE = "image_source"
         private const val IMAGE_THIRD_PARTY = "image_third_party"
         private const val EMOTE_ID = "emote_id"
+        private const val IMAGE_LINK = "image_link"
 
         fun newInstance(url: String?, name: String?, format: String?, isAnimated: Boolean?, source: Int?, thirdParty: Boolean?, emoteId: String?): ImageClickedDialog {
             return ImageClickedDialog().apply {
@@ -58,6 +61,19 @@ class ImageClickedDialog : BottomSheetDialogFragment() {
                 }
             }
         }
+
+        fun newGifInstance(url: String, description: String): ImageClickedDialog =
+            newInstance(
+                url = url,
+                name = description,
+                format = "gif",
+                isAnimated = true,
+                source = null,
+                thirdParty = true,
+                emoteId = null,
+            ).apply {
+                arguments?.putString(IMAGE_LINK, url)
+            }
     }
 
     private var _binding: DialogChatImageClickBinding? = null
@@ -132,6 +148,13 @@ class ImageClickedDialog : BottomSheetDialogFragment() {
                     Emote.GLOBAL_BTTV -> getString(R.string.global_bttv_emote)
                     Emote.GLOBAL_FFZ -> getString(R.string.global_ffz_emote)
                     else -> null
+                }
+            }
+            args.getString(IMAGE_LINK)?.let { url ->
+                imageSource.visibility = View.VISIBLE
+                imageSource.text = getString(R.string.open_url)
+                imageSource.setOnClickListener {
+                    startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url)))
                 }
             }
             args.getString(EMOTE_ID)?.let {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/MessageClickedChatAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/MessageClickedChatAdapter.kt
@@ -29,11 +29,22 @@ import com.github.andreyasadchy.xtra.model.chat.STVUser
 import com.github.andreyasadchy.xtra.model.chat.TwitchBadge
 import com.github.andreyasadchy.xtra.model.chat.TwitchEmote
 import com.github.andreyasadchy.xtra.ui.view.NamePaintImageSpan
+import com.github.andreyasadchy.xtra.ui.chat.v2.assets.ChatAssetRepository
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatEmoteInteraction
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatGifInteraction
+import com.github.andreyasadchy.xtra.ui.chat.v2.presentation.ChatRowUiModel
+import com.github.andreyasadchy.xtra.ui.chat.v2.ui.ChatMessageTextView
 import com.github.andreyasadchy.xtra.util.chat.ChatAdapterUtils
 import com.github.andreyasadchy.xtra.util.chat.isHighlightedMessage
 import com.github.andreyasadchy.xtra.util.chat.isWatchStreakNotice
 import java.util.Random
 import kotlin.math.roundToInt
+
+internal fun isChatPopupMessageSelected(
+    message: ChatMessage,
+    selectedMessageId: String?,
+    selectedMessage: ChatMessage?,
+): Boolean = selectedMessageId?.takeIf { it.isNotBlank() }?.let { message.id == it } ?: (message === selectedMessage)
 
 class MessageClickedChatAdapter(
     messages: List<ChatMessage>,
@@ -88,7 +99,16 @@ class MessageClickedChatAdapter(
     private val savedLocalEmotes: MutableMap<String, ByteArray>,
     private val loggedInUser: String?,
     var selectedMessage: ChatMessage?,
+    private var v2Rows: List<ChatRowUiModel>? = null,
+    private val v2Assets: ChatAssetRepository? = null,
+    private val v2EmoteClick: ((ChatEmoteInteraction) -> Unit)? = null,
+    private val v2GifClick: ((ChatGifInteraction) -> Unit)? = null,
 ) : RecyclerView.Adapter<MessageClickedChatAdapter.ViewHolder>() {
+
+    private var selectedMessageId: String? = selectedMessage?.id?.takeIf { it.isNotBlank() }
+
+    private fun isSelected(message: ChatMessage): Boolean =
+        isChatPopupMessageSelected(message, selectedMessageId, selectedMessage)
 
     val type = selectedMessage?.type
     val userId = selectedMessage?.userId
@@ -111,13 +131,29 @@ class MessageClickedChatAdapter(
     var messageClickListener: ((ChatMessage, ChatMessage?) -> Unit)? = null
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
-        return ViewHolder(LayoutInflater.from(parent.context).inflate(R.layout.chat_list_item, parent, false))
+        val itemView = v2Assets?.let {
+            ChatMessageTextView(parent.context, it).apply {
+                setMessageTextSizeSp(messageTextSize)
+                setAnimateGifs(animateGifs)
+                layoutParams = RecyclerView.LayoutParams(-1, -2)
+            }
+        } ?: LayoutInflater.from(parent.context).inflate(R.layout.chat_list_item, parent, false)
+        return ViewHolder(itemView)
     }
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
         val chatMessage = synchronized(messages) {
             messages.getOrNull(position)
         } ?: return
+        val v2Row = v2Rows?.getOrNull(position)
+        if (v2Row != null && holder.textView is ChatMessageTextView) {
+            val v2View = holder.textView as ChatMessageTextView
+            v2View.setInteractionCallbacks(null, v2EmoteClick, v2GifClick)
+            v2View.bind(v2Row)
+            bindSelectionClick(holder.textView, chatMessage)
+            if (isSelected(chatMessage)) holder.textView.setBackgroundResource(R.color.chatMessageSelected)
+            return
+        }
         val result = ChatAdapterUtils.prepareChatMessage(
             chatMessage, fragment.requireContext(), holder.textView, enableTimestamps, timestampFormat, firstMsgVisibility, firstChatMsg,
             redeemedChatMsg, redeemedNoMsg, replyMessage, { url, name, format, isAnimated, source, thirdParty, emoteId -> imageClick(url, name, format, isAnimated, source, thirdParty, emoteId) },
@@ -126,7 +162,7 @@ class MessageClickedChatAdapter(
             userColors, savedColors, translateAllMessages, translateMessage, showLanguageDownloadDialog, false, localTwitchEmotes,
             thirdPartyEmotes, globalBadges, channelBadges, cheerEmotes, savedLocalTwitchEmotes, savedLocalBadges, savedLocalCheerEmotes, savedLocalEmotes
         )
-        if (chatMessage == selectedMessage) {
+        if (isSelected(chatMessage)) {
             holder.textView.setBackgroundResource(R.color.chatMessageSelected)
         }
         ChatAdapterUtils.installImagePlaceholders(
@@ -197,6 +233,44 @@ class MessageClickedChatAdapter(
 
     override fun getItemCount(): Int = synchronized(messages) {
         messages.size
+    }
+
+    /** Replaces the popup's rows from the canonical v2 publication. */
+    fun updateV2Messages(sourceMessages: List<ChatMessage>, rows: List<ChatRowUiModel>) {
+        if (v2Assets == null) return
+        val filteredMessages = sourceMessages.filter(::belongsToSelectedUser)
+        val ids: Set<String?> = filteredMessages.mapTo(HashSet()) { it.id }
+        val filteredRows = rows.filter { it.id.value in ids }
+        synchronized(messages) {
+            messages.clear()
+            messages.addAll(filteredMessages)
+        }
+        selectedMessage = selectedMessageId?.let { id ->
+            filteredMessages.firstOrNull { it.id == id }
+        } ?: selectedMessage?.let { selected ->
+            filteredMessages.firstOrNull { it === selected } ?: selected
+        }
+        v2Rows = filteredRows
+        notifyDataSetChanged()
+    }
+
+    private fun belongsToSelectedUser(message: ChatMessage): Boolean {
+        if (type != ChatMessage.USER_MESSAGE) return message.type == type
+        if (!userId.isNullOrBlank() && (message.userId == userId || message.replyParent?.userId == userId)) return true
+        return !userLogin.isNullOrBlank() &&
+            (message.userLogin.equals(userLogin, true) || message.replyParent?.userLogin.equals(userLogin, true))
+    }
+
+    private fun bindSelectionClick(view: TextView, chatMessage: ChatMessage) {
+        view.setOnClickListener {
+            if (view.selectionStart == -1 && view.selectionEnd == -1 && !isSelected(chatMessage)) {
+                val previous = selectedMessage
+                messageClickListener?.invoke(chatMessage, previous)
+                selectedMessage = chatMessage
+                selectedMessageId = chatMessage.id?.takeIf { it.isNotBlank() }
+                view.setBackgroundResource(R.color.chatMessageSelected)
+            }
+        }
     }
 
     override fun onViewAttachedToWindow(holder: ViewHolder) {
@@ -300,9 +374,10 @@ class MessageClickedChatAdapter(
                     ellipsize = null
                     TooltipCompat.setTooltipText(this, chatMessage.message ?: chatMessage.systemMsg)
                     setOnClickListener {
-                        if (selectionStart == -1 && selectionEnd == -1 && chatMessage != selectedMessage) {
+                        if (selectionStart == -1 && selectionEnd == -1 && !isSelected(chatMessage)) {
                             messageClickListener?.invoke(chatMessage, selectedMessage)
                             selectedMessage = chatMessage
+                            selectedMessageId = chatMessage.id?.takeIf { it.isNotBlank() }
                             setBackgroundResource(R.color.chatMessageSelected)
                             (text as? Spannable)?.let { view ->
                                 view.getSpans<NamePaintImageSpan>().forEach {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/MessageClickedDialog.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/MessageClickedDialog.kt
@@ -141,7 +141,9 @@ class MessageClickedDialog : BottomSheetDialogFragment() {
                     updateButtons(selectedMessage)
                     previousSelectedMessage?.let {
                         synchronized(adapter.messages) {
-                            adapter.messages.indexOf(it).takeIf { it != -1 }
+                            adapter.messages.indexOfFirst { message ->
+                                if (!it.id.isNullOrBlank()) message.id == it.id else message === it
+                            }.takeIf { it != -1 }
                         }?.let {
                             (recyclerView.layoutManager?.findViewByPosition(it) as? TextView)?.let {
                                 adapter.updateBackground(previousSelectedMessage, it)
@@ -202,6 +204,9 @@ class MessageClickedDialog : BottomSheetDialogFragment() {
                                 networkLibrary = requireContext().prefs().getString(C.NETWORK_LIBRARY, C.OKHTTP),
                                 gqlHeaders = TwitchApiHelper.getGQLHeaders(requireContext(), true),
                                 helixHeaders = TwitchApiHelper.getHelixHeaders(requireContext()),
+                                isSubscribedHint = selectedMessage.badges.orEmpty().any {
+                                    it.setId.equals("subscriber", ignoreCase = true)
+                                },
                             )
                             viewLifecycleOwner.lifecycleScope.launch {
                                 repeatOnLifecycle(Lifecycle.State.STARTED) {
@@ -270,6 +275,9 @@ class MessageClickedDialog : BottomSheetDialogFragment() {
             id = message.userId,
             login = message.userLogin,
             name = message.userName,
+            isSubscribed = message.badges.orEmpty().any {
+                it.setId.equals("subscriber", ignoreCase = true)
+            },
         )
     }
 
@@ -396,7 +404,7 @@ class MessageClickedDialog : BottomSheetDialogFragment() {
             }
 
             val months = user.subscriptionMonths ?: 0
-            userSubscription.isVisible = months > 0
+            userSubscription.isVisible = months > 0 || user.isSubscribed
             if (months > 0) {
                 userSubscription.text = resources.getQuantityString(
                     if (user.isSubscribed) {
@@ -407,6 +415,8 @@ class MessageClickedDialog : BottomSheetDialogFragment() {
                     months,
                     months,
                 )
+            } else if (user.isSubscribed) {
+                userSubscription.setText(R.string.user_card_subscribed)
             }
 
             val badges = user.displayBadges
@@ -587,6 +597,13 @@ class MessageClickedDialog : BottomSheetDialogFragment() {
                 }
             }
         }
+    }
+
+    fun updateV2Messages(
+        messages: List<ChatMessage>,
+        rows: List<com.github.andreyasadchy.xtra.ui.chat.v2.presentation.ChatRowUiModel>,
+    ) {
+        adapter?.updateV2Messages(messages, rows)
     }
 
     fun addMessages(messages: List<ChatMessage>) {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/MessageClickedViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/MessageClickedViewModel.kt
@@ -31,7 +31,7 @@ class MessageClickedViewModel(
     val followResult = MutableStateFlow<FollowResult?>(null)
     private var isLoading = false
 
-    fun loadUser(channelId: String?, channelLogin: String?, targetId: String?, targetLogin: String?, networkLibrary: String?, gqlHeaders: Map<String, String>, helixHeaders: Map<String, String>) {
+    fun loadUser(channelId: String?, channelLogin: String?, targetId: String?, targetLogin: String?, networkLibrary: String?, gqlHeaders: Map<String, String>, helixHeaders: Map<String, String>, isSubscribedHint: Boolean = false) {
         if (user.value == null && !isLoading) {
             isLoading = true
             viewModelScope.launch {
@@ -56,7 +56,7 @@ class MessageClickedViewModel(
                                     imageUrl = badge.imageURL,
                                 )
                             }
-                            mapUser(user = clickedUser, earnedBadges = earnedBadges)
+                            mapUser(user = clickedUser, earnedBadges = earnedBadges, isSubscribedHint = isSubscribedHint)
                         }
                     } catch (e: Exception) {
                         null
@@ -73,7 +73,7 @@ class MessageClickedViewModel(
                             targetId,
                         ).data
                         data?.user?.userMessageClickedUser?.let { clickedUser ->
-                            mapUser(clickedUser)
+                            mapUser(clickedUser, isSubscribedHint = isSubscribedHint)
                         }
                     } catch (e: Exception) {
                         null
@@ -94,6 +94,7 @@ class MessageClickedViewModel(
                                 type = it.type,
                                 broadcasterType = it.broadcasterType,
                                 createdAt = it.createdAt,
+                                isSubscribed = isSubscribedHint,
                             )
                         }
                     } catch (e: Exception) {
@@ -109,6 +110,7 @@ class MessageClickedViewModel(
     private fun mapUser(
         user: com.github.andreyasadchy.xtra.graphql.fragment.UserMessageClickedUser,
         earnedBadges: List<UserCardBadge> = emptyList(),
+        isSubscribedHint: Boolean = false,
     ): User {
         return mapUser(
             id = user.id,
@@ -124,7 +126,7 @@ class MessageClickedViewModel(
                 }
             },
             subscriptionMonths = user.relationship?.subscriptionTenure?.months,
-            isSubscribed = user.relationship?.subscriptionBenefit != null,
+            isSubscribed = user.relationship?.subscriptionBenefit != null || isSubscribedHint,
             viewerFollowsUser = user.self?.follower != null,
             viewerCanFollowUser = user.self?.canFollow == true,
         )

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/catalog/ChatCatalogRepository.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/catalog/ChatCatalogRepository.kt
@@ -41,6 +41,10 @@ data class ChatCatalogLoadResult(
     val hasSuccessfulProvider: Boolean
         get() = twitch != null || sevenTv != null || bttv != null || ffz != null || badges != null
 
+    val hasFailedThirdPartyProvider: Boolean
+        get() = sevenTv == null || sevenTv.hasFailedScope ||
+                bttv == null || bttv.hasFailedScope || ffz == null || ffz.hasFailedScope
+
     /** Sources must return an explicit empty update for a provider that successfully has no entries. */
     val hasFailedProvider: Boolean
         get() = twitch == null || sevenTv == null || sevenTv.hasFailedScope ||
@@ -99,7 +103,12 @@ class ChatCatalogRepository(
                             if (networkProvidersObserved.isEmpty() && networkEmoteScopesObserved.isEmpty()) {
                                 // A refresh may already be in flight while disk hydration is pending.
                                 // Publish the last-good cache before that refresh completes.
-                                _state.value = ChatCatalogState(cached, hydrated = true)
+                                _state.value = ChatCatalogState(
+                                    cached,
+                                    hydrated = true,
+                                    refreshFailed = currentState.refreshFailed,
+                                    thirdPartyRefreshFailed = currentState.thirdPartyRefreshFailed,
+                                )
                             } else {
                                 // Hydrate only providers that have not produced a network result yet.
                                 // A partial refresh must not erase cached data for providers that are
@@ -116,6 +125,7 @@ class ChatCatalogRepository(
                                         merged.copy(revision = current.revision + 1),
                                         hydrated = true,
                                         refreshFailed = currentState.refreshFailed,
+                                        thirdPartyRefreshFailed = currentState.thirdPartyRefreshFailed,
                                     )
                                 } else {
                                     _state.value = currentState.copy(hydrated = true)
@@ -157,8 +167,11 @@ class ChatCatalogRepository(
         synchronized(this@ChatCatalogRepository) {
             if (closed || requestGeneration != generation) return@synchronized
             if (result == null || !result.hasSuccessfulProvider) {
-                if (!_state.value.refreshFailed) {
-                    _state.value = _state.value.copy(refreshFailed = true)
+                if (!_state.value.refreshFailed || !_state.value.thirdPartyRefreshFailed) {
+                    _state.value = _state.value.copy(
+                        refreshFailed = true,
+                        thirdPartyRefreshFailed = true,
+                    )
                 }
                 refreshJob = launchRefresh(requestGeneration, attempt + 1, retryDelay(attempt))
                 return@synchronized
@@ -189,11 +202,15 @@ class ChatCatalogRepository(
                 next,
                 hydrated = currentState.hydrated,
                 refreshFailed = result.hasFailedProvider,
+                thirdPartyRefreshFailed = result.hasFailedThirdPartyProvider,
             )
             if (changed) {
                 _state.value = nextState
                 enqueuePersistence(next)
-            } else if (currentState.refreshFailed != nextState.refreshFailed) {
+            } else if (
+                currentState.refreshFailed != nextState.refreshFailed ||
+                currentState.thirdPartyRefreshFailed != nextState.thirdPartyRefreshFailed
+            ) {
                 _state.value = nextState
             }
             refreshJob = if (result.hasFailedProvider) {
@@ -232,28 +249,33 @@ class ChatCatalogRepository(
     }
 
     private fun mergeEmoteScopes(
-        current: Map<String, ChatCatalogEmote>,
+        current: ScopedEmoteCatalog,
         update: ChatCatalogProviderUpdate<Map<String, ChatCatalogEmote>>,
-    ): Map<String, ChatCatalogEmote> {
-        if (update.global == null && update.channel == null) return update.value
-        val merged = current.toMutableMap()
-        val completeScopedRefresh =
-            update.global is ScopeUpdate.Success && update.channel is ScopeUpdate.Success
-        if (completeScopedRefresh) {
-            merged.entries.removeAll { it.value.scope == ChatEmoteScope.LEGACY_COMBINED }
-        }
+    ): ScopedEmoteCatalog {
+        if (update.global == null && update.channel == null) return ScopedEmoteCatalog.fromEffective(update.value)
+        var global = current.global
+        var channel = current.channel
+        var personal = current.personal
+        var legacyCombined = current.legacyCombined
         fun apply(scope: ChatEmoteScope, result: ScopeUpdate<Map<String, ChatCatalogEmote>>?) {
             when (result) {
                 is ScopeUpdate.Success -> {
-                    merged.entries.removeAll { it.value.scope == scope }
-                    merged.putAll(result.value)
+                    when (scope) {
+                        ChatEmoteScope.GLOBAL -> global = result.value
+                        ChatEmoteScope.CHANNEL -> channel = result.value
+                        ChatEmoteScope.PERSONAL -> personal = result.value
+                        ChatEmoteScope.LEGACY_COMBINED -> legacyCombined = result.value
+                    }
                 }
                 ScopeUpdate.Failed, null -> Unit
             }
         }
         apply(ChatEmoteScope.GLOBAL, update.global)
         apply(ChatEmoteScope.CHANNEL, update.channel)
-        return merged
+        if (update.global is ScopeUpdate.Success && update.channel is ScopeUpdate.Success) {
+            legacyCombined = emptyMap()
+        }
+        return ScopedEmoteCatalog(global, channel, personal, legacyCombined)
     }
 
     private fun observeEmoteScopes(
@@ -268,18 +290,23 @@ class ChatCatalogRepository(
     }
 
     private fun hydrateUnobservedScopes(
-        current: Map<String, ChatCatalogEmote>,
-        cached: Map<String, ChatCatalogEmote>,
+        current: ScopedEmoteCatalog,
+        cached: ScopedEmoteCatalog,
         provider: Provider,
-    ): Map<String, ChatCatalogEmote> {
+    ): ScopedEmoteCatalog {
         if (provider in networkProvidersObserved) return current
         val observed = networkEmoteScopesObserved[provider].orEmpty()
-        val merged = current.toMutableMap()
-        for (scope in ChatEmoteScope.entries) {
-            if (scope in observed) continue
-            merged.entries.removeAll { it.value.scope == scope }
-            merged.putAll(cached.filterValues { it.scope == scope })
-        }
-        return merged
+        val realScopesAuthoritative =
+            ChatEmoteScope.GLOBAL in observed && ChatEmoteScope.CHANNEL in observed
+        return current.copy(
+            global = if (ChatEmoteScope.GLOBAL in observed) current.global else cached.global,
+            channel = if (ChatEmoteScope.CHANNEL in observed) current.channel else cached.channel,
+            personal = if (ChatEmoteScope.PERSONAL in observed) current.personal else cached.personal,
+            legacyCombined = when {
+                realScopesAuthoritative -> emptyMap()
+                current.legacyCombined.isNotEmpty() -> current.legacyCombined
+                else -> cached.legacyCombined
+            },
+        )
     }
 }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/catalog/ChatCatalogSnapshot.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/catalog/ChatCatalogSnapshot.kt
@@ -6,6 +6,53 @@ enum class ChatAssetProvider { TWITCH, SEVEN_TV, BTTV, FFZ }
 
 enum class ChatEmoteScope { GLOBAL, CHANNEL, PERSONAL, LEGACY_COMBINED }
 
+/**
+ * Keeps provider scopes independent. The effective map is only a lookup projection;
+ * it must never be used as the provider's persisted state because aliases can collide.
+ */
+data class ScopedEmoteCatalog(
+    val global: Map<String, ChatCatalogEmote> = emptyMap(),
+    val channel: Map<String, ChatCatalogEmote> = emptyMap(),
+    val personal: Map<String, ChatCatalogEmote> = emptyMap(),
+    /** Entries from the pre-v2 combined cache, whose original scope is unknown. */
+    val legacyCombined: Map<String, ChatCatalogEmote> = emptyMap(),
+) {
+    private val effectiveProjection: Map<String, ChatCatalogEmote> by lazy(LazyThreadSafetyMode.PUBLICATION) {
+        legacyCombined + global + personal + channel
+    }
+
+    /** Channel wins over personal, which wins over global, matching legacy precedence. */
+    val effective: Map<String, ChatCatalogEmote>
+        get() = effectiveProjection
+
+    operator fun get(name: String): ChatCatalogEmote? =
+        channel[name] ?: personal[name] ?: global[name] ?: legacyCombined[name]
+
+    operator fun contains(name: String): Boolean = get(name) != null
+
+    val values: Collection<ChatCatalogEmote>
+        get() = effectiveValues()
+
+    /** Builds the merged projection once for consumers such as the picker. */
+    fun effectiveValues(): Collection<ChatCatalogEmote> =
+        (legacyCombined + global + personal + channel).values
+
+    fun isEmpty(): Boolean =
+        global.isEmpty() && channel.isEmpty() && personal.isEmpty() && legacyCombined.isEmpty()
+
+    companion object {
+        fun fromEffective(emotes: Map<String, ChatCatalogEmote>): ScopedEmoteCatalog {
+            val scopes = emotes.entries.groupBy { it.value.scope }
+            return ScopedEmoteCatalog(
+                global = scopes[ChatEmoteScope.GLOBAL].orEmpty().associate { it.toPair() },
+                channel = scopes[ChatEmoteScope.CHANNEL].orEmpty().associate { it.toPair() },
+                personal = scopes[ChatEmoteScope.PERSONAL].orEmpty().associate { it.toPair() },
+                legacyCombined = scopes[ChatEmoteScope.LEGACY_COMBINED].orEmpty().associate { it.toPair() },
+            )
+        }
+    }
+}
+
 data class ChatCatalogEmote(
     val name: String,
     val asset: ChatAssetSpec,
@@ -28,9 +75,9 @@ data class ChatCatalogBadge(
 data class ChatCatalogSnapshot(
     val revision: Long,
     val twitch: Map<String, ChatCatalogEmote> = emptyMap(),
-    val sevenTv: Map<String, ChatCatalogEmote> = emptyMap(),
-    val bttv: Map<String, ChatCatalogEmote> = emptyMap(),
-    val ffz: Map<String, ChatCatalogEmote> = emptyMap(),
+    val sevenTv: ScopedEmoteCatalog = ScopedEmoteCatalog(),
+    val bttv: ScopedEmoteCatalog = ScopedEmoteCatalog(),
+    val ffz: ScopedEmoteCatalog = ScopedEmoteCatalog(),
     val badges: Map<String, ChatCatalogBadge> = emptyMap(),
 )
 
@@ -43,4 +90,5 @@ data class ChatCatalogState(
     val snapshot: ChatCatalogSnapshot,
     val hydrated: Boolean,
     val refreshFailed: Boolean = false,
+    val thirdPartyRefreshFailed: Boolean = false,
 )

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/catalog/TwitchChatCatalogSource.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/catalog/TwitchChatCatalogSource.kt
@@ -242,14 +242,14 @@ class TwitchChatCatalogCache(
     }
 
     private fun encode(snapshot: ChatCatalogSnapshot): JSONObject = JSONObject().apply {
-        put("schemaVersion", 2)
+        put("schemaVersion", 3)
         put("revision", snapshot.revision)
         put("provider", "combined")
         put("fetchedAt", System.currentTimeMillis())
         put("twitch", encodeEmotes(snapshot.twitch))
-        put("sevenTv", encodeEmotes(snapshot.sevenTv))
-        put("bttv", encodeEmotes(snapshot.bttv))
-        put("ffz", encodeEmotes(snapshot.ffz))
+        put("sevenTv", encodeScopedEmotes(snapshot.sevenTv))
+        put("bttv", encodeScopedEmotes(snapshot.bttv))
+        put("ffz", encodeScopedEmotes(snapshot.ffz))
         put("badges", encodeBadges(snapshot.badges))
     }
 
@@ -265,6 +265,13 @@ class TwitchChatCatalogCache(
                 put("asset", encodeSpec(emote.asset))
             })
         }
+    }
+
+    private fun encodeScopedEmotes(scoped: ScopedEmoteCatalog) = JSONObject().apply {
+        put("global", encodeEmotes(scoped.global))
+        put("channel", encodeEmotes(scoped.channel))
+        put("personal", encodeEmotes(scoped.personal))
+        put("legacyCombined", encodeEmotes(scoped.legacyCombined))
     }
 
     private fun encodeBadges(map: Map<String, ChatCatalogBadge>) = JSONArray().apply {
@@ -292,9 +299,12 @@ class TwitchChatCatalogCache(
 
     private fun decode(root: JSONObject): ChatCatalogSnapshot {
         val schemaVersion = root.optInt("schemaVersion")
-        check(schemaVersion in 1..2)
-        fun emotes(name: String): Map<String, ChatCatalogEmote> = buildMap {
-            val array = root.optJSONArray(name) ?: return@buildMap
+        check(schemaVersion in 1..3)
+        fun emoteArray(
+            array: JSONArray?,
+            legacyCombined: Boolean = false,
+        ): Map<String, ChatCatalogEmote> = buildMap {
+            array ?: return@buildMap
             for (i in 0 until array.length()) {
                 val item = array.optJSONObject(i) ?: continue
                 val emoteName = item.optString("name").takeIf { it.isNotBlank() } ?: continue
@@ -303,12 +313,6 @@ class TwitchChatCatalogCache(
                     ?: continue
                 val provider = runCatching { ChatAssetProvider.valueOf(item.optString("provider")) }.getOrNull() ?: continue
                 val storedScope = item.optString("scope").takeIf { it.isNotBlank() }
-                val scope = if (schemaVersion == 1 && storedScope == null) {
-                    ChatEmoteScope.LEGACY_COMBINED
-                } else {
-                    runCatching { ChatEmoteScope.valueOf(storedScope.orEmpty()) }
-                        .getOrDefault(ChatEmoteScope.GLOBAL)
-                }
                 put(emoteName, ChatCatalogEmote(
                     name = emoteName,
                     asset = decodeSpec(item.optJSONObject("asset")),
@@ -316,8 +320,34 @@ class TwitchChatCatalogCache(
                     animated = item.optBoolean("animated"),
                     zeroWidth = item.optBoolean("zeroWidth"),
                     id = id,
-                    scope = scope,
+                    scope = if (legacyCombined || schemaVersion == 1 && storedScope == null) {
+                        ChatEmoteScope.LEGACY_COMBINED
+                    } else {
+                        runCatching { ChatEmoteScope.valueOf(storedScope.orEmpty()) }
+                            .getOrDefault(ChatEmoteScope.GLOBAL)
+                    },
                 ))
+            }
+        }
+        fun emotes(name: String): ScopedEmoteCatalog {
+            val value = root.opt(name)
+            if (value is JSONObject) {
+                return ScopedEmoteCatalog(
+                    global = emoteArray(value.optJSONArray("global")),
+                    channel = emoteArray(value.optJSONArray("channel")),
+                    personal = emoteArray(value.optJSONArray("personal")),
+                    legacyCombined = emoteArray(value.optJSONArray("legacyCombined")),
+                )
+            }
+            // Schema 1/2 used one array per provider. Schema 1 had no stable provider
+            // identity, so retain those records as legacy combined entries and synthesize
+            // the emote name as their only available identity.
+            return if (schemaVersion == 1) {
+                ScopedEmoteCatalog(
+                    legacyCombined = emoteArray(root.optJSONArray(name), legacyCombined = true),
+                )
+            } else {
+                ScopedEmoteCatalog.fromEffective(emoteArray(root.optJSONArray(name)))
             }
         }
         val badges = buildMap {
@@ -337,7 +367,7 @@ class TwitchChatCatalogCache(
         }
         return ChatCatalogSnapshot(
             revision = root.optLong("revision", 0L),
-            twitch = emotes("twitch"),
+            twitch = emoteArray(root.optJSONArray("twitch"), legacyCombined = schemaVersion == 1),
             sevenTv = emotes("sevenTv"),
             bttv = emotes("bttv"),
             ffz = emotes("ffz"),

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/domain/ChatMessage.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/domain/ChatMessage.kt
@@ -1,5 +1,8 @@
 package com.github.andreyasadchy.xtra.ui.chat.v2.domain
 
+import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatAssetProvider
+import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatEmoteScope
+
 data class ChatUser(
     val id: String?,
     val login: String?,
@@ -44,6 +47,21 @@ data class ChatAssetSpec(
     fun scaledTo(height: Int): ChatAssetSpec = copy(targetHeight = height, overlays = overlays.map { it.scaledTo(height) })
 }
 
+data class ChatEmoteInteraction(
+    val id: String?,
+    val name: String,
+    val url: String?,
+    val animated: Boolean,
+    val provider: ChatAssetProvider,
+    val scope: ChatEmoteScope?,
+)
+
+data class ChatGifInteraction(
+    val id: String,
+    val description: String,
+    val url: String,
+)
+
 data class ChatReply(
     val parentMessageId: ChatMessageId,
     val parentMessageBody: String?,
@@ -75,8 +93,14 @@ sealed interface ChatSegment {
         val asset: ChatAssetSpec,
         val fallbackText: String,
         val animated: Boolean,
+        val interaction: ChatEmoteInteraction? = null,
     ) : ChatSegment
-    data class Gif(val gifId: String, val url: String, val fallbackText: String) : ChatSegment
+    data class Gif(
+        val gifId: String,
+        val url: String,
+        val fallbackText: String,
+        val interaction: ChatGifInteraction = ChatGifInteraction(gifId, fallbackText, url),
+    ) : ChatSegment
     data class Cheermote(val asset: ChatAssetSpec, val text: String, val bits: Int, val color: Int?) : ChatSegment
 }
 
@@ -99,11 +123,16 @@ data class ChatMessage(
     val user: ChatUser?,
     val badges: List<ChatBadgeRef>,
     val segments: List<ChatSegment>,
+    /** The exact plain-text body supplied by Twitch, including GIF message text. */
+    val rawText: String? = null,
     val kind: ChatMessageKind,
     val reply: ChatReply? = null,
     val source: SharedChatSource? = null,
     val rewardId: String? = null,
+    val isFirst: Boolean = false,
     val bits: Int? = null,
+    val watchStreakCount: Int? = null,
+    val watchStreakPoints: Int? = null,
     val twitchType: TwitchChatMessageType = TwitchChatMessageType.Text,
     val systemText: String? = null,
     val noticeType: String? = null,

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/presentation/ChatPresentationResolver.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/presentation/ChatPresentationResolver.kt
@@ -7,9 +7,26 @@ import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessage
 class ChatPresentationResolver(
     private var compiler: ChatRowCompiler = ChatRowCompiler(),
 ) {
+    class Snapshot internal constructor(
+        private val compiler: ChatRowCompiler,
+        val generation: Long,
+    ) {
+        fun resolve(message: ChatMessage, catalog: ChatCatalogSnapshot): ChatRowUiModel =
+            compiler.compile(message, catalog)
+    }
+
+    private var generation = 0L
+
     @Synchronized fun replaceCompiler(value: ChatRowCompiler) {
         compiler = value
+        generation++
     }
+
+    @Synchronized
+    fun snapshot(): Snapshot = Snapshot(compiler, generation)
+
+    @Synchronized
+    fun isCurrent(snapshot: Snapshot): Boolean = generation == snapshot.generation
 
     @Synchronized
     fun resolve(message: ChatMessage, catalog: ChatCatalogSnapshot): ChatRowUiModel =

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/presentation/ChatRowCompiler.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/presentation/ChatRowCompiler.kt
@@ -1,6 +1,8 @@
 package com.github.andreyasadchy.xtra.ui.chat.v2.presentation
 
+import com.github.andreyasadchy.xtra.R
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessage
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatEmoteInteraction
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatAssetKey
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatAssetSpec
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatBadgeRef
@@ -9,6 +11,21 @@ import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatSegment
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.TwitchChatMessageType
 import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatCatalogEmote
 import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatCatalogSnapshot
+import com.github.andreyasadchy.xtra.ui.chat.v2.presentation.ChatRowBackground
+import java.text.NumberFormat
+
+data class ChatPresentationLabels(
+    val firstChatter: String = "First Time Chatter",
+    val redeemed: (String) -> String = { "Redeemed $it" },
+    val highlightTitle: String = "Highlight My Message",
+    val highlightRedeemed: (String) -> String = { "Redeemed $it" },
+    val watchStreakReached: String = "Watch Streak Reached",
+    val watchStreakStatus: (String, Int) -> String = { user, count -> "$user is currently on a $count-stream streak!" },
+    val reply: (String, String) -> String = { user, message -> "Replying to $user: $message" },
+    val sharedChat: (String) -> String = { "Shared chat from $it" },
+    val announcement: String = "Announcement",
+    val reward: String = "Channel points reward",
+)
 
 class ChatRowCompiler(
     private val colors: ChatColorResolver = ChatColorResolver(),
@@ -16,38 +33,130 @@ class ChatRowCompiler(
     private val badgeHeightPx: Int = 18,
     private val showBadges: Boolean = true,
     private val enableOverlayEmotes: Boolean = true,
+    private val firstMessageVisibility: Int = 0,
+    private val boldNames: Boolean = false,
     private val timestampText: (Long) -> String? = { null },
     private val background: (ChatMessage) -> Int = { 0 },
+    private val labels: ChatPresentationLabels = ChatPresentationLabels(),
 ) {
     fun compile(message: ChatMessage, catalog: ChatCatalogSnapshot = ChatCatalogSnapshot(0)): ChatRowUiModel {
         val targetHeight = emoteHeightPx * if (message.twitchType == TwitchChatMessageType.GigantifiedEmote) 2 else 1
         val rowBackground = background(message)
+        val isWatchStreak = message.noticeType.equals("watch_streak", ignoreCase = true) ||
+            (message.noticeType.equals("viewermilestone", ignoreCase = true) && message.watchStreakCount != null)
         val hasSemanticBody = message.segments.any {
             it !is ChatSegment.Text || it.text.isNotBlank()
         }
-        val noticeBody = message.systemText?.takeIf { message.kind == ChatMessageKind.NOTICE && it.isNotBlank() }
-        val resolvedSegments = if (noticeBody != null && !hasSemanticBody) {
-            listOf(ChatSegment.Text(noticeBody))
+        val noticeBody = message.systemText?.takeIf {
+            it.isNotBlank() &&
+                (message.kind == ChatMessageKind.NOTICE ||
+                    message.kind == ChatMessageKind.SYSTEM ||
+                    message.kind == ChatMessageKind.RAID ||
+                    message.kind == ChatMessageKind.ANNOUNCEMENT) &&
+                !(isWatchStreak && message.watchStreakCount != null)
+        }
+        val resolvedSegments = if (noticeBody != null) {
+            val body = resolveSegments(message.segments, catalog)
+            if (hasSemanticBody) {
+                listOf(ChatSegment.Text("$noticeBody\n")) + body
+            } else {
+                listOf(ChatSegment.Text(noticeBody))
+            }
         } else {
             resolveSegments(message.segments, catalog)
         }
+        val isFirstChatter = (message.isFirst || message.twitchType == TwitchChatMessageType.UserIntro) &&
+            firstMessageVisibility == 0
+        val mutedColor = 0xFFC4BEC9.toInt()
         val pieces = buildList {
-            if (showBadges) message.badges.forEach { badge -> add(ChatPiece.Badge(badgeSpec(badge, catalog))) }
+            val specialNotice = isFirstChatter || isWatchStreak
+            if (showBadges && !specialNotice) message.badges.forEach { badge -> add(ChatPiece.Badge(badgeSpec(badge, catalog))) }
+            if (isFirstChatter) {
+                add(ChatPiece.Icon(R.drawable.ic_chat_first_chatter))
+                add(ChatPiece.Text(" ${labels.firstChatter}\n", bold = true))
+            }
+            if (isWatchStreak) {
+                add(ChatPiece.Icon(R.drawable.ic_watch_streak, sizeDp = 22))
+                add(ChatPiece.Text(" ${labels.watchStreakReached}", bold = true))
+                message.watchStreakPoints?.let { points ->
+                    add(ChatPiece.Text("  "))
+                    add(ChatPiece.Icon(R.drawable.ic_chat_channel_points, sizeDp = 20))
+                    add(ChatPiece.Text(" +${NumberFormat.getInstance().format(points)}", bold = true))
+                }
+                add(ChatPiece.Text("\n"))
+                if (message.watchStreakCount != null) {
+                    val user = message.user?.displayName ?: message.user?.login ?: ""
+                    val marker = "\uE000"
+                    val status = labels.watchStreakStatus(marker, message.watchStreakCount)
+                    val markerStart = status.indexOf(marker)
+                    if (markerStart >= 0) {
+                        add(ChatPiece.Text(status.substring(0, markerStart), color = mutedColor))
+                        add(ChatPiece.Text(user, color = colors.resolve(message.user?.color?.let(::colorToHex), message.user?.id ?: message.user?.login ?: user, rowBackground), bold = true))
+                        add(ChatPiece.Text(status.substring(markerStart + marker.length), color = mutedColor))
+                    } else {
+                        add(ChatPiece.Text(status, color = mutedColor))
+                    }
+                    add(ChatPiece.Text("\n"))
+                    add(ChatPiece.Icon(R.drawable.ic_chat_speaker_muted, tint = mutedColor, sizeDp = 18))
+                    add(ChatPiece.Text(" "))
+                }
+            }
+            message.reply?.let { reply ->
+                val user = reply.parentUserName ?: reply.parentUserLogin ?: ""
+                val body = reply.parentMessageBody.orEmpty()
+                add(ChatPiece.Icon(R.drawable.ic_chat_reply, tint = mutedColor, sizeDp = 18))
+                val replyUser = user.takeIf { it.startsWith("@") }?.let { it } ?: "@$user"
+                add(ChatPiece.Text(" ${labels.reply(replyUser, body)}\n", color = mutedColor))
+            }
+            message.source?.let { source ->
+                val sourceName = source.broadcasterName ?: source.broadcasterLogin ?: source.broadcasterId
+                add(ChatPiece.Text("${labels.sharedChat(sourceName)}\n"))
+            }
+            if (message.kind == ChatMessageKind.ANNOUNCEMENT) {
+                add(ChatPiece.Text("${labels.announcement}\n", bold = true))
+            }
+            if (message.twitchType == TwitchChatMessageType.Highlighted) {
+                add(ChatPiece.Text("${labels.highlightRedeemed(labels.highlightTitle)}\n", bold = true))
+            }
             message.user?.takeIf { noticeBody == null || hasSemanticBody }?.let { user ->
                 val name = user.displayName ?: user.login
                 name?.let {
                     add(ChatPiece.Username(
                         it,
                         colors.resolve(user.color?.let(::colorToHex), user.id ?: user.login ?: it, rowBackground),
+                        bold = boldNames || specialNotice,
                     ))
                 }
+            }
+            if (message.rewardId != null && message.twitchType != TwitchChatMessageType.Highlighted) {
+                add(ChatPiece.Text("${labels.redeemed(labels.reward)}\n"))
             }
             resolvedSegments.forEach { segment ->
                 when (segment) {
                     is ChatSegment.Text -> add(ChatPiece.Text(segment.text))
                     is ChatSegment.Mention -> add(ChatPiece.Mention(segment.text, segment.userId, segment.login))
-                    is ChatSegment.Emote -> add(ChatPiece.Emote(segment.asset.scaledTo(targetHeight), segment.fallbackText, segment.animated))
-                    is ChatSegment.Gif -> add(ChatPiece.Gif(ChatAssetSpec(ChatAssetKey(segment.url), 1, 1, targetHeight), segment.url, segment.fallbackText))
+                    is ChatSegment.Emote -> add(
+                        ChatPiece.Emote(
+                            segment.asset.scaledTo(targetHeight),
+                            segment.fallbackText,
+                            segment.animated,
+                            segment.interaction,
+                        ),
+                    )
+                    is ChatSegment.Gif -> {
+                        // Twitch's EventSub GIF fragment carries an id and URL, but no
+                        // dimensions. Keep the same large, 16:9 presentation as Twitch chat.
+                        if (lastOrNull() !is ChatPiece.Text || !(last() as ChatPiece.Text).value.endsWith("\n")) {
+                            add(ChatPiece.Text("\n"))
+                        }
+                        add(ChatPiece.Gif(
+                            ChatAssetSpec(ChatAssetKey(segment.url), 16, 9, 180),
+                            segment.url,
+                            segment.fallbackText,
+                            segment.interaction,
+                        ))
+                        add(ChatPiece.Text("\n"))
+                    }
                     is ChatSegment.Cheermote -> add(ChatPiece.Cheermote(segment.asset.scaledTo(targetHeight), segment.text, segment.bits, segment.color))
                 }
             }
@@ -58,6 +167,15 @@ class ChatRowCompiler(
             timestampText = timestampText(message.timestampMs),
             pieces = pieces,
             background = rowBackground,
+            backgroundStyle = when {
+                message.twitchType == TwitchChatMessageType.Highlighted -> ChatRowBackground.HIGHLIGHT
+                isWatchStreak -> ChatRowBackground.WATCH_STREAK
+                message.isFirst && firstMessageVisibility == 0 -> ChatRowBackground.FIRST_CHATTER
+                message.isFirst && firstMessageVisibility == 1 -> ChatRowBackground.FIRST_CHATTER_TINT
+                message.rewardId != null && firstMessageVisibility < 2 -> ChatRowBackground.REWARD
+                message.kind != ChatMessageKind.CHAT || !message.noticeType.isNullOrBlank() || !message.systemText.isNullOrBlank() -> ChatRowBackground.NOTICE
+                else -> ChatRowBackground.NORMAL
+            },
             reply = message.reply,
             source = message.source,
             isAction = message.kind == com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessageKind.ACTION,
@@ -111,6 +229,14 @@ class ChatRowCompiler(
                 asset = definition.asset,
                 fallbackText = token,
                 animated = definition.animated,
+                interaction = ChatEmoteInteraction(
+                    id = definition.id,
+                    name = definition.name,
+                    url = definition.asset.key.value,
+                    animated = definition.animated,
+                    provider = definition.provider,
+                    scope = definition.scope,
+                ),
             )
         }
     }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/presentation/ChatRowUiModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/presentation/ChatRowUiModel.kt
@@ -1,6 +1,9 @@
 package com.github.andreyasadchy.xtra.ui.chat.v2.presentation
 
+import androidx.annotation.DrawableRes
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatAssetSpec
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatEmoteInteraction
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatGifInteraction
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessageId
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatReply
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.SharedChatSource
@@ -12,6 +15,7 @@ data class ChatRowUiModel(
     val timestampText: String?,
     val pieces: List<ChatPiece>,
     val background: Int,
+    val backgroundStyle: ChatRowBackground = ChatRowBackground.NORMAL,
     val accessibilityText: String,
     val reply: ChatReply?,
     val source: SharedChatSource?,
@@ -19,12 +23,37 @@ data class ChatRowUiModel(
     val twitchType: TwitchChatMessageType = TwitchChatMessageType.Text,
 )
 
+enum class ChatRowBackground {
+    NORMAL,
+    HIGHLIGHT,
+    FIRST_CHATTER,
+    FIRST_CHATTER_TINT,
+    WATCH_STREAK,
+    REWARD,
+    NOTICE,
+}
+
 sealed interface ChatPiece {
-    data class Text(val value: String, val color: Int? = null) : ChatPiece
-    data class Username(val value: String, val color: Int) : ChatPiece
+    data class Text(val value: String, val color: Int? = null, val bold: Boolean = false) : ChatPiece
+    data class Username(val value: String, val color: Int, val bold: Boolean = false) : ChatPiece
+    data class Icon(
+        @DrawableRes val drawableRes: Int,
+        val tint: Int? = null,
+        val sizeDp: Int = 22,
+    ) : ChatPiece
     data class Badge(val asset: ChatAssetSpec) : ChatPiece
     data class Mention(val value: String, val userId: String?, val login: String?) : ChatPiece
-    data class Emote(val asset: ChatAssetSpec, val fallback: String, val animated: Boolean = true) : ChatPiece
-    data class Gif(val asset: ChatAssetSpec, val url: String, val fallback: String) : ChatPiece
+    data class Emote(
+        val asset: ChatAssetSpec,
+        val fallback: String,
+        val animated: Boolean = true,
+        val interaction: ChatEmoteInteraction? = null,
+    ) : ChatPiece
+    data class Gif(
+        val asset: ChatAssetSpec,
+        val url: String,
+        val fallback: String,
+        val interaction: ChatGifInteraction? = null,
+    ) : ChatPiece
     data class Cheermote(val asset: ChatAssetSpec, val value: String, val bits: Int, val color: Int?) : ChatPiece
 }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/transport/TwitchChatEventParser.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/transport/TwitchChatEventParser.kt
@@ -7,6 +7,7 @@ import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatAssetKey
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatAssetSpec
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatBadgeRef
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatEvent
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatEmoteInteraction
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessage
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessageId
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessageKind
@@ -15,6 +16,7 @@ import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatSegment
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatUser
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.SharedChatSource
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.TwitchChatMessageType
+import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatAssetProvider
 import com.github.andreyasadchy.xtra.util.chat.ChatUtils
 import org.json.JSONArray
 import org.json.JSONObject
@@ -29,7 +31,11 @@ import kotlin.time.Instant
  */
 object TwitchChatEventParser {
     fun fromIrc(message: ChatUtils.IRCMessage, channelId: String): ChatEvent? = when (message.command) {
-        "PRIVMSG", "USERNOTICE" -> ChatEvent.Message(fromLegacy(ChatUtils.parseChatMessage(message), channelId))
+        "PRIVMSG" -> {
+            val legacy = ChatUtils.parseChatMessage(message)
+            ChatEvent.Message(fromLegacy(legacy, channelId, gifTag = message.tags["gifs"]))
+        }
+        "USERNOTICE" -> ChatEvent.Message(fromLegacy(ChatUtils.parseChatMessage(message), channelId, forceNotice = true))
         "CLEARMSG" -> ChatEvent.Delete(
             messageId = ChatMessageId(message.tags["target-msg-id"] ?: return null),
             eventId = message.tags["target-msg-id"],
@@ -97,6 +103,7 @@ object TwitchChatEventParser {
         )
         val rawType = event.optString("message_type").takeIf { it.isNotBlank() } ?: "text"
         val type = parseMessageType(rawType)
+        val noticeType = event.optString("notice_type").takeIf { it.isNotBlank() }
         val fullText = segments.joinToString(separator = "") { segment ->
             when (segment) {
                 is ChatSegment.Text -> segment.text
@@ -122,7 +129,10 @@ object TwitchChatEventParser {
             ),
             badges = parseBadges(event.optJSONArray("badges")),
             segments = segments,
+            rawText = messageObject?.optString("text")?.takeIf { it.isNotEmpty() },
             kind = when {
+                noticeType.equals("raid", ignoreCase = true) || noticeType.equals("unraid", ignoreCase = true) -> ChatMessageKind.RAID
+                noticeType.equals("announcement", ignoreCase = true) || noticeType.equals("shared_chat_announcement", ignoreCase = true) -> ChatMessageKind.ANNOUNCEMENT
                 notice -> ChatMessageKind.NOTICE
                 fullText.startsWith(ChatUtils.ACTION) -> ChatMessageKind.ACTION
                 type == TwitchChatMessageType.Highlighted -> ChatMessageKind.REWARD
@@ -131,10 +141,15 @@ object TwitchChatEventParser {
             reply = parseReply(event.optJSONObject("reply")),
             source = parseSource(event),
             rewardId = event.optString("channel_points_custom_reward_id").takeIf { it.isNotBlank() },
+            isFirst = type == TwitchChatMessageType.UserIntro ||
+                noticeType.equals("first_message", ignoreCase = true) ||
+                noticeType.equals("first_message_highlight", ignoreCase = true),
             bits = event.optJSONObject("cheer")?.optInt("bits")?.takeIf { it > 0 },
+            watchStreakCount = event.optJSONObject("watch_streak")?.optInt("streak_count")?.takeIf { it > 0 },
+            watchStreakPoints = event.optJSONObject("watch_streak")?.optInt("channel_points_awarded")?.takeIf { it > 0 },
             twitchType = type,
             systemText = event.optString("system_message").takeIf { it.isNotBlank() },
-            noticeType = event.optString("notice_type").takeIf { it.isNotBlank() },
+            noticeType = noticeType,
         )
     }
 
@@ -153,6 +168,16 @@ object TwitchChatEventParser {
                             animated = emote.optJSONArray("format")?.let { formats ->
                                 (0 until formats.length()).any { formats.optString(it) == "animated" }
                             } == true,
+                            interaction = ChatEmoteInteraction(
+                                id = id,
+                                name = text,
+                                url = "https://static-cdn.jtvnw.net/emoticons/v2/$id/default/dark/3.0",
+                                animated = emote.optJSONArray("format")?.let { formats ->
+                                    (0 until formats.length()).any { formats.optString(it) == "animated" }
+                                } == true,
+                                provider = ChatAssetProvider.TWITCH,
+                                scope = null,
+                            ),
                         ),
                     )
                 }
@@ -173,7 +198,10 @@ object TwitchChatEventParser {
                 }
                 "gif" -> {
                     val gif = fragment.optJSONObject("gif")
-                    val gifId = gif?.optString("id")?.takeIf { it.isNotBlank() }
+                    // EventSub calls this field gif_id. Accept the older id spelling
+                    // as well so cached/test payloads remain readable.
+                    val gifId = gif?.optString("gif_id")?.takeIf { it.isNotBlank() }
+                        ?: gif?.optString("id")?.takeIf { it.isNotBlank() }
                     val url = gif?.optString("url")?.takeIf { it.isNotBlank() }
                     if (gifId == null || url == null) add(ChatSegment.Text(text)) else add(ChatSegment.Gif(gifId, url, text))
                 }
@@ -220,10 +248,19 @@ object TwitchChatEventParser {
         )
     }
 
-    private fun fromLegacy(message: LegacyChatMessage, channelId: String): ChatMessage {
+    private fun fromLegacy(
+        message: LegacyChatMessage,
+        channelId: String,
+        forceNotice: Boolean = false,
+        gifTag: String? = null,
+    ): ChatMessage {
         val raw = message.message.orEmpty()
-        val segments = legacySegments(raw, message.emotes.orEmpty())
+        val segments = ircSegments(raw, message.emotes.orEmpty(), gifTag)
         val legacyReply = message.reply
+        // Twitch uses source-msg-id for some notification variants (including the
+        // watch-streak viewermilestone). Keep the effective notice ID so the v2
+        // presentation does not silently downgrade those events to ordinary chat.
+        val legacyNoticeType = (message.sourceMsgId ?: message.msgId)?.lowercase()
         return ChatMessage(
             id = ChatMessageId(message.id ?: "irc-${message.hashCode()}-${message.timestamp ?: System.currentTimeMillis()}"),
             channelId = channelId,
@@ -232,36 +269,126 @@ object TwitchChatEventParser {
             badges = message.badges.orEmpty().map { ChatBadgeRef(it.setId, it.version) },
             segments = segments,
             kind = when {
+                legacyNoticeType == "raid" || legacyNoticeType == "unraid" -> ChatMessageKind.RAID
+                legacyNoticeType == "announcement" || legacyNoticeType == "shared_chat_announcement" -> ChatMessageKind.ANNOUNCEMENT
                 message.isAction -> ChatMessageKind.ACTION
-                message.type == LegacyChatMessage.NOTICE_MESSAGE -> ChatMessageKind.NOTICE
+                forceNotice || message.type == LegacyChatMessage.NOTICE_MESSAGE -> ChatMessageKind.NOTICE
                 else -> ChatMessageKind.CHAT
             },
             reply = legacyReply?.toChatReply(),
             source = message.sourceMsgId?.let { SharedChatSource(channelId, null, null, ChatMessageId(it), emptyList(), false) },
             rewardId = message.reward?.id,
+            isFirst = message.isFirst,
             bits = message.bits,
+            watchStreakCount = message.watchStreakCount,
+            watchStreakPoints = message.watchStreakPoints,
             twitchType = message.msgId?.let(::parseMessageType) ?: TwitchChatMessageType.Text,
             systemText = message.systemMsg,
-            noticeType = message.msgId,
+            noticeType = legacyNoticeType,
         )
     }
 
-    private fun legacySegments(text: String, emotes: List<TwitchEmote>): List<ChatSegment> {
-        if (text.isEmpty() || emotes.isEmpty()) return listOf(ChatSegment.Text(text))
-        val byStart = emotes.filter { it.id != null && it.begin >= 0 && it.end >= it.begin }
-            .sortedBy { it.begin }
+    private sealed interface IrcInlineAsset {
+        val start: Int
+        val endInclusive: Int
+
+        data class Emote(val value: TwitchEmote) : IrcInlineAsset {
+            override val start: Int get() = value.begin
+            override val endInclusive: Int get() = value.end
+        }
+
+        data class Gif(val value: IrcGif) : IrcInlineAsset {
+            override val start: Int get() = value.start
+            override val endInclusive: Int get() = value.endInclusive
+        }
+    }
+
+    private data class IrcGif(
+        val start: Int,
+        val endInclusive: Int,
+        val id: String,
+        val url: String,
+    )
+
+    private fun ircSegments(
+        text: String,
+        emotes: List<TwitchEmote>,
+        gifTag: String?,
+    ): List<ChatSegment> {
+        if (text.isEmpty()) return listOf(ChatSegment.Text(text))
+
+        val assets = buildList {
+            emotes.forEach { emote ->
+                if (emote.id != null && isValidRange(emote.begin, emote.end, text.length)) {
+                    add(IrcInlineAsset.Emote(emote))
+                }
+            }
+            parseIrcGifs(gifTag).forEach { gif ->
+                if (isValidRange(gif.start, gif.endInclusive, text.length)) {
+                    add(IrcInlineAsset.Gif(gif))
+                }
+            }
+        }.sortedWith(compareBy<IrcInlineAsset> { it.start }.thenBy { it.endInclusive })
+
+        if (assets.isEmpty()) return listOf(ChatSegment.Text(text))
+
         val result = ArrayList<ChatSegment>()
         var cursor = 0
-        byStart.forEach { emote ->
-            val start = emote.begin.coerceIn(cursor, text.length)
-            val endExclusive = (emote.end + 1).coerceIn(start, text.length)
+        assets.forEach { asset ->
+            if (asset.start < cursor) return@forEach
+            val start = asset.start
+            val endExclusive = asset.endInclusive + 1
             if (start > cursor) result += ChatSegment.Text(text.substring(cursor, start))
             val token = text.substring(start, endExclusive)
-            result += ChatSegment.Emote(nativeSpec("twitch-emote:${emote.id}", 56, 56), token, emote.isAnimated)
+            when (asset) {
+                is IrcInlineAsset.Emote -> {
+                    val emote = asset.value
+                    result += ChatSegment.Emote(
+                        nativeSpec("twitch-emote:${emote.id}", 56, 56),
+                        token,
+                        emote.isAnimated,
+                        ChatEmoteInteraction(
+                            id = emote.id,
+                            name = token,
+                            url = "https://static-cdn.jtvnw.net/emoticons/v2/${emote.id}/default/dark/3.0",
+                            animated = emote.isAnimated,
+                            provider = ChatAssetProvider.TWITCH,
+                            scope = null,
+                        ),
+                    )
+                }
+                is IrcInlineAsset.Gif -> {
+                    val gif = asset.value
+                    result += ChatSegment.Gif(gif.id, gif.url, token)
+                }
+            }
             cursor = endExclusive
         }
         if (cursor < text.length) result += ChatSegment.Text(text.substring(cursor))
         return result
+    }
+
+    private fun isValidRange(start: Int, endInclusive: Int, textLength: Int): Boolean =
+        start >= 0 && endInclusive >= start && endInclusive < textLength
+
+    private fun parseIrcGifs(value: String?): List<IrcGif> {
+        if (value.isNullOrBlank()) return emptyList()
+
+        return value.split(',').mapNotNull { entry ->
+            val parts = entry.split('|', limit = 3)
+            if (parts.size != 3) return@mapNotNull null
+
+            val range = parts[0].split('-', limit = 2)
+            if (range.size != 2) return@mapNotNull null
+
+            val start = range[0].toIntOrNull() ?: return@mapNotNull null
+            val endInclusive = range[1].toIntOrNull() ?: return@mapNotNull null
+            val id = parts[1].takeIf(String::isNotBlank) ?: return@mapNotNull null
+            val url = parts[2].takeIf(String::isNotBlank) ?: return@mapNotNull null
+            if (start < 0 || endInclusive < start) return@mapNotNull null
+
+            IrcGif(start, endInclusive, id, url)
+        }
     }
 
     private fun LegacyReply.toChatReply(): ChatReply? {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/transport/TwitchChatTransport.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/transport/TwitchChatTransport.kt
@@ -1,6 +1,9 @@
 package com.github.andreyasadchy.xtra.ui.chat.v2.transport
 
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatEvent
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessage
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessageId
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessageKind
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatSessionKey
 import com.github.andreyasadchy.xtra.util.chat.ChatReadWebSocket
 import com.github.andreyasadchy.xtra.util.chat.ChatUtils
@@ -22,6 +25,12 @@ data class TwitchChatTransportConfig(
     val accountId: String? = null,
     val helixHeaders: Map<String, String> = emptyMap(),
     val networkLibrary: String? = null,
+    val showUserNotices: Boolean = true,
+    val showClearMessages: Boolean = true,
+    val showClearChat: Boolean = true,
+    val joinedMessage: String? = null,
+    val messageDeletedMessage: String? = null,
+    val chatClearedMessage: String? = null,
 )
 
 /**
@@ -52,16 +61,35 @@ class TwitchChatTransport(
             channelLogin = config.channelLogin,
             trustManager = trustManager,
             listener = object : ChatReadWebSocket.Listener {
+                override suspend fun onConnect() {
+                    systemMessage(session, "join", config.joinedMessage)?.let { flowScope.send(it) }
+                }
+
                 override suspend fun onChatMessage(message: ChatUtils.IRCMessage, userNotice: Boolean) {
+                    if (userNotice && !config.showUserNotices) return
                     TwitchChatEventParser.fromIrc(message, config.channelId)?.let { event -> send(event) }
                 }
 
                 override suspend fun onClearMessage(message: ChatUtils.IRCMessage) {
-                    TwitchChatEventParser.fromIrc(message, config.channelId)?.let { event -> send(event) }
+                    TwitchChatEventParser.fromIrc(message, config.channelId)?.let { event ->
+                        send(event)
+                        if (config.showClearMessages) {
+                            val eventKey = message.tags["target-msg-id"]
+                                ?: message.tags["tmi-sent-ts"]
+                                ?: System.nanoTime().toString()
+                            systemMessage(session, "delete-$eventKey", config.messageDeletedMessage)?.let { flowScope.send(it) }
+                        }
+                    }
                 }
 
                 override suspend fun onClearChat(message: ChatUtils.IRCMessage) {
-                    TwitchChatEventParser.fromIrc(message, config.channelId)?.let { event -> send(event) }
+                    TwitchChatEventParser.fromIrc(message, config.channelId)?.let { event ->
+                        send(event)
+                        if (config.showClearChat) {
+                            val eventKey = message.tags["tmi-sent-ts"] ?: System.nanoTime().toString()
+                            systemMessage(session, "clear-$eventKey", config.chatClearedMessage)?.let { flowScope.send(it) }
+                        }
+                    }
                 }
 
                 override suspend fun onNotice(message: ChatUtils.IRCMessage) {
@@ -88,6 +116,10 @@ class TwitchChatTransport(
         val socket = EventSubWebSocket(
             trustManager = trustManager,
             listener = object : EventSubWebSocket.Listener {
+                override suspend fun onConnect() {
+                    systemMessage(session, "join", config.joinedMessage)?.let { flowScope.send(it) }
+                }
+
                 override suspend fun onWelcomeMessage(sessionId: String) {
                     flowScope.launch {
                         EVENTSUB_CHAT_SUBSCRIPTIONS.forEach { type ->
@@ -101,19 +133,32 @@ class TwitchChatTransport(
                 }
 
                 override suspend fun onUserNotice(event: org.json.JSONObject, timestamp: String?) {
+                    if (!config.showUserNotices) return
                     flowScope.send(TwitchChatEventParser.fromEventSub(event, timestamp, notice = true))
                 }
 
                 override suspend fun onClearChat(event: org.json.JSONObject, timestamp: String?) {
-                    flowScope.send(TwitchChatEventParser.fromEventSubClear(event, timestamp))
+                    val clearEvent = TwitchChatEventParser.fromEventSubClear(event, timestamp)
+                    flowScope.send(clearEvent)
+                    if (config.showClearChat) {
+                        systemMessage(session, "clear-${clearEvent.eventId ?: timestamp ?: System.nanoTime()}", config.chatClearedMessage)?.let { flowScope.send(it) }
+                    }
                 }
 
                 override suspend fun onClearUserMessages(event: org.json.JSONObject, timestamp: String?) {
-                    flowScope.send(TwitchChatEventParser.fromEventSubClear(event, timestamp))
+                    val clearEvent = TwitchChatEventParser.fromEventSubClear(event, timestamp)
+                    flowScope.send(clearEvent)
+                    if (config.showClearChat) {
+                        systemMessage(session, "clear-user-${clearEvent.eventId ?: timestamp ?: System.nanoTime()}", config.chatClearedMessage)?.let { flowScope.send(it) }
+                    }
                 }
 
                 override suspend fun onMessageDelete(event: org.json.JSONObject, timestamp: String?) {
-                    flowScope.send(TwitchChatEventParser.fromEventSubClear(event, timestamp))
+                    val deleteEvent = TwitchChatEventParser.fromEventSubClear(event, timestamp)
+                    flowScope.send(deleteEvent)
+                    if (config.showClearMessages) {
+                        systemMessage(session, "delete-${deleteEvent.eventId ?: timestamp ?: System.nanoTime()}", config.messageDeletedMessage)?.let { flowScope.send(it) }
+                    }
                 }
 
                 override suspend fun onRoomState(event: org.json.JSONObject, timestamp: String?) {
@@ -130,6 +175,22 @@ class TwitchChatTransport(
             flowScope.launch { socket.disconnect(connectionJob) }
         }
     }.buffer(4096, kotlinx.coroutines.channels.BufferOverflow.SUSPEND)
+
+    private fun systemMessage(session: ChatSessionKey, suffix: String, text: String?): ChatEvent.Message? =
+        text?.takeIf { it.isNotBlank() }?.let {
+            ChatEvent.Message(
+                message = ChatMessage(
+                    id = ChatMessageId("system-$suffix-${session.generation}"),
+                    channelId = config.channelId,
+                    timestampMs = System.currentTimeMillis(),
+                    user = null,
+                    badges = emptyList(),
+                    segments = emptyList(),
+                    kind = ChatMessageKind.SYSTEM,
+                    systemText = it,
+                ),
+            )
+        }
 
     private companion object {
         val EVENTSUB_CHAT_SUBSCRIPTIONS = listOf(

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatMessageTextView.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatMessageTextView.kt
@@ -2,32 +2,73 @@ package com.github.andreyasadchy.xtra.ui.chat.v2.ui
 
 import android.content.Context
 import android.graphics.Canvas
+import android.graphics.Color
 import android.graphics.Paint
 import android.graphics.RectF
 import android.graphics.drawable.Animatable
 import android.graphics.drawable.Drawable
 import android.text.SpannableStringBuilder
+import android.text.Spanned
+import android.text.TextPaint
+import android.text.method.LinkMovementMethod
+import android.text.style.ClickableSpan
 import android.text.style.ForegroundColorSpan
 import android.text.style.ReplacementSpan
 import android.text.style.StyleSpan
+import android.graphics.Typeface
 import android.view.Gravity
+import android.os.Handler
+import android.os.Looper
+import android.view.MotionEvent
+import android.view.ViewConfiguration
 import android.widget.TextView
 import android.util.TypedValue
+import androidx.core.content.ContextCompat
 import androidx.appcompat.widget.AppCompatTextView
+import com.github.andreyasadchy.xtra.R
 import com.github.andreyasadchy.xtra.ui.chat.v2.assets.ChatAssetRepository
 import com.github.andreyasadchy.xtra.ui.chat.v2.assets.ChatAssetState
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatAssetKey
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatAssetSpec
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatEmoteInteraction
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatGifInteraction
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessageId
 import com.github.andreyasadchy.xtra.ui.chat.v2.presentation.ChatPiece
 import com.github.andreyasadchy.xtra.ui.chat.v2.presentation.ChatRowUiModel
+import com.github.andreyasadchy.xtra.ui.chat.v2.presentation.ChatRowBackground
+import com.github.andreyasadchy.xtra.ui.view.CenteredImageSpan
+import kotlin.math.roundToInt
 
 open class ChatMessageTextView(context: Context, private val assets: ChatAssetRepository) : AppCompatTextView(context) {
+    private val initialPaddingStart = paddingStart
+    private val initialPaddingTop = paddingTop
+    private val initialPaddingEnd = paddingEnd
+    private val initialPaddingBottom = paddingBottom
     private var keys = emptySet<ChatAssetKey>()
     private val drawables = HashMap<ChatAssetKey, Drawable>()
     private val drawableHandles = HashMap<ChatAssetKey, Any>()
     private val invalidator: () -> Unit = { postInvalidateOnAnimation() }
     private var renderingActive = true
     private var animateGifs = true
+    private var boundMessageId: ChatMessageId? = null
+    private var longPressConsumed = false
+    private var touchDownX = 0f
+    private var touchDownY = 0f
+    private var longPressRunnable: Runnable? = null
+    private val mainHandler = Handler(Looper.getMainLooper())
+    private var onMessageLongClick: ((ChatMessageId) -> Unit)? = null
+    private var onEmoteClick: ((ChatEmoteInteraction) -> Unit)? = null
+    private var onGifClick: ((ChatGifInteraction) -> Unit)? = null
+
+    fun setInteractionCallbacks(
+        onMessageLongClick: ((ChatMessageId) -> Unit)?,
+        onEmoteClick: ((ChatEmoteInteraction) -> Unit)?,
+        onGifClick: ((ChatGifInteraction) -> Unit)? = null,
+    ) {
+        this.onMessageLongClick = onMessageLongClick
+        this.onEmoteClick = onEmoteClick
+        this.onGifClick = onGifClick
+    }
 
     fun setMessageTextSizeSp(value: Float) {
         setTextSize(TypedValue.COMPLEX_UNIT_SP, value)
@@ -46,6 +87,11 @@ open class ChatMessageTextView(context: Context, private val assets: ChatAssetRe
     }
 
     fun bind(row: ChatRowUiModel) {
+        boundMessageId = row.id
+        longPressConsumed = false
+        longPressRunnable?.let(mainHandler::removeCallbacks)
+        longPressRunnable = null
+        isLongClickable = onMessageLongClick != null
         keys.forEach { assets.removeObserver(it, invalidator) }
         drawables.values.forEach { it.stopIfNeeded(); it.callback = null }
         drawables.clear()
@@ -61,17 +107,40 @@ open class ChatMessageTextView(context: Context, private val assets: ChatAssetRe
             spec?.let { it.allKeys() }.orEmpty()
         }.toSet()
         keys.forEach { assets.observe(it, invalidator) }
-        setBackgroundColor(row.background)
+        when (row.backgroundStyle) {
+            ChatRowBackground.NORMAL -> setBackgroundColor(row.background)
+            ChatRowBackground.HIGHLIGHT -> setBackgroundResource(R.drawable.bg_chat_highlight)
+            ChatRowBackground.FIRST_CHATTER -> setBackgroundResource(R.drawable.bg_chat_first_chatter)
+            ChatRowBackground.FIRST_CHATTER_TINT -> setBackgroundColor(ContextCompat.getColor(context, R.color.chatMessageFirst))
+            ChatRowBackground.WATCH_STREAK -> setBackgroundResource(R.drawable.bg_chat_watch_streak)
+            ChatRowBackground.REWARD -> setBackgroundColor(ContextCompat.getColor(context, R.color.chatMessageReward))
+            ChatRowBackground.NOTICE -> setBackgroundColor(ContextCompat.getColor(context, R.color.chatMessageNotice))
+        }
+        val extraStartPadding = if (row.backgroundStyle == ChatRowBackground.WATCH_STREAK) {
+            (30 * resources.displayMetrics.density).roundToInt()
+        } else {
+            0
+        }
+        setPaddingRelative(
+            initialPaddingStart + extraStartPadding,
+            initialPaddingTop,
+            initialPaddingEnd,
+            initialPaddingBottom,
+        )
         gravity = Gravity.CENTER_VERTICAL
+        movementMethod = LinkMovementMethod.getInstance()
+        linksClickable = true
+        highlightColor = Color.TRANSPARENT
         val output = SpannableStringBuilder()
         row.pieces.forEach { piece ->
             when (piece) {
-                is ChatPiece.Text -> appendStyled(output, piece.value, piece.color)
-                is ChatPiece.Username -> appendStyled(output, piece.value + ": ", piece.color)
+                is ChatPiece.Text -> appendStyled(output, piece.value, piece.color, piece.bold)
+                is ChatPiece.Username -> appendStyled(output, piece.value + ": ", piece.color, piece.bold)
+                is ChatPiece.Icon -> appendIcon(output, piece)
                 is ChatPiece.Mention -> appendStyled(output, piece.value, null)
                 is ChatPiece.Badge -> appendAsset(output, piece.asset, "badge")
-                is ChatPiece.Emote -> appendAsset(output, piece.asset, piece.fallback)
-                is ChatPiece.Gif -> appendAsset(output, piece.asset, piece.fallback)
+                is ChatPiece.Emote -> appendAsset(output, piece.asset, piece.fallback, piece.interaction)
+                is ChatPiece.Gif -> appendAsset(output, piece.asset, piece.fallback, gifInteraction = piece.interaction)
                 is ChatPiece.Cheermote -> {
                     appendAsset(output, piece.asset, piece.bits.toString())
                     appendStyled(output, " ${piece.bits}", piece.color)
@@ -84,16 +153,122 @@ open class ChatMessageTextView(context: Context, private val assets: ChatAssetRe
         text = output
     }
 
-    private fun appendStyled(output: SpannableStringBuilder, value: String, color: Int?) {
+    /**
+     * TextView's normal long-click is intentionally the row action. In particular,
+     * it must win over LinkMovementMethod when the pointer goes down on an emote.
+     * The consumed flag suppresses LinkMovementMethod's ACTION_UP click after the
+     * long press has already opened the user card.
+     */
+    override fun performLongClick(): Boolean {
+        val id = boundMessageId
+        val callback = onMessageLongClick
+        if (longPressConsumed) return true
+        if (id != null && callback != null) {
+            longPressConsumed = true
+            callback(id)
+            return true
+        }
+        return super.performLongClick()
+    }
+
+    override fun onTouchEvent(event: MotionEvent): Boolean {
+        when (event.actionMasked) {
+            MotionEvent.ACTION_DOWN -> {
+                longPressConsumed = false
+                touchDownX = event.x
+                touchDownY = event.y
+                longPressRunnable?.let(mainHandler::removeCallbacks)
+                if (onMessageLongClick != null && boundMessageId != null) {
+                    longPressRunnable = Runnable { performLongClick() }.also {
+                        mainHandler.postDelayed(it, ViewConfiguration.getLongPressTimeout().toLong())
+                    }
+                }
+            }
+
+            MotionEvent.ACTION_MOVE -> {
+                val slop = ViewConfiguration.get(context).scaledTouchSlop
+                if (kotlin.math.abs(event.x - touchDownX) > slop ||
+                    kotlin.math.abs(event.y - touchDownY) > slop
+                ) {
+                    longPressRunnable?.let(mainHandler::removeCallbacks)
+                    longPressRunnable = null
+                }
+            }
+
+            MotionEvent.ACTION_CANCEL -> {
+                longPressRunnable?.let(mainHandler::removeCallbacks)
+                longPressRunnable = null
+            }
+
+            MotionEvent.ACTION_UP -> {
+                longPressRunnable?.let(mainHandler::removeCallbacks)
+                longPressRunnable = null
+                if (longPressConsumed) {
+                    longPressConsumed = false
+                    return true
+                }
+            }
+        }
+        if (event.actionMasked == MotionEvent.ACTION_UP && longPressConsumed) {
+            longPressConsumed = false
+            return true
+        }
+        val handled = super.onTouchEvent(event)
+        return if (event.actionMasked == MotionEvent.ACTION_UP && longPressConsumed) {
+            longPressConsumed = false
+            true
+        } else {
+            handled
+        }
+    }
+
+    private fun appendStyled(output: SpannableStringBuilder, value: String, color: Int?, bold: Boolean = false) {
         val start = output.length
         output.append(value)
         if (color != null) output.setSpan(ForegroundColorSpan(color), start, output.length, 0)
+        if (bold) output.setSpan(StyleSpan(Typeface.BOLD), start, output.length, 0)
     }
 
-    private fun appendAsset(output: SpannableStringBuilder, spec: ChatAssetSpec, fallback: String) {
+    private fun appendIcon(output: SpannableStringBuilder, piece: ChatPiece.Icon) {
+        val drawable = ContextCompat.getDrawable(context, piece.drawableRes)?.mutate() ?: return
+        piece.tint?.let(drawable::setTint)
+        val size = (piece.sizeDp * resources.displayMetrics.density).roundToInt().coerceAtLeast(1)
+        drawable.setBounds(0, 0, size, size)
+        val start = output.length
+        output.append('.')
+        output.setSpan(ForegroundColorSpan(Color.TRANSPARENT), start, output.length, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+        output.setSpan(CenteredImageSpan(drawable, size, size), start, output.length, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+    }
+
+    private fun appendAsset(
+        output: SpannableStringBuilder,
+        spec: ChatAssetSpec,
+        fallback: String,
+        interaction: ChatEmoteInteraction? = null,
+        gifInteraction: ChatGifInteraction? = null,
+    ) {
         val start = output.length
         output.append(" ")
-        output.setSpan(ChatAssetSpan(spec, fallback) { drawableLayersFor(spec) }, start, output.length, 0)
+        val end = output.length
+        output.setSpan(ChatAssetSpan(spec, fallback) { drawableLayersFor(spec) }, start, end, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+        interaction?.let { value ->
+            output.setSpan(object : ClickableSpan() {
+                override fun onClick(widget: android.view.View) {
+                    onEmoteClick?.invoke(value)
+                }
+
+                override fun updateDrawState(ds: TextPaint) = Unit
+            }, start, end, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+        }
+        gifInteraction?.let { value ->
+            output.setSpan(object : ClickableSpan() {
+                override fun onClick(widget: android.view.View) {
+                    onGifClick?.invoke(value)
+                }
+
+                override fun updateDrawState(ds: TextPaint) = Unit
+            }, start, end, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+        }
     }
 
     private fun drawableFor(key: ChatAssetKey, spec: ChatAssetSpec): Drawable? {
@@ -125,6 +300,8 @@ open class ChatMessageTextView(context: Context, private val assets: ChatAssetRe
     }
 
     fun recycle() {
+        longPressRunnable?.let(mainHandler::removeCallbacks)
+        longPressRunnable = null
         keys.forEach { assets.removeObserver(it, invalidator) }
         drawables.values.forEach { it.stopIfNeeded(); it.callback = null }
         drawables.clear()
@@ -152,6 +329,8 @@ open class ChatMessageTextView(context: Context, private val assets: ChatAssetRe
     }
 
     override fun onDetachedFromWindow() {
+        longPressRunnable?.let(mainHandler::removeCallbacks)
+        longPressRunnable = null
         keys.forEach { assets.removeObserver(it, invalidator) }
         drawables.values.forEach { it.stopIfNeeded(); it.callback = null }
         super.onDetachedFromWindow()

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatTimelineAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatTimelineAdapter.kt
@@ -5,17 +5,24 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.github.andreyasadchy.xtra.ui.chat.v2.assets.ChatAssetRepository
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatEmoteInteraction
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatGifInteraction
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessageId
 import com.github.andreyasadchy.xtra.ui.chat.v2.presentation.ChatRowUiModel
 
 class ChatTimelineAdapter(
     private val assets: ChatAssetRepository,
     private var textSizeSp: Float,
     private var animateGifs: Boolean,
+    private val onMessageLongClick: ((ChatMessageId) -> Unit)? = null,
+    private val onEmoteClick: ((ChatEmoteInteraction) -> Unit)? = null,
+    private val onGifClick: ((ChatGifInteraction) -> Unit)? = null,
 ) : ListAdapter<ChatRowUiModel, ChatTimelineAdapter.Holder>(DIFF) {
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): Holder = Holder(
         ChatMessageTextView(parent.context, assets).also {
             it.setMessageTextSizeSp(textSizeSp)
             it.setAnimateGifs(animateGifs)
+            it.setInteractionCallbacks(onMessageLongClick, onEmoteClick, onGifClick)
             it.layoutParams = ViewGroup.LayoutParams(-1, -2)
         },
     )

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatV2RendererController.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatV2RendererController.kt
@@ -8,10 +8,14 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.github.andreyasadchy.xtra.ui.chat.v2.assets.ChatAssetRepository
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessageId
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessage
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatEmoteInteraction
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatGifInteraction
 import com.github.andreyasadchy.xtra.ui.chat.v2.presentation.ChatColorResolver
 import com.github.andreyasadchy.xtra.ui.chat.v2.presentation.ChatPresentationResolver
 import com.github.andreyasadchy.xtra.ui.chat.v2.presentation.ChatRowCompiler
 import com.github.andreyasadchy.xtra.ui.chat.v2.presentation.ChatRowUiModel
+import com.github.andreyasadchy.xtra.ui.chat.v2.presentation.ChatPresentationLabels
 import com.github.andreyasadchy.xtra.ui.chat.v2.session.ActiveChatSession
 import com.github.andreyasadchy.xtra.ui.chat.v2.session.ChatSessionManager
 import com.github.andreyasadchy.xtra.ui.chat.ChatRenderStyle
@@ -26,6 +30,19 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+
+internal fun countNewLiveMessages(
+    previousIds: Set<ChatMessageId>?,
+    previousTailId: ChatMessageId?,
+    messages: List<com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessage>,
+): Int {
+    if (previousIds == null || previousTailId == null) return 0
+    val previousTailIndex = messages.indexOfFirst { it.id == previousTailId }
+    if (previousTailIndex == -1) return 0
+    return messages.asSequence()
+        .drop(previousTailIndex + 1)
+        .count { it.id !in previousIds }
+}
 
 /**
  * Bridges a playback-owned v2 session to one disposable RecyclerView renderer.
@@ -48,11 +65,18 @@ class ChatV2RendererController(
     animateGifs: Boolean = true,
     showBadges: Boolean = true,
     enableOverlayEmotes: Boolean = true,
+    firstMessageVisibility: Int = 0,
+    boldNames: Boolean = false,
     timestampFormat: String? = "0",
     showTimestamps: Boolean = false,
     private val readableUsernameColors: Boolean = true,
     private val backgroundColor: Int = 0xFF101010.toInt(),
+    private val presentationLabels: ChatPresentationLabels = ChatPresentationLabels(),
     private val onStateChanged: (ChatViewportState) -> Unit = {},
+    private val onMessageLongClick: (ChatMessage) -> Unit = {},
+    private val onEmoteClick: (ChatEmoteInteraction) -> Unit = {},
+    private val onGifClick: (ChatGifInteraction) -> Unit = {},
+    private val onPublicationChanged: (List<ChatMessage>, List<ChatRowUiModel>) -> Unit = { _, _ -> },
 ) {
     private var renderStyle = ChatRenderStyle(
         textSizeSp = messageTextSizeSp,
@@ -61,15 +85,29 @@ class ChatV2RendererController(
         animateGifs = animateGifs,
         showBadges = showBadges,
         enableOverlayEmotes = enableOverlayEmotes,
+        firstMessageVisibility = firstMessageVisibility,
+        boldNames = boldNames,
         showTimestamps = showTimestamps,
         timestampFormat = timestampFormat,
     )
-    private val adapter = ChatTimelineAdapter(assets, renderStyle.textSizeSp, renderStyle.animateGifs)
+    private val adapter = ChatTimelineAdapter(
+        assets,
+        renderStyle.textSizeSp,
+        renderStyle.animateGifs,
+        onMessageLongClick = { id ->
+            latestPublication?.messages?.firstOrNull { it.id == id }?.let(onMessageLongClick)
+        },
+        onEmoteClick = onEmoteClick,
+        onGifClick = onGifClick,
+    )
     private val viewport = ChatViewportController(recyclerView, initialState)
     private val presentation = createPresentation(readableUsernameColors, backgroundColor, renderStyle)
     private var collectionJob: Job? = null
+    private var styleRefreshJob: Job? = null
+    private var lifecycleOwner: LifecycleOwner? = null
     private var currentKey: com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatSessionKey? = null
     private var previousIds: Set<ChatMessageId>? = null
+    private var previousTailId: ChatMessageId? = null
     private var latestRows: List<ChatRowUiModel> = emptyList()
     private var latestPublication: PresentationPublication? = null
     private val rendererVisible = MutableStateFlow(true)
@@ -85,8 +123,12 @@ class ChatV2RendererController(
     val state: ChatViewportState
         get() = viewport.state
 
+    internal fun currentMessages(): List<ChatMessage> = latestPublication?.messages.orEmpty()
+    internal fun currentRows(): List<ChatRowUiModel> = latestRows
+
     fun attach(owner: LifecycleOwner) {
         collectionJob?.cancel()
+        lifecycleOwner = owner
         collectionJob = owner.lifecycleScope.launch {
             owner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 rendererVisible
@@ -123,6 +165,9 @@ class ChatV2RendererController(
     fun detach() {
         collectionJob?.cancel()
         collectionJob = null
+        styleRefreshJob?.cancel()
+        styleRefreshJob = null
+        lifecycleOwner = null
         rendererVisible.value = false
         for (index in 0 until recyclerView.childCount) {
             (recyclerView.getChildAt(index) as? ChatMessageTextView)?.setRenderingActive(false)
@@ -131,6 +176,7 @@ class ChatV2RendererController(
         adapter.submitList(emptyList())
         latestRows = emptyList()
         previousIds = null
+        previousTailId = null
         currentKey = null
     }
 
@@ -140,14 +186,29 @@ class ChatV2RendererController(
     }
 
     internal fun refreshStyle(style: ChatRenderStyle) {
+        if (style == renderStyle) return
         renderStyle = style
         presentation.replaceCompiler(createPresentationCompiler(style))
         adapter.setMessageTextSizeSp(style.textSizeSp)
         adapter.setAnimateGifs(style.animateGifs)
+        for (index in 0 until recyclerView.childCount) {
+            (recyclerView.getChildAt(index) as? ChatMessageTextView)?.apply {
+                setMessageTextSizeSp(style.textSizeSp)
+                setAnimateGifs(style.animateGifs)
+            }
+        }
         val publication = latestPublication ?: return
-        val rows = publication.messages.map { presentation.resolve(it, publication.catalog) }
-        latestRows = rows
-        adapter.submitList(rows.toList())
+        val owner = lifecycleOwner ?: return
+        styleRefreshJob?.cancel()
+        styleRefreshJob = owner.lifecycleScope.launch {
+            val rows = compileCurrent(publication)
+            withContext(Dispatchers.Main.immediate) {
+                if (!rendererVisible.value || latestPublication !== publication) return@withContext
+                latestRows = rows
+                onPublicationChanged(publication.messages, rows)
+                adapter.submitList(rows.toList())
+            }
+        }
     }
 
     fun jumpToNewest() {
@@ -156,27 +217,46 @@ class ChatV2RendererController(
     }
 
     private suspend fun publish(publication: PresentationPublication) {
-        val rows = withContext(Dispatchers.Default) {
-            publication.messages.map { presentation.resolve(it, publication.catalog) }
-        }
         if (!rendererVisible.value) return
         withContext(Dispatchers.Main.immediate) {
             if (!rendererVisible.value) return@withContext
+            latestPublication = publication
+        }
+        val rows = compileCurrent(publication)
+        if (!rendererVisible.value) return
+        withContext(Dispatchers.Main.immediate) {
+            if (!rendererVisible.value) return@withContext
+            if (latestPublication !== publication) return@withContext
             if (currentKey != publication.key) {
                 if (currentKey != null) viewport.resetForNewSession()
                 currentKey = publication.key
                 previousIds = null
+                previousTailId = null
             }
             latestPublication = publication
             val oldIds = previousIds
             val previousAnchor = if (oldIds == null) null else viewport.captureAnchor(adapter)
-            val appendedCount = oldIds?.let { ids -> rows.count { it.id !in ids } } ?: 0
+            // Reconciliation can insert older messages into the middle/front of the timeline.
+            // Only messages newer than the previous tail are live appends.
+            val appendedCount = countNewLiveMessages(oldIds, previousTailId, publication.messages)
             previousIds = rows.asSequence().map(ChatRowUiModel::id).toSet()
+            previousTailId = publication.messages.lastOrNull()?.id
             latestRows = rows
+            onPublicationChanged(publication.messages, rows)
             adapter.submitList(rows.toList()) {
                 viewport.onSnapshotCommitted(previousAnchor, rows, appendedCount)
                 onStateChanged(viewport.state)
             }
+        }
+    }
+
+    private suspend fun compileCurrent(publication: PresentationPublication): List<ChatRowUiModel> {
+        while (true) {
+            val compiler = presentation.snapshot()
+            val rows = withContext(Dispatchers.Default) {
+                publication.messages.map { compiler.resolve(it, publication.catalog) }
+            }
+            if (presentation.isCurrent(compiler)) return rows
         }
     }
 
@@ -190,12 +270,15 @@ class ChatV2RendererController(
             badgeHeightPx = style.badgeHeightPx,
             showBadges = style.showBadges,
             enableOverlayEmotes = style.enableOverlayEmotes,
+            firstMessageVisibility = style.firstMessageVisibility,
+            boldNames = style.boldNames,
             timestampText = if (style.showTimestamps) {
                 { timestamp -> com.github.andreyasadchy.xtra.util.TwitchApiHelper.getTimestamp(timestamp, style.timestampFormat) }
             } else {
                 { null }
             },
             background = { background },
+            labels = presentationLabels,
         )
 
     private fun ActiveChatSession.presentationFlow() =

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/LandscapeChatWidth.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/LandscapeChatWidth.kt
@@ -1,9 +1,21 @@
 package com.github.andreyasadchy.xtra.ui.player
 
+import kotlin.math.roundToInt
+
 internal fun clampLandscapeChatWidth(
     configuredWidth: Int,
     availableWidth: Int,
 ): Int {
     if (configuredWidth <= 0) return 0
     return if (availableWidth > 0) configuredWidth.coerceAtMost(availableWidth) else configuredWidth
+}
+
+internal fun landscapeChatWidthForAvailableWidth(
+    availableWidth: Int,
+    percentage: Int,
+): Int {
+    if (availableWidth <= 0 || percentage <= 0) return 0
+    return (availableWidth * percentage / 100f)
+        .roundToInt()
+        .coerceIn(1, availableWidth)
 }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/Media3PlayerFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/Media3PlayerFragment.kt
@@ -1928,10 +1928,10 @@ abstract class Media3PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFr
 
     private fun effectiveLandscapeChatWidth(): Int {
         if (chatWidthLandscape <= 0) return 0
-        if (!isMaximized || resizeMode != AspectRatioFrameLayout.RESIZE_MODE_FIT) return chatWidthLandscape
-
         val availableWidth = binding.slidingLayout.width - binding.slidingLayout.paddingLeft - binding.slidingLayout.paddingRight
-        return clampLandscapeChatWidth(chatWidthLandscape, availableWidth)
+        if (availableWidth <= 0) return chatWidthLandscape
+        val percentage = requireContext().prefs().getInt(C.CHAT_WIDTH_PERCENT, 30)
+        return landscapeChatWidthForAvailableWidth(availableWidth, percentage)
     }
 
     protected fun setQualityButtonColor(color: Int) {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/PlayerFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/PlayerFragment.kt
@@ -2541,10 +2541,10 @@ abstract class PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFragment
 
     private fun effectiveLandscapeChatWidth(): Int {
         if (chatWidthLandscape <= 0) return 0
-        if (!isMaximized || resizeMode != AspectRatioFrameLayout.RESIZE_MODE_FIT) return chatWidthLandscape
-
         val availableWidth = binding.slidingLayout.width - binding.slidingLayout.paddingLeft - binding.slidingLayout.paddingRight
-        return clampLandscapeChatWidth(chatWidthLandscape, availableWidth)
+        if (availableWidth <= 0) return chatWidthLandscape
+        val percentage = requireContext().prefs().getInt(C.CHAT_WIDTH_PERCENT, 30)
+        return landscapeChatWidthForAvailableWidth(availableWidth, percentage)
     }
 
     protected fun setQualityButtonColor(color: Int) {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/NetworkUtils.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/NetworkUtils.kt
@@ -659,4 +659,12 @@ object NetworkUtils {
                 },
             )
         }
+
+    suspend fun Call.executeAsyncChecked(): Response {
+        val response = executeAsync()
+        if (response.isSuccessful) return response
+        val statusCode = response.code
+        response.close()
+        throw HttpStatusException(statusCode)
+    }
 }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/chat/ChatUtils.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/chat/ChatUtils.kt
@@ -32,7 +32,7 @@ object ChatUtils {
                 index = next
                 buildMap {
                     message.substring(start, index).split(';').forEach { tag ->
-                        val split = tag.split('=')
+                        val split = tag.split('=', limit = 2)
                         val key = split.getOrNull(0)
                         val value = split.getOrNull(1)
                         if (key != null && !value.isNullOrEmpty()) {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/chat/ChatWriteIRCSocket.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/chat/ChatWriteIRCSocket.kt
@@ -93,10 +93,12 @@ class ChatWriteIRCSocket(
         writer?.write(message + System.lineSeparator())
     }
 
-    suspend fun send(message: CharSequence, replyId: String?) = withContext(Dispatchers.IO) {
+    suspend fun send(message: CharSequence, replyId: String?): Boolean = withContext(Dispatchers.IO) {
+        if (writer == null) return@withContext false
         val reply = replyId?.let { "@reply-parent-msg-id=${it} " } ?: ""
         write("${reply}PRIVMSG #$channelLogin :$message")
-        writer?.flush()
+        writer!!.flush()
+        true
     }
 
     suspend fun disconnect(job: Job?) = withContext(Dispatchers.IO) {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/chat/ChatWriteWebSocket.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/chat/ChatWriteWebSocket.kt
@@ -57,9 +57,10 @@ class ChatWriteWebSocket(
         }
     }
 
-    suspend fun send(message: CharSequence, replyId: String?) = withContext(Dispatchers.IO) {
+    suspend fun send(message: CharSequence, replyId: String?): Boolean = withContext(Dispatchers.IO) {
         val reply = replyId?.let { "@reply-parent-msg-id=${it} " } ?: ""
         webSocket?.write("${reply}PRIVMSG #$channelLogin :$message")
+        webSocket != null
     }
 
     private inner class WebSocketListener : WebSocket.Listener {

--- a/app/src/main/res/drawable/ic_chat_reply.xml
+++ b/app/src/main/res/drawable/ic_chat_reply.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M10,9V5l-7,7 7,7v-4.1c5,0 8.5,1.6 11,5.1 -1,-5 -4,-10 -11,-11z" />
+</vector>

--- a/app/src/main/res/drawable/ic_chat_speaker_muted.xml
+++ b/app/src/main/res/drawable/ic_chat_speaker_muted.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M3,9v6h4l5,4V5L7,9H3zM16.5,12c0,-1.77 -1,-3.29 -2.5,-4.05v8.1c1.5,-0.76 2.5,-2.28 2.5,-4.05zM18,3.27l-1.41,1.41C18.29,6.13 19,8 19,10s-0.71,3.87 -2.41,5.32L18,16.73C20.07,14.87 21,12.54 21,10s-0.93,-4.87 -3,-6.73zM14.27,14.27L12.86,12.86 11.45,11.45 10.04,10.04 8.63,8.63 7.22,7.22 5.81,5.81 4.4,4.4 3.39,5.41 4.4,6.42 5.98,8 7.39,9.41 8.8,10.82 10.21,12.23 11.62,13.64 13.03,15.05 14.44,16.46z" />
+</vector>

--- a/app/src/main/res/layout/fragment_chat.xml
+++ b/app/src/main/res/layout/fragment_chat.xml
@@ -324,8 +324,8 @@
         <LinearLayout
             android:id="@+id/messageView"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:animateLayoutChanges="true"
+            android:layout_height="48dp"
+            android:baselineAligned="false"
             android:orientation="horizontal"
             android:visibility="gone"
             app:layout_constraintBottom_toTopOf="@id/emoteMenu"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -732,6 +732,7 @@
     <string name="chat_timeout">%1$s has been timed out for %2$s.</string>
     <string name="chat_ban">%s has been permanently banned.</string>
     <string name="chat_clearmsg">Message deleted from %1$s\: %2$s</string>
+    <string name="chat_message_deleted" translatable="false">Message deleted.</string>
     <string name="chat_first">First Time Chatter</string>
     <string name="always">Always</string>
     <string name="local">Local</string>
@@ -747,6 +748,7 @@
     <string name="created_at">Created at %s</string>
     <string name="user_card_created">Account created %1$s</string>
     <string name="user_card_following_since">Following since %1$s</string>
+    <string name="user_card_subscribed">Subscribed</string>
     <string name="user_card_badges">Badges</string>
     <string name="user_card_view_all">View all (%1$d)</string>
     <string name="user_card_show_less">Show less</string>

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/ChatComposerVisibilityTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/ChatComposerVisibilityTest.kt
@@ -1,0 +1,17 @@
+package com.github.andreyasadchy.xtra.ui.chat
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ChatComposerVisibilityTest {
+    @Test
+    fun hiddenChatBarPreferenceStaysHiddenInSlidingPlayerLayout() {
+        assertFalse(shouldShowChatComposer(true, true, false))
+    }
+
+    @Test
+    fun enabledComposerIsVisibleWhenPreferenceAllowsIt() {
+        assertTrue(shouldShowChatComposer(true, true, true))
+    }
+}

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/ChatPickerCatalogTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/ChatPickerCatalogTest.kt
@@ -1,0 +1,71 @@
+package com.github.andreyasadchy.xtra.ui.chat
+
+import com.github.andreyasadchy.xtra.model.chat.Emote
+import com.github.andreyasadchy.xtra.model.chat.FavoriteEmote
+import com.github.andreyasadchy.xtra.model.chat.FavoriteEmoteCatalog
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ChatPickerCatalogTest {
+    @Test
+    fun v2ProjectionKeepsTwitchAndThirdPartyEmotesForEveryPickerSection() {
+        val subscriber = Emote(name = "sub", id = "sub-id")
+        val sevenTv = Emote(
+            name = "party",
+            id = "7tv-id",
+            source = Emote.CHANNEL_STV,
+        )
+        val catalog = ChatViewModel.PickerCatalog(
+            twitch = listOf(subscriber),
+            thirdParty = listOf(sevenTv),
+        )
+
+        assertEquals(listOf(subscriber, sevenTv), catalog.all)
+        assertTrue(catalog.twitch.any { it.name == "sub" })
+        assertTrue(catalog.thirdParty.any { it.name == "party" })
+    }
+
+    @Test
+    fun v2ThirdPartyIdentityResolvesFavoritesAndRecents() {
+        val sevenTv = Emote(name = "party", id = "7tv-id", source = Emote.CHANNEL_STV)
+        val catalog = ChatViewModel.PickerCatalog(emptyList(), listOf(sevenTv))
+        val favorite = FavoriteEmote("SEVENTV", "7tv-id", favoritedAt = 1L)
+
+        assertEquals(
+            listOf(sevenTv),
+            FavoriteEmoteCatalog.availableFavorites(listOf(favorite), catalog.all),
+        )
+        assertEquals(sevenTv, catalog.all.single { it.name == "party" })
+    }
+
+    @Test
+    fun v2ThirdPartyProjectionKeepsPersonalSevenTvEmotes() {
+        val personal = Emote(
+            name = "personalParty",
+            id = "personal-7tv-id",
+            source = Emote.PERSONAL_STV,
+        )
+
+        assertEquals(
+            listOf(personal),
+            mergePickerThirdPartyEmotes(listOf(personal), emptyList()),
+        )
+    }
+
+    @Test
+    fun initialPersonalSevenTvHydrationMakesTheRestEmotesPickerEligible() {
+        var userSetId: String? = null
+        var personalEmoteSets = emptyMap<String, List<Emote>>()
+        assertTrue(personalSevenTvEmotesForPicker(userSetId, personalEmoteSets[userSetId]).isEmpty())
+
+        userSetId = "personal-set-id"
+        personalEmoteSets = mapOf(
+            userSetId to listOf(Emote(name = "personalParty", id = "personal-7tv-id")),
+        )
+        val hydrated = personalSevenTvEmotesForPicker(userSetId, personalEmoteSets[userSetId])
+
+        assertEquals(Emote.PERSONAL_STV, hydrated.single().source)
+        assertEquals("personal-7tv-id", hydrated.single().id)
+    }
+}

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/ChatViewModelTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/ChatViewModelTest.kt
@@ -1,10 +1,17 @@
 package com.github.andreyasadchy.xtra.ui.chat
 
 import com.github.andreyasadchy.xtra.model.chat.ChatMessage
+import com.github.andreyasadchy.xtra.repository.parseSTVEntitledEmoteSetIds
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessage as V2ChatMessage
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessageId
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessageKind
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatReply
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatUser
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.json.JSONObject
 import com.github.andreyasadchy.xtra.ui.chat.v2.session.LiveChatSessionSpec
 
 class ChatViewModelTest {
@@ -140,4 +147,70 @@ class ChatViewModelTest {
         assertFalse(shouldSynchronizeChatSnapshot(displayedRevision = 20, snapshotRevision = 20))
         assertFalse(shouldSynchronizeChatSnapshot(displayedRevision = 21, snapshotRevision = 20))
     }
+
+    @Test
+    fun v2UserHistoryUsesIdAndIncludesReplyParents() {
+        val selected = v2Message("selected", ChatUser("user-1", "alice", "Alice", null))
+        val sameUser = v2Message("same", ChatUser("user-1", "different-login", "Alice", null))
+        val otherUser = v2Message("other", ChatUser("user-2", "alice", "Alice", null))
+        val replyToUser = v2Message(
+            "reply",
+            ChatUser("user-2", "bob", "Bob", null),
+            ChatReply(
+                parentMessageId = ChatMessageId("selected"),
+                parentMessageBody = "hello",
+                parentUserId = "user-1",
+                parentUserName = "Alice",
+                parentUserLogin = "alice",
+                threadMessageId = null,
+                threadUserId = null,
+                threadUserName = null,
+                threadUserLogin = null,
+            ),
+        )
+
+        val history = listOf(selected, sameUser, otherUser, replyToUser)
+        assertEquals(
+            listOf("selected", "same", "reply"),
+            history.filter { matchesV2MessageUser(it, selected) }.map { it.id.value },
+        )
+    }
+
+    @Test
+    fun v2UserHistoryFallsBackToLoginWhenSelectedIdIsMissing() {
+        val selected = v2Message("selected", ChatUser(null, "Alice", "Alice", null))
+        val sameLogin = v2Message("same", ChatUser("user-1", "alice", "Alice", null))
+        val other = v2Message("other", ChatUser("user-2", "bob", "Bob", null))
+
+        assertEquals(
+            listOf("selected", "same"),
+            listOf(selected, sameLogin, other)
+                .filter { matchesV2MessageUser(it, selected) }
+                .map { it.id.value },
+        )
+    }
+
+    @Test
+    fun personalSevenTvHydrationUsesEntitledSetIds() {
+        val response = JSONObject(
+            """
+            {"data":{"userByConnection":{"emote_sets":[
+              {"id":"personal-set"},{"id":"special-set"}
+            ]}}}
+            """.trimIndent(),
+        ).toString()
+
+        assertEquals(listOf("personal-set", "special-set"), parseSTVEntitledEmoteSetIds(response))
+    }
+
+    private fun v2Message(id: String, user: ChatUser, reply: ChatReply? = null) = V2ChatMessage(
+        id = ChatMessageId(id),
+        channelId = "channel",
+        timestampMs = 1,
+        user = user,
+        badges = emptyList(),
+        segments = emptyList(),
+        kind = ChatMessageKind.CHAT,
+        reply = reply,
+    )
 }

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/ChatWriteTransportDecisionTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/ChatWriteTransportDecisionTest.kt
@@ -1,0 +1,39 @@
+package com.github.andreyasadchy.xtra.ui.chat
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ChatWriteTransportDecisionTest {
+    @Test
+    fun v2ApiDisabledStillStartsWriteTransportWhenEventSubIsEnabled() {
+        assertTrue(
+            shouldStartLegacyChatWriteTransport(
+                startMessageTransport = false,
+                startWriteTransport = true,
+                readOnly = false,
+                isLoggedIn = true,
+                useEventSubChat = true,
+                hasGqlToken = true,
+                hasHelixToken = true,
+                useApiChatMessages = false,
+            ),
+        )
+    }
+
+    @Test
+    fun legacyEventSubReadStillDoesNotStartTheLegacyWriteSocket() {
+        assertFalse(
+            shouldStartLegacyChatWriteTransport(
+                startMessageTransport = true,
+                startWriteTransport = true,
+                readOnly = false,
+                isLoggedIn = true,
+                useEventSubChat = true,
+                hasGqlToken = true,
+                hasHelixToken = true,
+                useApiChatMessages = false,
+            ),
+        )
+    }
+}

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/ComposerOverlayStateStoreTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/ComposerOverlayStateStoreTest.kt
@@ -1,0 +1,87 @@
+package com.github.andreyasadchy.xtra.ui.chat
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ComposerOverlayStateStoreTest {
+    private data class RestoreState(
+        val draft: String,
+        val selection: Int,
+        val replyId: String?,
+    )
+
+    @Test
+    fun unsentRewardInputSurvivesRecreation() {
+        val store = ComposerOverlayStateStore<String, RestoreState>()
+        val restore = RestoreState("normal draft", 6, "reply-1")
+
+        store.open("reward", restore)
+        store.set(
+            captureComposerOverlaySnapshot(
+                overlay = "reward",
+                existing = store.active,
+                pendingRestoreState = null,
+                pendingInput = null,
+                currentInput = "reward text",
+                submissionPending = false,
+            )!!,
+        )
+
+        // This is the state that onViewCreated() reads after onDestroyView().
+        val recreated = store.active
+        assertNotNull(recreated)
+        assertEquals("reward", recreated?.overlay)
+        assertEquals("reward text", recreated?.input)
+        assertFalse(recreated?.submissionPending ?: true)
+        assertEquals(restore, recreated?.restoreState)
+    }
+
+    @Test
+    fun pendingStreakRemainsLockedAndFailedStreakCanRestoreUnderlyingComposer() {
+        val store = ComposerOverlayStateStore<String, RestoreState>()
+        val restore = RestoreState("reply draft", 4, "reply-2")
+
+        store.open("streak", restore)
+        val pending = store.submit("streak text")
+        assertTrue(pending?.submissionPending == true)
+        assertEquals("streak text", pending?.input)
+        assertEquals(restore, pending?.restoreState)
+
+        store.set(
+            captureComposerOverlaySnapshot(
+                overlay = "streak",
+                existing = store.active,
+                pendingRestoreState = pending?.restoreState,
+                pendingInput = pending?.input,
+                currentInput = "",
+                submissionPending = true,
+            )!!,
+        )
+        val recreated = store.active
+        assertTrue(recreated?.submissionPending == true)
+        assertEquals("streak text", recreated?.input)
+
+        val failed = store.markFailed("streak text")
+        assertFalse(failed?.submissionPending ?: true)
+        assertEquals("streak text", failed?.input)
+
+        store.set(
+            captureComposerOverlaySnapshot(
+                overlay = "streak",
+                existing = store.active,
+                pendingRestoreState = null,
+                pendingInput = null,
+                currentInput = failed?.input,
+                submissionPending = false,
+            )!!,
+        )
+        assertFalse(store.active?.submissionPending ?: true)
+        assertEquals("streak text", store.active?.input)
+        assertEquals(restore, store.clear())
+        assertNull(store.active)
+    }
+}

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/MessageClickedChatAdapterTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/MessageClickedChatAdapterTest.kt
@@ -1,0 +1,27 @@
+package com.github.andreyasadchy.xtra.ui.chat
+
+import com.github.andreyasadchy.xtra.model.chat.ChatMessage
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MessageClickedChatAdapterTest {
+    @Test
+    fun nullIdLegacyRowsUseObjectIdentity() {
+        val selected = ChatMessage(message = "selected")
+        val other = ChatMessage(message = "other")
+
+        assertTrue(isChatPopupMessageSelected(selected, null, selected))
+        assertFalse(isChatPopupMessageSelected(other, null, selected))
+    }
+
+    @Test
+    fun v2RowsUseTheirStableId() {
+        val selected = ChatMessage(id = "message-1")
+        val replacement = ChatMessage(id = "message-1")
+        val other = ChatMessage(id = "message-2")
+
+        assertTrue(isChatPopupMessageSelected(replacement, "message-1", selected))
+        assertFalse(isChatPopupMessageSelected(other, "message-1", selected))
+    }
+}

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatCatalogRepositoryTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatCatalogRepositoryTest.kt
@@ -10,6 +10,7 @@ import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatCatalogSource
 import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatCatalogState
 import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatEmoteScope
 import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ScopeUpdate
+import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ScopedEmoteCatalog
 import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatAssetProvider
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatAssetKey
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatAssetSpec
@@ -33,16 +34,81 @@ import java.util.concurrent.atomic.AtomicInteger
 
 class ChatCatalogRepositoryTest {
     @Test
-    fun failedChannelScopeKeepsLastGoodChannelEmotesAndRetries() = runBlocking {
-        val oldGlobal = emote("old-global", ChatAssetProvider.SEVEN_TV).copy(scope = ChatEmoteScope.GLOBAL)
-        val oldChannel = emote("old-channel", ChatAssetProvider.SEVEN_TV).copy(scope = ChatEmoteScope.CHANNEL)
-        val newGlobal = emote("new-global", ChatAssetProvider.SEVEN_TV).copy(scope = ChatEmoteScope.GLOBAL)
-        val retryStarted = CompletableDeferred<Unit>()
+    fun thirdPartyFailureRecoveryIsPublishedWhenBadgesKeepFailing() = runBlocking {
+        val attempts = AtomicInteger()
+        val firstWait = CompletableDeferred<Unit>()
+        val releaseRetry = CompletableDeferred<Unit>()
         val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
         val repository = ChatCatalogRepository(
             scope = scope,
             source = ChatCatalogSource {
-                retryStarted.complete(Unit)
+                if (attempts.incrementAndGet() == 1) {
+                    ChatCatalogLoadResult(
+                        twitch = ChatCatalogProviderUpdate(emptyMap()),
+                        badges = null,
+                    )
+                } else {
+                    ChatCatalogLoadResult(
+                        twitch = ChatCatalogProviderUpdate(emptyMap()),
+                        sevenTv = ChatCatalogProviderUpdate(emptyMap()),
+                        bttv = ChatCatalogProviderUpdate(emptyMap()),
+                        ffz = ChatCatalogProviderUpdate(emptyMap()),
+                        badges = null,
+                    )
+                }
+            },
+            wait = { delayMs ->
+                if (delayMs == 1_000L) {
+                    firstWait.complete(Unit)
+                    releaseRetry.await()
+                } else {
+                    awaitCancellation()
+                }
+            },
+        )
+        repository.refresh()
+        withTimeout(1_000) { firstWait.await() }
+        assertTrue(repository.state.value.thirdPartyRefreshFailed)
+        releaseRetry.complete(Unit)
+        withTimeout(1_000) {
+            while (attempts.get() < 2 || repository.state.value.thirdPartyRefreshFailed) delay(1)
+        }
+
+        assertTrue(repository.state.value.refreshFailed)
+        assertFalse(repository.state.value.thirdPartyRefreshFailed)
+        repository.close()
+        scope.cancel()
+    }
+
+    @Test
+    fun badgeFailureDoesNotMarkThirdPartyPickerAsFailed() {
+        val result = ChatCatalogLoadResult(
+            sevenTv = ChatCatalogProviderUpdate(emptyMap()),
+            bttv = ChatCatalogProviderUpdate(emptyMap()),
+            ffz = ChatCatalogProviderUpdate(emptyMap()),
+            // Badges are unrelated to the third-party emote picker.
+            badges = null,
+        )
+
+        assertFalse(result.hasFailedThirdPartyProvider)
+        assertTrue(result.hasFailedProvider)
+    }
+
+    @Test
+    fun failedChannelScopeKeepsLastGoodChannelEmotesAndRetries() = runBlocking {
+        val oldGlobal = emote("old-global", ChatAssetProvider.SEVEN_TV).copy(scope = ChatEmoteScope.GLOBAL)
+        val oldChannel = emote("old-channel", ChatAssetProvider.SEVEN_TV).copy(scope = ChatEmoteScope.CHANNEL)
+        val newGlobal = emote("new-global", ChatAssetProvider.SEVEN_TV).copy(scope = ChatEmoteScope.GLOBAL)
+        val attempts = AtomicInteger()
+        val waitStarted = CompletableDeferred<Unit>()
+        val releaseRetry = CompletableDeferred<Unit>()
+        val retryInvocation = CompletableDeferred<Unit>()
+        val waits = CopyOnWriteArrayList<Long>()
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val repository = ChatCatalogRepository(
+            scope = scope,
+            source = ChatCatalogSource {
+                if (attempts.incrementAndGet() == 2) retryInvocation.complete(Unit)
                 ChatCatalogLoadResult(
                     sevenTv = ChatCatalogProviderUpdate(
                         value = emptyMap(),
@@ -54,18 +120,26 @@ class ChatCatalogRepositoryTest {
             cache = object : ChatCatalogCache {
                 override suspend fun read() = ChatCatalogSnapshot(
                     revision = 1,
-                    sevenTv = mapOf("old-global" to oldGlobal, "old-channel" to oldChannel),
+                    sevenTv = ScopedEmoteCatalog(global = mapOf("old-global" to oldGlobal), channel = mapOf("old-channel" to oldChannel)),
                 )
                 override suspend fun write(snapshot: ChatCatalogSnapshot) = Unit
             },
-            wait = { awaitCancellation() },
+            wait = { delayMs ->
+                if (waits.isEmpty()) {
+                    waits += delayMs
+                    waitStarted.complete(Unit)
+                    releaseRetry.await()
+                } else {
+                    awaitCancellation()
+                }
+            },
         )
 
         withTimeout(1_000) {
             while (!repository.state.value.hydrated) delay(1)
         }
         repository.refresh()
-        withTimeout(1_000) { retryStarted.await() }
+        withTimeout(1_000) { waitStarted.await() }
         withTimeout(1_000) {
             while (repository.state.value.snapshot.sevenTv["new-global"] != newGlobal) delay(1)
         }
@@ -73,102 +147,139 @@ class ChatCatalogRepositoryTest {
         assertEquals(newGlobal, repository.state.value.snapshot.sevenTv["new-global"])
         assertEquals(oldChannel, repository.state.value.snapshot.sevenTv["old-channel"])
         assertTrue(repository.state.value.refreshFailed)
+        assertEquals(1, attempts.get())
+        releaseRetry.complete(Unit)
+        withTimeout(1_000) { retryInvocation.await() }
+        assertEquals(2, attempts.get())
+        assertEquals(listOf(1_000L), waits)
         repository.close()
         scope.cancel()
     }
 
     @Test
-    fun failedChannelScopeKeepsSchemaV1CombinedCacheEntries() = runBlocking {
-        val legacyChannel = emote("legacy-channel", ChatAssetProvider.SEVEN_TV)
-            .copy(scope = ChatEmoteScope.LEGACY_COMBINED)
-        val newGlobal = emote("new-global", ChatAssetProvider.SEVEN_TV)
-            .copy(scope = ChatEmoteScope.GLOBAL)
+    fun sameAliasKeepsLastGoodChannelWhenGlobalRefreshSucceeds() = runBlocking {
+        val oldChannel = emote("same-channel", ChatAssetProvider.SEVEN_TV).copy(
+            name = "same",
+            scope = ChatEmoteScope.CHANNEL,
+        )
+        val newGlobal = emote("same-global", ChatAssetProvider.SEVEN_TV).copy(
+            name = "same",
+            scope = ChatEmoteScope.GLOBAL,
+        )
         val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
         val repository = ChatCatalogRepository(
             scope = scope,
             source = ChatCatalogSource {
                 ChatCatalogLoadResult(
+                    twitch = ChatCatalogProviderUpdate(emptyMap()),
                     sevenTv = ChatCatalogProviderUpdate(
-                        value = emptyMap(),
-                        global = ScopeUpdate.Success(mapOf("new-global" to newGlobal)),
+                        value = mapOf("same" to newGlobal),
+                        global = ScopeUpdate.Success(mapOf("same" to newGlobal)),
                         channel = ScopeUpdate.Failed,
                     ),
+                    bttv = ChatCatalogProviderUpdate(emptyMap()),
+                    ffz = ChatCatalogProviderUpdate(emptyMap()),
+                    badges = ChatCatalogProviderUpdate(emptyMap()),
                 )
             },
             cache = object : ChatCatalogCache {
                 override suspend fun read() = ChatCatalogSnapshot(
                     revision = 1,
-                    sevenTv = mapOf("legacy-channel" to legacyChannel),
+                    sevenTv = ScopedEmoteCatalog(
+                        global = mapOf("same" to emote("same-global-old", ChatAssetProvider.SEVEN_TV).copy(name = "same", scope = ChatEmoteScope.GLOBAL)),
+                        channel = mapOf("same" to oldChannel),
+                    ),
                 )
-
                 override suspend fun write(snapshot: ChatCatalogSnapshot) = Unit
             },
             wait = { awaitCancellation() },
         )
 
-        withTimeout(1_000) {
-            while (!repository.state.value.hydrated) delay(1)
-        }
+        withTimeout(1_000) { while (!repository.state.value.hydrated) delay(1) }
         repository.refresh()
         withTimeout(1_000) {
-            while (repository.state.value.snapshot.sevenTv["new-global"] != newGlobal) delay(1)
+            while (repository.state.value.snapshot.sevenTv.global["same"] != newGlobal) delay(1)
         }
 
-        assertEquals(legacyChannel, repository.state.value.snapshot.sevenTv["legacy-channel"])
-        assertEquals(newGlobal, repository.state.value.snapshot.sevenTv["new-global"])
+        assertEquals(oldChannel, repository.state.value.snapshot.sevenTv.channel["same"])
+        assertEquals(oldChannel, repository.state.value.snapshot.sevenTv["same"])
         repository.close()
         scope.cancel()
     }
 
     @Test
-    fun successfulGlobalAndChannelRefreshRetiresLegacyCombinedEntries() = runBlocking {
-        val legacyGlobalAlias = emote("A", ChatAssetProvider.SEVEN_TV)
-            .copy(scope = ChatEmoteScope.LEGACY_COMBINED)
-        val legacyChannelAlias = emote("B", ChatAssetProvider.SEVEN_TV)
-            .copy(scope = ChatEmoteScope.LEGACY_COMBINED)
-        val staleLegacy = emote("RemovedOldEmote", ChatAssetProvider.SEVEN_TV)
-            .copy(scope = ChatEmoteScope.LEGACY_COMBINED)
-        val currentGlobal = emote("A", ChatAssetProvider.SEVEN_TV)
-            .copy(scope = ChatEmoteScope.GLOBAL)
-        val currentChannel = emote("B", ChatAssetProvider.SEVEN_TV)
-            .copy(scope = ChatEmoteScope.CHANNEL)
+    fun sameAliasKeepsLastGoodGlobalWhenChannelBecomesEmpty() = runBlocking {
+        val oldGlobal = emote("same-global", ChatAssetProvider.BTTV).copy(
+            name = "same",
+            scope = ChatEmoteScope.GLOBAL,
+        )
+        val oldChannel = emote("same-channel", ChatAssetProvider.BTTV).copy(
+            name = "same",
+            scope = ChatEmoteScope.CHANNEL,
+        )
         val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
         val repository = ChatCatalogRepository(
             scope = scope,
             source = ChatCatalogSource {
                 ChatCatalogLoadResult(
-                    sevenTv = ChatCatalogProviderUpdate(
-                        value = mapOf("A" to currentGlobal, "B" to currentChannel),
-                        global = ScopeUpdate.Success(mapOf("A" to currentGlobal)),
-                        channel = ScopeUpdate.Success(mapOf("B" to currentChannel)),
+                    twitch = ChatCatalogProviderUpdate(emptyMap()),
+                    sevenTv = ChatCatalogProviderUpdate(emptyMap()),
+                    bttv = ChatCatalogProviderUpdate(
+                        value = mapOf("same" to oldGlobal),
+                        global = ScopeUpdate.Failed,
+                        channel = ScopeUpdate.Success(emptyMap()),
                     ),
+                    ffz = ChatCatalogProviderUpdate(emptyMap()),
+                    badges = ChatCatalogProviderUpdate(emptyMap()),
                 )
             },
             cache = object : ChatCatalogCache {
                 override suspend fun read() = ChatCatalogSnapshot(
                     revision = 1,
-                    sevenTv = mapOf(
-                        "A" to legacyGlobalAlias,
-                        "B" to legacyChannelAlias,
-                        "RemovedOldEmote" to staleLegacy,
+                    bttv = ScopedEmoteCatalog(
+                        global = mapOf("same" to oldGlobal),
+                        channel = mapOf("same" to oldChannel),
                     ),
                 )
+                override suspend fun write(snapshot: ChatCatalogSnapshot) = Unit
+            },
+            wait = { awaitCancellation() },
+        )
 
+        withTimeout(1_000) { while (!repository.state.value.hydrated) delay(1) }
+        repository.refresh()
+        withTimeout(1_000) {
+            while (repository.state.value.snapshot.bttv.channel.isNotEmpty()) delay(1)
+        }
+
+        assertEquals(oldGlobal, repository.state.value.snapshot.bttv.global["same"])
+        assertEquals(oldGlobal, repository.state.value.snapshot.bttv["same"])
+        repository.close()
+        scope.cancel()
+    }
+
+    @Test
+    fun scopedCacheRestoresShadowedAliasesAfterRestart() = runBlocking {
+        val global = emote("global", ChatAssetProvider.FFZ).copy(name = "same", scope = ChatEmoteScope.GLOBAL)
+        val channel = emote("channel", ChatAssetProvider.FFZ).copy(name = "same", scope = ChatEmoteScope.CHANNEL)
+        val cached = ChatCatalogSnapshot(
+            revision = 5,
+            ffz = ScopedEmoteCatalog(global = mapOf("same" to global), channel = mapOf("same" to channel)),
+        )
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val repository = ChatCatalogRepository(
+            scope = scope,
+            source = ChatCatalogSource { ChatCatalogLoadResult() },
+            cache = object : ChatCatalogCache {
+                override suspend fun read() = cached
                 override suspend fun write(snapshot: ChatCatalogSnapshot) = Unit
             },
         )
 
-        withTimeout(1_000) {
-            while (!repository.state.value.hydrated) delay(1)
-        }
-        repository.refresh()
-        withTimeout(1_000) {
-            while (repository.state.value.snapshot.sevenTv["A"] != currentGlobal) delay(1)
-        }
-
-        assertEquals(currentGlobal, repository.state.value.snapshot.sevenTv["A"])
-        assertEquals(currentChannel, repository.state.value.snapshot.sevenTv["B"])
-        assertTrue("RemovedOldEmote" !in repository.state.value.snapshot.sevenTv)
+        withTimeout(1_000) { while (!repository.state.value.hydrated) delay(1) }
+        assertEquals(global, repository.state.value.snapshot.ffz.global["same"])
+        assertEquals(channel, repository.state.value.snapshot.ffz.channel["same"])
+        assertEquals(channel, repository.state.value.snapshot.ffz["same"])
         repository.close()
         scope.cancel()
     }
@@ -196,7 +307,7 @@ class ChatCatalogRepositoryTest {
             cache = object : ChatCatalogCache {
                 override suspend fun read() = ChatCatalogSnapshot(
                     revision = 1,
-                    bttv = mapOf("global" to oldGlobal, "channel" to oldChannel),
+                    bttv = ScopedEmoteCatalog(global = mapOf("global" to oldGlobal), channel = mapOf("channel" to oldChannel)),
                 )
                 override suspend fun write(snapshot: ChatCatalogSnapshot) = Unit
             },
@@ -206,7 +317,7 @@ class ChatCatalogRepositoryTest {
         withTimeout(1_000) { while (repository.state.value.snapshot.revision < 2) delay(1) }
 
         assertEquals(oldGlobal, repository.state.value.snapshot.bttv["global"])
-        assertTrue("channel" !in repository.state.value.snapshot.bttv)
+        assertTrue("channel" !in repository.state.value.snapshot.bttv.effective)
         assertTrue(!repository.state.value.refreshFailed)
         repository.close()
         scope.cancel()
@@ -218,7 +329,7 @@ class ChatCatalogRepositoryTest {
         val releaseRead = CompletableDeferred<Unit>()
         val cached = ChatCatalogSnapshot(
             revision = 3,
-            sevenTv = mapOf("Party" to emote("party", ChatAssetProvider.SEVEN_TV)),
+            sevenTv = ScopedEmoteCatalog(global = mapOf("Party" to emote("party", ChatAssetProvider.SEVEN_TV))),
         )
         val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
         val repository = ChatCatalogRepository(
@@ -267,7 +378,7 @@ class ChatCatalogRepositoryTest {
         val releaseNetwork = CompletableDeferred<Unit>()
         val cached = ChatCatalogSnapshot(
             revision = 7,
-            sevenTv = mapOf("cached" to emote("cached", ChatAssetProvider.SEVEN_TV)),
+            sevenTv = ScopedEmoteCatalog(global = mapOf("cached" to emote("cached", ChatAssetProvider.SEVEN_TV))),
         )
         val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
         val repository = ChatCatalogRepository(
@@ -328,8 +439,8 @@ class ChatCatalogRepositoryTest {
                     releaseCacheRead.await()
                     return ChatCatalogSnapshot(
                         revision = 4,
-                        sevenTv = mapOf("cached" to emote("cached-seven", ChatAssetProvider.SEVEN_TV)),
-                        bttv = mapOf("cached" to cachedBttv),
+                        sevenTv = ScopedEmoteCatalog(global = mapOf("cached" to emote("cached-seven", ChatAssetProvider.SEVEN_TV))),
+                        bttv = ScopedEmoteCatalog(global = mapOf("cached" to cachedBttv)),
                     )
                 }
 
@@ -365,7 +476,11 @@ class ChatCatalogRepositoryTest {
             source = ChatCatalogSource {
                 val result = ChatCatalogLoadResult(
                     twitch = ChatCatalogProviderUpdate(emptyMap()),
-                    sevenTv = ChatCatalogProviderUpdate(emptyMap()),
+                    sevenTv = ChatCatalogProviderUpdate(
+                        value = emptyMap(),
+                        global = ScopeUpdate.Success(emptyMap()),
+                        channel = ScopeUpdate.Success(emptyMap()),
+                    ),
                     bttv = ChatCatalogProviderUpdate(emptyMap()),
                     ffz = ChatCatalogProviderUpdate(emptyMap()),
                     badges = ChatCatalogProviderUpdate(emptyMap()),
@@ -379,7 +494,12 @@ class ChatCatalogRepositoryTest {
                     releaseCacheRead.await()
                     return ChatCatalogSnapshot(
                         revision = 4,
-                        sevenTv = mapOf("stale" to emote("stale", ChatAssetProvider.SEVEN_TV)),
+                        sevenTv = ScopedEmoteCatalog(
+                            legacyCombined = mapOf(
+                                "stale" to emote("stale", ChatAssetProvider.SEVEN_TV)
+                                    .copy(scope = ChatEmoteScope.LEGACY_COMBINED),
+                            ),
+                        ),
                     )
                 }
 
@@ -393,7 +513,10 @@ class ChatCatalogRepositoryTest {
         releaseCacheRead.complete(Unit)
         delay(50)
 
-        assertTrue(repository.state.value.snapshot.sevenTv.isEmpty())
+        assertTrue(repository.state.value.snapshot.sevenTv.global.isEmpty())
+        assertTrue(repository.state.value.snapshot.sevenTv.channel.isEmpty())
+        assertTrue(repository.state.value.snapshot.sevenTv.legacyCombined.isEmpty())
+        assertTrue("stale" !in repository.state.value.snapshot.sevenTv)
         repository.close()
         scope.cancel()
     }
@@ -414,8 +537,8 @@ class ChatCatalogRepositoryTest {
             cache = object : ChatCatalogCache {
                 override suspend fun read() = ChatCatalogSnapshot(
                     revision = 7,
-                    sevenTv = mapOf("old" to oldSevenTv),
-                    bttv = mapOf("old-bttv" to oldBttv),
+                    sevenTv = ScopedEmoteCatalog(global = mapOf("old" to oldSevenTv)),
+                    bttv = ScopedEmoteCatalog(global = mapOf("old-bttv" to oldBttv)),
                 )
 
                 override suspend fun write(snapshot: ChatCatalogSnapshot) = Unit

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatDomainPresentationTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatDomainPresentationTest.kt
@@ -6,17 +6,21 @@ import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatBadgeRef
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessage
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessageId
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessageKind
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatEmoteInteraction
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatReply
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatSegment
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatUser
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.TwitchChatMessageType
 import com.github.andreyasadchy.xtra.ui.chat.v2.presentation.ChatPiece
+import com.github.andreyasadchy.xtra.ui.chat.v2.presentation.ChatRowBackground
 import com.github.andreyasadchy.xtra.ui.chat.v2.presentation.ChatRowCompiler
 import com.github.andreyasadchy.xtra.ui.chat.v2.presentation.ChatPresentationResolver
 import com.github.andreyasadchy.xtra.ui.chat.v2.presentation.ChatColorResolver
 import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatAssetProvider
 import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatCatalogEmote
 import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatCatalogSnapshot
+import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatEmoteScope
+import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ScopedEmoteCatalog
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -31,7 +35,10 @@ class ChatDomainPresentationTest {
         val gif = row.pieces.filterIsInstance<ChatPiece.Gif>().single()
         assertEquals(url, gif.url)
         assertEquals(url, gif.asset.key.value)
-        assertEquals(28, gif.asset.targetHeight)
+        assertEquals(180, gif.asset.targetHeight)
+        assertEquals("gif-1", gif.interaction?.id)
+        assertEquals("party", gif.interaction?.description)
+        assertEquals(url, gif.interaction?.url)
     }
 
     @Test
@@ -49,6 +56,54 @@ class ChatDomainPresentationTest {
         val row = ChatRowCompiler().compile(message)
         assertEquals(TwitchChatMessageType.GigantifiedEmote, row.twitchType)
         assertEquals(reply, row.reply)
+        assertTrue(row.pieces.filterIsInstance<ChatPiece.Text>().any { it.value.contains("Replying to") })
+    }
+
+    @Test
+    fun firstChatterRewardAndAnnouncementHaveVisiblePresentation() {
+        val first = ChatRowCompiler().compile(
+            message(ChatSegment.Text("hello")).copy(isFirst = true),
+        )
+        assertTrue(first.pieces.filterIsInstance<ChatPiece.Text>().any { it.value.contains("First Time Chatter") })
+        assertEquals(ChatRowBackground.FIRST_CHATTER, first.backgroundStyle)
+
+        val reward = ChatRowCompiler().compile(
+            message(ChatSegment.Text("redeemed message")).copy(rewardId = "reward"),
+        )
+        assertTrue(reward.pieces.filterIsInstance<ChatPiece.Text>().any { it.value.contains("Channel points reward") })
+        assertEquals(ChatRowBackground.REWARD, reward.backgroundStyle)
+
+        val announcement = ChatRowCompiler().compile(
+            message(ChatSegment.Text("announcement")).copy(kind = ChatMessageKind.ANNOUNCEMENT),
+        )
+        assertTrue(announcement.pieces.filterIsInstance<ChatPiece.Text>().any { it.value.contains("Announcement") })
+        assertEquals(ChatRowBackground.NOTICE, announcement.backgroundStyle)
+    }
+
+    @Test
+    fun sharedChatAndWatchStreakRemainVisibleWhenSystemBodyIsUsed() {
+        val message = message(ChatSegment.Text("hello")).copy(
+            kind = ChatMessageKind.NOTICE,
+            noticeType = "watch_streak",
+            systemText = "Viewer is on a streak",
+            watchStreakCount = 7,
+            watchStreakPoints = 700,
+            source = com.github.andreyasadchy.xtra.ui.chat.v2.domain.SharedChatSource(
+                broadcasterId = "source",
+                broadcasterLogin = "source_login",
+                broadcasterName = "Source",
+                messageId = null,
+                badges = emptyList(),
+                sourceOnly = false,
+            ),
+        )
+        val row = ChatRowCompiler().compile(message)
+        val text = row.pieces.filterIsInstance<ChatPiece.Text>().joinToString("") { it.value }
+        assertTrue(text.contains("Watch Streak Reached"))
+        assertTrue(text.contains("7-stream streak"))
+        assertTrue(text.contains("+700"))
+        assertTrue(text.contains("Shared chat from Source"))
+        assertEquals(ChatRowBackground.WATCH_STREAK, row.backgroundStyle)
     }
 
     @Test
@@ -82,11 +137,62 @@ class ChatDomainPresentationTest {
 
         val catalog = ChatCatalogSnapshot(
             revision = 2,
-            sevenTv = mapOf("Party" to emote("Party", ChatAssetProvider.SEVEN_TV)),
+            sevenTv = ScopedEmoteCatalog(global = mapOf("Party" to emote("Party", ChatAssetProvider.SEVEN_TV))),
         )
         val withCatalog = resolver.resolve(message, catalog)
         assertTrue(withCatalog.pieces.any { it is ChatPiece.Emote && it.fallback == "Party" })
         assertEquals(message.id, withCatalog.id)
+    }
+
+    @Test
+    fun thirdPartyEmotePieceRetainsProviderIdentityForInteraction() {
+        val definition = emote("Party", ChatAssetProvider.BTTV).copy(
+            id = "bttv-id",
+            scope = ChatEmoteScope.CHANNEL,
+            animated = true,
+        )
+        val row = ChatRowCompiler().compile(
+            message(ChatSegment.Text("Party")),
+            ChatCatalogSnapshot(
+                1,
+                bttv = ScopedEmoteCatalog(channel = mapOf("Party" to definition)),
+            ),
+        )
+
+        val interaction = row.pieces.filterIsInstance<ChatPiece.Emote>().single().interaction
+        assertEquals(
+            ChatEmoteInteraction(
+                id = "bttv-id",
+                name = "Party",
+                url = "Party",
+                animated = true,
+                provider = ChatAssetProvider.BTTV,
+                scope = ChatEmoteScope.CHANNEL,
+            ),
+            interaction,
+        )
+    }
+
+    @Test
+    fun overlayCompositionKeepsBaseEmoteInteraction() {
+        val baseEmote = emote("Party", ChatAssetProvider.SEVEN_TV).copy(id = "base-id")
+        val modifier = emote("Crown", ChatAssetProvider.SEVEN_TV).copy(
+            id = "modifier-id",
+            zeroWidth = true,
+        )
+        val row = ChatRowCompiler().compile(
+            message(ChatSegment.Text("Party Crown")),
+            ChatCatalogSnapshot(
+                1,
+                sevenTv = ScopedEmoteCatalog(
+                    global = mapOf("Party" to baseEmote, "Crown" to modifier),
+                ),
+            ),
+        )
+        val piece = row.pieces.filterIsInstance<ChatPiece.Emote>().single()
+        assertEquals("base-id", piece.interaction?.id)
+        assertEquals(ChatAssetProvider.SEVEN_TV, piece.interaction?.provider)
+        assertEquals(1, piece.asset.overlays.size)
     }
 
     @Test
@@ -110,7 +216,7 @@ class ChatDomainPresentationTest {
         val modifier = emote("modifier", ChatAssetProvider.SEVEN_TV).copy(zeroWidth = true)
         val catalog = ChatCatalogSnapshot(
             revision = 1,
-            sevenTv = mapOf("ZW" to modifier),
+            sevenTv = ScopedEmoteCatalog(global = mapOf("ZW" to modifier)),
         )
         val nativeThenModifier = message(ChatSegment.Emote(base, "Kappa", false)).copy(
             segments = listOf(ChatSegment.Emote(base, "Kappa", false), ChatSegment.Text(" ZW")),
@@ -120,7 +226,9 @@ class ChatDomainPresentationTest {
         assertEquals(1, nativeEmote.asset.overlays.size)
 
         val thirdPartyRow = ChatPresentationResolver().resolve(message(ChatSegment.Text("Party ZW")), catalog.copy(
-            sevenTv = catalog.sevenTv + ("Party" to emote("Party", ChatAssetProvider.SEVEN_TV)),
+            sevenTv = ScopedEmoteCatalog(
+                global = catalog.sevenTv.effective + ("Party" to emote("Party", ChatAssetProvider.SEVEN_TV)),
+            ),
         ))
         assertEquals(1, thirdPartyRow.pieces.filterIsInstance<ChatPiece.Emote>().single().asset.overlays.size)
     }
@@ -131,10 +239,31 @@ class ChatDomainPresentationTest {
         val seven = emote("same", ChatAssetProvider.SEVEN_TV)
         val bttv = emote("same", ChatAssetProvider.BTTV)
         val ffz = emote("same", ChatAssetProvider.FFZ)
-        val first = ChatPresentationResolver().resolve(message, ChatCatalogSnapshot(1, sevenTv = mapOf("same" to seven), bttv = mapOf("same" to bttv), ffz = mapOf("same" to ffz)))
+        val first = ChatPresentationResolver().resolve(
+            message,
+            ChatCatalogSnapshot(
+                1,
+                sevenTv = ScopedEmoteCatalog(global = mapOf("same" to seven)),
+                bttv = ScopedEmoteCatalog(global = mapOf("same" to bttv)),
+                ffz = ScopedEmoteCatalog(global = mapOf("same" to ffz)),
+            ),
+        )
         assertEquals(seven.asset.key, (first.pieces.single() as ChatPiece.Emote).asset.key)
-        val replaced = ChatPresentationResolver().resolve(message, ChatCatalogSnapshot(2, ffz = mapOf("same" to ffz)))
+        val replaced = ChatPresentationResolver().resolve(message, ChatCatalogSnapshot(2, ffz = ScopedEmoteCatalog(global = mapOf("same" to ffz))))
         assertEquals(ffz.asset.key, (replaced.pieces.single() as ChatPiece.Emote).asset.key)
+    }
+
+    @Test
+    fun scopedNameLookupUsesChannelPrecedenceWithoutRebuildingTheProjection() {
+        val global = emote("global", ChatAssetProvider.SEVEN_TV).copy(name = "same")
+        val channel = emote("channel", ChatAssetProvider.SEVEN_TV).copy(name = "same", scope = ChatEmoteScope.CHANNEL)
+        val scoped = ScopedEmoteCatalog(
+            global = mapOf("same" to global),
+            channel = mapOf("same" to channel),
+        )
+
+        assertEquals(channel, scoped["same"])
+        assertTrue("same" in scoped)
     }
 
     @Test

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatV2PublicationSemanticsTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatV2PublicationSemanticsTest.kt
@@ -1,0 +1,75 @@
+package com.github.andreyasadchy.xtra.ui.chat.v2
+
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessage
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessageId
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessageKind
+import com.github.andreyasadchy.xtra.ui.chat.v2.ui.countNewLiveMessages
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ChatV2PublicationSemanticsTest {
+    @Test
+    fun recoveredOlderHistoryDoesNotCountAsNewLiveMessages() {
+        val visible = (100..200).map(::message)
+        val reconciled = (50..200).map(::message)
+
+        assertEquals(
+            0,
+            countNewLiveMessages(
+                previousIds = visible.map { it.id }.toSet(),
+                previousTailId = visible.last().id,
+                messages = reconciled,
+            ),
+        )
+    }
+
+    @Test
+    fun messageAfterPreviousTailCountsAsNew() {
+        val visible = (100..200).map(::message)
+        val appended = (100..201).map(::message)
+
+        assertEquals(
+            1,
+            countNewLiveMessages(
+                previousIds = visible.map { it.id }.toSet(),
+                previousTailId = visible.last().id,
+                messages = appended,
+            ),
+        )
+    }
+
+    @Test
+    fun messageWithSameTimestampAfterPreviousTailCountsAsNew() {
+        val previous = message("A", 1_000L)
+        val current = listOf(previous, message("B", 1_000L))
+
+        assertEquals(
+            1,
+            countNewLiveMessages(
+                previousIds = setOf(previous.id),
+                previousTailId = previous.id,
+                messages = current,
+            ),
+        )
+    }
+
+    private fun message(index: Int) = ChatMessage(
+        id = ChatMessageId(index.toString()),
+        channelId = "channel",
+        timestampMs = index.toLong(),
+        user = null,
+        badges = emptyList(),
+        segments = emptyList(),
+        kind = ChatMessageKind.CHAT,
+    )
+
+    private fun message(id: String, timestampMs: Long) = ChatMessage(
+        id = ChatMessageId(id),
+        channelId = "channel",
+        timestampMs = timestampMs,
+        user = null,
+        badges = emptyList(),
+        segments = emptyList(),
+        kind = ChatMessageKind.CHAT,
+    )
+}

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/TwitchChatEventParserTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/TwitchChatEventParserTest.kt
@@ -4,6 +4,7 @@ import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatEvent
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatSegment
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.TwitchChatMessageType
 import com.github.andreyasadchy.xtra.ui.chat.v2.transport.TwitchChatEventParser
+import com.github.andreyasadchy.xtra.util.chat.ChatUtils
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -50,7 +51,7 @@ class TwitchChatEventParserTest {
                   {"type":"text","text":" "},
                   {"type":"cheermote","text":"Cheer100","cheermote":{"prefix":"Cheer","bits":100,"tier":1}},
                   {"type":"text","text":" party"},
-                  {"type":"gif","text":"party","gif":{"id":"gif-1","url":"%s"}}
+                  {"type":"gif","text":"party","gif":{"gif_id":"gif-1","url":"%s"}}
                 ]
               }
             }
@@ -70,6 +71,8 @@ class TwitchChatEventParserTest {
         assertTrue(message.source.sourceOnly)
 
         assertTrue(message.segments[0] is ChatSegment.Emote)
+        assertEquals("25", (message.segments[0] as ChatSegment.Emote).interaction?.id)
+        assertEquals("TWITCH", (message.segments[0] as ChatSegment.Emote).interaction?.provider?.name)
         assertEquals("mentioned", (message.segments[2] as ChatSegment.Mention).userId)
         assertEquals(100, (message.segments[4] as ChatSegment.Cheermote).bits)
         val gif = message.segments.last() as ChatSegment.Gif
@@ -94,4 +97,210 @@ class TwitchChatEventParserTest {
         assertEquals(TwitchChatMessageType.Unknown("future_type"), message.twitchType)
         assertEquals(ChatSegment.Text("future text"), message.segments.single())
     }
+
+    @Test
+    fun eventSubKeepsFirstChatterAndWatchStreakMetadata() {
+        val first = JSONObject(
+            """
+            {
+              "broadcaster_user_id":"broadcaster",
+              "chatter_user_id":"chatter",
+              "chatter_user_name":"Viewer",
+              "message_id":"first",
+              "message_type":"user_intro",
+              "message":{"text":"hello","fragments":[{"type":"text","text":"hello"}]}
+            }
+            """.trimIndent(),
+        )
+        val firstMessage = (TwitchChatEventParser.fromEventSub(first, null) as ChatEvent.Message).message
+        assertTrue(firstMessage.isFirst)
+        assertEquals(TwitchChatMessageType.UserIntro, firstMessage.twitchType)
+
+        val streak = JSONObject(
+            """
+            {
+              "broadcaster_user_id":"broadcaster",
+              "chatter_user_id":"chatter",
+              "chatter_user_name":"Viewer",
+              "notice_type":"watch_streak",
+              "system_message":"Viewer is on a streak",
+              "watch_streak":{"streak_count":7,"channel_points_awarded":700}
+            }
+            """.trimIndent(),
+        )
+        val streakMessage = (TwitchChatEventParser.fromEventSub(streak, null, notice = true) as ChatEvent.Message).message
+        assertEquals(7, streakMessage.watchStreakCount)
+        assertEquals(700, streakMessage.watchStreakPoints)
+        assertEquals("watch_streak", streakMessage.noticeType)
+    }
+
+    @Test
+    fun eventSubFirstMessageNotificationIsShownAsFirstChatter() {
+        val event = JSONObject(
+            """
+            {
+              "broadcaster_user_id":"broadcaster",
+              "chatter_user_id":"chatter",
+              "chatter_user_login":"viewer",
+              "chatter_user_name":"Viewer",
+              "message_id":"first-notice",
+              "notice_type":"first_message",
+              "message":{"text":"hello","fragments":[{"type":"text","text":"hello"}]}
+            }
+            """.trimIndent(),
+        )
+
+        val message = (TwitchChatEventParser.fromEventSub(event, null, notice = true) as ChatEvent.Message).message
+        assertTrue(message.isFirst)
+        assertEquals("first_message", message.noticeType)
+    }
+
+    @Test
+    fun ircUserNoticeIsNormalizedAsNotice() {
+        val message = ChatUtils.IRCMessage(
+            tags = mapOf("msg-id" to "sub", "system-msg" to "Viewer subscribed"),
+            prefix = "user!user@user.tmi.twitch.tv",
+            command = "USERNOTICE",
+            params = listOf("#channel", "hello"),
+            fullMessage = "USERNOTICE #channel :hello",
+        )
+        val event = TwitchChatEventParser.fromIrc(message, "channel-id") as ChatEvent.Message
+
+        assertEquals(com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessageKind.NOTICE, event.message.kind)
+    }
+
+    @Test
+    fun ircGifOnlyMessageUsesTheProvidedUrlAndFallbackText() {
+        val text = "[Dog Eat GIF by Respective]"
+        val url = "https://media4.giphy.com/media/gif/giphy.gif?token=a=b&format=webp"
+        val event = TwitchChatEventParser.fromIrc(
+            ircMessage(text, mapOf("gifs" to "0-${text.lastIndex}|gif-1|$url")),
+            "channel-id",
+        ) as ChatEvent.Message
+
+        assertEquals(
+            ChatSegment.Gif("gif-1", url, text),
+            event.message.segments.single(),
+        )
+    }
+
+    @Test
+    fun ircGifKeepsTextBeforeAndAfterIt() {
+        val text = "hello [gif] world"
+        val event = TwitchChatEventParser.fromIrc(
+            ircMessage(text, mapOf("gifs" to "6-10|gif-1|https://example.test/one.gif")),
+            "channel-id",
+        ) as ChatEvent.Message
+
+        assertEquals(
+            listOf(
+                ChatSegment.Text("hello "),
+                ChatSegment.Gif("gif-1", "https://example.test/one.gif", "[gif]"),
+                ChatSegment.Text(" world"),
+            ),
+            event.message.segments,
+        )
+    }
+
+    @Test
+    fun ircGifsAndNativeEmotesAreMergedInTextOrder() {
+        val event = TwitchChatEventParser.fromIrc(
+            ircMessage(
+                "GIF LUL",
+                mapOf(
+                    "gifs" to "0-2|gif-1|https://example.test/one.gif",
+                    "emotes" to "425618:4-6",
+                ),
+            ),
+            "channel-id",
+        ) as ChatEvent.Message
+
+        assertTrue(event.message.segments[0] is ChatSegment.Gif)
+        assertEquals(ChatSegment.Text(" "), event.message.segments[1])
+        assertTrue(event.message.segments[2] is ChatSegment.Emote)
+        assertEquals("425618", (event.message.segments[2] as ChatSegment.Emote).interaction?.id)
+    }
+
+    @Test
+    fun ircSupportsMultipleGifs() {
+        val event = TwitchChatEventParser.fromIrc(
+            ircMessage(
+                "A B C",
+                mapOf(
+                    "gifs" to "0-0|gif-a|https://example.test/a.gif,2-2|gif-b|https://example.test/b.gif,4-4|gif-c|https://example.test/c.gif",
+                ),
+            ),
+            "channel-id",
+        ) as ChatEvent.Message
+
+        assertEquals(
+            listOf(
+                ChatSegment.Gif("gif-a", "https://example.test/a.gif", "A"),
+                ChatSegment.Text(" "),
+                ChatSegment.Gif("gif-b", "https://example.test/b.gif", "B"),
+                ChatSegment.Text(" "),
+                ChatSegment.Gif("gif-c", "https://example.test/c.gif", "C"),
+            ),
+            event.message.segments,
+        )
+    }
+
+    @Test
+    fun malformedOrOutOfRangeIrcGifRemainsPlainText() {
+        val malformedText = "[broken gif]"
+        val malformed = TwitchChatEventParser.fromIrc(
+            ircMessage(malformedText, mapOf("gifs" to "not-a-gif")),
+            "channel-id",
+        ) as ChatEvent.Message
+        assertEquals(listOf(ChatSegment.Text(malformedText)), malformed.message.segments)
+
+        val outOfRangeText = "GIF"
+        val outOfRange = TwitchChatEventParser.fromIrc(
+            ircMessage(outOfRangeText, mapOf("gifs" to "0-99|gif-1|https://example.test/one.gif")),
+            "channel-id",
+        ) as ChatEvent.Message
+        assertEquals(listOf(ChatSegment.Text(outOfRangeText)), outOfRange.message.segments)
+    }
+
+    @Test
+    fun anonymousIrcMessageStillProducesGifSegment() {
+        val text = "[Dog Eat GIF by Respective]"
+        val message = ChatUtils.IRCMessage(
+            tags = mapOf("gifs" to "0-${text.lastIndex}|gif-1|https://example.test/one.gif"),
+            prefix = "justinfan123!justinfan123@justinfan123.tmi.twitch.tv",
+            command = "PRIVMSG",
+            params = listOf("#channel", text),
+            fullMessage = text,
+        )
+
+        val event = TwitchChatEventParser.fromIrc(message, "channel-id") as ChatEvent.Message
+
+        assertTrue(event.message.user?.id == null)
+        assertTrue(event.message.segments.single() is ChatSegment.Gif)
+    }
+
+    @Test
+    fun ircTagParsingPreservesGifUrlQueryParameters() {
+        val url = "https://media4.giphy.com/gif.gif?token=a=b&format=webp"
+        val message = ChatUtils.parseIRCMessage(
+            "@gifs=0-2|gif-1|$url;id=message-1 :viewer!viewer@viewer.tmi.twitch.tv PRIVMSG #channel :GIF",
+        )
+
+        assertEquals("0-2|gif-1|$url", message.tags["gifs"])
+        val event = TwitchChatEventParser.fromIrc(message, "channel-id") as ChatEvent.Message
+        assertEquals(ChatSegment.Gif("gif-1", url, "GIF"), event.message.segments.single())
+    }
+
+    private fun ircMessage(text: String, extraTags: Map<String, String> = emptyMap()): ChatUtils.IRCMessage =
+        ChatUtils.IRCMessage(
+            tags = mapOf(
+                "id" to "message-1",
+                "display-name" to "Viewer",
+                "login" to "viewer",
+            ) + extraTags,
+            prefix = "viewer!viewer@viewer.tmi.twitch.tv",
+            command = "PRIVMSG",
+            params = listOf("#channel", text),
+            fullMessage = text,
+        )
 }

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/player/LandscapeChatWidthTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/player/LandscapeChatWidthTest.kt
@@ -30,4 +30,11 @@ class LandscapeChatWidthTest {
     fun `chat width is capped when it exceeds the available width`() {
         assertEquals(800, clampLandscapeChatWidth(1000, 800))
     }
+
+    @Test
+    fun `chat width follows the available width on narrow layouts`() {
+        assertEquals(384, landscapeChatWidthForAvailableWidth(1280, 30))
+        assertEquals(96, landscapeChatWidthForAvailableWidth(320, 30))
+        assertEquals(1, landscapeChatWidthForAvailableWidth(1, 70))
+    }
 }

--- a/app/src/test/java/com/github/andreyasadchy/xtra/util/NetworkUtilsTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/util/NetworkUtilsTest.kt
@@ -5,9 +5,51 @@ import java.io.ByteArrayOutputStream
 import java.io.IOException
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
+import kotlinx.coroutines.runBlocking
+import okhttp3.OkHttpClient
+import okhttp3.Protocol
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.ResponseBody.Companion.toResponseBody
+import com.github.andreyasadchy.xtra.util.NetworkUtils.executeAsync
+import com.github.andreyasadchy.xtra.util.NetworkUtils.executeAsyncChecked
 import org.junit.Test
 
 class NetworkUtilsTest {
+    private fun clientReturning(statusCode: Int): OkHttpClient = OkHttpClient.Builder()
+        .addInterceptor { chain ->
+            Response.Builder()
+                .request(chain.request())
+                .protocol(Protocol.HTTP_1_1)
+                .code(statusCode)
+                .message("test")
+                .body("body".toResponseBody())
+                .build()
+        }
+        .build()
+
+    @Test
+    fun `executeAsync exposes non-success responses`() = runBlocking {
+        val request = Request.Builder().url("https://example.test/status").build()
+
+        clientReturning(404).newCall(request).executeAsync().use { response ->
+            assertEquals(404, response.code)
+            assertEquals("body", response.body.string())
+        }
+    }
+
+    @Test
+    fun `executeAsyncChecked throws the HTTP status`() = runBlocking {
+        val request = Request.Builder().url("https://example.test/status").build()
+
+        try {
+            clientReturning(404).newCall(request).executeAsyncChecked()
+            throw AssertionError("Expected HttpStatusException")
+        } catch (error: NetworkUtils.HttpStatusException) {
+            assertEquals(404, error.statusCode)
+        }
+    }
+
     @Test
     fun `limited streaming copy writes the complete response`() {
         val output = ByteArrayOutputStream()


### PR DESCRIPTION
Fixes chat-v2 text sizing and keeps emote picker data on the active v2 catalog. Adds visible picker hydration/error states, preserves emote identity in cache, parallelizes provider loading, and restores key display settings.