### PR TITLE
Fix favorite emote flicker and delayed chat-box clear

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatFragment.kt
@@ -2626,6 +2626,10 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
                 pendingChatSubmission = PendingChatSubmission(text = text, replyId = replyId)
                 composerSubmissionInProgress = true
                 editText.isEnabled = false
+                // Clear immediately so the message does not linger in the box
+                // while the send completes. Failures restore it from the
+                // pending submission in handleChatSendResult.
+                editText.text.clear()
                 viewModel.send(
                     message = text,
                     replyId = replyId,

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/EmotesAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/EmotesAdapter.kt
@@ -65,6 +65,10 @@ class EmotesAdapter(
      */
     fun submitList(newItems: List<Emote>) {
         if (reorderable) {
+            // The favorites tab rebinds every item on notifyDataSetChanged,
+            // which reloads all visible images. Skip redundant submissions
+            // from coincident flows so the grid does not flicker.
+            if (items == newItems) return
             items.clear()
             items.addAll(newItems)
             notifyDataSetChanged()
@@ -97,7 +101,10 @@ class EmotesAdapter(
     fun setFavoriteKeys(keys: Set<FavoriteEmoteKey>) {
         if (favoriteKeys != keys) {
             favoriteKeys = keys
-            if (itemCount > 0) {
+            // The reorderable favorites grid does not render anything from
+            // these keys (only the long-press label of other tabs does), so
+            // skip the full rebind that would reload every visible image.
+            if (!reorderable && itemCount > 0) {
                 notifyItemRangeChanged(0, itemCount)
             }
         }
@@ -179,17 +186,23 @@ class EmotesAdapter(
                         item.name,
                     )
                     emote.isFocusable = true
-                    if (imageLibrary == "0" || (imageLibrary == "1" && !item.format.equals("webp", true))) {
+                    val imageUrl = when (emoteQuality) {
+                        "4" -> item.url4x ?: item.url3x ?: item.url2x ?: item.url1x
+                        "3" -> item.url3x ?: item.url2x ?: item.url1x
+                        "2" -> item.url2x ?: item.url1x
+                        else -> item.url1x
+                    }
+                    // Rebinds (scroll, list resubmission) must not reload an
+                    // image that is already displayed: the crossfade would
+                    // blink even when fading from the image onto itself.
+                    val alreadyLoaded = emote.getTag(R.id.emote_image_url_key) == imageUrl && emote.drawable != null
+                    if (alreadyLoaded) {
+                        // Keep the current drawable; fall through to listeners.
+                    } else if (imageLibrary == "0" || (imageLibrary == "1" && !item.format.equals("webp", true))) {
+                        emote.setTag(R.id.emote_image_url_key, imageUrl)
                         fragment.requireContext().imageLoader.enqueue(
                             ImageRequest.Builder(fragment.requireContext()).apply {
-                                data(
-                                    when (emoteQuality) {
-                                        "4" -> item.url4x ?: item.url3x ?: item.url2x ?: item.url1x
-                                        "3" -> item.url3x ?: item.url2x ?: item.url1x
-                                        "2" -> item.url2x ?: item.url1x
-                                        else -> item.url1x
-                                    }
-                                )
+                                data(imageUrl)
                                 if (item.thirdParty) {
                                     httpHeaders(NetworkHeaders.Builder().apply {
                                         add("User-Agent", "Xtra/" + BuildConfig.VERSION_NAME)
@@ -200,14 +213,10 @@ class EmotesAdapter(
                             }.build()
                         )
                     } else {
+                        emote.setTag(R.id.emote_image_url_key, imageUrl)
                         Glide.with(fragment)
                             .load(
-                                when (emoteQuality) {
-                                    "4" -> item.url4x ?: item.url3x ?: item.url2x ?: item.url1x
-                                    "3" -> item.url3x ?: item.url2x ?: item.url1x
-                                    "2" -> item.url2x ?: item.url1x
-                                    else -> item.url1x
-                                }.let {
+                                imageUrl.let {
                                     if (item.thirdParty) {
                                         GlideUrl(it) { mapOf("User-Agent" to "Xtra/" + BuildConfig.VERSION_NAME) }
                                     } else it

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/EmotesAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/EmotesAdapter.kt
@@ -40,6 +40,25 @@ internal fun <T> moveListItem(items: MutableList<T>, from: Int, to: Int): Boolea
     return true
 }
 
+/**
+ * Binding-relevant equality for picker cells. [Emote.equals] only compares
+ * [Emote.name], but Favorites treats the live instance (URLs included) as the
+ * source of truth, so a catalog refresh that keeps the name while changing
+ * the asset must still count as a change.
+ */
+internal fun Emote.hasSamePickerBinding(other: Emote): Boolean =
+    favoriteKey() == other.favoriteKey() &&
+        name == other.name &&
+        url1x == other.url1x &&
+        url2x == other.url2x &&
+        url3x == other.url3x &&
+        url4x == other.url4x &&
+        format == other.format &&
+        source == other.source
+
+internal fun List<Emote>.hasSamePickerBinding(other: List<Emote>): Boolean =
+    size == other.size && indices.all { this[it].hasSamePickerBinding(other[it]) }
+
 class EmotesAdapter(
     private val fragment: Fragment,
     private val clickListener: (Emote) -> Unit,
@@ -67,8 +86,10 @@ class EmotesAdapter(
         if (reorderable) {
             // The favorites tab rebinds every item on notifyDataSetChanged,
             // which reloads all visible images. Skip redundant submissions
-            // from coincident flows so the grid does not flicker.
-            if (items == newItems) return
+            // from coincident flows so the grid does not flicker. The check
+            // is binding-aware: Emote.equals only compares names, while a
+            // catalog refresh may keep the name and change the asset.
+            if (items.hasSamePickerBinding(newItems)) return
             items.clear()
             items.addAll(newItems)
             notifyDataSetChanged()

--- a/app/src/main/res/values/ids.xml
+++ b/app/src/main/res/values/ids.xml
@@ -6,4 +6,5 @@
     <item name="stream_thumbnail_display_state" type="id" />
     <item name="stream_profile_request_key" type="id" />
     <item name="tv_focus_helper_installed" type="id" />
+    <item name="emote_image_url_key" type="id" />
 </resources>

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/EmotePickerBindingTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/EmotePickerBindingTest.kt
@@ -1,0 +1,65 @@
+package com.github.andreyasadchy.xtra.ui.chat
+
+import com.github.andreyasadchy.xtra.model.chat.Emote
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class EmotePickerBindingTest {
+    @Test
+    fun refreshedAssetWithSameNameIdAndProviderCountsAsChanged() {
+        val old = Emote(name = "posty5head", id = "emote-id", url1x = "https://example.test/a.png")
+        val refreshed = Emote(name = "posty5head", id = "emote-id", url1x = "https://example.test/b.png")
+
+        // Emote.equals only compares names, so assert the premise first.
+        assertTrue(old == refreshed)
+        assertFalse(old.hasSamePickerBinding(refreshed))
+        assertFalse(listOf(old).hasSamePickerBinding(listOf(refreshed)))
+    }
+
+    @Test
+    fun identicalBindingContentCountsAsUnchanged() {
+        val first = Emote(
+            name = "party",
+            id = "7tv-id",
+            url1x = "https://example.test/1x.png",
+            url4x = "https://example.test/4x.png",
+            format = "webp",
+            source = Emote.CHANNEL_STV,
+        )
+        val second = Emote(
+            name = "party",
+            id = "7tv-id",
+            url1x = "https://example.test/1x.png",
+            url4x = "https://example.test/4x.png",
+            format = "webp",
+            source = Emote.CHANNEL_STV,
+        )
+
+        assertTrue(first.hasSamePickerBinding(second))
+        assertTrue(listOf(first).hasSamePickerBinding(listOf(second)))
+    }
+
+    @Test
+    fun changedIdentityMetadataOrOrderCountsAsChanged() {
+        val base = Emote(name = "party", id = "7tv-id", url1x = "https://example.test/1x.png", source = Emote.CHANNEL_STV)
+        fun variant(
+            name: String? = "party",
+            id: String? = "7tv-id",
+            url1x: String? = "https://example.test/1x.png",
+            format: String? = null,
+            source: Int? = Emote.CHANNEL_STV,
+        ) = Emote(name = name, id = id, url1x = url1x, format = format, source = source)
+
+        assertFalse(base.hasSamePickerBinding(variant(name = "other")))
+        assertFalse(base.hasSamePickerBinding(variant(id = "other-id")))
+        assertFalse(base.hasSamePickerBinding(variant(source = Emote.GLOBAL_STV)))
+        assertFalse(base.hasSamePickerBinding(variant(format = "webp")))
+        assertFalse(listOf(base).hasSamePickerBinding(listOf(base, base)))
+        assertFalse(
+            listOf(base, variant(name = "other", id = "other-id")).hasSamePickerBinding(
+                listOf(variant(name = "other", id = "other-id"), base),
+            ),
+        )
+    }
+}


### PR DESCRIPTION
Follow-up from AVD testing (verified on xtra-phone-api35 against a live stream).\n\n**Favorite emote tab flicker** (\EmotesAdapter\): the reorderable favorites grid ran \
otifyDataSetChanged()\ on every \updateList()\, and \EmotesFragment\ calls that from 6 flow collectors, so any unrelated emission reloaded the whole grid. \setFavoriteKeys()\ additionally forced a full rebind (called back-to-back with \updateList\). Every rebind re-enqueued each image with crossfade, which blinks even when fading an image onto itself. Fixes: skip resubmissions whose binding content is unchanged (new \hasSamePickerBinding()\ compares favorite identity, name, all picker URLs, format, source, size, and order — not \Emote.equals()\, which only compares names), skip the keys rebind for the reorderable grid (it renders nothing from those keys), and skip the image request in \ind()\ when the same URL is already displayed (new \R.id.emote_image_url_key\ view tag + drawable guard so failed loads still retry).\n\n**Message lingering after send** (\ChatFragment.sendMessage()\): the normal chat path only cleared the composer in \handleChatSendResult(Success)\, leaving the text visible for the network round-trip. Now clears immediately at send time like the overlay path already did; the text is captured into \pendingChatSubmission\ first and the failure branch restores it.\n\nVerified: debug APK on AVD — picker opens, long-press adds favorite, Favorites tab renders instantly on return with no reload flash; full \:app:testDebugUnitTest\ green.