### PR TITLE
Fix highlighted channel point messages

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/XtraModule.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/XtraModule.kt
@@ -884,6 +884,30 @@ class XtraModule(application: Application) {
                                 )
                             }
                         }
+                        settings.automaticRewards.forEach { reward ->
+                            val id = reward.id?.takeIf { it.isNotBlank() }
+                            val type = reward.type?.uppercase()
+                            val title = when (type) {
+                                "RANDOM_SUB_EMOTE_UNLOCK" -> "Unlock a Random Sub Emote"
+                                "SINGLE_MESSAGE_BYPASS_SUB_MODE" -> "Send a Message in Sub-Only Mode"
+                                "CHOSEN_SUB_EMOTE_UNLOCK" -> "Choose an Emote to Unlock"
+                                "CHOSEN_MODIFIED_SUB_EMOTE_UNLOCK" -> "Modify a Single Emote"
+                                "SEND_HIGHLIGHTED_MESSAGE" -> "Highlight My Message"
+                                else -> null
+                            }
+                            val cost = reward.cost ?: reward.defaultCost
+                            if (id != null && title != null && cost != null && cost > 0) {
+                                put(
+                                    id,
+                                    ChatReward(
+                                        title = title,
+                                        cost = cost,
+                                        imageUrl = reward.image?.url4x ?: reward.image?.url2x ?: reward.image?.url1x
+                                            ?: reward.defaultImage?.url4x ?: reward.defaultImage?.url2x ?: reward.defaultImage?.url1x,
+                                    ),
+                                )
+                            }
+                        }
                     }
                 }
                 rewards

--- a/app/src/main/java/com/github/andreyasadchy/xtra/XtraModule.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/XtraModule.kt
@@ -57,6 +57,7 @@ import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.TwitchChatCatalogCache
 import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.TwitchChatCatalogSource
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatEvent
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatReward
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatRewardCatalog
 import com.github.andreyasadchy.xtra.ui.chat.v2.session.ChatSessionManager
 import com.github.andreyasadchy.xtra.ui.chat.v2.session.LiveChatSessionSpec
 import com.github.andreyasadchy.xtra.ui.chat.v2.session.RecentChatHistoryRepository
