### PR TITLE
Render special subscription events like Twitch

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/model/chat/ChatMessage.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/model/chat/ChatMessage.kt
@@ -28,6 +28,8 @@ class ChatMessage(
     var translatedMessage: String? = null,
     var translationFailed: Boolean = false,
     var messageLanguage: String? = null,
+    val subscriptionPlan: String? = null,
+    val isPrimeSubscription: Boolean? = null,
 ) {
     companion object {
         const val SYSTEM_MESSAGE = 0

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/presentation/ChatRowCompiler.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/presentation/ChatRowCompiler.kt
@@ -55,10 +55,12 @@ class ChatRowCompiler(
         val rowBackground = background(message)
         val isWatchStreak = message.noticeType.equals("watch_streak", ignoreCase = true) ||
             (message.noticeType.equals("viewermilestone", ignoreCase = true) && message.watchStreakCount != null)
-        val isSubscription = message.noticeType?.lowercase() in SUBSCRIPTION_NOTICE_TYPES &&
-            (message.isPrimeSubscription == true ||
-                message.subscriptionPlan?.contains("prime", ignoreCase = true) == true ||
-                message.noticeType.equals("prime_paid_upgrade", ignoreCase = true))
+        val noticeType = message.noticeType?.lowercase()
+        val isSubscription = noticeType in SUBSCRIPTION_NOTICE_TYPES
+        val isPrimeSubscription = isSubscription && (
+            message.isPrimeSubscription == true ||
+                message.subscriptionPlan?.contains("prime", ignoreCase = true) == true
+            )
         val reward = message.rewardId?.let { rewardId ->
             catalog.channelPointRewards[rewardId]
                 ?: message.rewardTitle?.let { title -> ChatReward(title, message.rewardCost, message.rewardImageUrl) }
@@ -130,12 +132,28 @@ class ChatRowCompiler(
             }
             if (subscriptionBody != null) {
                 val headingColor = 0xFFE8E4EC.toInt()
-                add(ChatPiece.Icon(R.drawable.ic_chat_subscription, tint = headingColor))
+                val icon = if (isPrimeSubscription) {
+                    R.drawable.ic_chat_subscription
+                } else {
+                    R.drawable.ic_chat_subscription_gift
+                }
+                add(ChatPiece.Icon(icon, tint = headingColor))
                 add(ChatPiece.Text(" "))
-                val nameEnd = subscriptionBody.indexOf(' ').takeIf { it > 0 } ?: subscriptionBody.length
-                add(ChatPiece.Text(subscriptionBody.substring(0, nameEnd), color = headingColor, bold = true))
-                if (nameEnd < subscriptionBody.length) {
+                val systemUser = message.user?.displayName ?: message.user?.login
+                val actor = systemUser ?: subscriptionBody.substringBefore(' ').takeIf { !it.equals("An", ignoreCase = true) }
+                val nameEnd = actor
+                    ?.takeIf { subscriptionBody.startsWith(it, ignoreCase = true) }
+                    ?.length
+                if (nameEnd != null) {
+                    val userColor = if (systemUser == null) headingColor else colors.resolve(
+                        message.user?.color?.let(::colorToHex),
+                        message.user?.id ?: message.user?.login ?: systemUser,
+                        rowBackground,
+                    )
+                    add(ChatPiece.Text(subscriptionBody.substring(0, nameEnd), color = userColor, bold = true))
                     add(ChatPiece.Text(subscriptionBody.substring(nameEnd), color = mutedColor))
+                } else {
+                    add(ChatPiece.Text(subscriptionBody, color = mutedColor))
                 }
                 if (hasSemanticBody) add(ChatPiece.Text("\n"))
             }
@@ -216,7 +234,9 @@ class ChatRowCompiler(
                 }
                 if (!isRewardOnly) add(ChatPiece.Text("\n", color = mutedColor))
             }
-            message.user?.takeIf { !isRewardOnly && (noticeBody == null || hasSemanticBody) }?.let { user ->
+            message.user?.takeIf {
+                !isRewardOnly && ((noticeBody == null && !isSubscription) || hasSemanticBody)
+            }?.let { user ->
                 val name = user.displayName(nameDisplay)
                 name?.let {
                     add(ChatPiece.Username(
@@ -429,6 +449,10 @@ class ChatRowCompiler(
             "shared_chat_resub",
             "shared_chat_sub_gift",
             "shared_chat_community_sub_gift",
+            "pay_it_forward",
+            "shared_chat_gift_paid_upgrade",
+            "shared_chat_prime_paid_upgrade",
+            "shared_chat_pay_it_forward",
         )
     }
 }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/transport/TwitchChatEventParser.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/transport/TwitchChatEventParser.kt
@@ -176,10 +176,14 @@ object TwitchChatEventParser {
         val rawType = event.optString("message_type").takeIf { it.isNotBlank() } ?: "text"
         val type = parseMessageType(rawType)
         val noticeType = event.optString("notice_type").takeIf { it.isNotBlank() }
+        val subscription = event.optJSONObject("sub")
+            ?: event.optJSONObject("resub")
+            ?: event.optJSONObject("shared_chat_sub")
+            ?: event.optJSONObject("shared_chat_resub")
         val subscriptionPlan = event.optString("sub_tier").takeIf { it.isNotBlank() }
-            ?: event.optJSONObject("sub")?.optString("sub_tier")?.takeIf { it.isNotBlank() }
+            ?: subscription?.optString("sub_tier")?.takeIf { it.isNotBlank() }
         val isPrimeSubscription = event.optBooleanOrNull("is_prime")
-            ?: event.optJSONObject("sub")?.optBooleanOrNull("is_prime")
+            ?: subscription?.optBooleanOrNull("is_prime")
         val fullText = segments.joinToString(separator = "") { segment ->
             when (segment) {
                 is ChatSegment.Text -> segment.text

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/chat/ChatAdapterUtils.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/chat/ChatAdapterUtils.kt
@@ -366,7 +366,7 @@ object ChatAdapterUtils {
                 }
                 if (chatMessage.systemMsg != null) {
                     if (chatMessage.isSubscriptionNotice()) {
-                        appendSpecialIcon(builder, context, R.drawable.ic_chat_subscription, getSavedColor("#E8E4EC", savedColors, useReadableColors, isLightTheme))
+                        appendSpecialIcon(builder, context, chatMessage.subscriptionIcon(), getSavedColor("#E8E4EC", savedColors, useReadableColors, isLightTheme))
                         builder.append(' ')
                         builderIndex = builder.length
                     }
@@ -375,8 +375,10 @@ object ChatAdapterUtils {
                         appendSubscriptionSystemMessage(
                             builder,
                             chatMessage.systemMsg,
-                            getSavedColor("#E8E4EC", savedColors, useReadableColors, isLightTheme),
                             getSavedColor("#C4BEC9", savedColors, useReadableColors, isLightTheme),
+                            chatMessage.color?.let { getSavedColor(it, savedColors, useReadableColors, isLightTheme) }
+                                ?: getSavedColor("#E8E4EC", savedColors, useReadableColors, isLightTheme),
+                            chatMessage.userName ?: chatMessage.userLogin,
                         )
                     } else {
                         builder.append(chatMessage.systemMsg)
@@ -459,7 +461,7 @@ object ChatAdapterUtils {
                     builderIndex = builder.length
                 } else if (chatMessage.systemMsg != null) {
                     if (chatMessage.isSubscriptionNotice()) {
-                        appendSpecialIcon(builder, context, R.drawable.ic_chat_subscription, getSavedColor("#E8E4EC", savedColors, useReadableColors, isLightTheme))
+                        appendSpecialIcon(builder, context, chatMessage.subscriptionIcon(), getSavedColor("#E8E4EC", savedColors, useReadableColors, isLightTheme))
                         builder.append(' ')
                         builderIndex = builder.length
                     }
@@ -468,8 +470,10 @@ object ChatAdapterUtils {
                         appendSubscriptionSystemMessage(
                             builder,
                             chatMessage.systemMsg,
-                            getSavedColor("#E8E4EC", savedColors, useReadableColors, isLightTheme),
                             getSavedColor("#C4BEC9", savedColors, useReadableColors, isLightTheme),
+                            chatMessage.color?.let { getSavedColor(it, savedColors, useReadableColors, isLightTheme) }
+                                ?: getSavedColor("#E8E4EC", savedColors, useReadableColors, isLightTheme),
+                            chatMessage.userName ?: chatMessage.userLogin,
                         )
                     } else {
                         builder.append(chatMessage.systemMsg)
@@ -1811,7 +1815,22 @@ internal fun ChatMessage.isSubscriptionNotice(): Boolean = effectiveNoticeId()?.
     "shared_chat_resub",
     "shared_chat_sub_gift",
     "shared_chat_community_sub_gift",
+    "pay_it_forward",
+    "shared_chat_gift_paid_upgrade",
+    "shared_chat_prime_paid_upgrade",
+    "shared_chat_pay_it_forward",
 )
+
+internal fun ChatMessage.isPrimeSubscriptionNotice(): Boolean = isSubscriptionNotice() && (
+    isPrimeSubscription == true ||
+        subscriptionPlan?.contains("prime", ignoreCase = true) == true
+    )
+
+internal fun ChatMessage.subscriptionIcon(): Int = if (isPrimeSubscriptionNotice()) {
+    R.drawable.ic_chat_subscription
+} else {
+    R.drawable.ic_chat_subscription_gift
+}
 
 internal fun ChatMessage.displayName(nameDisplay: String?): String? = when {
     userName.isNullOrBlank() -> userLogin
@@ -1857,13 +1876,19 @@ private fun appendSpecialText(
 private fun appendSubscriptionSystemMessage(
     builder: SpannableStringBuilder,
     message: String,
-    headingColor: Int,
     mutedColor: Int,
+    userColor: Int,
+    userName: String?,
 ) {
-    val nameEnd = message.indexOf(' ').takeIf { it > 0 } ?: message.length
-    appendSpecialText(builder, message.substring(0, nameEnd), headingColor, bold = true)
-    if (nameEnd < message.length) {
+    val actor = userName ?: message.substringBefore(' ').takeIf { !it.equals("An", ignoreCase = true) }
+    val nameEnd = actor
+        ?.takeIf { message.startsWith(it, ignoreCase = true) }
+        ?.length
+    if (nameEnd != null) {
+        appendSpecialText(builder, message.substring(0, nameEnd), userColor, bold = true)
         appendSpecialText(builder, message.substring(nameEnd), mutedColor)
+    } else {
+        appendSpecialText(builder, message, mutedColor)
     }
 }
 

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/chat/ChatUtils.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/chat/ChatUtils.kt
@@ -165,6 +165,9 @@ object ChatUtils {
             watchStreakPoints = if (effectiveNoticeId.equals("viewermilestone", true) && message.tags["msg-param-category"] == "watch-streak") {
                 message.tags["msg-param-copoReward"]?.toIntOrNull()?.takeIf { it > 0 }
             } else null,
+            subscriptionPlan = message.tags["msg-param-sub-plan"]
+                ?: message.tags["msg-param-sub-plan-name"],
+            isPrimeSubscription = message.tags["msg-param-sub-plan"]?.equals("Prime", true),
             fullMsg = message.fullMessage
         )
     }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/chat/EventSubUtils.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/chat/EventSubUtils.kt
@@ -78,6 +78,14 @@ object EventSubUtils {
         val messageText = if (messageObj?.isNull("text") == false) messageObj.optString("text").takeIf { it.isNotBlank() } else null
         val systemMsg = if (!json.isNull("system_message")) json.optString("system_message").takeIf { it.isNotBlank() } else null
         val noticeType = json.optString("notice_type")
+        val subscription = json.optJSONObject("sub")
+            ?: json.optJSONObject("resub")
+            ?: json.optJSONObject("shared_chat_sub")
+            ?: json.optJSONObject("shared_chat_resub")
+        val subscriptionPlan = subscription?.optString("sub_tier")?.takeIf { it.isNotBlank() }
+        val isPrimeSubscription = subscription
+            ?.takeIf { !it.isNull("is_prime") }
+            ?.optBoolean("is_prime")
         val watchStreak = json.optJSONObject("watch_streak")
         val watchStreakCount = if (noticeType == "watch_streak") {
             watchStreak?.optInt("streak_count")?.takeIf { it > 0 }
@@ -139,6 +147,8 @@ object EventSubUtils {
                 timestamp = timestamp?.let { Instant.parseOrNull(it)?.toEpochMilliseconds()?.takeIf { ms -> ms > 0 } },
                 watchStreakCount = watchStreakCount,
                 watchStreakPoints = watchStreakPoints,
+                subscriptionPlan = subscriptionPlan,
+                isPrimeSubscription = isPrimeSubscription,
                 fullMsg = json.toString()
             )
         } else {
@@ -147,11 +157,14 @@ object EventSubUtils {
                 userId = if (!json.isNull("chatter_user_id")) json.optString("chatter_user_id").takeIf { it.isNotBlank() } else null,
                 userLogin = if (!json.isNull("chatter_user_login")) json.optString("chatter_user_login").takeIf { it.isNotBlank() } else null,
                 userName = if (!json.isNull("chatter_user_name")) json.optString("chatter_user_name").takeIf { it.isNotBlank() } else null,
+                color = if (!json.isNull("color")) json.optString("color").takeIf { it.isNotBlank() } else null,
                 systemMsg = systemMsg,
                 timestamp = timestamp?.let { Instant.parseOrNull(it)?.toEpochMilliseconds()?.takeIf { ms -> ms > 0 } },
                 msgId = noticeType.takeIf { it.isNotBlank() },
                 watchStreakCount = watchStreakCount,
                 watchStreakPoints = watchStreakPoints,
+                subscriptionPlan = subscriptionPlan,
+                isPrimeSubscription = isPrimeSubscription,
                 fullMsg = json.toString()
             )
         }

--- a/app/src/main/res/drawable/ic_chat_subscription_gift.xml
+++ b/app/src/main/res/drawable/ic_chat_subscription_gift.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M12,2.5L14.65,8.1L20.75,8.85L16.25,13.05L17.45,19.1L12,16.15L6.55,19.1L7.75,13.05L3.25,8.85L9.35,8.1Z" />
+</vector>

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatDomainPresentationTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatDomainPresentationTest.kt
@@ -176,19 +176,79 @@ class ChatDomainPresentationTest {
     }
 
     @Test
-    fun paidSubscriptionNoticeDoesNotUseThePrimeRail() {
+    fun paidSubscriptionNoticeUsesTheGiftRailAndKeepsTheActorColored() {
         val row = ChatRowCompiler().compile(
             message(ChatSegment.Text("They've been subscribed for 6 months!")).copy(
+                user = ChatUser("user", "viewer", "Viewer", 0xff9147ff.toInt()),
                 kind = ChatMessageKind.NOTICE,
                 noticeType = "resub",
                 subscriptionPlan = "1000",
+                isPrimeSubscription = false,
                 systemText = "Viewer subscribed with Tier 1.",
             ),
         )
 
-        assertEquals(ChatRowBackground.NOTICE, row.backgroundStyle)
-        assertTrue(row.pieces.filterIsInstance<ChatPiece.Text>().any { it.value.contains("Viewer subscribed") })
-        assertTrue(row.pieces.none { it is ChatPiece.Icon && it.drawableRes == R.drawable.ic_chat_subscription })
+        assertEquals(ChatRowBackground.SUBSCRIPTION, row.backgroundStyle)
+        assertTrue(row.pieces.any { it is ChatPiece.Icon && it.drawableRes == R.drawable.ic_chat_subscription_gift })
+        assertTrue(row.pieces.filterIsInstance<ChatPiece.Text>().any { it.value == "Viewer" && it.bold && it.color == 0xff9147ff.toInt() })
+        assertTrue(row.pieces.filterIsInstance<ChatPiece.Text>().any { it.value == " subscribed with Tier 1." && it.color == 0xffc4bec9.toInt() })
+    }
+
+    @Test
+    fun giftedSubscriptionNoticeUsesTheSameInlineEventTreatment() {
+        val row = ChatRowCompiler().compile(
+            message(ChatSegment.Text("")).copy(
+                user = ChatUser("gifter", "renagade45", "renagade45", 0xff9147ff.toInt()),
+                kind = ChatMessageKind.NOTICE,
+                noticeType = "sub_gift",
+                systemText = "renagade45 gifted a Tier 1 Sub to posty's community!",
+                segments = emptyList(),
+            ),
+        )
+
+        assertEquals(ChatRowBackground.SUBSCRIPTION, row.backgroundStyle)
+        assertTrue(row.pieces.any { it is ChatPiece.Icon && it.drawableRes == R.drawable.ic_chat_subscription_gift })
+        assertTrue(row.pieces.none { it is ChatPiece.Username })
+        assertTrue(row.pieces.filterIsInstance<ChatPiece.Text>().any { it.value == "renagade45" && it.bold })
+    }
+
+    @Test
+    fun primePaidUpgradeUsesThePaidSubscriptionIcon() {
+        listOf("prime_paid_upgrade", "shared_chat_prime_paid_upgrade").forEach { noticeType ->
+            val row = ChatRowCompiler().compile(
+                message(ChatSegment.Text("")).copy(
+                    user = ChatUser("user", "viewer", "Viewer", null),
+                    kind = ChatMessageKind.NOTICE,
+                    noticeType = noticeType,
+                    subscriptionPlan = "1000",
+                    systemText = "Viewer upgraded to a paid Tier 1 Sub.",
+                    segments = emptyList(),
+                ),
+            )
+
+            assertTrue(row.pieces.any { it is ChatPiece.Icon && it.drawableRes == R.drawable.ic_chat_subscription_gift })
+            assertTrue(row.pieces.none { it is ChatPiece.Icon && it.drawableRes == R.drawable.ic_chat_subscription })
+        }
+    }
+
+    @Test
+    fun primeSubscriptionMetadataUsesTheCrownAcrossSharedChatVariants() {
+        listOf("resub", "shared_chat_sub", "shared_chat_resub").forEach { noticeType ->
+            val row = ChatRowCompiler().compile(
+                message(ChatSegment.Text("")).copy(
+                    user = ChatUser("user", "viewer", "Viewer", null),
+                    kind = ChatMessageKind.NOTICE,
+                    noticeType = noticeType,
+                    subscriptionPlan = "1000",
+                    isPrimeSubscription = true,
+                    systemText = "Viewer subscribed with Prime Gaming.",
+                    segments = emptyList(),
+                ),
+            )
+
+            assertTrue(row.pieces.any { it is ChatPiece.Icon && it.drawableRes == R.drawable.ic_chat_subscription })
+            assertTrue(row.pieces.none { it is ChatPiece.Icon && it.drawableRes == R.drawable.ic_chat_subscription_gift })
+        }
     }
 
     @Test

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/TwitchChatEventParserTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/TwitchChatEventParserTest.kt
@@ -249,6 +249,42 @@ class TwitchChatEventParserTest {
     }
 
     @Test
+    fun eventSubReadsPrimeMetadataFromAllSubscriptionObjects() {
+        listOf("resub", "shared_chat_sub", "shared_chat_resub").forEach { objectName ->
+            val event = JSONObject(
+                """
+                {
+                  "notice_type":"$objectName",
+                  "$objectName":{"sub_tier":"1000","is_prime":true},
+                  "system_message":"Viewer subscribed with Prime Gaming."
+                }
+                """.trimIndent(),
+            )
+
+            val message = (TwitchChatEventParser.fromEventSub(event, null, notice = true) as ChatEvent.Message).message
+            assertEquals("1000", message.subscriptionPlan)
+            assertEquals(true, message.isPrimeSubscription)
+        }
+    }
+
+    @Test
+    fun eventSubPaidSubscriptionMetadataRemainsNonPrime() {
+        val event = JSONObject(
+            """
+            {
+              "notice_type":"shared_chat_resub",
+              "shared_chat_resub":{"sub_tier":"1000","is_prime":false},
+              "system_message":"Viewer subscribed with Tier 1."
+            }
+            """.trimIndent(),
+        )
+
+        val message = (TwitchChatEventParser.fromEventSub(event, null, notice = true) as ChatEvent.Message).message
+        assertEquals("1000", message.subscriptionPlan)
+        assertEquals(false, message.isPrimeSubscription)
+    }
+
+    @Test
     fun ircGifOnlyMessageUsesTheProvidedUrlAndFallbackText() {
         val text = "[Dog Eat GIF by Respective]"
         val url = "https://media4.giphy.com/media/gif/giphy.gif?token=a=b&format=webp"

--- a/app/src/test/java/com/github/andreyasadchy/xtra/util/chat/SpecialChatMessageParsingTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/util/chat/SpecialChatMessageParsingTest.kt
@@ -77,6 +77,51 @@ class SpecialChatMessageParsingTest {
     }
 
     @Test
+    fun eventSubSystemOnlySubscriptionKeepsChatterColor() {
+        val message = EventSubUtils.parseUserNotice(
+            JSONObject(
+                """
+                {
+                  "chatter_user_id": "gifter-id",
+                  "chatter_user_login": "renagade45",
+                  "chatter_user_name": "renagade45",
+                  "color": "#9147ff",
+                  "notice_type": "sub_gift",
+                  "system_message": "renagade45 gifted a Tier 1 Sub to posty's community!",
+                  "message": {"text": "", "fragments": []}
+                }
+                """.trimIndent(),
+            ),
+            null,
+        )
+
+        assertEquals("#9147ff", message.color)
+        assertEquals("sub_gift", message.msgId)
+    }
+
+    @Test
+    fun legacyEventSubReadsPrimeMetadataFromSharedChatSubscriptionObjects() {
+        listOf("resub", "shared_chat_sub", "shared_chat_resub").forEach { objectName ->
+            val message = EventSubUtils.parseUserNotice(
+                JSONObject(
+                    """
+                    {
+                      "notice_type": "$objectName",
+                      "$objectName": {"sub_tier": "1000", "is_prime": true},
+                      "system_message": "Viewer subscribed with Prime Gaming.",
+                      "message": {"text": "", "fragments": []}
+                    }
+                    """.trimIndent(),
+                ),
+                null,
+            )
+
+            assertEquals("1000", message.subscriptionPlan)
+            assertTrue(message.isPrimeSubscription == true)
+        }
+    }
+
+    @Test
     fun sharedChatSubscriptionUsesOriginalNoticeId() {
         val message = ChatUtils.parseChatMessage(
             ChatUtils.parseIRCMessage(


### PR DESCRIPTION
Match Twitch chat for subscription events: gifted and paid subscriptions use the star treatment, Prime uses the crown, and the event actor keeps their chat color. The same rendering is used by both chat paths.