### PR TITLE
Fix chat emote loading

### DIFF
--- a/app/src/androidTest/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatMessageTextViewTest.kt
+++ b/app/src/androidTest/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatMessageTextViewTest.kt
@@ -39,6 +39,7 @@ import com.github.andreyasadchy.xtra.util.prefs
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
@@ -92,22 +93,34 @@ class ChatMessageTextViewTest {
     }
 
     @Test
-    fun usernameHasExplicitFallbackColorAndMissingAssetHasStableGeometry() {
+    fun fallbackTextReflowsToCompactAssetWidthWhenLoaded() = runBlocking {
         val context = InstrumentationRegistry.getInstrumentation().targetContext
         val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
-        val repository = ChatAssetRepository(scope, ChatAssetLoader { null })
+        val asset = CompletableDeferred<ChatImageHandle?>()
+        val repository = ChatAssetRepository(scope, ChatAssetLoader { asset.await() })
         val view = TestTextView(context, repository)
         val spec = ChatAssetSpec(ChatAssetKey("missing"), 20, 20, 28)
+        lateinit var span: ReplacementSpan
         runOnMain {
-            view.bind(row(spec, username = "login"))
+            view.bind(row(spec, username = "login", fallback = "OMEGALUL"))
             val spanned = view.text as Spanned
             val usernameColor = spanned.getSpans(0, 5, ForegroundColorSpan::class.java).single().foregroundColor
             assertNotEquals(Color.WHITE, usernameColor)
             assertTrue(view.text.toString().contains("login"))
-            val span = spanned.getSpans(0, spanned.length, ReplacementSpan::class.java).single()
+            span = spanned.getSpans(0, spanned.length, ReplacementSpan::class.java).single()
+            val metrics = Paint.FontMetricsInt()
+            assertTrue(span.getSize(Paint(), spanned, 0, 1, metrics) > spec.compositionWidth)
+            assertTrue(metrics.descent - metrics.ascent >= spec.compositionHeight)
+            draw(span, spanned, metrics)
+        }
+        asset.complete(ChatImageHandle { SolidDrawable(Color.RED) })
+        withTimeout(2_000) {
+            while (repository.peek(spec.key) !is ChatAssetState.Ready) delay(1)
+        }
+        runOnMain {
+            val spanned = view.text as Spanned
             val metrics = Paint.FontMetricsInt()
             assertEquals(spec.compositionWidth, span.getSize(Paint(), spanned, 0, 1, metrics))
-            assertTrue(metrics.descent - metrics.ascent >= spec.compositionHeight)
             draw(span, spanned, metrics)
         }
         scope.cancel()
@@ -474,11 +487,12 @@ class ChatMessageTextViewTest {
         spec: ChatAssetSpec,
         username: String? = null,
         interaction: ChatEmoteInteraction? = null,
+        fallback: String = ":asset:",
     ) = ChatRowUiModel(
         id = ChatMessageId("row"), channelId = "channel", timestampText = null,
         pieces = buildList {
             username?.let { add(ChatPiece.Username(it, 0xffff8a80.toInt())) }
-            add(ChatPiece.Emote(spec, ":asset:", interaction = interaction))
+            add(ChatPiece.Emote(spec, fallback, interaction = interaction))
         },
         background = 0xff101010.toInt(), accessibilityText = "row", reply = null,
         source = null, isAction = false,

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/assets/ChatAssetRepository.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/assets/ChatAssetRepository.kt
@@ -3,6 +3,7 @@ package com.github.andreyasadchy.xtra.ui.chat.v2.assets
 import android.os.SystemClock
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatAssetKey
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -10,6 +11,8 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
 import java.util.LinkedHashMap
 
 /** Bounded async cache. A request can only invalidate interested attached views. */
@@ -17,6 +20,7 @@ class ChatAssetRepository(
     private val scope: CoroutineScope,
     private val loader: ChatAssetLoader,
     private val maxEntries: Int = 512,
+    private val maxConcurrentLoads: Int = 8,
     private val nowMs: () -> Long = { SystemClock.elapsedRealtime() },
     private val wait: suspend (Long) -> Unit = { delay(it) },
 ) {
@@ -24,6 +28,8 @@ class ChatAssetRepository(
     private val states = LinkedHashMap<ChatAssetKey, ChatAssetState>(maxEntries, .75f, true)
     private val listeners = HashMap<ChatAssetKey, MutableSet<() -> Unit>>()
     private val retryJobs = HashMap<ChatAssetKey, Job>()
+    private val loadJobs = HashMap<ChatAssetKey, Job>()
+    private val loadPermits = Semaphore(maxConcurrentLoads.coerceAtLeast(1))
     private val _changes = MutableStateFlow<ChatAssetKey?>(null)
     val changes: StateFlow<ChatAssetKey?> = _changes.asStateFlow()
 
@@ -41,13 +47,19 @@ class ChatAssetRepository(
         request(key)
     }
 
-    @Synchronized fun removeObserver(key: ChatAssetKey, listener: () -> Unit) {
-        listeners[key]?.remove(listener)
-        if (listeners[key].isNullOrEmpty()) {
-            listeners.remove(key)
-            retryJobs.remove(key)?.cancel()
+    fun removeObserver(key: ChatAssetKey, listener: () -> Unit) {
+        var loadJob: Job? = null
+        synchronized(this) {
+            listeners[key]?.remove(listener)
+            if (listeners[key].isNullOrEmpty()) {
+                listeners.remove(key)
+                retryJobs.remove(key)?.cancel()
+                loadJob = loadJobs.remove(key)
+                if (states[key] is ChatAssetState.Loading) states.remove(key)
+            }
+            trimCacheLocked()
         }
-        trimCacheLocked()
+        loadJob?.cancel()
     }
 
     /** Catalog revisions can make a previous negative result valid again. */
@@ -62,8 +74,8 @@ class ChatAssetRepository(
 
     private fun request(key: ChatAssetKey) {
         val now = nowMs()
-        val attempt = synchronized(this) {
-            when (val state = states[key]) {
+        val loadJob = synchronized(this) {
+            val attempt = when (val state = states[key]) {
                 is ChatAssetState.Ready, ChatAssetState.Loading -> return
                 is ChatAssetState.Failed if state.nextRetryAtMs > now -> {
                     scheduleRetry(key, state.nextRetryAtMs - now)
@@ -72,38 +84,72 @@ class ChatAssetRepository(
                 is ChatAssetState.Failed -> state.attempts + 1
                 ChatAssetState.Missing, null -> 1
             }.also { states[key] = ChatAssetState.Loading }
+            scope.launch(start = CoroutineStart.LAZY) {
+                val currentJob = coroutineContext[Job]
+                try {
+                    var completedAt: Long
+                    val state = try {
+                        val loaded = loadPermits.withPermit { loader.load(key) }
+                        completedAt = nowMs()
+                        loaded?.let(ChatAssetState::Ready)
+                            ?: ChatAssetState.Failed(completedAt + retryDelay(attempt), attempt)
+                    } catch (e: CancellationException) {
+                        // A loader-local timeout is retryable while the repository is alive. A
+                        // load canceled after its last observer disappears is discarded instead.
+                        val stillObserved = synchronized(this@ChatAssetRepository) {
+                            !listeners[key].isNullOrEmpty()
+                        }
+                        if (repositoryJob?.isActive == false) throw e
+                        if (!stillObserved) {
+                            synchronized(this@ChatAssetRepository) {
+                                if (
+                                    loadJobs[key] === currentJob &&
+                                    listeners[key].isNullOrEmpty() &&
+                                    states[key] is ChatAssetState.Loading
+                                ) {
+                                    states.remove(key)
+                                }
+                            }
+                            return@launch
+                        }
+                        completedAt = nowMs()
+                        ChatAssetState.Failed(completedAt + retryDelay(attempt), attempt)
+                    } catch (e: ChatAssetLoadException) {
+                        completedAt = nowMs()
+                        if (e.statusCode == 400 || e.statusCode == 404 || e.statusCode == 410) {
+                            ChatAssetState.Failed(completedAt + 5 * 60_000L, attempt, completedAt + 5 * 60_000L)
+                        } else ChatAssetState.Failed(completedAt + retryDelay(attempt), attempt)
+                    } catch (_: Throwable) {
+                        completedAt = nowMs()
+                        ChatAssetState.Failed(completedAt + retryDelay(attempt), attempt)
+                    }
+                    val callbacks = synchronized(this@ChatAssetRepository) {
+                        if (loadJobs[key] !== currentJob) null else {
+                            states[key] = state
+                            retryJobs.remove(key)
+                            trimCacheLocked()
+                            listeners[key]?.toList().orEmpty()
+                        }
+                    } ?: return@launch
+                    _changes.value = key
+                    callbacks.forEach { it() }
+                    if (state is ChatAssetState.Failed) scheduleRetry(key, state.nextRetryAtMs - nowMs())
+                } finally {
+                    synchronized(this@ChatAssetRepository) {
+                        if (loadJobs[key] === currentJob) loadJobs.remove(key)
+                    }
+                }
+            }.also { loadJobs[key] = it }
         }
-        scope.launch {
-            var completedAt: Long
-            val state = try {
-                val loaded = loader.load(key)
-                completedAt = nowMs()
-                loaded?.let(ChatAssetState::Ready)
-                    ?: ChatAssetState.Failed(completedAt + retryDelay(attempt), attempt)
-            } catch (e: CancellationException) {
-                // A loader-local timeout is retryable while the repository is alive. Only
-                // cancellation of the repository's own scope should terminate the attempt.
-                if (repositoryJob?.isActive == false) throw e
-                completedAt = nowMs()
-                ChatAssetState.Failed(completedAt + retryDelay(attempt), attempt)
-            } catch (e: ChatAssetLoadException) {
-                completedAt = nowMs()
-                if (e.statusCode == 404 || e.statusCode == 410) {
-                    ChatAssetState.Failed(completedAt + 5 * 60_000L, attempt, completedAt + 5 * 60_000L)
-                } else ChatAssetState.Failed(completedAt + retryDelay(attempt), attempt)
-            } catch (_: Throwable) {
-                completedAt = nowMs()
-                ChatAssetState.Failed(completedAt + retryDelay(attempt), attempt)
+        if (!loadJob.start()) {
+            synchronized(this) {
+                if (loadJobs[key] === loadJob) {
+                    loadJobs.remove(key)
+                    if (listeners[key].isNullOrEmpty() && states[key] is ChatAssetState.Loading) {
+                        states.remove(key)
+                    }
+                }
             }
-            val callbacks = synchronized(this@ChatAssetRepository) {
-                states[key] = state
-                retryJobs.remove(key)
-                trimCacheLocked()
-                listeners[key]?.toList().orEmpty()
-            }
-            _changes.value = key
-            callbacks.forEach { it() }
-            if (state is ChatAssetState.Failed) scheduleRetry(key, state.nextRetryAtMs - nowMs())
         }
     }
 

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/assets/CoilChatAssetLoader.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/assets/CoilChatAssetLoader.kt
@@ -1,12 +1,19 @@
 package com.github.andreyasadchy.xtra.ui.chat.v2.assets
 
 import android.content.Context
+import android.net.Uri
 import coil3.ImageLoader
 import coil3.asDrawable
 import coil3.imageLoader
+import coil3.network.HttpException
+import coil3.network.NetworkHeaders
+import coil3.network.httpHeaders
+import coil3.request.CachePolicy
+import coil3.request.ErrorResult
 import coil3.request.ImageRequest
 import coil3.request.SuccessResult
 import coil3.request.crossfade
+import com.github.andreyasadchy.xtra.BuildConfig
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatAssetKey
 
 /** One Coil-backed loader for v2 chat assets. */
@@ -17,16 +24,59 @@ class CoilChatAssetLoader(
     private val context = context.applicationContext
 
     override suspend fun load(key: ChatAssetKey): ChatImageHandle? {
+        val url = key.value.takeIf(::isHttpUrl) ?: throw ChatAssetLoadException(
+            statusCode = 400,
+            cause = IllegalArgumentException("Not an image URL"),
+        )
         val result = imageLoader.execute(
             ImageRequest.Builder(context)
-                .data(key.value)
+                .data(url)
+                .memoryCacheKey("xtra:chat-v2:$url")
+                .diskCacheKey(url)
+                .memoryCachePolicy(CachePolicy.ENABLED)
+                .diskCachePolicy(CachePolicy.ENABLED)
+                .networkCachePolicy(CachePolicy.ENABLED)
                 .crossfade(false)
+                .apply {
+                    if (isThirdPartyUrl(url)) {
+                        httpHeaders(NetworkHeaders.Builder()
+                            .add("User-Agent", "Xtra/${BuildConfig.VERSION_NAME}")
+                            .build())
+                    }
+                }
                 .build(),
-        ) as? SuccessResult ?: return null
-        // Keep the decoded image handle, not a mutable Drawable. Every bound TextView asks
-        // Coil for its own Drawable instance, which is required for animated assets.
-        return ChatImageHandle {
-            result.image.asDrawable(context.resources).mutate()
+        )
+        return when (result) {
+            is SuccessResult -> {
+                // Keep the decoded image handle, not a mutable Drawable. Every bound TextView
+                // asks Coil for its own Drawable instance, which is required for animated assets.
+                ChatImageHandle {
+                    result.image.asDrawable(context.resources).mutate()
+                }
+            }
+            is ErrorResult -> throw ChatAssetLoadException(result.throwable.httpStatusCode(), result.throwable)
         }
+    }
+
+    private fun isHttpUrl(value: String): Boolean {
+        val uri = Uri.parse(value)
+        return (uri.scheme == "http" || uri.scheme == "https") && !uri.host.isNullOrBlank()
+    }
+
+    private fun isThirdPartyUrl(value: String): Boolean {
+        val host = Uri.parse(value).host?.lowercase() ?: return false
+        return host == "7tv.app" || host.endsWith(".7tv.app") ||
+            host == "betterttv.net" || host.endsWith(".betterttv.net") ||
+            host == "frankerfacez.com" || host.endsWith(".frankerfacez.com")
+    }
+
+    private fun Throwable.httpStatusCode(): Int? {
+        var current: Throwable? = this
+        repeat(8) {
+            val value = current ?: return null
+            if (value is HttpException) return value.response.code
+            current = value.cause
+        }
+        return null
     }
 }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/catalog/TwitchChatCatalogSource.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/catalog/TwitchChatCatalogSource.kt
@@ -217,7 +217,10 @@ class TwitchChatCatalogSource(
         return ChatCatalogBadge(
             name = "$setId:$version",
             asset = ChatAssetSpec(
-                key = ChatAssetKey(url ?: "twitch-badge:$setId:$version"),
+                key = ChatAssetKey(
+                    url?.takeIf { it.isNotBlank() }
+                        ?: "twitch-badge:$setId:$version",
+                ),
                 sourceWidth = 18,
                 sourceHeight = 18,
                 targetHeight = 18,

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/presentation/ChatRowCompiler.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/presentation/ChatRowCompiler.kt
@@ -106,9 +106,11 @@ class ChatRowCompiler(
                 add(ChatPiece.Reply(" ${labels.reply(replyUser, body)}", color = mutedColor))
                 add(ChatPiece.Text("\n", color = mutedColor))
             }
-            if (showBadges && !specialNotice) message.badges.forEach { badge ->
-                add(ChatPiece.Badge(badgeSpec(badge, catalog), badgeInteraction(badge, catalog)))
-            }
+            if (showBadges && !specialNotice) message.badges
+                .filter { it.setId.isNotBlank() && it.versionId.isNotBlank() }
+                .forEach { badge ->
+                    add(ChatPiece.Badge(badgeSpec(badge, catalog), badgeInteraction(badge, catalog)))
+                }
             if (showThirdPartyBadges && !specialNotice) {
                 message.user?.id?.let(catalog.userDecorations::get)?.badgeId?.let { badgeId ->
                     catalog.sevenTvBadges[badgeId]?.let { badge ->

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/session/RecentChatHistoryRepository.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/session/RecentChatHistoryRepository.kt
@@ -134,7 +134,9 @@ fun VideoMessagesResponse.Comment.toV2(
             message?.userColor?.removePrefix("#")?.toLongOrNull(16)?.toInt(),
         ),
         badges = message?.userBadges.orEmpty().mapNotNull { badge ->
-            if (badge.setID != null && badge.version != null) ChatBadgeRef(badge.setID, badge.version) else null
+            if (!badge.setID.isNullOrBlank() && !badge.version.isNullOrBlank()) {
+                ChatBadgeRef(badge.setID, badge.version)
+            } else null
         },
         segments = segments, rawText = body,
         kind = com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessageKind.CHAT,

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/transport/TwitchChatEventParser.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/transport/TwitchChatEventParser.kt
@@ -352,7 +352,11 @@ object TwitchChatEventParser {
             channelId = channelId,
             timestampMs = message.timestamp ?: System.currentTimeMillis(),
             user = ChatUser(message.userId, message.userLogin, message.userName, parseColor(message.color)),
-            badges = message.badges.orEmpty().map { ChatBadgeRef(it.setId, it.version) },
+            badges = message.badges.orEmpty().mapNotNull { badge ->
+                badge.setId.takeIf { it.isNotBlank() }?.let { setId ->
+                    badge.version.takeIf { it.isNotBlank() }?.let { version -> ChatBadgeRef(setId, version) }
+                }
+            },
             segments = segments,
             kind = when {
                 legacyNoticeType == "raid" || legacyNoticeType == "unraid" -> ChatMessageKind.RAID

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatMessageTextView.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatMessageTextView.kt
@@ -55,6 +55,7 @@ import com.github.andreyasadchy.xtra.ui.chat.v2.preview.formatClipDuration
 import com.github.andreyasadchy.xtra.ui.chat.v2.preview.parseClipTimestamp
 import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatNamePaint
 import com.github.andreyasadchy.xtra.ui.view.CenteredImageSpan
+import kotlin.math.min
 import kotlin.math.roundToInt
 
 open class ChatMessageTextView private constructor(
@@ -92,7 +93,12 @@ open class ChatMessageTextView private constructor(
     private var keys = emptySet<ChatAssetKey>()
     private val drawables = HashMap<ChatAssetKey, Drawable>()
     private val drawableHandles = HashMap<ChatAssetKey, Any>()
-    private val assetInvalidator: () -> Unit = { postInvalidateOnAnimation() }
+    private val assetInvalidator: () -> Unit = {
+        post {
+            requestLayout()
+            postInvalidateOnAnimation()
+        }
+    }
     private val clipMetadataInvalidator: () -> Unit = {
         post {
             refreshClipPreviewAssets()
@@ -242,7 +248,7 @@ open class ChatMessageTextView private constructor(
                 is ChatPiece.Source -> appendStyled(output, "[${piece.value}] ", piece.color)
                 is ChatPiece.Icon -> appendIcon(output, piece)
                 is ChatPiece.Mention -> appendStyled(output, piece.value, null)
-                is ChatPiece.Badge -> appendAsset(output, piece.asset, "badge", piece.interaction)
+                is ChatPiece.Badge -> appendAsset(output, piece.asset, piece.interaction?.name ?: "badge", piece.interaction)
                 is ChatPiece.RewardIcon -> appendAsset(output, piece.asset, piece.fallback)
                 is ChatPiece.Emote -> appendAsset(output, piece.asset, piece.fallback, piece.interaction)
                 is ChatPiece.Gif -> appendAsset(output, piece.asset, piece.fallback, gifInteraction = piece.interaction)
@@ -601,7 +607,17 @@ open class ChatMessageTextView private constructor(
         val start = output.length
         output.append(" ")
         val end = output.length
-        output.setSpan(ChatAssetSpan(spec, fallback) { drawableLayersFor(spec) }, start, end, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+        output.setSpan(
+            ChatAssetSpan(
+                spec,
+                fallback,
+                { drawableLayersFor(spec) },
+                { spec.flatten().all { assets.peek(it.key) is ChatAssetState.Ready } },
+            ),
+            start,
+            end,
+            Spanned.SPAN_EXCLUSIVE_EXCLUSIVE,
+        )
         interaction?.let { value ->
             output.setSpan(object : ClickableSpan() {
                 override fun onClick(widget: android.view.View) {
@@ -804,6 +820,7 @@ private class ChatAssetSpan(
     private val spec: ChatAssetSpec,
     private val fallback: String,
     private val drawables: () -> List<DrawableLayer>?,
+    private val isReady: () -> Boolean,
 ) : ReplacementSpan() {
     override fun getSize(paint: Paint, text: CharSequence, start: Int, end: Int, fm: Paint.FontMetricsInt?): Int {
         val height = spec.compositionHeight
@@ -819,7 +836,7 @@ private class ChatAssetSpan(
                 fm.bottom = fm.descent
             }
         }
-        return spec.compositionWidth
+        return if (isReady()) spec.compositionWidth else maxOf(spec.compositionWidth, fallbackWidth(paint))
     }
 
     override fun draw(canvas: Canvas, text: CharSequence, start: Int, end: Int, x: Float, top: Int, y: Int, bottom: Int, paint: Paint) {
@@ -828,8 +845,15 @@ private class ChatAssetSpan(
         val oldTextSize = paint.textSize
         val oldTextAlign = paint.textAlign
         val centerY = (top + bottom) / 2f
-        val rect = RectF(x, centerY - spec.compositionHeight / 2f, x + spec.compositionWidth, centerY + spec.compositionHeight / 2f)
+        val label = fallback.trim().ifEmpty { "?" }
+        val fallbackPaint = fallbackPaint(paint)
         val images = drawables()
+        val reservedWidth = if (images != null) {
+            spec.compositionWidth
+        } else {
+            maxOf(spec.compositionWidth, fallbackPaint.measureText(label).roundToInt())
+        }
+        val rect = RectF(x, centerY - spec.compositionHeight / 2f, x + reservedWidth, centerY + spec.compositionHeight / 2f)
         if (images != null) {
             images.forEach { layer ->
                 val width = layer.spec.computedWidth
@@ -840,15 +864,14 @@ private class ChatAssetSpan(
                 layer.drawable.draw(canvas)
             }
         } else {
-            paint.color = 0x55777777
+            // Keep the original token readable while the image is loading or retrying. The
+            // Reserve enough room for the original token while the image is unavailable. A
+            // fake pill suggests that an image exists when it does not and was especially
+            // confusing for missing badge URLs.
+            paint.color = oldColor
             paint.style = Paint.Style.FILL
-            canvas.drawRoundRect(rect, spec.targetHeight / 4f, spec.targetHeight / 4f, paint)
-            paint.color = 0xFFDDDDDD.toInt()
-            canvas.drawCircle(rect.centerX(), rect.centerY(), (spec.targetHeight / 8f).coerceAtLeast(1f), paint)
-            paint.color = 0xFF202020.toInt()
             paint.textAlign = Paint.Align.CENTER
-            paint.textSize = (spec.compositionHeight * 0.55f).coerceAtLeast(6f)
-            val label = fallback.trim().firstOrNull()?.toString() ?: "?"
+            paint.textSize = fallbackPaint.textSize
             val baseline = rect.centerY() - (paint.ascent() + paint.descent()) / 2f
             canvas.drawText(label, rect.centerX(), baseline, paint)
         }
@@ -856,5 +879,16 @@ private class ChatAssetSpan(
         paint.style = oldStyle
         paint.textSize = oldTextSize
         paint.textAlign = oldTextAlign
+    }
+
+    private fun fallbackWidth(paint: Paint): Int = fallbackPaint(paint)
+        .measureText(fallback.trim().ifEmpty { "?" })
+        .roundToInt()
+
+    private fun fallbackPaint(paint: Paint): Paint = Paint(paint).apply {
+        textSize = min(
+            paint.textSize.takeIf { it > 0f } ?: Float.MAX_VALUE,
+            (spec.compositionHeight * 0.5f).coerceAtLeast(8f),
+        )
     }
 }

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatAssetRepositoryTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatAssetRepositoryTest.kt
@@ -8,6 +8,7 @@ import com.github.andreyasadchy.xtra.ui.chat.v2.assets.ChatAssetState
 import com.github.andreyasadchy.xtra.ui.chat.v2.assets.ChatImageHandle
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatAssetKey
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel
@@ -126,6 +127,48 @@ class ChatAssetRepositoryTest {
         }
         assertTrue(repository.cachedStateCount() <= 2)
         assertTrue(attempts.values.all { it == 1 })
+        scope.cancel()
+    }
+
+    @Test
+    fun unobservedQueuedLoadDoesNotDelayNewlyObservedAsset() = runBlocking {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val first = ChatAssetKey("first")
+        val second = ChatAssetKey("second")
+        val third = ChatAssetKey("third")
+        val firstStarted = CompletableDeferred<Unit>()
+        val releaseFirst = CompletableDeferred<Unit>()
+        val secondStarted = CompletableDeferred<Unit>()
+        val thirdStarted = CompletableDeferred<Unit>()
+        val repository = ChatAssetRepository(
+            scope,
+            ChatAssetLoader { key ->
+                when (key) {
+                    first -> {
+                        firstStarted.complete(Unit)
+                        releaseFirst.await()
+                    }
+                    second -> secondStarted.complete(Unit)
+                    third -> thirdStarted.complete(Unit)
+                }
+                ChatImageHandle { ColorDrawable(1) }
+            },
+            maxConcurrentLoads = 1,
+            nowMs = { 0L },
+        )
+        val firstListener: () -> Unit = {}
+        val secondListener: () -> Unit = {}
+        repository.observe(first, firstListener)
+        withTimeout(2_000) { firstStarted.await() }
+
+        repository.observe(second, secondListener)
+        assertTrue(repository.peek(second) is ChatAssetState.Loading)
+        repository.removeObserver(second, secondListener)
+        repository.observe(third) {}
+
+        releaseFirst.complete(Unit)
+        withTimeout(2_000) { thirdStarted.await() }
+        assertTrue(!secondStarted.isCompleted)
         scope.cancel()
     }
 }

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatDomainPresentationTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatDomainPresentationTest.kt
@@ -567,6 +567,16 @@ class ChatDomainPresentationTest {
     }
 
     @Test
+    fun malformedBadgeIdentityDoesNotCreateAnAssetPlaceholder() {
+        val row = ChatRowCompiler().compile(
+            message(ChatSegment.Text("hi")).copy(badges = listOf(ChatBadgeRef("", ""))),
+            ChatCatalogSnapshot(0),
+        )
+
+        assertTrue(row.pieces.none { it is ChatPiece.Badge })
+    }
+
+    @Test
     fun usernameDisplayModeAndRandomFallbackRemainConfigurable() {
         val message = message(ChatSegment.Text("hello")).copy(
             user = ChatUser("user", "login", "Display", null),


### PR DESCRIPTION
Make chat emotes and badges load reliably, including while scrolling. Keep the original chat text readable when an image is temporarily unavailable.