### PR TITLE
Fix chat clip link previews and open clips in-app

### DIFF
--- a/.github/scripts/check-resources.py
+++ b/.github/scripts/check-resources.py
@@ -152,6 +152,10 @@ INTENTIONAL_FALLBACK_RESOURCES = {
     "third_party_emotes_empty",
     "third_party_emotes_error",
     "user_card_subscribed",
+    # Chat clip unfurls ship with the default English resources until their
+    # translations are reviewed by native speakers.
+    "chat_clip_playing",
+    "chat_clip_clipped_by",
 }
 
 

--- a/app/src/main/graphql/Clip.graphql
+++ b/app/src/main/graphql/Clip.graphql
@@ -6,7 +6,7 @@ query Clip($slug: ID!) {
             login
             profileImageURL(width: 300)
         }
-        creator {
+        curator {
             displayName
             login
         }

--- a/app/src/main/graphql/schema.graphqls
+++ b/app/src/main/graphql/schema.graphqls
@@ -100,7 +100,7 @@ type CheermoteTier {
 type Clip {
     assets: [ClipAsset]
     broadcaster: User
-    creator: User
+    curator: User
     createdAt: Time
     durationSeconds: Int
     game: Game

--- a/app/src/main/java/com/github/andreyasadchy/xtra/XtraModule.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/XtraModule.kt
@@ -696,8 +696,11 @@ class XtraModule(application: Application) {
                 ChatClipPreview(
                     title = clip.title,
                     broadcasterName = clip.broadcaster?.displayName ?: clip.broadcaster?.login,
-                    creatorName = clip.creator?.displayName ?: clip.creator?.login,
+                    creatorName = clip.curator?.displayName ?: clip.curator?.login,
                     thumbnailUrl = TwitchApiHelper.getClipThumbnail(clip.thumbnailURL),
+                    gameName = clip.game?.displayName,
+                    durationSeconds = clip.durationSeconds,
+                    createdAt = clip.createdAt?.toString(),
                 )
             },
         )

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatAdapter.kt
@@ -24,6 +24,7 @@ import androidx.core.text.getSpans
 import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.RecyclerView
 import com.github.andreyasadchy.xtra.R
+import com.github.andreyasadchy.xtra.XtraApp
 import com.github.andreyasadchy.xtra.model.chat.ChatMessage
 import com.github.andreyasadchy.xtra.model.chat.CheerEmote
 import com.github.andreyasadchy.xtra.model.chat.Emote
@@ -35,6 +36,8 @@ import com.github.andreyasadchy.xtra.model.chat.STVUser
 import com.github.andreyasadchy.xtra.model.chat.TwitchBadge
 import com.github.andreyasadchy.xtra.model.chat.TwitchEmote
 import com.github.andreyasadchy.xtra.ui.view.NamePaintImageSpan
+import com.github.andreyasadchy.xtra.ui.chat.v2.preview.ChatClipPreview
+import com.github.andreyasadchy.xtra.ui.chat.v2.preview.ChatClipPreviewRepository
 import com.github.andreyasadchy.xtra.ui.chat.v2.assets.ChatAssetRepository
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatEmoteInteraction
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatGifInteraction
@@ -202,6 +205,7 @@ class ChatAdapter(
         val translatedMessage: String?,
         val translationFailed: Boolean,
         val messageLanguage: String?,
+        val clipPreviews: List<ChatClipPreview?> = emptyList(),
     ) {
         // ChatMessage translation/moderation fields are mutable. Cache by object identity so a
         // mutation cannot change the hash of an entry that is already in the LRU map.
@@ -211,7 +215,8 @@ class ChatAdapter(
             translateAllMessages == other.translateAllMessages &&
             translatedMessage == other.translatedMessage &&
             translationFailed == other.translationFailed &&
-            messageLanguage == other.messageLanguage
+            messageLanguage == other.messageLanguage &&
+            clipPreviews == other.clipPreviews
 
         override fun hashCode(): Int {
             var result = System.identityHashCode(message)
@@ -220,6 +225,7 @@ class ChatAdapter(
             result = 31 * result + (translatedMessage?.hashCode() ?: 0)
             result = 31 * result + translationFailed.hashCode()
             result = 31 * result + (messageLanguage?.hashCode() ?: 0)
+            result = 31 * result + clipPreviews.hashCode()
             return result
         }
     }
@@ -364,6 +370,8 @@ class ChatAdapter(
             emoteSize, badgeSize, inlineIconSize,
         )
         holder.bind(chatMessage, cacheKey, result)
+        // A failed clip request stays retryable: revisiting the row re-arms observation.
+        clipLinksOf(chatMessage.message).forEach { ensureClipSlugObserved(it.slug) }
         if (animateGifs && holder.canAnimate(bindGeneration)) {
             setAnimations(holder.textView, start = true)
         }
@@ -1587,7 +1595,34 @@ class ChatAdapter(
         translatedMessage = message.translatedMessage,
         translationFailed = message.translationFailed,
         messageLanguage = message.messageLanguage,
+        clipPreviews = clipLinksOf(message.message).map { link -> clipPreviewRepository()?.peek(link.slug) },
     )
+
+    private fun clipPreviewRepository(): ChatClipPreviewRepository? =
+        (fragment.context?.applicationContext as? XtraApp)?.xtraModule?.chatClipPreviewRepository
+
+    /** One shared observer per clip slug; loaded metadata re-renders every row linking it. */
+    private val observedClipSlugs = HashSet<String>()
+
+    private fun ensureClipSlugObserved(slug: String) {
+        val repository = clipPreviewRepository() ?: return
+        synchronized(observedClipSlugs) {
+            if (!observedClipSlugs.add(slug)) return
+        }
+        repository.observe(slug) {
+            if (repository.peek(slug) == null) return@observe
+            mainHandler.post { refreshClipPreviewRenders(slug) }
+        }
+    }
+
+    private fun refreshClipPreviewRenders(slug: String) {
+        if (!fragment.isAdded) return
+        messages.toList().forEach { message ->
+            if (clipLinksOf(message.message).any { it.slug.equals(slug, ignoreCase = true) }) {
+                updateMessageContent(message)
+            }
+        }
+    }
 
     private fun isActiveConfiguration(configuration: ChatRenderConfiguration): Boolean =
         configuration.revision == activeConfiguration.revision &&
@@ -1641,6 +1676,19 @@ class ChatAdapter(
             savedLocalTwitchEmotes, savedLocalBadges, savedLocalCheerEmotes, savedLocalEmotes,
             catalogIndexes = indexes, includeAccessibilityDescription = true,
         )
+        val clipLinks = clipLinksOf(chatMessage.message)
+        if (clipLinks.isNotEmpty()) {
+            installLegacyClipLinkClicks(result.builder)
+            val repository = clipPreviewRepository()
+            appendLegacyClipEmbeds(
+                context,
+                result.builder,
+                result.images,
+                clipLinks,
+                clipLinks.map { repository?.peek(it.slug) },
+            )
+            clipLinks.forEach { ensureClipSlugObserved(it.slug) }
+        }
         val (resolvedImages, resolvedImagePaint) = ChatAdapterUtils.resolveChatImages(
             context, result.images, result.imagePaint, imageLibrary, emoteQuality,
             emoteSize, badgeSize, inlineIconSize,

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatAdapter.kt
@@ -817,6 +817,7 @@ class ChatAdapter(
         prewarmJob = null
         recyclerView.removeCallbacks(prewarmRunnable)
         prewarmPosted = false
+        clearClipPreviewObservers()
         visibleRenderQueue.close()
         prewarmRenderQueue.close()
         renderSignal.close()
@@ -1602,17 +1603,44 @@ class ChatAdapter(
         (fragment.context?.applicationContext as? XtraApp)?.xtraModule?.chatClipPreviewRepository
 
     /** One shared observer per clip slug; loaded metadata re-renders every row linking it. */
-    private val observedClipSlugs = HashSet<String>()
+    private val clipPreviewObservers = HashMap<String, () -> Unit>()
 
     private fun ensureClipSlugObserved(slug: String) {
         val repository = clipPreviewRepository() ?: return
-        synchronized(observedClipSlugs) {
-            if (!observedClipSlugs.add(slug)) return
+        val listener: () -> Unit = { onClipSlugLoaded(slug) }
+        val registered = synchronized(clipPreviewObservers) {
+            if (clipPreviewObservers.containsKey(slug)) {
+                false
+            } else {
+                clipPreviewObservers[slug] = listener
+                true
+            }
         }
-        repository.observe(slug) {
-            if (repository.peek(slug) == null) return@observe
-            mainHandler.post { refreshClipPreviewRenders(slug) }
+        if (registered) repository.observe(slug, listener)
+    }
+
+    private fun onClipSlugLoaded(slug: String) {
+        // One-shot: the shared listener is done whether the load succeeded or not.
+        // A failed load stays retryable because the next ensureClipSlugObserved()
+        // registers a fresh listener, which the repository loads again.
+        removeClipSlugObserver(slug)
+        if (clipPreviewRepository()?.peek(slug) == null) return
+        mainHandler.post { refreshClipPreviewRenders(slug) }
+    }
+
+    private fun removeClipSlugObserver(slug: String) {
+        val listener = synchronized(clipPreviewObservers) {
+            clipPreviewObservers.remove(slug)
+        } ?: return
+        clipPreviewRepository()?.removeObserver(slug, listener)
+    }
+
+    private fun clearClipPreviewObservers() {
+        val repository = clipPreviewRepository()
+        val entries = synchronized(clipPreviewObservers) {
+            clipPreviewObservers.entries.toList().also { clipPreviewObservers.clear() }
         }
+        entries.forEach { (entrySlug, listener) -> repository?.removeObserver(entrySlug, listener) }
     }
 
     private fun refreshClipPreviewRenders(slug: String) {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatClipEmbeds.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatClipEmbeds.kt
@@ -1,0 +1,157 @@
+package com.github.andreyasadchy.xtra.ui.chat
+
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import android.graphics.Typeface
+import android.net.Uri
+import android.text.SpannableStringBuilder
+import android.text.Spanned
+import android.text.TextPaint
+import android.text.format.DateUtils
+import android.text.style.ClickableSpan
+import android.text.style.ForegroundColorSpan
+import android.text.style.StyleSpan
+import android.text.style.URLSpan
+import android.view.View
+import com.github.andreyasadchy.xtra.R
+import com.github.andreyasadchy.xtra.model.chat.Image
+import com.github.andreyasadchy.xtra.model.chat.ImageKind
+import com.github.andreyasadchy.xtra.ui.chat.v2.preview.ChatClipPreview
+import com.github.andreyasadchy.xtra.ui.chat.v2.preview.ChatClipPreviewLink
+import com.github.andreyasadchy.xtra.ui.chat.v2.preview.formatClipDuration
+import com.github.andreyasadchy.xtra.ui.chat.v2.preview.parseClipTimestamp
+
+/** Extracts Twitch clip links from a legacy chat message body. */
+internal fun clipLinksOf(message: String?): List<ChatClipPreviewLink> =
+    if (message.isNullOrBlank()) emptyList() else ChatClipPreviewLink.parse(message)
+
+/**
+ * Routes raw clip URL spans to the in-app clip player (with chat and controls)
+ * instead of a browser. Other links keep their default handling.
+ */
+internal fun installLegacyClipLinkClicks(builder: SpannableStringBuilder) {
+    builder.getSpans(0, builder.length, URLSpan::class.java).forEach { span ->
+        val url = span.url ?: return@forEach
+        if (!ChatClipPreviewLink.isClipUrl(url)) return@forEach
+        val start = builder.getSpanStart(span)
+        val end = builder.getSpanEnd(span)
+        val flags = builder.getSpanFlags(span)
+        builder.removeSpan(span)
+        builder.setSpan(object : ClickableSpan() {
+            override fun onClick(widget: View) {
+                openClipInApp(widget.context, url)
+            }
+        }, start, end, flags)
+    }
+}
+
+/**
+ * Opens a Twitch clip URL with the app's own player when possible, falling back
+ * to a generic view intent. MainActivity handles twitch.tv clip links in-app.
+ */
+internal fun openClipInApp(context: Context, url: String) {
+    val normalized = if (url.startsWith("http://", ignoreCase = true) ||
+        url.startsWith("https://", ignoreCase = true)
+    ) url else "https://$url"
+    val inApp = Intent(Intent.ACTION_VIEW, Uri.parse(normalized)).apply {
+        setPackage(context.packageName)
+        if (context !is Activity) addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+    }
+    if (runCatching { context.startActivity(inApp) }.isSuccess) return
+    runCatching {
+        context.startActivity(
+            Intent(Intent.ACTION_VIEW, Uri.parse(normalized)).apply {
+                if (context !is Activity) addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            },
+        )
+    }
+}
+
+/**
+ * Appends a compact clip unfurl (thumbnail, title, broadcaster/game, clipper)
+ * to a legacy chat builder. Thumbnails reuse the regular chat image pipeline
+ * through [images]; the whole block opens the clip in-app.
+ */
+internal fun appendLegacyClipEmbeds(
+    context: Context,
+    builder: SpannableStringBuilder,
+    images: ArrayList<Image>,
+    links: List<ChatClipPreviewLink>,
+    previews: List<ChatClipPreview?>,
+) {
+    links.forEachIndexed { index, link ->
+        val preview = previews.getOrNull(index) ?: return@forEachIndexed
+        builder.append('\n')
+        val blockStart = builder.length
+        preview.thumbnailUrl?.takeIf { it.isNotBlank() }?.let { thumbnail ->
+            val thumbStart = builder.length
+            builder.append("￼")
+            val thumbEnd = builder.length
+            images.add(
+                Image(
+                    url1x = thumbnail,
+                    url2x = thumbnail,
+                    url3x = thumbnail,
+                    url4x = thumbnail,
+                    kind = ImageKind.EMOTE,
+                    sourceWidth = 16,
+                    sourceHeight = 9,
+                    start = thumbStart,
+                    end = thumbEnd,
+                ),
+            )
+            builder.append(' ')
+        }
+        val titleStart = builder.length
+        builder.append(preview.title?.takeIf { it.isNotBlank() } ?: link.slug)
+        builder.setSpan(StyleSpan(Typeface.BOLD), titleStart, builder.length, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+        builder.append('\n')
+        val subtitleStart = builder.length
+        builder.append(legacyClipSubtitle(context, preview))
+        builder.setSpan(
+            ForegroundColorSpan(LEGACY_CLIP_SECONDARY_COLOR),
+            subtitleStart,
+            builder.length,
+            Spanned.SPAN_EXCLUSIVE_EXCLUSIVE,
+        )
+        builder.append('\n')
+        val attributionStart = builder.length
+        builder.append(legacyClipAttribution(context, preview))
+        builder.setSpan(
+            ForegroundColorSpan(LEGACY_CLIP_SECONDARY_COLOR),
+            attributionStart,
+            builder.length,
+            Spanned.SPAN_EXCLUSIVE_EXCLUSIVE,
+        )
+        builder.setSpan(object : ClickableSpan() {
+            override fun onClick(widget: View) {
+                openClipInApp(widget.context, link.url)
+            }
+
+            override fun updateDrawState(ds: TextPaint) = Unit
+        }, blockStart, builder.length, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+    }
+}
+
+internal fun legacyClipSubtitle(context: Context, preview: ChatClipPreview): String {
+    val broadcaster = preview.broadcasterName?.takeIf { it.isNotBlank() } ?: "Twitch"
+    val base = preview.gameName?.takeIf { it.isNotBlank() }?.let { game ->
+        context.getString(R.string.chat_clip_playing, broadcaster, game)
+    } ?: broadcaster
+    return formatClipDuration(preview.durationSeconds)?.let { "$base — $it" } ?: base
+}
+
+internal fun legacyClipAttribution(context: Context, preview: ChatClipPreview): String {
+    val creator = preview.creatorName?.takeIf { it.isNotBlank() } ?: "unknown"
+    val base = context.getString(R.string.chat_clip_clipped_by, creator)
+    return legacyClipRelativeTime(preview.createdAt)?.let { "$base — $it" } ?: base
+}
+
+internal fun legacyClipRelativeTime(createdAt: String?): String? {
+    val epochMs = parseClipTimestamp(createdAt) ?: return null
+    if (epochMs > System.currentTimeMillis()) return null
+    return DateUtils.getRelativeTimeSpanString(epochMs, System.currentTimeMillis(), DateUtils.MINUTE_IN_MILLIS).toString()
+}
+
+private const val LEGACY_CLIP_SECONDARY_COLOR = 0xFF999999.toInt()

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/MessageClickedChatAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/MessageClickedChatAdapter.kt
@@ -20,6 +20,7 @@ import androidx.core.text.getSpans
 import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.RecyclerView
 import com.github.andreyasadchy.xtra.R
+import com.github.andreyasadchy.xtra.XtraApp
 import com.github.andreyasadchy.xtra.model.chat.ChatMessage
 import com.github.andreyasadchy.xtra.model.chat.CheerEmote
 import com.github.andreyasadchy.xtra.model.chat.Emote
@@ -164,6 +165,19 @@ class MessageClickedChatAdapter(
         )
         if (isSelected(chatMessage)) {
             holder.textView.setBackgroundResource(R.color.chatMessageSelected)
+        }
+        // Peek-only: the main list owns clip loading through the shared repository,
+        // so a dialog opened after the row loaded shows the same unfurl.
+        installLegacyClipLinkClicks(result.builder)
+        clipLinksOf(chatMessage.message).takeIf { it.isNotEmpty() }?.let { clipLinks ->
+            val repository = (fragment.context?.applicationContext as? XtraApp)?.xtraModule?.chatClipPreviewRepository
+            appendLegacyClipEmbeds(
+                fragment.requireContext(),
+                result.builder,
+                result.images,
+                clipLinks,
+                clipLinks.map { repository?.peek(it.slug) },
+            )
         }
         ChatAdapterUtils.installImagePlaceholders(
             result.builder,

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/presentation/ChatRowCompiler.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/presentation/ChatRowCompiler.kt
@@ -14,13 +14,9 @@ import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatCatalogSnapshot
 import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ScopedEmoteCatalog
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatReward
 import com.github.andreyasadchy.xtra.ui.chat.v2.presentation.ChatRowBackground
+import com.github.andreyasadchy.xtra.ui.chat.v2.preview.ChatClipPreviewLink
 import com.github.andreyasadchy.xtra.ui.chat.ChatGifDisplayMode
 import java.text.NumberFormat
-
-private val TWITCH_CLIP_LINK = Regex(
-    "(?i)(https?://)?(?:www\\.)?twitch\\.tv/(?:[^/\\s]+/)?clip/([A-Za-z0-9_-]+)|" +
-        "(?i)(https?://)?clips\\.twitch\\.tv/([A-Za-z0-9_-]+)",
-)
 
 data class ChatPresentationLabels(
     val firstChatter: String = "First Time Chatter",
@@ -440,7 +436,7 @@ class ChatRowCompiler(
 
     private fun colorToHex(color: Int): String = "#%06X".format(color and 0xFFFFFF)
 
-    private fun extractClipPreviews(message: ChatMessage): List<com.github.andreyasadchy.xtra.ui.chat.v2.preview.ChatClipPreviewLink> {
+    private fun extractClipPreviews(message: ChatMessage): List<ChatClipPreviewLink> {
         val body = message.rawText ?: message.segments.joinToString("") { segment ->
             when (segment) {
                 is ChatSegment.Text -> segment.text
@@ -450,14 +446,7 @@ class ChatRowCompiler(
                 is ChatSegment.Cheermote -> segment.text
             }
         }
-        return TWITCH_CLIP_LINK.findAll(body).mapNotNull { match ->
-            val slug = match.groups[2]?.value ?: match.groups[4]?.value ?: return@mapNotNull null
-            val matchedUrl = match.value.trimEnd('.', ',', '!', '?', ':', ';', ')', ']', '}')
-            val url = if (matchedUrl.startsWith("http://", ignoreCase = true) ||
-                matchedUrl.startsWith("https://", ignoreCase = true)
-            ) matchedUrl else "https://$matchedUrl"
-            com.github.andreyasadchy.xtra.ui.chat.v2.preview.ChatClipPreviewLink(slug, url)
-        }.distinctBy { it.slug.lowercase() }.toList()
+        return ChatClipPreviewLink.parse(body)
     }
 
     private companion object {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/preview/ChatClipPreviewRepository.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/preview/ChatClipPreviewRepository.kt
@@ -8,12 +8,55 @@ data class ChatClipPreview(
     val broadcasterName: String?,
     val creatorName: String?,
     val thumbnailUrl: String?,
+    val gameName: String?,
+    val durationSeconds: Int?,
+    /** Raw `createdAt` timestamp as returned by the API (ISO-8601), if known. */
+    val createdAt: String?,
 )
 
 data class ChatClipPreviewLink(
     val slug: String,
     val url: String,
-)
+) {
+    companion object {
+        private val TWITCH_CLIP_LINK = Regex(
+            "(?i)(https?://)?(?:www\\.)?twitch\\.tv/(?:[^/\\s]+/)?clip/([A-Za-z0-9_-]+)|" +
+                "(?i)(https?://)?clips\\.twitch\\.tv/([A-Za-z0-9_-]+)",
+        )
+
+        /** Extracts every Twitch clip link in [body], deduplicated by slug. */
+        fun parse(body: String): List<ChatClipPreviewLink> =
+            TWITCH_CLIP_LINK.findAll(body).mapNotNull { match ->
+                val slug = match.groups[2]?.value ?: match.groups[4]?.value ?: return@mapNotNull null
+                val matchedUrl = match.value.trimEnd('.', ',', '!', '?', ':', ';', ')', ']', '}')
+                val url = if (matchedUrl.startsWith("http://", ignoreCase = true) ||
+                    matchedUrl.startsWith("https://", ignoreCase = true)
+                ) matchedUrl else "https://$matchedUrl"
+                ChatClipPreviewLink(slug, url)
+            }.distinctBy { it.slug.lowercase() }.toList()
+
+        fun isClipUrl(url: String): Boolean = TWITCH_CLIP_LINK.containsMatchIn(url)
+    }
+}
+
+/** Formats a clip duration the way Twitch does (`m:ss`, `h:mm:ss` past an hour). */
+fun formatClipDuration(durationSeconds: Int?): String? {
+    if (durationSeconds == null || durationSeconds < 0) return null
+    val hours = durationSeconds / 3600
+    val minutes = (durationSeconds % 3600) / 60
+    val seconds = durationSeconds % 60
+    return if (hours > 0) {
+        "$hours:${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}"
+    } else {
+        "$minutes:${seconds.toString().padStart(2, '0')}"
+    }
+}
+
+/** Parses the API `createdAt` timestamp to epoch millis, or null when unknown. */
+fun parseClipTimestamp(createdAt: String?): Long? {
+    val epochMs = createdAt?.let { kotlin.time.Instant.parseOrNull(it)?.toEpochMilliseconds() } ?: return null
+    return epochMs.takeIf { it > 0 }
+}
 
 /** Shares clip metadata between recycled chat rows and between chat surfaces. */
 class ChatClipPreviewRepository(

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatMessageTextView.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatMessageTextView.kt
@@ -16,6 +16,7 @@ import android.text.TextPaint
 import android.text.TextUtils
 import android.text.method.LinkMovementMethod
 import android.text.style.ClickableSpan
+import android.text.style.URLSpan
 import android.text.style.CharacterStyle
 import android.text.style.ForegroundColorSpan
 import android.text.style.ReplacementSpan
@@ -23,6 +24,7 @@ import android.text.style.StyleSpan
 import android.text.util.Linkify
 import android.content.Intent
 import android.net.Uri
+import android.text.format.DateUtils
 import android.graphics.Typeface
 import android.view.Gravity
 import android.os.Handler
@@ -49,6 +51,8 @@ import com.github.andreyasadchy.xtra.ui.chat.v2.presentation.ChatRowBackground
 import com.github.andreyasadchy.xtra.ui.chat.v2.preview.ChatClipPreviewLink
 import com.github.andreyasadchy.xtra.ui.chat.v2.preview.ChatClipPreview
 import com.github.andreyasadchy.xtra.ui.chat.v2.preview.ChatClipPreviewRepository
+import com.github.andreyasadchy.xtra.ui.chat.v2.preview.formatClipDuration
+import com.github.andreyasadchy.xtra.ui.chat.v2.preview.parseClipTimestamp
 import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatNamePaint
 import com.github.andreyasadchy.xtra.ui.view.CenteredImageSpan
 import kotlin.math.roundToInt
@@ -260,6 +264,7 @@ open class ChatMessageTextView private constructor(
         // URL spans must be added after all pieces are assembled so offsets remain correct
         // around badges, emotes, GIFs, and timestamp text.
         Linkify.addLinks(output, Linkify.WEB_URLS)
+        redirectClipUrlSpans(output)
         if (row.isAction) output.setSpan(StyleSpan(android.graphics.Typeface.ITALIC), 0, output.length, 0)
         contentDescription = row.accessibilityText
         text = output
@@ -346,8 +351,28 @@ open class ChatMessageTextView private constructor(
             textSize = paint.textSize
         }
         drawClipLine(canvas, preview.title?.takeIf { it.isNotBlank() } ?: link.slug, titlePaint, textLeft, textRight, top + 18 * density)
-        drawClipLine(canvas, "Post by ${preview.broadcasterName ?: "Twitch"}", secondaryPaint, textLeft, textRight, top + 36 * density)
-        drawClipLine(canvas, "Clipped by ${preview.creatorName ?: "unknown"}", secondaryPaint, textLeft, textRight, top + 54 * density)
+        drawClipLine(canvas, clipSubtitle(preview), secondaryPaint, textLeft, textRight, top + 36 * density)
+        drawClipLine(canvas, clipAttribution(preview), secondaryPaint, textLeft, textRight, top + 54 * density)
+    }
+
+    private fun clipSubtitle(preview: ChatClipPreview): String {
+        val broadcaster = preview.broadcasterName?.takeIf { it.isNotBlank() } ?: "Twitch"
+        val base = preview.gameName?.takeIf { it.isNotBlank() }?.let { game ->
+            context.getString(R.string.chat_clip_playing, broadcaster, game)
+        } ?: broadcaster
+        return formatClipDuration(preview.durationSeconds)?.let { "$base — $it" } ?: base
+    }
+
+    private fun clipAttribution(preview: ChatClipPreview): String {
+        val creator = preview.creatorName?.takeIf { it.isNotBlank() } ?: "unknown"
+        val base = context.getString(R.string.chat_clip_clipped_by, creator)
+        return clipRelativeTime(preview.createdAt)?.let { "$base — $it" } ?: base
+    }
+
+    private fun clipRelativeTime(createdAt: String?): String? {
+        val epochMs = parseClipTimestamp(createdAt) ?: return null
+        if (epochMs > System.currentTimeMillis()) return null
+        return DateUtils.getRelativeTimeSpanString(epochMs, System.currentTimeMillis(), DateUtils.MINUTE_IN_MILLIS).toString()
     }
 
     private fun drawClipLine(canvas: Canvas, value: String, paint: TextPaint, left: Float, right: Float, baseline: Float) {
@@ -366,6 +391,50 @@ open class ChatMessageTextView private constructor(
         if (index !in previews.indices) return null
         val top = start + index * (clipPreviewBlockHeight() + clipPreviewGap())
         return previews[index].first.url.takeIf { event.y >= top && event.y <= top + clipPreviewBlockHeight() && event.x >= totalPaddingLeft && event.x <= width - totalPaddingRight }
+    }
+
+    /**
+     * Twitch clip links open inside Xtra (player with chat and controls) instead of a
+     * browser. The embedded preview card below uses the same entry point.
+     */
+    private fun redirectClipUrlSpans(output: SpannableStringBuilder) {
+        output.getSpans(0, output.length, URLSpan::class.java).forEach { span ->
+            val url = span.url ?: return@forEach
+            if (!ChatClipPreviewLink.isClipUrl(url)) return@forEach
+            val start = output.getSpanStart(span)
+            val end = output.getSpanEnd(span)
+            val flags = output.getSpanFlags(span)
+            output.removeSpan(span)
+            output.setSpan(object : ClickableSpan() {
+                override fun onClick(widget: android.view.View) {
+                    openClipUrl(url)
+                }
+            }, start, end, flags)
+        }
+    }
+
+    private fun openClipUrl(url: String) {
+        val normalizedUrl = if (url.startsWith("http://", ignoreCase = true) ||
+            url.startsWith("https://", ignoreCase = true)
+        ) url else "https://$url"
+        (onClipPreviewClick ?: ::openTwitchUrlInApp)(normalizedUrl)
+    }
+
+    private fun openTwitchUrlInApp(url: String) {
+        // MainActivity declares a browsable twitch.tv filter and loads the clip in-app,
+        // so pin the intent to our own package with a browser fallback.
+        val inApp = Intent(Intent.ACTION_VIEW, Uri.parse(url)).apply {
+            setPackage(context.packageName)
+            if (context !is android.app.Activity) addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+        if (runCatching { context.startActivity(inApp) }.isSuccess) return
+        runCatching {
+            context.startActivity(
+                Intent(Intent.ACTION_VIEW, Uri.parse(url)).apply {
+                    if (context !is android.app.Activity) addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                },
+            )
+        }
     }
 
     override fun onSizeChanged(w: Int, h: Int, oldw: Int, oldh: Int) {
@@ -428,10 +497,7 @@ open class ChatMessageTextView private constructor(
             MotionEvent.ACTION_UP -> {
                 hasClipPreviewAt(event)?.let { url ->
                     if (!touchMoved && !longPressConsumed) {
-                        val normalizedUrl = if (url.startsWith("http://", ignoreCase = true) ||
-                            url.startsWith("https://", ignoreCase = true)
-                        ) url else "https://$url"
-                        (onClipPreviewClick ?: { value -> runCatching { context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(value))) } })(normalizedUrl)
+                        openClipUrl(url)
                         longPressRunnable?.let(mainHandler::removeCallbacks)
                         longPressRunnable = null
                         return true

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -895,6 +895,8 @@
     <string name="chat_highlight_title">Highlight My Message</string>
     <string name="chat_watch_streak_reached">Watch Streak Reached</string>
     <string name="chat_watch_streak_status">%1$s is currently on a %2$s-stream streak!</string>
+    <string name="chat_clip_playing">%1$s playing %2$s</string>
+    <string name="chat_clip_clipped_by">Clipped by %1$s</string>
     <string name="channel_points_rewards">Rewards</string>
     <string name="channel_points_rewards_for">%s\'s rewards</string>
     <string name="channel_points_reward">%1$s — %2$s points</string>

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatCatalogRepositoryTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatCatalogRepositoryTest.kt
@@ -78,14 +78,15 @@ class ChatCatalogRepositoryTest {
                 "ffz-value"
             }
         }
+        // The duplicate must join the first load rather than win the race to own it.
+        withTimeout(1_000) {
+            while (duplicateCalls.get() < 1) delay(1)
+        }
         val duplicateSecond = async(Dispatchers.Default) {
             cache.get("ffz") {
                 duplicateCalls.incrementAndGet()
                 "unexpected"
             }
-        }
-        withTimeout(1_000) {
-            while (duplicateCalls.get() < 1) delay(1)
         }
         assertEquals(1, duplicateCalls.get())
         duplicateRelease.complete(Unit)

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatClipLinkParserTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatClipLinkParserTest.kt
@@ -1,0 +1,67 @@
+package com.github.andreyasadchy.xtra.ui.chat.v2
+
+import com.github.andreyasadchy.xtra.ui.chat.v2.preview.ChatClipPreviewLink
+import com.github.andreyasadchy.xtra.ui.chat.v2.preview.formatClipDuration
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ChatClipLinkParserTest {
+
+    @Test
+    fun screenshotClipUrlExtractsSlug() {
+        val body = "StreamElements: \"How do fk do u fish??\" " +
+            "https://www.twitch.tv/posty/clip/AliveNiceVampirePeteZarolTie-5_jmEx1vlvmZNDAm"
+        val links = ChatClipPreviewLink.parse(body)
+        assertEquals(1, links.size)
+        assertEquals("AliveNiceVampirePeteZarolTie-5_jmEx1vlvmZNDAm", links.single().slug)
+        assertEquals("https://www.twitch.tv/posty/clip/AliveNiceVampirePeteZarolTie-5_jmEx1vlvmZNDAm", links.single().url)
+    }
+
+    @Test
+    fun clipsSubdomainUrlExtractsSlug() {
+        val links = ChatClipPreviewLink.parse("https://clips.twitch.tv/AliveNiceVampirePeteZarolTie-5_jmEx1vlvmZNDAm")
+        assertEquals(1, links.size)
+        assertEquals("AliveNiceVampirePeteZarolTie-5_jmEx1vlvmZNDAm", links.single().slug)
+    }
+
+    @Test
+    fun trailingPunctuationIsTrimmed() {
+        val links = ChatClipPreviewLink.parse("wow https://www.twitch.tv/posty/clip/SomeSlug-abc123_-.")
+        assertEquals(1, links.size)
+        assertEquals("SomeSlug-abc123_-", links.single().slug)
+        assertEquals("https://www.twitch.tv/posty/clip/SomeSlug-abc123_-", links.single().url)
+    }
+
+    @Test
+    fun duplicatesAreCollapsedCaseInsensitively() {
+        val links = ChatClipPreviewLink.parse(
+            "https://www.twitch.tv/posty/clip/SomeSlug-abc123 https://clips.twitch.tv/someslug-ABC123",
+        )
+        assertEquals(1, links.size)
+    }
+
+    @Test
+    fun nonClipUrlsAreIgnored() {
+        assertTrue(ChatClipPreviewLink.parse("https://www.twitch.tv/posty").isEmpty())
+        assertTrue(ChatClipPreviewLink.parse("https://www.twitch.tv/videos/1234567890").isEmpty())
+        assertTrue(ChatClipPreviewLink.parse("just chatting").isEmpty())
+    }
+
+    @Test
+    fun isClipUrlMatchesBothHosts() {
+        assertTrue(ChatClipPreviewLink.isClipUrl("https://www.twitch.tv/posty/clip/SomeSlug-abc123"))
+        assertTrue(ChatClipPreviewLink.isClipUrl("https://clips.twitch.tv/SomeSlug-abc123"))
+        assertFalse(ChatClipPreviewLink.isClipUrl("https://www.twitch.tv/posty"))
+    }
+
+    @Test
+    fun durationFormatsLikeTwitch() {
+        assertEquals("0:05", formatClipDuration(5))
+        assertEquals("1:05", formatClipDuration(65))
+        assertEquals("1:02:05", formatClipDuration(3725))
+        assertEquals(null, formatClipDuration(null))
+        assertEquals(null, formatClipDuration(-1))
+    }
+}

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatClipPreviewRepositoryTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatClipPreviewRepositoryTest.kt
@@ -1,0 +1,70 @@
+package com.github.andreyasadchy.xtra.ui.chat.v2
+
+import com.github.andreyasadchy.xtra.ui.chat.v2.preview.ChatClipPreview
+import com.github.andreyasadchy.xtra.ui.chat.v2.preview.ChatClipPreviewRepository
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ChatClipPreviewRepositoryTest {
+
+    private val preview = ChatClipPreview(
+        title = "title",
+        broadcasterName = "broadcaster",
+        creatorName = "creator",
+        thumbnailUrl = null,
+        gameName = "game",
+        durationSeconds = 30,
+        createdAt = null,
+    )
+
+    @Test
+    fun failedLoadStaysRetryable() = runBlocking {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        try {
+            var attempts = 0
+            val repository = ChatClipPreviewRepository(scope) {
+                if (++attempts == 1) null else preview
+            }
+            val first = CompletableDeferred<Unit>()
+            repository.observe("slug") { first.complete(Unit) }
+            withTimeout(5_000) { first.await() }
+            assertNull(repository.peek("slug"))
+            val second = CompletableDeferred<Unit>()
+            repository.observe("slug") { second.complete(Unit) }
+            withTimeout(5_000) { second.await() }
+            assertEquals(preview, repository.peek("slug"))
+            assertEquals(2, attempts)
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun removedObserverIsNotCalled() = runBlocking {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        try {
+            val gate = CompletableDeferred<ChatClipPreview?>()
+            val repository = ChatClipPreviewRepository(scope) { gate.await() }
+            var calls = 0
+            val listener: () -> Unit = { calls++ }
+            repository.observe("slug", listener)
+            repository.removeObserver("slug", listener)
+            gate.complete(preview)
+            withTimeout(5_000) {
+                while (repository.peek("slug") == null) delay(10)
+            }
+            assertEquals(0, calls)
+        } finally {
+            scope.cancel()
+        }
+    }
+}


### PR DESCRIPTION
Follow-up to #226: clip links posted in chat never rendered a preview.

Root cause: the Clip query asked for a \creator\ field that does not exist on Twitch's Clip type, so the whole query errored and the preview loader always got null. The real clipper field is \curator\.

Changes:
- Query \curator\ instead of the nonexistent \creator\; carry game, duration and createdAt into ChatClipPreview.
- v2 card now reads title / \{broadcaster} playing {game} — {m:ss}\ / \Clipped by {curator} — {relative time}\, matching the Twitch embed.
- Legacy ChatAdapter (offline channel chat, VOD chat) gains the same unfurl: thumbnail through the regular image pipeline, bold title, gray subtitle/attribution, async load + row re-render via the shared ChatClipPreviewRepository; same peek-only unfurl in the message-clicked dialog.
- Clip taps (card, embed, raw link) open the clip with Xtra's own player (video + VOD chat + controls) via an explicit-package intent, with a browser fallback.
- Shared link parser + duration/timestamp helpers in the preview package, covered by ChatClipLinkParserTest.

Verified on AVD (amy19b channel chat shows the unfurl; tapping it plays the clip in-app with chat). Unit suite green; ChatMessageTextViewTest instrumentation (14 tests) green.