### PR TITLE
Allow unlimited navigation tabs

### DIFF
--- a/app/src/androidTest/java/com/github/andreyasadchy/xtra/ui/main/UnlimitedBottomNavigationViewTest.kt
+++ b/app/src/androidTest/java/com/github/andreyasadchy/xtra/ui/main/UnlimitedBottomNavigationViewTest.kt
@@ -1,0 +1,39 @@
+package com.github.andreyasadchy.xtra.ui.main
+
+import android.view.View
+import android.view.ContextThemeWrapper
+import com.github.andreyasadchy.xtra.R
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class UnlimitedBottomNavigationViewTest {
+
+    @Test
+    fun acceptsAndLaysOutMoreThanMaterialMobileLimit() {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        instrumentation.runOnMainSync {
+            val view = UnlimitedBottomNavigationView(
+                ContextThemeWrapper(ApplicationProvider.getApplicationContext(), R.style.DarkTheme),
+            )
+            repeat(7) { index ->
+                view.menu.add(View.NO_ID, index + 1, index, "Tab $index")
+            }
+
+            val width = 1080
+            val height = 96
+            view.measure(
+                View.MeasureSpec.makeMeasureSpec(width, View.MeasureSpec.EXACTLY),
+                View.MeasureSpec.makeMeasureSpec(height, View.MeasureSpec.AT_MOST),
+            )
+            view.layout(0, 0, width, view.measuredHeight)
+
+            assertEquals(7, view.menu.size())
+            assertEquals(7, view.menuViewGroup.childCount)
+        }
+    }
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/main/MainActivity.kt
@@ -93,8 +93,6 @@ import com.github.andreyasadchy.xtra.ui.saved.SavedMediaFragment
 import com.github.andreyasadchy.xtra.ui.saved.SavedPagerFragment
 import com.github.andreyasadchy.xtra.ui.saved.downloads.DownloadsFragment
 import com.github.andreyasadchy.xtra.ui.settings.openTabCustomization
-import com.github.andreyasadchy.xtra.ui.settings.limitNavigationVisibleItems
-import com.github.andreyasadchy.xtra.ui.settings.MAX_TV_NAVIGATION_VISIBLE_ITEMS
 import com.github.andreyasadchy.xtra.ui.settings.resolveNavigationTabList
 import com.github.andreyasadchy.xtra.ui.tv.applyTvSafePadding
 import com.github.andreyasadchy.xtra.ui.tv.disableTvClippingUpTree
@@ -1590,12 +1588,7 @@ class MainActivity : AppCompatActivity() {
         val tabList = resolveNavigationTabList(
             prefs.getString(C.UI_NAVIGATION_TAB_LIST, null),
             isTv,
-        ).let {
-            limitNavigationVisibleItems(
-                it,
-                if (isTv) MAX_TV_NAVIGATION_VISIBLE_ITEMS else 6,
-            )
-        }
+        )
         navController.setGraph(navController.navInflater.inflate(R.navigation.nav_graph).also {
             val defaultItem = tabList.find { it.split(':')[1] != "0" }?.split(':')[0] ?: "1"
             when {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/main/UnlimitedBottomNavigationView.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/main/UnlimitedBottomNavigationView.kt
@@ -1,0 +1,16 @@
+package com.github.andreyasadchy.xtra.ui.main
+
+import android.content.Context
+import android.util.AttributeSet
+import com.google.android.material.bottomnavigation.BottomNavigationView
+import com.google.android.material.navigation.NavigationBarMenu
+
+/** Bottom navigation whose item count follows the user's navigation configuration. */
+class UnlimitedBottomNavigationView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = com.google.android.material.R.attr.bottomNavigationStyle,
+) : BottomNavigationView(context, attrs, defStyleAttr) {
+
+    override fun getMaxItemCount(): Int = NavigationBarMenu.NO_MAX_ITEM_LIMIT
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/settings/SettingsActivity.kt
@@ -291,11 +291,6 @@ class SettingsActivity : AppCompatActivity() {
     ) {
         val listAdapter = SettingsDragListAdapter()
         listAdapter.minimumVisibleItems = minimumVisibleItemsForPreference(prefKey)
-        listAdapter.maximumVisibleItems = if (isTelevision() && prefKey == C.UI_NAVIGATION_TAB_LIST) {
-            MAX_TV_NAVIGATION_VISIBLE_ITEMS
-        } else {
-            maximumVisibleItemsForPreference(prefKey)
-        }
         ensureMinimumVisibleItems(list, listAdapter.minimumVisibleItems)
         if (showDefaultSelector) promoteDefaultToVisible(list)
         val preview = when (prefKey) {
@@ -2099,7 +2094,7 @@ class SettingsActivity : AppCompatActivity() {
                                 list.add(index, item)
                             }
                         }
-                        limitNavigationVisibleItems(list)
+                        list
                     } else defaultTabs
                 }
                 val tabs = tabList.map {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/settings/SettingsDragListAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/settings/SettingsDragListAdapter.kt
@@ -34,7 +34,6 @@ class SettingsDragListAdapter : ListAdapter<SettingsDragListItem, SettingsDragLi
     var cycleGroup: ((SettingsDragListItem) -> Unit)? = null
     var showVisibilityToggle = true
     var minimumVisibleItems = 0
-    var maximumVisibleItems: Int? = null
     var onItemChanged: (() -> Unit)? = null
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
@@ -105,7 +104,7 @@ class SettingsDragListAdapter : ListAdapter<SettingsDragListItem, SettingsDragLi
                         itemEnabled = item.enabled,
                         visibleItemCount = visibleItemCount,
                         minimumVisibleItems = minimumVisibleItems,
-                    ) && (item.enabled || maximumVisibleItems == null || visibleItemCount < maximumVisibleItems!!)
+                    )
                     checkBox.setOnCheckedChangeListener { _, isChecked ->
                         item.enabled = isChecked
                         onItemChanged?.invoke()

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/settings/SettingsTabCustomization.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/settings/SettingsTabCustomization.kt
@@ -13,8 +13,6 @@ internal const val SETTINGS_SCREEN_TABS = "tabs"
 internal const val SETTINGS_SCREEN_PLAYER_CONTROLS = "player_controls"
 internal const val SETTINGS_SCREEN_PLAYER = "player"
 internal const val SETTINGS_SCREEN_CHAT = "chat"
-internal const val MAX_NAVIGATION_VISIBLE_ITEMS = 6
-internal const val MAX_TV_NAVIGATION_VISIBLE_ITEMS = 8
 
 internal fun navigationTabDefaults(isTelevision: Boolean): String =
     if (isTelevision) {
@@ -37,33 +35,13 @@ internal fun resolveNavigationTabList(stored: String?, isTelevision: Boolean): L
         }
         .distinctBy { it.substringBefore(':') }
         .toMutableList()
-    val storedHasDrops = result.any { it.substringBefore(':') == "6" }
-
     defaults.forEach { defaultEntry ->
         if (result.none { it.substringBefore(':') == defaultEntry.substringBefore(':') }) {
             result += defaultEntry
         }
     }
 
-    if (!isTelevision && !storedHasDrops && result.count { it.split(':').getOrNull(2) == "1" } > MAX_NAVIGATION_VISIBLE_ITEMS) {
-        val discoverIndex = result.indexOfFirst { it.substringBefore(':') == "4" }
-        val dropsIndex = result.indexOfFirst { it.substringBefore(':') == "6" }
-        if (discoverIndex >= 0 && dropsIndex >= 0 && result[discoverIndex].split(':').getOrNull(2) == "1") {
-            val discoverParts = result[discoverIndex].split(':')
-            val dropsParts = result.removeAt(dropsIndex).split(':')
-            result[discoverIndex] = discoverParts.let { parts ->
-                "${parts[0]}:0:0"
-            }
-            result.add(
-                discoverIndex,
-                "${dropsParts[0]}:${if (discoverParts[1] == "1") "1" else dropsParts[1]}:${dropsParts[2]}",
-            )
-        }
-    }
-    return limitNavigationVisibleItems(
-        result,
-        if (isTelevision) MAX_TV_NAVIGATION_VISIBLE_ITEMS else MAX_NAVIGATION_VISIBLE_ITEMS,
-    )
+    return result
 }
 
 internal fun Context.openTabCustomization(preferenceKey: String) {
@@ -96,25 +74,6 @@ internal fun minimumVisibleItemsForPreference(preferenceKey: String): Int = when
     C.UI_SEARCH_TABS,
     -> 1
     else -> 0
-}
-
-internal fun maximumVisibleItemsForPreference(preferenceKey: String): Int? =
-    MAX_NAVIGATION_VISIBLE_ITEMS.takeIf { preferenceKey == C.UI_NAVIGATION_TAB_LIST }
-
-internal fun limitNavigationVisibleItems(
-    items: List<String>,
-    maximumVisibleItems: Int = MAX_NAVIGATION_VISIBLE_ITEMS,
-): List<String> {
-    val result = items.toMutableList()
-    while (result.count { it.split(':').getOrNull(2) != "0" } > maximumVisibleItems) {
-        val index = result.indexOfLast { it.split(':').getOrNull(2) != "0" && !it.startsWith("4:") }
-            .takeIf { it >= 0 }
-            ?: result.indexOfLast { it.startsWith("4:") && it.split(':').getOrNull(2) != "0" }
-        if (index < 0) break
-        val parts = result[index].split(':')
-        result[index] = "${parts[0]}:${parts.getOrElse(1) { "0" }}:0"
-    }
-    return result
 }
 
 internal fun canDisableVisibleItem(

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/C.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/C.kt
@@ -324,7 +324,6 @@ object C {
     const val TOKEN_SUPPORTED_CODECS = "token_supported_codecs"
     const val TOKEN_SKIP_VIDEO_ACCESS_TOKEN = "token_skip_video_access_token"
     const val TOKEN_SKIP_CLIP_ACCESS_TOKEN = "token_skip_clip_access_token"
-    // BottomNavigationView supports six items; Drops takes the default slot previously used by Discover.
     const val DEFAULT_NAVIGATION_TAB_LIST = "0:0:1,4:0:0,1:1:1,2:0:1,3:0:1,5:0:1,6:0:1"
     const val DEFAULT_FOLLOWING_TABS = "1:1:1,3:1:1,2:0:1,0:0:1"
     const val DEFAULT_FOLLOWING_OVERVIEW_SECTIONS = "live:0:1,recommended:0:1,continue:0:1,upcoming:0:1"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -82,7 +82,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content" />
 
-        <com.google.android.material.bottomnavigation.BottomNavigationView
+        <com.github.andreyasadchy.xtra.ui.main.UnlimitedBottomNavigationView
             android:id="@+id/navBar"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/settings/SettingsActivityTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/settings/SettingsActivityTest.kt
@@ -72,7 +72,7 @@ class SettingsActivityTest {
     }
 
     @Test
-    fun navigationLimitKeepsConfiguredItemsInOrder() {
+    fun navigationResolutionKeepsAllConfiguredVisibleItems() {
         val items = listOf(
             "0:0:1",
             "4:0:1",
@@ -83,11 +83,11 @@ class SettingsActivityTest {
             "6:0:1",
         )
 
-        val limited = limitNavigationVisibleItems(items)
+        val resolved = resolveNavigationTabList(items.joinToString(","), isTelevision = false)
 
-        assertEquals(6, limited.count { it.endsWith(":1") })
-        assertTrue(limited.first { it.startsWith("4:") }.endsWith(":1"))
-        assertTrue(limited.last { it.startsWith("6:") }.endsWith(":0"))
+        assertEquals(7, resolved.count { it.endsWith(":1") })
+        assertTrue(resolved.first { it.startsWith("4:") }.endsWith(":1"))
+        assertTrue(resolved.last { it.startsWith("6:") }.endsWith(":1"))
     }
 
     @Test
@@ -114,26 +114,26 @@ class SettingsActivityTest {
     }
 
     @Test
-    fun legacyMaxedNavigationLayoutGivesDiscoverSlotToDrops() {
+    fun legacyMaxedNavigationLayoutKeepsDiscoverAndAddsDrops() {
         val resolved = resolveNavigationTabList(
             "0:0:1,4:0:1,1:1:1,2:0:1,3:0:1,5:0:1",
             isTelevision = false,
         )
 
-        assertEquals(6, resolved.count { it.endsWith(":1") })
-        assertEquals("4:0:0", resolved.first { it.startsWith("4:") })
+        assertEquals(7, resolved.count { it.endsWith(":1") })
+        assertEquals("4:0:1", resolved.first { it.startsWith("4:") })
         assertEquals("6:0:1", resolved.first { it.startsWith("6:") })
     }
 
     @Test
-    fun legacyMaxedNavigationLayoutMovesDefaultFromDiscoverToDrops() {
+    fun legacyMaxedNavigationLayoutKeepsDiscoverAsDefault() {
         val resolved = resolveNavigationTabList(
             "0:0:1,4:1:1,1:0:1,2:0:1,3:0:1,5:0:1",
             isTelevision = false,
         )
 
-        assertEquals("4:0:0", resolved.first { it.startsWith("4:") })
-        assertEquals("6:1:1", resolved.first { it.startsWith("6:") })
-        assertEquals(listOf("6"), resolved.filter { it.split(':')[1] == "1" }.map { it.substringBefore(':') })
+        assertEquals("4:1:1", resolved.first { it.startsWith("4:") })
+        assertEquals("6:0:1", resolved.first { it.startsWith("6:") })
+        assertEquals(listOf("4"), resolved.filter { it.split(':')[1] == "1" }.map { it.substringBefore(':') })
     }
 }


### PR DESCRIPTION
Allow all configured navigation tabs to remain visible, including Drops, without a fixed phone or TV limit. Mobile uses a navigation view with no Material item-count cap.