### PR TITLE
Fix navigation tab visibility settings

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/main/MainActivity.kt
@@ -95,7 +95,7 @@ import com.github.andreyasadchy.xtra.ui.saved.downloads.DownloadsFragment
 import com.github.andreyasadchy.xtra.ui.settings.openTabCustomization
 import com.github.andreyasadchy.xtra.ui.settings.limitNavigationVisibleItems
 import com.github.andreyasadchy.xtra.ui.settings.MAX_TV_NAVIGATION_VISIBLE_ITEMS
-import com.github.andreyasadchy.xtra.ui.settings.navigationTabDefaults
+import com.github.andreyasadchy.xtra.ui.settings.resolveNavigationTabList
 import com.github.andreyasadchy.xtra.ui.tv.applyTvSafePadding
 import com.github.andreyasadchy.xtra.ui.tv.disableTvClippingUpTree
 import com.github.andreyasadchy.xtra.ui.team.TeamFragmentDirections
@@ -1587,20 +1587,10 @@ class MainActivity : AppCompatActivity() {
     private fun initNavigation() {
         navController = (supportFragmentManager.findFragmentById(R.id.navHostFragment) as NavHostFragment).navController
         navController.setOnBackPressedDispatcher(onBackPressedDispatcher)
-        val tabList = prefs.getString(C.UI_NAVIGATION_TAB_LIST, null).let { tabPref ->
-            val defaultTabs = navigationTabDefaults(isTv).split(',')
-            if (tabPref != null) {
-                val list = tabPref.split(',').filter { item ->
-                    defaultTabs.find { it.first() == item.first() } != null
-                }.toMutableList()
-                defaultTabs.forEachIndexed { index, item ->
-                    if (list.find { it.first() == item.first() } == null) {
-                        list.add(index, item)
-                    }
-                }
-                list
-            } else defaultTabs
-        }.let {
+        val tabList = resolveNavigationTabList(
+            prefs.getString(C.UI_NAVIGATION_TAB_LIST, null),
+            isTv,
+        ).let {
             limitNavigationVisibleItems(
                 it,
                 if (isTv) MAX_TV_NAVIGATION_VISIBLE_ITEMS else 6,

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/settings/SettingsActivity.kt
@@ -2048,20 +2048,10 @@ class SettingsActivity : AppCompatActivity() {
                 true
             }
             findPreference<Preference>("ui_navigation_tab_list_dialog")?.setOnPreferenceClickListener { preference ->
-                val tabList = requireContext().prefs().getString(C.UI_NAVIGATION_TAB_LIST, null).let { tabPref ->
-                    val defaultTabs = C.DEFAULT_NAVIGATION_TAB_LIST.split(',')
-                    if (tabPref != null) {
-                        val list = tabPref.split(',').filter { item ->
-                            defaultTabs.find { it.first() == item.first() } != null
-                        }.toMutableList()
-                        defaultTabs.forEachIndexed { index, item ->
-                            if (list.find { it.first() == item.first() } == null) {
-                                list.add(index, item)
-                            }
-                        }
-                        list
-                    } else defaultTabs
-                }
+                val tabList = resolveNavigationTabList(
+                    requireContext().prefs().getString(C.UI_NAVIGATION_TAB_LIST, null),
+                    requireActivity().isTelevision(),
+                )
                 val tabs = tabList.map {
                     val split = it.split(':')
                     SettingsDragListItem(

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/settings/SettingsDragListAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/settings/SettingsDragListAdapter.kt
@@ -22,7 +22,10 @@ class SettingsDragListAdapter : ListAdapter<SettingsDragListItem, SettingsDragLi
         }
 
         override fun areContentsTheSame(oldItem: SettingsDragListItem, newItem: SettingsDragListItem): Boolean {
-            return true
+            return oldItem.text == newItem.text &&
+                oldItem.default == newItem.default &&
+                oldItem.enabled == newItem.enabled &&
+                oldItem.group == newItem.group
         }
     }
 ) {
@@ -116,21 +119,19 @@ class SettingsDragListAdapter : ListAdapter<SettingsDragListItem, SettingsDragLi
                     checkBox.isEnabled = true
                     checkBox.visibility = View.GONE
                 }
-                if (isTv) {
-                    val checkboxVisible = checkBox.visibility == View.VISIBLE
-                    root.setOnClickListener {
-                        if (checkboxVisible && checkBox.isEnabled) {
-                            checkBox.performClick()
-                        } else if (setAsDefault.visibility == View.VISIBLE && setAsDefault.isClickable) {
-                            setAsDefault.performClick()
-                        }
+                root.setOnClickListener {
+                    if (checkBox.visibility == View.VISIBLE && checkBox.isEnabled) {
+                        checkBox.performClick()
+                    } else if (setAsDefault.visibility == View.VISIBLE && setAsDefault.isClickable) {
+                        setAsDefault.performClick()
                     }
+                }
+                if (isTv) {
                     checkBox.scaleX = 1.35f
                     checkBox.scaleY = 1.35f
                     setAsDefault.scaleX = 1.25f
                     setAsDefault.scaleY = 1.25f
                 } else {
-                    root.setOnClickListener(null)
                     checkBox.scaleX = 1f
                     checkBox.scaleY = 1f
                     setAsDefault.scaleX = 1f

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/settings/SettingsTabCustomization.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/settings/SettingsTabCustomization.kt
@@ -23,6 +23,49 @@ internal fun navigationTabDefaults(isTelevision: Boolean): String =
         C.DEFAULT_NAVIGATION_TAB_LIST
     }
 
+internal fun resolveNavigationTabList(stored: String?, isTelevision: Boolean): List<String> {
+    val defaults = navigationTabDefaults(isTelevision).split(',')
+    val knownKeys = defaults.mapTo(hashSetOf()) { it.substringBefore(':') }
+    val result = stored.orEmpty().split(',')
+        .mapNotNull { entry ->
+            val parts = entry.split(':')
+            if (parts.size == 3 && parts[0] in knownKeys && parts[1] in setOf("0", "1") && parts[2] in setOf("0", "1")) {
+                parts.joinToString(":")
+            } else {
+                null
+            }
+        }
+        .distinctBy { it.substringBefore(':') }
+        .toMutableList()
+    val storedHasDrops = result.any { it.substringBefore(':') == "6" }
+
+    defaults.forEach { defaultEntry ->
+        if (result.none { it.substringBefore(':') == defaultEntry.substringBefore(':') }) {
+            result += defaultEntry
+        }
+    }
+
+    if (!isTelevision && !storedHasDrops && result.count { it.split(':').getOrNull(2) == "1" } > MAX_NAVIGATION_VISIBLE_ITEMS) {
+        val discoverIndex = result.indexOfFirst { it.substringBefore(':') == "4" }
+        val dropsIndex = result.indexOfFirst { it.substringBefore(':') == "6" }
+        if (discoverIndex >= 0 && dropsIndex >= 0 && result[discoverIndex].split(':').getOrNull(2) == "1") {
+            val discoverParts = result[discoverIndex].split(':')
+            val dropsParts = result.removeAt(dropsIndex).split(':')
+            result[discoverIndex] = discoverParts.let { parts ->
+                "${parts[0]}:0:0"
+            }
+            result.add(
+                discoverIndex,
+                "${dropsParts[0]}:${if (discoverParts[1] == "1") "1" else dropsParts[1]}:${dropsParts[2]}",
+            )
+        }
+    }
+    return limitNavigationVisibleItems(
+        result,
+        if (isTelevision) MAX_TV_NAVIGATION_VISIBLE_ITEMS else MAX_NAVIGATION_VISIBLE_ITEMS,
+    )
+}
+
 internal fun Context.openTabCustomization(preferenceKey: String) {
     startActivity(Intent(this, SettingsActivity::class.java).apply {
         putExtra(EXTRA_SETTINGS_SCREEN, SETTINGS_SCREEN_TABS)

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/settings/SettingsActivityTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/settings/SettingsActivityTest.kt
@@ -89,4 +89,51 @@ class SettingsActivityTest {
         assertTrue(limited.first { it.startsWith("4:") }.endsWith(":1"))
         assertTrue(limited.last { it.startsWith("6:") }.endsWith(":0"))
     }
+
+    @Test
+    fun navigationResolutionRestoresMissingDropsWithoutChangingSavedTabs() {
+        val resolved = resolveNavigationTabList(
+            "0:0:1,1:1:1,2:0:1,3:0:1,5:0:1",
+            isTelevision = false,
+        )
+
+        assertEquals(listOf("0", "1", "2", "3", "5", "4", "6"), resolved.map { it.substringBefore(':') })
+        assertEquals("6:0:1", resolved.last())
+    }
+
+    @Test
+    fun navigationResolutionDropsMalformedAndDuplicateEntries() {
+        val resolved = resolveNavigationTabList(
+            "6:0:0,6:1:1,bad,0:0:2",
+            isTelevision = false,
+        )
+
+        assertEquals("6:0:0", resolved.first())
+        assertEquals(1, resolved.count { it.startsWith("6:") })
+        assertTrue(resolved.none { it.contains("bad") || it.endsWith(":2") })
+    }
+
+    @Test
+    fun legacyMaxedNavigationLayoutGivesDiscoverSlotToDrops() {
+        val resolved = resolveNavigationTabList(
+            "0:0:1,4:0:1,1:1:1,2:0:1,3:0:1,5:0:1",
+            isTelevision = false,
+        )
+
+        assertEquals(6, resolved.count { it.endsWith(":1") })
+        assertEquals("4:0:0", resolved.first { it.startsWith("4:") })
+        assertEquals("6:0:1", resolved.first { it.startsWith("6:") })
+    }
+
+    @Test
+    fun legacyMaxedNavigationLayoutMovesDefaultFromDiscoverToDrops() {
+        val resolved = resolveNavigationTabList(
+            "0:0:1,4:1:1,1:0:1,2:0:1,3:0:1,5:0:1",
+            isTelevision = false,
+        )
+
+        assertEquals("4:0:0", resolved.first { it.startsWith("4:") })
+        assertEquals("6:1:1", resolved.first { it.startsWith("6:") })
+        assertEquals(listOf("6"), resolved.filter { it.split(':')[1] == "1" }.map { it.substringBefore(':') })
+    }
 }


### PR DESCRIPTION
Fix navigation tab visibility controls and restore missing Drops entries from saved layouts. Harden stored tab parsing and make row toggles work consistently.