@@ -860,7 +861,7 @@ class XtraModule(application: Application) {
                 }
             },
             rewardCatalogFactory = { spec, scope ->
-                val rewards = MutableStateFlow<Map<String, ChatReward>>(emptyMap())
+                val rewards = MutableStateFlow(ChatRewardCatalog())
                 scope.launch {
                     val network = appContext.prefs().getString(C.NETWORK_LIBRARY, C.OKHTTP)
                     val headers = TwitchApiHelper.getGQLHeaders(appContext, true)
@@ -868,7 +869,7 @@ class XtraModule(application: Application) {
                         graphQLRepository.loadChannelPointsContext(network, headers, spec.channelLogin)
                             .data?.community?.channel?.communityPointsSettings
                     }.getOrNull() ?: return@launch
-                    rewards.value = buildMap {
+                    val byId = buildMap {
                         settings.customRewards.forEach { reward ->
                             val id = reward.id?.takeIf { it.isNotBlank() }
                             val title = reward.title?.takeIf { it.isNotBlank() }
@@ -886,32 +887,48 @@ class XtraModule(application: Application) {
                         }
                         settings.automaticRewards.forEach { reward ->
                             val id = reward.id?.takeIf { it.isNotBlank() }
-                            val type = reward.type?.uppercase()
-                            val title = when (type) {
-                                "RANDOM_SUB_EMOTE_UNLOCK" -> "Unlock a Random Sub Emote"
-                                "SINGLE_MESSAGE_BYPASS_SUB_MODE" -> "Send a Message in Sub-Only Mode"
-                                "CHOSEN_SUB_EMOTE_UNLOCK" -> "Choose an Emote to Unlock"
-                                "CHOSEN_MODIFIED_SUB_EMOTE_UNLOCK" -> "Modify a Single Emote"
-                                "SEND_HIGHLIGHTED_MESSAGE" -> "Highlight My Message"
-                                else -> null
-                            }
-                            val cost = reward.cost ?: reward.defaultCost
-                            if (id != null && title != null && cost != null && cost > 0) {
-                                put(
-                                    id,
-                                    ChatReward(
-                                        title = title,
-                                        cost = cost,
-                                        imageUrl = reward.image?.url4x ?: reward.image?.url2x ?: reward.image?.url1x
-                                            ?: reward.defaultImage?.url4x ?: reward.defaultImage?.url2x ?: reward.defaultImage?.url1x,
-                                    ),
-                                )
+                            val automatic = automaticChatReward(reward.type, reward.cost ?: reward.defaultCost, reward.image, reward.defaultImage)
+                            if (id != null && automatic != null) {
+                                put(id, automatic)
                             }
                         }
                     }
+                    val automaticByType = buildMap {
+                        settings.automaticRewards.forEach { reward ->
+                            val type = reward.type?.uppercase()?.takeIf { it.isNotBlank() } ?: return@forEach
+                            val automatic = automaticChatReward(reward.type, reward.cost ?: reward.defaultCost, reward.image, reward.defaultImage)
+                            if (automatic != null) {
+                                put(type, automatic)
+                            }
+                        }
+                    }
+                    rewards.value = ChatRewardCatalog(byId = byId, automaticByType = automaticByType)
                 }
                 rewards
             },
+        )
+    }
+
+    private fun automaticChatReward(
+        type: String?,
+        cost: Int?,
+        image: com.github.andreyasadchy.xtra.model.gql.chat.ChannelPointContextResponse.RewardImage?,
+        defaultImage: com.github.andreyasadchy.xtra.model.gql.chat.ChannelPointContextResponse.RewardImage?,
+    ): ChatReward? {
+        val title = when (type?.uppercase()) {
+            "RANDOM_SUB_EMOTE_UNLOCK" -> "Unlock a Random Sub Emote"
+            "SINGLE_MESSAGE_BYPASS_SUB_MODE" -> "Send a Message in Sub-Only Mode"
+            "CHOSEN_SUB_EMOTE_UNLOCK" -> "Choose an Emote to Unlock"
+            "CHOSEN_MODIFIED_SUB_EMOTE_UNLOCK" -> "Modify a Single Emote"
+            "SEND_HIGHLIGHTED_MESSAGE" -> "Highlight My Message"
+            else -> null
+        } ?: return null
+        if (cost == null || cost <= 0) return null
+        return ChatReward(
+            title = title,
+            cost = cost,
+            imageUrl = image?.url4x ?: image?.url2x ?: image?.url1x
+                ?: defaultImage?.url4x ?: defaultImage?.url2x ?: defaultImage?.url1x,
         )
     }
 }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatFragment.kt
