### PR TITLE
Fix washed-out chat colors

### DIFF
--- a/app/src/androidTest/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatColorResolverTest.kt
+++ b/app/src/androidTest/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatColorResolverTest.kt
@@ -1,0 +1,48 @@
+package com.github.andreyasadchy.xtra.ui.chat.v2
+
+import android.graphics.Color
+import androidx.core.graphics.ColorUtils
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.andreyasadchy.xtra.ui.chat.v2.presentation.ChatColorResolver
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ChatColorResolverTest {
+    @Test
+    fun midToneBackgroundUsesBlackDirectionWhenWhiteCannotMeetContrast() {
+        val background = Color.rgb(0xA0, 0xA0, 0xA0)
+        val original = Color.rgb(0x00, 0x80, 0x80)
+
+        val resolved = ChatColorResolver(readable = true).resolve("#008080", "mid-tone", background)
+
+        assertNotEquals(original, resolved)
+        assertTrue(Color.red(resolved) <= 8)
+        assertTrue(Color.green(resolved) < Color.green(original))
+        assertTrue(Color.blue(resolved) < Color.blue(original))
+        assertTrue(ColorUtils.calculateContrast(resolved, background) >= 3.0)
+    }
+
+    @Test
+    fun whiteBackgroundDarkensAnUnreadableColor() {
+        val background = Color.WHITE
+        val original = Color.rgb(0xA0, 0xA0, 0xA0)
+
+        val resolved = ChatColorResolver(readable = true).resolve("#A0A0A0", "white", background)
+
+        assertNotEquals(original, resolved)
+        assertTrue(ColorUtils.calculateContrast(resolved, background) >= 3.0)
+    }
+
+    @Test
+    fun blackBackgroundKeepsAnAlreadyReadableColor() {
+        val original = Color.rgb(0xFF, 0x00, 0x00)
+
+        val resolved = ChatColorResolver(readable = true).resolve("#FF0000", "red", Color.BLACK)
+
+        assertEquals(original, resolved)
+    }
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/presentation/ChatColorResolver.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/presentation/ChatColorResolver.kt
@@ -1,8 +1,11 @@
 package com.github.andreyasadchy.xtra.ui.chat.v2.presentation
 
+import android.graphics.Color
 import androidx.annotation.ColorInt
-import kotlin.math.pow
+import androidx.core.graphics.ColorUtils
 import java.util.LinkedHashMap
+import kotlin.math.abs
+import kotlin.math.pow
 
 class ChatColorResolver(
     @ColorInt private val fallback: Int = 0xFF919191.toInt(),
@@ -10,6 +13,11 @@ class ChatColorResolver(
     private val maxEntries: Int = 128,
     @ColorInt private val background: Int = 0xFF101010.toInt(),
 ) {
+    private data class LightnessCandidate(
+        @ColorInt val color: Int,
+        val lightness: Float,
+    )
+
     private val cache = object : LinkedHashMap<String, Int>(maxEntries, .75f, true) {
         override fun removeEldestEntry(eldest: MutableMap.MutableEntry<String, Int>?): Boolean = size > maxEntries
     }
@@ -21,11 +29,8 @@ class ChatColorResolver(
         return cache.getOrPut(key) {
             val parsed = parseColor(raw)
             val identityFallback = fallbackColor(identity, rowBackground)
-            val color = parsed ?: identityFallback
-            val adjusted = if (parsed == null || isNearWhite(color) || !hasContrast(color, rowBackground)) {
-                identityFallback
-            } else color
-            val readableColor = if (readable) makeReadable(adjusted) else adjusted
+            val color = parsed?.takeUnless(::isNearWhite) ?: identityFallback
+            val readableColor = if (readable) makeReadable(color, rowBackground) else color
             if (hasContrast(readableColor, rowBackground) && !isNearWhite(readableColor)) {
                 readableColor
             } else {
@@ -81,13 +86,68 @@ class ChatColorResolver(
     private fun isNearWhite(@ColorInt color: Int): Boolean =
         red(color) >= 245 && green(color) >= 245 && blue(color) >= 245
 
-    private fun makeReadable(@ColorInt color: Int): Int {
-        val luminance = (0.299 * red(color) + 0.587 * green(color) + 0.114 * blue(color)) / 255
-        return if (luminance < 0.35) rgb(
-            (red(color) + 255) / 2,
-            (green(color) + 255) / 2,
-            (blue(color) + 255) / 2,
-        ) else color
+    private fun makeReadable(@ColorInt color: Int, @ColorInt rowBackground: Int): Int {
+        if (hasContrast(color, rowBackground)) return color
+
+        // Raise or lower lightness while retaining the Twitch-selected hue and saturation.
+        // Blending toward white makes reds and blues look pastel, which is unlike Twitch chat.
+        val hsl = FloatArray(3)
+        ColorUtils.colorToHSL(color, hsl)
+        val originalLightness = hsl[2]
+        val canDarken = hasContrast(Color.BLACK, rowBackground)
+        val canLighten = hasContrast(Color.WHITE, rowBackground)
+        val darkened = if (canDarken) {
+            findReadableCandidate(hsl, originalLightness, rowBackground, towardBlack = true)
+        } else {
+            null
+        }
+        val lightened = if (canLighten) {
+            findReadableCandidate(hsl, originalLightness, rowBackground, towardBlack = false)
+        } else {
+            null
+        }
+
+        return when {
+            darkened == null -> lightened?.color ?: color
+            lightened == null -> darkened.color
+            abs(darkened.lightness - originalLightness) <= abs(lightened.lightness - originalLightness) -> darkened.color
+            else -> lightened.color
+        }
+    }
+
+    private fun findReadableCandidate(
+        hsl: FloatArray,
+        originalLightness: Float,
+        @ColorInt rowBackground: Int,
+        towardBlack: Boolean,
+    ): LightnessCandidate? {
+        val searchHsl = hsl.copyOf()
+        val endpointLightness = if (towardBlack) 0f else 1f
+        searchHsl[2] = endpointLightness
+        val endpoint = ColorUtils.HSLToColor(searchHsl)
+        if (!hasContrast(endpoint, rowBackground)) return null
+
+        var low = if (towardBlack) 0f else originalLightness
+        var high = if (towardBlack) originalLightness else 1f
+        var best = LightnessCandidate(endpoint, endpointLightness)
+        repeat(12) {
+            val lightness = (low + high) / 2f
+            searchHsl[2] = lightness
+            val candidate = ColorUtils.HSLToColor(searchHsl)
+            if (hasContrast(candidate, rowBackground)) {
+                best = LightnessCandidate(candidate, lightness)
+                if (towardBlack) {
+                    low = lightness
+                } else {
+                    high = lightness
+                }
+            } else if (towardBlack) {
+                high = lightness
+            } else {
+                low = lightness
+            }
+        }
+        return best
     }
 
     @ColorInt
@@ -99,6 +159,4 @@ class ChatColorResolver(
     private fun red(@ColorInt color: Int): Int = color ushr 16 and 0xff
     private fun green(@ColorInt color: Int): Int = color ushr 8 and 0xff
     private fun blue(@ColorInt color: Int): Int = color and 0xff
-    private fun rgb(red: Int, green: Int, blue: Int): Int =
-        0xFF000000.toInt() or (red shl 16) or (green shl 8) or blue
 }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/presentation/ChatRowCompiler.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/presentation/ChatRowCompiler.kt
@@ -165,6 +165,7 @@ class ChatRowCompiler(
             id = message.id,
             channelId = message.channelId,
             timestampText = timestampText(message.timestampMs),
+            timestampColor = colors.resolve("#999999", rowBackground = rowBackground),
             pieces = pieces,
             background = rowBackground,
             backgroundStyle = when {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/presentation/ChatRowUiModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/presentation/ChatRowUiModel.kt
@@ -13,6 +13,7 @@ data class ChatRowUiModel(
     val id: ChatMessageId,
     val channelId: String,
     val timestampText: String?,
+    val timestampColor: Int = 0xFF999999.toInt(),
     val pieces: List<ChatPiece>,
     val background: Int,
     val backgroundStyle: ChatRowBackground = ChatRowBackground.NORMAL,

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatMessageTextView.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatMessageTextView.kt
@@ -147,7 +147,15 @@ open class ChatMessageTextView(context: Context, private val assets: ChatAssetRe
                 }
             }
         }
-        if (row.timestampText != null) output.insert(0, "${row.timestampText} ")
+        row.timestampText?.let { timestamp ->
+            output.insert(0, "$timestamp ")
+            output.setSpan(
+                ForegroundColorSpan(row.timestampColor),
+                0,
+                timestamp.length,
+                Spanned.SPAN_EXCLUSIVE_EXCLUSIVE,
+            )
+        }
         if (row.isAction) output.setSpan(StyleSpan(android.graphics.Typeface.ITALIC), 0, output.length, 0)
         contentDescription = row.accessibilityText
         text = output


### PR DESCRIPTION
Keep chat usernames saturated while preserving readable contrast. Render chat timestamps in grey.