### PR TITLE
Fix expired prediction panel sticking in channel points dialog

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatViewModel.kt
@@ -459,6 +459,8 @@ class ChatViewModel(
     private var pollVoteJob: Job? = null
     private var predictionBetJob: Job? = null
     private var predictionSnapshotJob: Job? = null
+    private var predictionTimeoutJob: Job? = null
+    private var predictionTimeoutPredictionId: String? = null
     private var predictionSessionToken = 0L
     private var predictionSubscriptionSessionToken: Long? = null
     private var started = false
@@ -3631,6 +3633,13 @@ class ChatViewModel(
         ongoingPrediction.value = value.takeIf { PredictionState.isOngoing(it) }
         bettablePrediction.value = value.takeIf { PredictionState.isBettingOpen(it) }
         updatePredictionTimer(value)
+        if (PredictionState.isFinal(value)) {
+            schedulePredictionDismissal(value)
+        } else {
+            predictionTimeoutJob?.cancel()
+            predictionTimeoutJob = null
+            predictionTimeoutPredictionId = null
+        }
         activeChannelId?.let { channelId ->
             PredictionCache.save(
                 preferences = applicationContext.prefs(),
@@ -3652,6 +3661,37 @@ class ChatViewModel(
         predictionDeadlineJob?.cancel()
         predictionDeadlineJob = null
         predictionDeadlineToken = null
+        predictionTimeoutJob?.cancel()
+        predictionTimeoutJob = null
+        predictionTimeoutPredictionId = null
+    }
+
+    private fun schedulePredictionDismissal(value: Prediction) {
+        val predictionId = value.id
+        if (predictionId.isNullOrBlank()) return
+        if (predictionTimeoutPredictionId == predictionId && predictionTimeoutJob?.isActive == true) return
+        predictionTimeoutJob?.cancel()
+        predictionTimeoutPredictionId = predictionId
+        val now = System.currentTimeMillis()
+        val endedAt = value.endedAt
+        val remaining = if (endedAt != null) {
+            (PredictionState.RESULT_DISPLAY_GRACE_MILLIS - (now - endedAt)).coerceAtLeast(0L)
+        } else {
+            PredictionState.RESULT_DISPLAY_GRACE_MILLIS
+        }
+        predictionTimeoutJob = viewModelScope.launch {
+            delay(remaining)
+            val cleared = predictionStateStore.clearIf(
+                { current -> current.id == predictionId && PredictionState.isFinal(current) },
+                ::clearPredictionState,
+            )
+            if (cleared) {
+                val channelId = activeChannelId
+                if (!channelId.isNullOrBlank()) {
+                    PredictionCache.clear(applicationContext.prefs(), channelId)
+                }
+            }
+        }
     }
 
     private fun restorePredictionBetState(prediction: Prediction) {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatViewModel.kt
@@ -88,6 +88,7 @@ import com.github.andreyasadchy.xtra.util.chat.isHighlightedMessage
 import com.github.andreyasadchy.xtra.util.chat.PollState
 import com.github.andreyasadchy.xtra.util.chat.PredictionBetPolicy
 import com.github.andreyasadchy.xtra.util.chat.PredictionCache
+import com.github.andreyasadchy.xtra.util.chat.PredictionDismissalPolicy
 import com.github.andreyasadchy.xtra.util.chat.PredictionState
 import com.github.andreyasadchy.xtra.util.chat.PredictionStateStore
 import com.github.andreyasadchy.xtra.util.chat.PubSubUtils
@@ -3633,13 +3634,6 @@ class ChatViewModel(
         ongoingPrediction.value = value.takeIf { PredictionState.isOngoing(it) }
         bettablePrediction.value = value.takeIf { PredictionState.isBettingOpen(it) }
         updatePredictionTimer(value)
-        if (PredictionState.isFinal(value)) {
-            schedulePredictionDismissal(value)
-        } else {
-            predictionTimeoutJob?.cancel()
-            predictionTimeoutJob = null
-            predictionTimeoutPredictionId = null
-        }
         activeChannelId?.let { channelId ->
             PredictionCache.save(
                 preferences = applicationContext.prefs(),
@@ -3647,6 +3641,13 @@ class ChatViewModel(
                 prediction = value,
                 broadcastId = streamId,
             )
+        }
+        if (PredictionState.isFinal(value)) {
+            schedulePredictionDismissal(value)
+        } else {
+            predictionTimeoutJob?.cancel()
+            predictionTimeoutJob = null
+            predictionTimeoutPredictionId = null
         }
     }
 
@@ -3672,17 +3673,11 @@ class ChatViewModel(
         if (predictionTimeoutPredictionId == predictionId && predictionTimeoutJob?.isActive == true) return
         predictionTimeoutJob?.cancel()
         predictionTimeoutPredictionId = predictionId
-        val now = System.currentTimeMillis()
-        val endedAt = value.endedAt
-        val remaining = if (endedAt != null) {
-            (PredictionState.RESULT_DISPLAY_GRACE_MILLIS - (now - endedAt)).coerceAtLeast(0L)
-        } else {
-            PredictionState.RESULT_DISPLAY_GRACE_MILLIS
-        }
+        val remaining = PredictionDismissalPolicy.dismissalDelayMillis(value.endedAt)
         predictionTimeoutJob = viewModelScope.launch {
             delay(remaining)
             val cleared = predictionStateStore.clearIf(
-                { current -> current.id == predictionId && PredictionState.isFinal(current) },
+                { current -> PredictionDismissalPolicy.shouldDismiss(current, predictionId) },
                 ::clearPredictionState,
             )
             if (cleared) {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/chat/PredictionDismissalPolicy.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/chat/PredictionDismissalPolicy.kt
@@ -1,0 +1,26 @@
+package com.github.andreyasadchy.xtra.util.chat
+
+import com.github.andreyasadchy.xtra.model.chat.Prediction
+
+/**
+ * Decides when a final prediction result stops being shown.
+ *
+ * Final results stay visible for [PredictionState.RESULT_DISPLAY_GRACE_MILLIS]
+ * so viewers can see the outcome, then the presentation is cleared. The delay
+ * is anchored to [Prediction.endedAt] so a duplicate final event cannot extend
+ * the display window; a final whose grace period already elapsed clears
+ * immediately.
+ */
+internal object PredictionDismissalPolicy {
+    fun dismissalDelayMillis(endedAt: Long?, now: Long = System.currentTimeMillis()): Long =
+        if (endedAt != null) {
+            (PredictionState.RESULT_DISPLAY_GRACE_MILLIS - (now - endedAt)).coerceAtLeast(0L)
+        } else {
+            PredictionState.RESULT_DISPLAY_GRACE_MILLIS
+        }
+
+    fun shouldDismiss(current: Prediction?, predictionId: String?): Boolean =
+        !predictionId.isNullOrBlank() &&
+            current?.id == predictionId &&
+            PredictionState.isFinal(current)
+}

--- a/app/src/test/java/com/github/andreyasadchy/xtra/util/chat/PredictionDismissalPolicyTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/util/chat/PredictionDismissalPolicyTest.kt
@@ -1,0 +1,118 @@
+package com.github.andreyasadchy.xtra.util.chat
+
+import com.github.andreyasadchy.xtra.model.chat.Prediction
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PredictionDismissalPolicyTest {
+    @Test
+    fun `fresh final waits the full display grace period`() {
+        val now = 1_000_000L
+
+        assertEquals(
+            PredictionState.RESULT_DISPLAY_GRACE_MILLIS,
+            PredictionDismissalPolicy.dismissalDelayMillis(endedAt = now, now = now),
+        )
+    }
+
+    @Test
+    fun `partially aged final waits only the remaining grace period`() {
+        val now = 1_000_000L
+
+        assertEquals(
+            5_000L,
+            PredictionDismissalPolicy.dismissalDelayMillis(
+                endedAt = now - (PredictionState.RESULT_DISPLAY_GRACE_MILLIS - 5_000L),
+                now = now,
+            ),
+        )
+    }
+
+    @Test
+    fun `already expired final dismisses immediately`() {
+        val now = 1_000_000L
+
+        assertEquals(
+            0L,
+            PredictionDismissalPolicy.dismissalDelayMillis(
+                endedAt = now - PredictionState.RESULT_DISPLAY_GRACE_MILLIS - 1L,
+                now = now,
+            ),
+        )
+    }
+
+    @Test
+    fun `final without end timestamp waits the full display grace period`() {
+        assertEquals(
+            PredictionState.RESULT_DISPLAY_GRACE_MILLIS,
+            PredictionDismissalPolicy.dismissalDelayMillis(endedAt = null, now = 1_000_000L),
+        )
+    }
+
+    @Test
+    fun `matching final is dismissed`() {
+        assertTrue(
+            PredictionDismissalPolicy.shouldDismiss(
+                current = prediction("p1", "RESOLVED"),
+                predictionId = "p1",
+            ),
+        )
+    }
+
+    @Test
+    fun `ongoing prediction is kept`() {
+        assertFalse(
+            PredictionDismissalPolicy.shouldDismiss(
+                current = prediction("p1", "LOCKED"),
+                predictionId = "p1",
+            ),
+        )
+        assertFalse(
+            PredictionDismissalPolicy.shouldDismiss(
+                current = prediction("p1", "ACTIVE"),
+                predictionId = "p1",
+            ),
+        )
+    }
+
+    @Test
+    fun `new prediction id is kept`() {
+        assertFalse(
+            PredictionDismissalPolicy.shouldDismiss(
+                current = prediction("p2", "RESOLVED"),
+                predictionId = "p1",
+            ),
+        )
+    }
+
+    @Test
+    fun `missing state or id is kept`() {
+        assertFalse(PredictionDismissalPolicy.shouldDismiss(current = null, predictionId = "p1"))
+        assertFalse(
+            PredictionDismissalPolicy.shouldDismiss(
+                current = prediction("p1", "RESOLVED"),
+                predictionId = null,
+            ),
+        )
+        assertFalse(
+            PredictionDismissalPolicy.shouldDismiss(
+                current = prediction("p1", "RESOLVED"),
+                predictionId = "",
+            ),
+        )
+    }
+
+    private fun prediction(id: String, status: String) = Prediction(
+        id = id,
+        createdAt = 1_000L,
+        outcomes = emptyList(),
+        predictionWindowSeconds = null,
+        status = status,
+        title = "Title",
+        winningOutcomeId = null,
+        endedAt = 2_000L,
+        observedAt = 2_000L,
+    )
+}


### PR DESCRIPTION
Final predictions stayed in the channel points dialog indefinitely instead of resetting to the default rewards panel after expiry. Unlike polls, which auto-dismiss 20s after going terminal via schedulePollDismissal, publishPrediction never scheduled a dismissal for final states, and clearStalePrediction only ran on snapshot load. This adds a predictionTimeoutJob mirroring the poll timeout: final predictions are cleared after RESULT_DISPLAY_GRACE_MILLIS (adjusted for endedAt age), including PredictionCache cleanup, and the timeout is cancelled on new ongoing predictions or channel teardown.