@@ -876,13 +876,25 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
                             },
                             profilePopoutGesture = profilePopoutGesture,
                             rewardCatalog = viewModel.channelPoints.map { points ->
-                                points?.rewards.orEmpty().associate { reward ->
-                                    reward.id to ChatReward(
-                                        title = reward.title,
-                                        cost = reward.cost,
-                                        imageUrl = reward.imageUrl,
-                                    )
-                                }
+                                val rewards = points?.rewards.orEmpty()
+                                com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatRewardCatalog(
+                                    byId = rewards.associate { reward ->
+                                        reward.id to ChatReward(
+                                            title = reward.title,
+                                            cost = reward.cost,
+                                            imageUrl = reward.imageUrl,
+                                        )
+                                    },
+                                    automaticByType = rewards
+                                        .filter { it.redemptionType == com.github.andreyasadchy.xtra.model.ui.ChannelPointRewardRedemption.HIGHLIGHTED_MESSAGE }
+                                        .associate { reward ->
+                                            com.github.andreyasadchy.xtra.ui.chat.v2.domain.HIGHLIGHTED_MESSAGE_REWARD_TYPE to ChatReward(
+                                                title = reward.title,
+                                                cost = reward.cost,
+                                                imageUrl = reward.imageUrl,
+                                            )
+                                        },
+                                )
                             },
                             decorationCatalog = merge(
                                 viewModel.thirdPartyEmotesUpdated,

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/catalog/ChatCatalogSnapshot.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/catalog/ChatCatalogSnapshot.kt
@@ -152,6 +152,8 @@ data class ChatCatalogSnapshot(
     val sevenTvBadges: Map<String, ChatCatalogBadge> = emptyMap(),
     /** Runtime channel-point metadata; intentionally not persisted with emote catalogs. */
     val channelPointRewards: Map<String, ChatReward> = emptyMap(),
+    /** Built-in rewards keyed by upper-cased GQL type (e.g. SEND_HIGHLIGHTED_MESSAGE). */
+    val automaticChannelPointRewards: Map<String, ChatReward> = emptyMap(),
     /** Changes when runtime reward metadata changes without a provider catalog refresh. */
     val channelPointRewardsRevision: Int = 0,
 )

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/domain/ChatReward.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/domain/ChatReward.kt
@@ -6,3 +6,35 @@ data class ChatReward(
     val cost: Int? = null,
     val imageUrl: String? = null,
 )
+
+/** GQL automatic reward type for the Highlight My Message redemption. */
+const val HIGHLIGHTED_MESSAGE_REWARD_TYPE = "SEND_HIGHLIGHTED_MESSAGE"
+
+/**
+ * Runtime channel-point metadata. Custom rewards are keyed by reward ID while
+ * automatic (built-in) rewards are keyed by their upper-cased GQL type, since
+ * real Highlight My Message events carry no custom reward ID on either IRC
+ * (`msg-id=highlighted-message` without `custom-reward-id`) or EventSub
+ * (`message_type=channel_points_highlighted` without
+ * `channel_points_custom_reward_id`).
+ */
+data class ChatRewardCatalog(
+    val byId: Map<String, ChatReward> = emptyMap(),
+    val automaticByType: Map<String, ChatReward> = emptyMap(),
+) {
+    fun rewardFor(message: ChatMessage): ChatReward? {
+        message.rewardId?.let { id ->
+            byId[id]?.let { return it }
+        }
+        if (message.twitchType == TwitchChatMessageType.Highlighted) {
+            automaticByType[HIGHLIGHTED_MESSAGE_REWARD_TYPE]?.let { return it }
+        }
+        // Inline EventSub/PubSub metadata covers redemptions whose reward is
+        // not (or not yet) in the catalog. Only highlights carry reward
+        // meaning without a reward ID.
+        if (message.rewardId == null && message.twitchType != TwitchChatMessageType.Highlighted) return null
+        return message.rewardTitle?.let { title ->
+            ChatReward(title, message.rewardCost, message.rewardImageUrl)
+        }
+    }
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/presentation/ChatRowCompiler.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/presentation/ChatRowCompiler.kt
@@ -199,7 +199,11 @@ class ChatRowCompiler(
             }
             if (message.twitchType == TwitchChatMessageType.Highlighted) {
                 val headingColor = 0xFFE8E4EC.toInt()
-                val highlightTitle = reward?.title?.takeIf { it.isNotBlank() } ?: labels.highlightTitle
+                // The displayed highlight title is always the localized
+                // presentation label. The catalog only provides the configured
+                // cost/image metadata, whose built-in titles are hardcoded
+                // English and must not override the label.
+                val highlightTitle = labels.highlightTitle
                 val heading = labels.highlightRedeemed(highlightTitle)
                 val titleStart = heading.indexOf(highlightTitle).coerceAtLeast(0)
                 add(ChatPiece.Text(heading.substring(0, titleStart), color = headingColor))

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/presentation/ChatRowCompiler.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/presentation/ChatRowCompiler.kt
@@ -12,7 +12,7 @@ import com.github.andreyasadchy.xtra.ui.chat.v2.domain.TwitchChatMessageType
 import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatCatalogEmote
 import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatCatalogSnapshot
 import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ScopedEmoteCatalog
-import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatReward
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatRewardCatalog
 import com.github.andreyasadchy.xtra.ui.chat.v2.presentation.ChatRowBackground
 import com.github.andreyasadchy.xtra.ui.chat.ChatGifDisplayMode
 import java.text.NumberFormat
@@ -66,10 +66,10 @@ class ChatRowCompiler(
             message.isPrimeSubscription == true ||
                 message.subscriptionPlan?.contains("prime", ignoreCase = true) == true
             )
-        val reward = message.rewardId?.let { rewardId ->
-            catalog.channelPointRewards[rewardId]
-                ?: message.rewardTitle?.let { title -> ChatReward(title, message.rewardCost, message.rewardImageUrl) }
-        }
+        val reward = ChatRewardCatalog(
+            byId = catalog.channelPointRewards,
+            automaticByType = catalog.automaticChannelPointRewards,
+        ).rewardFor(message)
         val hasSemanticBody = message.segments.any {
             it !is ChatSegment.Text || it.text.isNotBlank()
         }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/presentation/ChatRowCompiler.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/presentation/ChatRowCompiler.kt
@@ -198,7 +198,19 @@ class ChatRowCompiler(
                 add(ChatPiece.Text("${labels.announcement}\n", bold = true))
             }
             if (message.twitchType == TwitchChatMessageType.Highlighted) {
-                add(ChatPiece.Text("${labels.highlightRedeemed(labels.highlightTitle)}\n", bold = true))
+                val headingColor = 0xFFE8E4EC.toInt()
+                val highlightTitle = reward?.title?.takeIf { it.isNotBlank() } ?: labels.highlightTitle
+                val heading = labels.highlightRedeemed(highlightTitle)
+                val titleStart = heading.indexOf(highlightTitle).coerceAtLeast(0)
+                add(ChatPiece.Text(heading.substring(0, titleStart), color = headingColor))
+                add(ChatPiece.Text(heading.substring(titleStart), color = headingColor, bold = true))
+                add(ChatPiece.Text("\n", color = headingColor))
+                reward?.cost?.let { cost ->
+                    add(ChatPiece.Icon(R.drawable.ic_chat_channel_points, tint = headingColor, sizeDp = 22))
+                    add(ChatPiece.Text(" ", color = headingColor))
+                    add(ChatPiece.Text(NumberFormat.getInstance().format(cost), color = headingColor, bold = true))
+                    add(ChatPiece.Text("\n", color = headingColor))
+                }
             }
             if (message.rewardId != null && message.twitchType != TwitchChatMessageType.Highlighted) {
                 if (isRewardOnly) {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/session/ChatSessionManager.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/session/ChatSessionManager.kt
@@ -3,7 +3,7 @@ package com.github.andreyasadchy.xtra.ui.chat.v2.session
 import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatCatalogRepository
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatEvent
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessage
-import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatReward
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatRewardCatalog
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatSessionKey
 import com.github.andreyasadchy.xtra.ui.chat.v2.transport.ChatTransport
 import kotlinx.coroutines.CoroutineScope
@@ -37,7 +37,7 @@ data class ActiveChatSession(
     val key: ChatSessionKey,
     val session: ChatSession,
     val catalog: ChatCatalogRepository,
-    val rewardCatalog: Flow<Map<String, ChatReward>> = flowOf(emptyMap()),
+    val rewardCatalog: Flow<ChatRewardCatalog> = flowOf(ChatRewardCatalog()),
 )
 
 /** Creates independent live sessions. The player and Multiview use separate handles. */
@@ -47,7 +47,7 @@ class ChatSessionFactory(
     private val catalogFactory: (LiveChatSessionSpec, CoroutineScope) -> ChatCatalogRepository,
     private val recentHistory: suspend (LiveChatSessionSpec) -> List<ChatMessage> = { emptyList() },
     private val initialSettings: suspend (LiveChatSessionSpec) -> ChatEvent.SettingsUpdated? = { null },
-    private val rewardCatalogFactory: (LiveChatSessionSpec, CoroutineScope) -> Flow<Map<String, ChatReward>> = { _, _ -> flowOf(emptyMap()) },
+    private val rewardCatalogFactory: (LiveChatSessionSpec, CoroutineScope) -> Flow<ChatRewardCatalog> = { _, _ -> flowOf(ChatRewardCatalog()) },
     private val maxTimelineSize: Int = 600,
 ) {
     private var generation = 0L
@@ -76,7 +76,7 @@ class ChatSessionFactory(
         )
         // Keep the public flow stable for renderers, but defer the actual provider construction
         // until the owner explicitly starts this handle.
-        val rewardCatalog = MutableStateFlow<Map<String, ChatReward>>(emptyMap())
+        val rewardCatalog = MutableStateFlow(ChatRewardCatalog())
         val active = ActiveChatSession(spec, key, session, catalog, rewardCatalog)
         return ChatSessionHandle(
             active = active,
@@ -93,9 +93,9 @@ class ChatSessionHandle internal constructor(
     val active: ActiveChatSession,
     private val scope: CoroutineScope,
     private val reconcileRecent: suspend () -> Unit,
-    private val startRewardCatalog: (CoroutineScope) -> Flow<Map<String, ChatReward>>,
+    private val startRewardCatalog: (CoroutineScope) -> Flow<ChatRewardCatalog>,
     private val initialSettings: suspend () -> ChatEvent.SettingsUpdated?,
-    private val rewardCatalogState: MutableStateFlow<Map<String, ChatReward>>,
+    private val rewardCatalogState: MutableStateFlow<ChatRewardCatalog>,
 ) {
     private val lifecycleMutex = Mutex()
     private var started = false
@@ -177,7 +177,7 @@ class ChatSessionManager(
     private val catalogFactory: (LiveChatSessionSpec, CoroutineScope) -> ChatCatalogRepository,
     private val recentHistory: suspend (LiveChatSessionSpec) -> List<ChatMessage> = { emptyList() },
     private val initialSettings: suspend (LiveChatSessionSpec) -> ChatEvent.SettingsUpdated? = { null },
-    private val rewardCatalogFactory: (LiveChatSessionSpec, CoroutineScope) -> Flow<Map<String, ChatReward>> = { _, _ -> flowOf(emptyMap()) },
+    private val rewardCatalogFactory: (LiveChatSessionSpec, CoroutineScope) -> Flow<ChatRewardCatalog> = { _, _ -> flowOf(ChatRewardCatalog()) },
     private val maxTimelineSize: Int = 600,
 ) {
     private val managerJob = SupervisorJob(parentScope.coroutineContext[Job])

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/transport/TwitchChatEventParser.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/transport/TwitchChatEventParser.kt
@@ -512,7 +512,7 @@ object TwitchChatEventParser {
 
     private fun parseMessageType(raw: String): TwitchChatMessageType = when (raw.lowercase()) {
         "text" -> TwitchChatMessageType.Text
-        "channel_points_highlighted" -> TwitchChatMessageType.Highlighted
+        "channel_points_highlighted", "highlighted-message" -> TwitchChatMessageType.Highlighted
         "channel_points_sub_only" -> TwitchChatMessageType.SubscriberOnly
         "user_intro" -> TwitchChatMessageType.UserIntro
         "power_ups_message_effect" -> TwitchChatMessageType.MessageEffect

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatV2RendererController.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatV2RendererController.kt
@@ -9,7 +9,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.github.andreyasadchy.xtra.ui.chat.v2.assets.ChatAssetRepository
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessageId
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessage
-import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatReward
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatRewardCatalog
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatEmoteInteraction
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatGifInteraction
 import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatDecorationSnapshot
@@ -90,7 +90,7 @@ class ChatV2RendererController(
     private val onStateChanged: (ChatViewportState) -> Unit = {},
     private val onMessageLongClick: (ChatMessage) -> Unit = {},
     private val profilePopoutGesture: ChatProfilePopoutGesture = ChatProfilePopoutGesture.HOLD,
-    private val rewardCatalog: Flow<Map<String, ChatReward>> = flowOf(emptyMap()),
+    private val rewardCatalog: Flow<ChatRewardCatalog> = flowOf(ChatRewardCatalog()),
     private val decorationCatalog: Flow<ChatDecorationSnapshot> = flowOf(ChatDecorationSnapshot()),
     private val onEmoteClick: (ChatEmoteInteraction) -> Unit = {},
     private val onGifClick: (ChatGifInteraction) -> Unit = {},
@@ -355,7 +355,8 @@ class ChatV2RendererController(
                     key,
                     snapshot.messages,
                     catalogState.snapshot.copy(
-                        channelPointRewards = rewards,
+                        channelPointRewards = rewards.byId,
+                        automaticChannelPointRewards = rewards.automaticByType,
                         channelPointRewardsRevision = rewards.hashCode(),
                         // The v2 catalog owns live 7TV updates. Keep the legacy snapshot as a
                         // compatibility fallback without allowing it to erase newer v2 data.

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/multiview/CombinedChatFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/multiview/CombinedChatFragment.kt
@@ -546,7 +546,7 @@ private class CombinedChatAdapter(
         private val active: com.github.andreyasadchy.xtra.ui.chat.v2.session.ActiveChatSession,
         private val identity: String,
         val assets: ChatAssetRepository,
-        private val rewards: (String) -> Map<String, com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatReward>,
+        private val rewards: (String) -> com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatRewardCatalog,
         private val profileGesture: ChatProfilePopoutGesture,
     ) {
         private val context = fragment.requireContext()
@@ -601,10 +601,11 @@ private class CombinedChatAdapter(
             presentationRevision = fragment.translationFor(message)?.hashCode()?.toLong() ?: 0L,
         )
 
-        private fun catalog() = rewards(identity).let { rewardMap ->
+        private fun catalog() = rewards(identity).let { rewardCatalog ->
             active.catalog.state.value.snapshot.copy(
-                channelPointRewards = rewardMap,
-                channelPointRewardsRevision = rewardMap.hashCode(),
+                channelPointRewards = rewardCatalog.byId,
+                automaticChannelPointRewards = rewardCatalog.automaticByType,
+                channelPointRewardsRevision = rewardCatalog.hashCode(),
             )
         }
 
@@ -638,7 +639,8 @@ private class CombinedChatAdapter(
                     message = it.parentMessageBody,
                 )
             }
-            val reward = message.rewardId?.let(rewards(identity)::get)?.let {
+            val rewardCatalog = rewards(identity)
+            val reward = rewardCatalog.rewardFor(message)?.let {
                 com.github.andreyasadchy.xtra.model.chat.ChannelPointReward(
                     id = message.rewardId,
                     title = it.title,

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/multiview/chat/CombinedChatViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/multiview/chat/CombinedChatViewModel.kt
@@ -199,8 +199,8 @@ class CombinedChatViewModel(
 
     fun channelId(identity: String): String? = sessions[identity]?.stream?.channelId
 
-    fun rewardCatalog(identity: String): Map<String, com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatReward> =
-        sessions[identity]?.rewardCatalog.orEmpty()
+    fun rewardCatalog(identity: String): com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatRewardCatalog =
+        sessions[identity]?.rewardCatalog ?: com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatRewardCatalog()
 
     fun invalidateRendering(identity: String?) {
         if (identity == null || sessions[identity] == null) return
@@ -230,7 +230,8 @@ class CombinedChatViewModel(
         var renderGeneration: Long = 0L
         var networkActive = false
         var controlJob: Job? = null
-        var rewardCatalog: Map<String, com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatReward> = emptyMap()
+        var rewardCatalog: com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatRewardCatalog =
+            com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatRewardCatalog()
         val renderedMessages = linkedMapOf<com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessageId, CombinedChatMessage>()
 
         fun pause(scope: kotlinx.coroutines.CoroutineScope) {

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatDomainPresentationTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatDomainPresentationTest.kt
@@ -154,13 +154,13 @@ class ChatDomainPresentationTest {
         val row = ChatRowCompiler().compile(
             message(ChatSegment.Text("Lock them up!")).copy(
                 user = ChatUser("user", "viewer", "Viewer", null),
-                rewardId = "highlight",
+                rewardId = null,
                 twitchType = TwitchChatMessageType.Highlighted,
             ),
             ChatCatalogSnapshot(
                 0,
-                channelPointRewards = mapOf(
-                    "highlight" to ChatReward("Highlight My Message", 2_000, null),
+                automaticChannelPointRewards = mapOf(
+                    com.github.andreyasadchy.xtra.ui.chat.v2.domain.HIGHLIGHTED_MESSAGE_REWARD_TYPE to ChatReward("Highlight My Message", 2_000, null),
                 ),
             ),
         )
@@ -169,7 +169,7 @@ class ChatDomainPresentationTest {
         assertEquals("Redeemed ", row.pieces.filterIsInstance<ChatPiece.Text>().first().value)
         assertTrue(row.pieces.any { it is ChatPiece.Text && it.value == "Highlight My Message" && it.bold })
         assertTrue(row.pieces.any { it is ChatPiece.Icon && it.drawableRes == R.drawable.ic_chat_channel_points })
-        assertTrue(text.contains("2,000"))
+        assertTrue(text.filter(Char::isDigit).contains("2000"))
         assertTrue(row.pieces.any { it is ChatPiece.Username && it.value == "Viewer" })
         assertTrue(text.contains("Lock them up!"))
         assertEquals(ChatRowBackground.HIGHLIGHT, row.backgroundStyle)

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatDomainPresentationTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatDomainPresentationTest.kt
@@ -176,6 +176,35 @@ class ChatDomainPresentationTest {
     }
 
     @Test
+    fun highlightedRedemptionPrefersLocalizedTitleOverCatalogTitle() {
+        val row = ChatRowCompiler(
+            labels = com.github.andreyasadchy.xtra.ui.chat.v2.presentation.ChatPresentationLabels(
+                highlightTitle = "Zvýrazniť moju správu",
+                highlightRedeemed = { "Uplatnené: $it" },
+            ),
+        ).compile(
+            message(ChatSegment.Text("Lock them up!")).copy(
+                user = ChatUser("user", "viewer", "Viewer", null),
+                rewardId = null,
+                twitchType = TwitchChatMessageType.Highlighted,
+            ),
+            ChatCatalogSnapshot(
+                0,
+                automaticChannelPointRewards = mapOf(
+                    com.github.andreyasadchy.xtra.ui.chat.v2.domain.HIGHLIGHTED_MESSAGE_REWARD_TYPE to ChatReward("Highlight My Message", 2_000, null),
+                ),
+            ),
+        )
+
+        val text = row.pieces.filterIsInstance<ChatPiece.Text>().joinToString("") { it.value }
+        assertTrue(row.pieces.any { it is ChatPiece.Text && it.value == "Zvýrazniť moju správu" && it.bold })
+        assertTrue(row.pieces.none { it is ChatPiece.Text && it.value == "Highlight My Message" })
+        assertTrue(row.pieces.any { it is ChatPiece.Icon && it.drawableRes == R.drawable.ic_chat_channel_points })
+        assertTrue(text.filter(Char::isDigit).contains("2000"))
+        assertEquals(ChatRowBackground.HIGHLIGHT, row.backgroundStyle)
+    }
+
+    @Test
     fun translationIsRenderedAsASeparateMutedLine() {
         val row = ChatRowCompiler(
             translation = { "Translated: hello" },

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatDomainPresentationTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatDomainPresentationTest.kt
@@ -150,6 +150,32 @@ class ChatDomainPresentationTest {
     }
 
     @Test
+    fun highlightedRedemptionUsesTitleCostRowAndHighlightBackground() {
+        val row = ChatRowCompiler().compile(
+            message(ChatSegment.Text("Lock them up!")).copy(
+                user = ChatUser("user", "viewer", "Viewer", null),
+                rewardId = "highlight",
+                twitchType = TwitchChatMessageType.Highlighted,
+            ),
+            ChatCatalogSnapshot(
+                0,
+                channelPointRewards = mapOf(
+                    "highlight" to ChatReward("Highlight My Message", 2_000, null),
+                ),
+            ),
+        )
+
+        val text = row.pieces.filterIsInstance<ChatPiece.Text>().joinToString("") { it.value }
+        assertEquals("Redeemed ", row.pieces.filterIsInstance<ChatPiece.Text>().first().value)
+        assertTrue(row.pieces.any { it is ChatPiece.Text && it.value == "Highlight My Message" && it.bold })
+        assertTrue(row.pieces.any { it is ChatPiece.Icon && it.drawableRes == R.drawable.ic_chat_channel_points })
+        assertTrue(text.contains("2,000"))
+        assertTrue(row.pieces.any { it is ChatPiece.Username && it.value == "Viewer" })
+        assertTrue(text.contains("Lock them up!"))
+        assertEquals(ChatRowBackground.HIGHLIGHT, row.backgroundStyle)
+    }
+
+    @Test
     fun translationIsRenderedAsASeparateMutedLine() {
         val row = ChatRowCompiler(
             translation = { "Translated: hello" },

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/TwitchChatEventParserTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/TwitchChatEventParserTest.kt
@@ -1,8 +1,15 @@
 package com.github.andreyasadchy.xtra.ui.chat.v2
 
+import com.github.andreyasadchy.xtra.R
+import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatCatalogSnapshot
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatEvent
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatReward
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.HIGHLIGHTED_MESSAGE_REWARD_TYPE
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatSegment
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.TwitchChatMessageType
+import com.github.andreyasadchy.xtra.ui.chat.v2.presentation.ChatPiece
+import com.github.andreyasadchy.xtra.ui.chat.v2.presentation.ChatRowBackground
+import com.github.andreyasadchy.xtra.ui.chat.v2.presentation.ChatRowCompiler
 import com.github.andreyasadchy.xtra.ui.chat.v2.transport.TwitchChatEventParser
 import com.github.andreyasadchy.xtra.util.chat.ChatUtils
 import com.github.andreyasadchy.xtra.util.chat.PubSubUtils
@@ -231,19 +238,88 @@ class TwitchChatEventParserTest {
         val message = ChatUtils.IRCMessage(
             tags = mapOf(
                 "msg-id" to "highlighted-message",
-                "custom-reward-id" to "highlight",
                 "display-name" to "Viewer",
             ),
             prefix = "viewer!viewer@viewer.tmi.twitch.tv",
-            command = "USERNOTICE",
+            command = "PRIVMSG",
             params = listOf("#channel", "Lock them up!"),
-            fullMessage = "USERNOTICE #channel :Lock them up!",
+            fullMessage = "PRIVMSG #channel :Lock them up!",
         )
 
         val event = TwitchChatEventParser.fromIrc(message, "channel-id") as ChatEvent.Message
 
         assertEquals(TwitchChatMessageType.Highlighted, event.message.twitchType)
-        assertEquals("highlight", event.message.rewardId)
+        assertEquals(null, event.message.rewardId)
+    }
+
+    @Test
+    fun eventSubHighlightedMessageHasNoCustomRewardId() {
+        val event = JSONObject(
+            """
+            {
+              "broadcaster_user_id":"broadcaster",
+              "chatter_user_id":"chatter",
+              "chatter_user_login":"viewer",
+              "chatter_user_name":"Viewer",
+              "message_id":"highlight-1",
+              "message_type":"channel_points_highlighted",
+              "message":{"text":"Lock them up!","fragments":[{"type":"text","text":"Lock them up!"}]}
+            }
+            """.trimIndent(),
+        )
+
+        val message = (TwitchChatEventParser.fromEventSub(event, "2026-09-01T12:00:00Z") as ChatEvent.Message).message
+
+        assertEquals(TwitchChatMessageType.Highlighted, message.twitchType)
+        assertEquals(null, message.rewardId)
+    }
+
+    @Test
+    fun highlightedWireFormatsRenderConfiguredAutomaticReward() {
+        val irc = (TwitchChatEventParser.fromIrc(
+            ChatUtils.IRCMessage(
+                tags = mapOf(
+                    "msg-id" to "highlighted-message",
+                    "display-name" to "Viewer",
+                ),
+                prefix = "viewer!viewer@viewer.tmi.twitch.tv",
+                command = "PRIVMSG",
+                params = listOf("#channel", "Lock them up!"),
+                fullMessage = "PRIVMSG #channel :Lock them up!",
+            ),
+            "channel-id",
+        ) as ChatEvent.Message).message
+        val eventSub = (TwitchChatEventParser.fromEventSub(
+            JSONObject(
+                """
+                {
+                  "broadcaster_user_id":"broadcaster",
+                  "chatter_user_id":"chatter",
+                  "chatter_user_login":"viewer",
+                  "chatter_user_name":"Viewer",
+                  "message_id":"highlight-1",
+                  "message_type":"channel_points_highlighted",
+                  "message":{"text":"Lock them up!","fragments":[{"type":"text","text":"Lock them up!"}]}
+                }
+                """.trimIndent(),
+            ),
+            "2026-09-01T12:00:00Z",
+        ) as ChatEvent.Message).message
+        val catalog = ChatCatalogSnapshot(
+            0,
+            automaticChannelPointRewards = mapOf(
+                HIGHLIGHTED_MESSAGE_REWARD_TYPE to ChatReward("Highlight My Message", 2_000, null),
+            ),
+        )
+        listOf(irc, eventSub).forEach { message ->
+            val row = ChatRowCompiler().compile(message, catalog)
+            val text = row.pieces.filterIsInstance<ChatPiece.Text>().joinToString("") { it.value }
+            assertTrue(row.pieces.any { it is ChatPiece.Text && it.value == "Highlight My Message" && it.bold })
+            assertTrue(row.pieces.any { it is ChatPiece.Icon && it.drawableRes == R.drawable.ic_chat_channel_points })
+            assertTrue(text.filter(Char::isDigit).contains("2000"))
+            assertTrue(text.contains("Lock them up!"))
+            assertEquals(ChatRowBackground.HIGHLIGHT, row.backgroundStyle)
+        }
     }
 
     @Test

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/TwitchChatEventParserTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/TwitchChatEventParserTest.kt
@@ -227,6 +227,26 @@ class TwitchChatEventParserTest {
     }
 
     @Test
+    fun ircHighlightedMessageKeepsItsHighlightedType() {
+        val message = ChatUtils.IRCMessage(
+            tags = mapOf(
+                "msg-id" to "highlighted-message",
+                "custom-reward-id" to "highlight",
+                "display-name" to "Viewer",
+            ),
+            prefix = "viewer!viewer@viewer.tmi.twitch.tv",
+            command = "USERNOTICE",
+            params = listOf("#channel", "Lock them up!"),
+            fullMessage = "USERNOTICE #channel :Lock them up!",
+        )
+
+        val event = TwitchChatEventParser.fromIrc(message, "channel-id") as ChatEvent.Message
+
+        assertEquals(TwitchChatMessageType.Highlighted, event.message.twitchType)
+        assertEquals("highlight", event.message.rewardId)
+    }
+
+    @Test
     fun eventSubUsesTypedPrimeFlagInsteadOfSubscriptionTierText() {
         val event = JSONObject(
             """


### PR DESCRIPTION
Match highlighted channel point redemptions to the reference layout, including the reward title, points row, and message content. Keep IRC and EventSub highlighted events consistent and load built-in reward metadata.