### PR TITLE
Playback performance pass + review follow-ups

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/PlayerRepository.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/PlayerRepository.kt
@@ -176,6 +176,174 @@ class PlayerRepository(
     private val watchCreditMutex = Mutex()
     private var cachedSpadeEndpoint: CachedSpadeEndpoint? = null
 
+    private data class ProxyClientKey(
+        val host: String,
+        val port: Int,
+        val username: String?,
+        val password: String?,
+    )
+
+    private val proxyOkHttpClients = mutableMapOf<ProxyClientKey, OkHttpClient>()
+    private val proxyOkHttpClientsLock = Any()
+    private val proxyHttpEngines = mutableMapOf<ProxyClientKey, HttpEngine>()
+    private val proxyCronetEngines = mutableMapOf<ProxyClientKey, CronetEngine>()
+    private val proxyEnginesLock = Any()
+
+    private fun proxyOkHttpClient(
+        host: String,
+        port: Int,
+        username: String?,
+        password: String?,
+    ): OkHttpClient {
+        val key = ProxyClientKey(
+            host = host,
+            port = port,
+            username = username,
+            password = password,
+        )
+        return synchronized(proxyOkHttpClientsLock) {
+            proxyOkHttpClients.getOrPut(key) {
+                okHttpClient.value
+                    .newBuilder()
+                    .proxy(
+                        Proxy(
+                            Proxy.Type.HTTP,
+                            InetSocketAddress(host, port),
+                        )
+                    )
+                    .apply {
+                        if (!username.isNullOrBlank() && !password.isNullOrBlank()) {
+                            proxyAuthenticator { _, response ->
+                                response.request.newBuilder().header(
+                                    "Proxy-Authorization", Credentials.basic(username, password)
+                                ).build()
+                            }
+                        }
+                    }
+                    .build()
+            }
+        }
+    }
+
+    @SuppressLint("NewApi")
+    private fun buildProxyHttpEngine(
+        context: Context,
+        host: String,
+        port: Int,
+        username: String?,
+        password: String?,
+    ): HttpEngine? {
+        val proxyHeaders = if (!username.isNullOrBlank() && !password.isNullOrBlank()) {
+            listOf(android.util.Pair("Proxy-Authorization", Credentials.basic(username, password)))
+        } else emptyList()
+        val builder = HttpEngine.Builder(context)
+        return try {
+            builder.setProxyOptions(ProxyOptions.fromProxyList(
+                listOf(
+                    android.net.http.Proxy.createHttpProxy(
+                        android.net.http.Proxy.SCHEME_HTTP,
+                        host,
+                        port,
+                        cronetExecutor.value,
+                        object : android.net.http.Proxy.HttpConnectCallback {
+                            override fun onBeforeRequest(request: android.net.http.Proxy.HttpConnectCallback.Request) {
+                                request.proceed(proxyHeaders)
+                            }
+
+                            override fun onResponseReceived(responseHeaders: List<android.util.Pair<String?, String?>?>, statusCode: Int): Int {
+                                return android.net.http.Proxy.HttpConnectCallback.RESPONSE_ACTION_PROCEED
+                            }
+                        }
+                    )
+                ),
+                ProxyOptions.ALL_PROXIES_FAILED_BEHAVIOR_DISALLOW_DIRECT
+            ))
+        } catch (e: NoClassDefFoundError) {
+            null
+        }?.build()
+    }
+
+    private fun proxyHttpEngine(
+        context: Context,
+        host: String,
+        port: Int,
+        username: String?,
+        password: String?,
+    ): HttpEngine? {
+        val key = ProxyClientKey(host, port, username, password)
+        return synchronized(proxyEnginesLock) {
+            val cached = proxyHttpEngines[key]
+            if (cached != null) return@synchronized cached
+            val built = buildProxyHttpEngine(context.applicationContext, host, port, username, password)
+            if (built != null) {
+                proxyHttpEngines[key] = built
+            }
+            built
+        }
+    }
+
+    private fun buildProxyCronetEngine(
+        context: Context,
+        host: String,
+        port: Int,
+        username: String?,
+        password: String?,
+    ): CronetEngine? {
+        if (CronetProvider.getAllProviders(context).none { it.isEnabled }) return null
+        val proxyHeaders = if (!username.isNullOrBlank() && !password.isNullOrBlank()) {
+            mapOf("Proxy-Authorization" to Credentials.basic(username, password)).entries.toList()
+        } else emptyList()
+        val builder = CronetEngine.Builder(context).apply {
+            val userAgent = "Cronet/" + defaultUserAgent.substringAfter("Cronet/", "").substringBefore(')')
+            setUserAgent(userAgent)
+            @QuicOptions.Experimental
+            setQuicOptions(QuicOptions.builder().setHandshakeUserAgent(userAgent).build())
+        }
+        return try {
+            @org.chromium.net.ProxyOptions.Experimental
+            builder.setProxyOptions(org.chromium.net.ProxyOptions(
+                listOf(
+                    org.chromium.net.Proxy(
+                        org.chromium.net.Proxy.HTTP,
+                        host,
+                        port,
+                        cronetExecutor.value,
+                        object : org.chromium.net.Proxy.Callback() {
+                            override fun onBeforeTunnelRequest(request: Request) {
+                                request.proceed(proxyHeaders)
+                            }
+
+                            override fun onTunnelHeadersReceived(responseHeaders: List<Map.Entry<String?, String?>?>, statusCode: Int): Boolean {
+                                return true
+                            }
+                        }
+                    )
+                )
+            ))
+        } catch (e: UnsupportedOperationException) {
+            null
+        }?.build()
+    }
+
+    private fun proxyCronetEngine(
+        context: Context,
+        host: String,
+        port: Int,
+        username: String?,
+        password: String?,
+    ): CronetEngine? {
+        val key = ProxyClientKey(host, port, username, password)
+        return synchronized(proxyEnginesLock) {
+            val cached = proxyCronetEngines[key]
+            if (cached != null) return@synchronized cached
+            val built = buildProxyCronetEngine(context.applicationContext, host, port, username, password)
+            if (built != null) {
+                proxyCronetEngines[key] = built
+            }
+            built
+        }
+    }
+
     suspend fun loadStreamPlaylistUrl(context: Context, networkLibrary: String?, gqlHeaders: Map<String, String>, channelLogin: String, randomDeviceId: Boolean?, xDeviceId: String?, playerType: String?, supportedCodecs: String?, proxyPlaybackAccessToken: Boolean, proxyHost: String?, proxyPort: Int?, proxyUser: String?, proxyPassword: String?, lowLatency: Boolean = context.prefs().getBoolean(C.PLAYER_LOW_LATENCY, C.DEFAULT_PLAYER_LOW_LATENCY)): String = withContext(Dispatchers.IO) {
         val accessToken = loadStreamPlaybackAccessToken(context, networkLibrary, gqlHeaders, channelLogin, randomDeviceId, xDeviceId, playerType, proxyPlaybackAccessToken, proxyHost, proxyPort, proxyUser, proxyPassword).let { token ->
             if (token.second?.contains("\"forbidden\":true") == true && !gqlHeaders[C.HEADER_TOKEN].isNullOrBlank()) {
@@ -310,34 +478,7 @@ class PlayerRepository(
             val response = if (proxyPlaybackAccessToken && !proxyHost.isNullOrBlank() && proxyPort != null) {
                 when {
                     networkLibrary == C.HTTP_ENGINE && httpEngine.value != null -> @SuppressLint("NewApi") {
-                        val proxyHeaders = if (!proxyUser.isNullOrBlank() && !proxyPassword.isNullOrBlank()) {
-                            listOf(android.util.Pair("Proxy-Authorization", Credentials.basic(proxyUser, proxyPassword)))
-                        } else emptyList()
-                        val builder = HttpEngine.Builder(context)
-                        val httpEngine = try {
-                            builder.setProxyOptions(ProxyOptions.fromProxyList(
-                                listOf(
-                                    android.net.http.Proxy.createHttpProxy(
-                                        android.net.http.Proxy.SCHEME_HTTP,
-                                        proxyHost,
-                                        proxyPort,
-                                        cronetExecutor.value,
-                                        object : android.net.http.Proxy.HttpConnectCallback {
-                                            override fun onBeforeRequest(request: android.net.http.Proxy.HttpConnectCallback.Request) {
-                                                request.proceed(proxyHeaders)
-                                            }
-
-                                            override fun onResponseReceived(responseHeaders: List<android.util.Pair<String?, String?>?>, statusCode: Int): Int {
-                                                return android.net.http.Proxy.HttpConnectCallback.RESPONSE_ACTION_PROCEED
-                                            }
-                                        }
-                                    )
-                                ),
-                                ProxyOptions.ALL_PROXIES_FAILED_BEHAVIOR_DISALLOW_DIRECT
-                            ))
-                        } catch (e: NoClassDefFoundError) {
-                            null
-                        }?.build()
+                        val httpEngine = proxyHttpEngine(context, proxyHost, proxyPort, proxyUser, proxyPassword)
                         if (httpEngine != null) {
                             val response = suspendCancellableCoroutine { continuation ->
                                 val timeout = NetworkUtils.HttpEngineTimeout()
@@ -359,16 +500,7 @@ class PlayerRepository(
                             }
                             json.decodeFromString<PlaybackAccessTokenResponse>(response.body.decodeToString())
                         } else {
-                            okHttpClient.value.newBuilder().apply {
-                                proxy(Proxy(Proxy.Type.HTTP, InetSocketAddress(proxyHost, proxyPort)))
-                                if (!proxyUser.isNullOrBlank() && !proxyPassword.isNullOrBlank()) {
-                                    proxyAuthenticator { _, response ->
-                                        response.request.newBuilder().header(
-                                            "Proxy-Authorization", Credentials.basic(proxyUser, proxyPassword)
-                                        ).build()
-                                    }
-                                }
-                            }.build().newCall(Request.Builder().apply {
+                            proxyOkHttpClient(proxyHost, proxyPort, proxyUser, proxyPassword).newCall(Request.Builder().apply {
                                 url(url)
                                 headers.forEach {
                                     addHeader(it.key, it.value)
@@ -381,41 +513,7 @@ class PlayerRepository(
                         }
                     }
                     networkLibrary == C.CRONET && cronetEngine.value != null -> {
-                        val cronetEngine = if (CronetProvider.getAllProviders(context).any { it.isEnabled }) {
-                            val proxyHeaders = if (!proxyUser.isNullOrBlank() && !proxyPassword.isNullOrBlank()) {
-                                mapOf("Proxy-Authorization" to Credentials.basic(proxyUser, proxyPassword)).entries.toList()
-                            } else emptyList()
-                            val builder = CronetEngine.Builder(context).apply {
-                                val userAgent = "Cronet/" + defaultUserAgent.substringAfter("Cronet/", "").substringBefore(')')
-                                setUserAgent(userAgent)
-                                @QuicOptions.Experimental
-                                setQuicOptions(QuicOptions.builder().setHandshakeUserAgent(userAgent).build())
-                            }
-                            try {
-                                @org.chromium.net.ProxyOptions.Experimental
-                                builder.setProxyOptions(org.chromium.net.ProxyOptions(
-                                    listOf(
-                                        org.chromium.net.Proxy(
-                                            org.chromium.net.Proxy.HTTP,
-                                            proxyHost,
-                                            proxyPort,
-                                            cronetExecutor.value,
-                                            object : org.chromium.net.Proxy.Callback() {
-                                                override fun onBeforeTunnelRequest(request: Request) {
-                                                    request.proceed(proxyHeaders)
-                                                }
-
-                                                override fun onTunnelHeadersReceived(responseHeaders: List<Map.Entry<String?, String?>?>, statusCode: Int): Boolean {
-                                                    return true
-                                                }
-                                            }
-                                        )
-                                    )
-                                ))
-                            } catch (e: UnsupportedOperationException) {
-                                null
-                            }?.build()
-                        } else null
+                        val cronetEngine = proxyCronetEngine(context, proxyHost, proxyPort, proxyUser, proxyPassword)
                         if (cronetEngine != null) {
                             val response = suspendCancellableCoroutine { continuation ->
                                 val timeout = NetworkUtils.CronetTimeout()
@@ -437,16 +535,7 @@ class PlayerRepository(
                             }
                             json.decodeFromString<PlaybackAccessTokenResponse>(response.body.decodeToString())
                         } else {
-                            okHttpClient.value.newBuilder().apply {
-                                proxy(Proxy(Proxy.Type.HTTP, InetSocketAddress(proxyHost, proxyPort)))
-                                if (!proxyUser.isNullOrBlank() && !proxyPassword.isNullOrBlank()) {
-                                    proxyAuthenticator { _, response ->
-                                        response.request.newBuilder().header(
-                                            "Proxy-Authorization", Credentials.basic(proxyUser, proxyPassword)
-                                        ).build()
-                                    }
-                                }
-                            }.build().newCall(Request.Builder().apply {
+                            proxyOkHttpClient(proxyHost, proxyPort, proxyUser, proxyPassword).newCall(Request.Builder().apply {
                                 url(url)
                                 headers.forEach {
                                     addHeader(it.key, it.value)
@@ -459,16 +548,7 @@ class PlayerRepository(
                         }
                     }
                     else -> {
-                        okHttpClient.value.newBuilder().apply {
-                            proxy(Proxy(Proxy.Type.HTTP, InetSocketAddress(proxyHost, proxyPort)))
-                            if (!proxyUser.isNullOrBlank() && !proxyPassword.isNullOrBlank()) {
-                                proxyAuthenticator { _, response ->
-                                    response.request.newBuilder().header(
-                                        "Proxy-Authorization", Credentials.basic(proxyUser, proxyPassword)
-                                    ).build()
-                                }
-                            }
-                        }.build().newCall(Request.Builder().apply {
+                        proxyOkHttpClient(proxyHost, proxyPort, proxyUser, proxyPassword).newCall(Request.Builder().apply {
                             url(url)
                             headers.forEach {
                                 addHeader(it.key, it.value)
@@ -509,34 +589,7 @@ class PlayerRepository(
                 }
                 when {
                     networkLibrary == C.HTTP_ENGINE && httpEngine.value != null -> @SuppressLint("NewApi") {
-                        val proxyHeaders = if (!proxyUser.isNullOrBlank() && !proxyPassword.isNullOrBlank()) {
-                            listOf(android.util.Pair("Proxy-Authorization", Credentials.basic(proxyUser, proxyPassword)))
-                        } else emptyList()
-                        val builder = HttpEngine.Builder(context)
-                        val httpEngine = try {
-                            builder.setProxyOptions(ProxyOptions.fromProxyList(
-                                listOf(
-                                    android.net.http.Proxy.createHttpProxy(
-                                        android.net.http.Proxy.SCHEME_HTTP,
-                                        proxyHost,
-                                        proxyPort,
-                                        cronetExecutor.value,
-                                        object : android.net.http.Proxy.HttpConnectCallback {
-                                            override fun onBeforeRequest(request: android.net.http.Proxy.HttpConnectCallback.Request) {
-                                                request.proceed(proxyHeaders)
-                                            }
-
-                                            override fun onResponseReceived(responseHeaders: List<android.util.Pair<String?, String?>?>, statusCode: Int): Int {
-                                                return android.net.http.Proxy.HttpConnectCallback.RESPONSE_ACTION_PROCEED
-                                            }
-                                        }
-                                    )
-                                ),
-                                ProxyOptions.ALL_PROXIES_FAILED_BEHAVIOR_DISALLOW_DIRECT
-                            ))
-                        } catch (e: NoClassDefFoundError) {
-                            null
-                        }?.build()
+                        val httpEngine = proxyHttpEngine(context, proxyHost, proxyPort, proxyUser, proxyPassword)
                         if (httpEngine != null) {
                             val response = suspendCancellableCoroutine { continuation ->
                                 val timeout = NetworkUtils.HttpEngineTimeout()
@@ -560,16 +613,7 @@ class PlayerRepository(
                                 query.parseResponse(it)
                             }
                         } else {
-                            okHttpClient.value.newBuilder().apply {
-                                proxy(Proxy(Proxy.Type.HTTP, InetSocketAddress(proxyHost, proxyPort)))
-                                if (!proxyUser.isNullOrBlank() && !proxyPassword.isNullOrBlank()) {
-                                    proxyAuthenticator { _, response ->
-                                        response.request.newBuilder().header(
-                                            "Proxy-Authorization", Credentials.basic(proxyUser, proxyPassword)
-                                        ).build()
-                                    }
-                                }
-                            }.build().newCall(Request.Builder().apply {
+                            proxyOkHttpClient(proxyHost, proxyPort, proxyUser, proxyPassword).newCall(Request.Builder().apply {
                                 url(url)
                                 headers.forEach {
                                     addHeader(it.key, it.value)
@@ -584,41 +628,7 @@ class PlayerRepository(
                         }
                     }
                     networkLibrary == C.CRONET && cronetEngine.value != null -> {
-                        val cronetEngine = if (CronetProvider.getAllProviders(context).any { it.isEnabled }) {
-                            val proxyHeaders = if (!proxyUser.isNullOrBlank() && !proxyPassword.isNullOrBlank()) {
-                                mapOf("Proxy-Authorization" to Credentials.basic(proxyUser, proxyPassword)).entries.toList()
-                            } else emptyList()
-                            val builder = CronetEngine.Builder(context).apply {
-                                val userAgent = "Cronet/" + defaultUserAgent.substringAfter("Cronet/", "").substringBefore(')')
-                                setUserAgent(userAgent)
-                                @QuicOptions.Experimental
-                                setQuicOptions(QuicOptions.builder().setHandshakeUserAgent(userAgent).build())
-                            }
-                            try {
-                                @org.chromium.net.ProxyOptions.Experimental
-                                builder.setProxyOptions(org.chromium.net.ProxyOptions(
-                                    listOf(
-                                        org.chromium.net.Proxy(
-                                            org.chromium.net.Proxy.HTTP,
-                                            proxyHost,
-                                            proxyPort,
-                                            cronetExecutor.value,
-                                            object : org.chromium.net.Proxy.Callback() {
-                                                override fun onBeforeTunnelRequest(request: Request) {
-                                                    request.proceed(proxyHeaders)
-                                                }
-
-                                                override fun onTunnelHeadersReceived(responseHeaders: List<Map.Entry<String?, String?>?>, statusCode: Int): Boolean {
-                                                    return true
-                                                }
-                                            }
-                                        )
-                                    )
-                                ))
-                            } catch (e: UnsupportedOperationException) {
-                                null
-                            }?.build()
-                        } else null
+                        val cronetEngine = proxyCronetEngine(context, proxyHost, proxyPort, proxyUser, proxyPassword)
                         if (cronetEngine != null) {
                             val response = suspendCancellableCoroutine { continuation ->
                                 val timeout = NetworkUtils.CronetTimeout()
@@ -642,16 +652,7 @@ class PlayerRepository(
                                 query.parseResponse(it)
                             }
                         } else {
-                            okHttpClient.value.newBuilder().apply {
-                                proxy(Proxy(Proxy.Type.HTTP, InetSocketAddress(proxyHost, proxyPort)))
-                                if (!proxyUser.isNullOrBlank() && !proxyPassword.isNullOrBlank()) {
-                                    proxyAuthenticator { _, response ->
-                                        response.request.newBuilder().header(
-                                            "Proxy-Authorization", Credentials.basic(proxyUser, proxyPassword)
-                                        ).build()
-                                    }
-                                }
-                            }.build().newCall(Request.Builder().apply {
+                            proxyOkHttpClient(proxyHost, proxyPort, proxyUser, proxyPassword).newCall(Request.Builder().apply {
                                 url(url)
                                 headers.forEach {
                                     addHeader(it.key, it.value)
@@ -666,16 +667,7 @@ class PlayerRepository(
                         }
                     }
                     else -> {
-                        okHttpClient.value.newBuilder().apply {
-                            proxy(Proxy(Proxy.Type.HTTP, InetSocketAddress(proxyHost, proxyPort)))
-                            if (!proxyUser.isNullOrBlank() && !proxyPassword.isNullOrBlank()) {
-                                proxyAuthenticator { _, response ->
-                                    response.request.newBuilder().header(
-                                        "Proxy-Authorization", Credentials.basic(proxyUser, proxyPassword)
-                                    ).build()
-                                }
-                            }
-                        }.build().newCall(Request.Builder().apply {
+                        proxyOkHttpClient(proxyHost, proxyPort, proxyUser, proxyPassword).newCall(Request.Builder().apply {
                             url(url)
                             headers.forEach {
                                 addHeader(it.key, it.value)

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/channel/ChannelPagerFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/channel/ChannelPagerFragment.kt
@@ -14,13 +14,10 @@ import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.content.ContextCompat
 import androidx.core.content.edit
-import androidx.core.view.ViewCompat
-import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.doOnLayout
 import androidx.core.view.isVisible
 import androidx.core.view.marginBottom
 import androidx.core.view.marginTop
-import androidx.core.view.updateLayoutParams
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
@@ -56,6 +53,7 @@ import com.github.andreyasadchy.xtra.ui.search.SearchPagerFragmentDirections
 import com.github.andreyasadchy.xtra.ui.settings.SettingsActivity
 import com.github.andreyasadchy.xtra.ui.settings.setTabCustomizationLongPress
 import com.github.andreyasadchy.xtra.util.C
+import com.github.andreyasadchy.xtra.util.applyStickyTopSystemBarMargin
 import com.github.andreyasadchy.xtra.util.configureForSmoothPaging
 import com.github.andreyasadchy.xtra.util.TwitchApiHelper
 import com.github.andreyasadchy.xtra.util.getAlertDialogBuilder
@@ -516,13 +514,7 @@ class ChannelPagerFragment : BaseNetworkFragment(), Scrollable, FragmentHost {
                 }
             }.attach()
             tabLayout.setTabCustomizationLongPress(requireContext(), C.UI_CHANNEL_TABS)
-            ViewCompat.setOnApplyWindowInsetsListener(view) { _, windowInsets ->
-                val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout())
-                collapsingToolbar.updateLayoutParams<ViewGroup.MarginLayoutParams> {
-                    topMargin = insets.top
-                }
-                windowInsets
-            }
+            view.applyStickyTopSystemBarMargin(collapsingToolbar)
         }
         view.doOnLayout {
             if (isAdded) scrollToTop()

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/channel/ChannelPagerFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/channel/ChannelPagerFragment.kt
@@ -53,7 +53,7 @@ import com.github.andreyasadchy.xtra.ui.search.SearchPagerFragmentDirections
 import com.github.andreyasadchy.xtra.ui.settings.SettingsActivity
 import com.github.andreyasadchy.xtra.ui.settings.setTabCustomizationLongPress
 import com.github.andreyasadchy.xtra.util.C
-import com.github.andreyasadchy.xtra.util.applyStickyTopSystemBarMargin
+import com.github.andreyasadchy.xtra.util.applyStableTopSystemBarMargin
 import com.github.andreyasadchy.xtra.util.configureForSmoothPaging
 import com.github.andreyasadchy.xtra.util.TwitchApiHelper
 import com.github.andreyasadchy.xtra.util.getAlertDialogBuilder
@@ -514,7 +514,7 @@ class ChannelPagerFragment : BaseNetworkFragment(), Scrollable, FragmentHost {
                 }
             }.attach()
             tabLayout.setTabCustomizationLongPress(requireContext(), C.UI_CHANNEL_TABS)
-            view.applyStickyTopSystemBarMargin(collapsingToolbar)
+            view.applyStableTopSystemBarMargin(collapsingToolbar)
         }
         view.doOnLayout {
             if (isAdded) scrollToTop()

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatAdapter.kt
@@ -232,11 +232,32 @@ class ChatAdapter(
         val prewarmGeneration: Long?,
     )
 
-    private val renderCache = object : LinkedHashMap<RenderCacheKey, ChatAdapterUtils.MessageResult>(256, 0.75f, true) {
-        override fun removeEldestEntry(eldest: MutableMap.MutableEntry<RenderCacheKey, ChatAdapterUtils.MessageResult>?): Boolean =
-            size > MAX_RENDER_CACHE_ENTRIES && eldest?.key?.message?.let { message ->
-                messages.none { it === message }
-            } == true
+    private val renderCache = LinkedHashMap<RenderCacheKey, ChatAdapterUtils.MessageResult>(256, 0.75f, true)
+
+    /**
+     * Removes stale entries once the cache exceeds its target. Must be called
+     * while holding `synchronized(renderCache)` on the main thread, matching
+     * every other renderCache mutation.
+     */
+    private fun trimRenderCache() {
+        if (renderCache.size <= MAX_RENDER_CACHE_ENTRIES) {
+            return
+        }
+        val currentMessages =
+            Collections.newSetFromMap(
+                IdentityHashMap<ChatMessage, Boolean>()
+            )
+        currentMessages.addAll(messages)
+        val iterator = renderCache.entries.iterator()
+        while (
+            renderCache.size > MAX_RENDER_CACHE_ENTRIES &&
+            iterator.hasNext()
+        ) {
+            val entry = iterator.next()
+            if (entry.key.message !in currentMessages) {
+                iterator.remove()
+            }
+        }
     }
     private var renderScope = newRenderScope()
     private val renderJobs = HashSet<RenderCacheKey>()
@@ -558,7 +579,7 @@ class ChatAdapter(
                             // This catch can also cover queue/worker failures before renderMessage
                             // gets a chance to install its terminal result. Finish the same
                             // exceptional path here instead of retrying forever at the queue head.
-                            synchronized(renderCache) { renderCache[currentKey] = terminal }
+                            synchronized(renderCache) { renderCache[currentKey] = terminal; trimRenderCache() }
                         } else if (currentKey != failedKey) {
                             entry.state = PublicationState.QUEUED
                             scheduleDisplayEntry(entry, configuration, generation)
@@ -1303,7 +1324,7 @@ class ChatAdapter(
             )
             withContext(Dispatchers.Main.immediate) {
                 if (isKnownConfiguration(request.configuration) && currentRenderKey(chatMessage, request.configuration) == cacheKey) {
-                    synchronized(renderCache) { renderCache[cacheKey] = prepared }
+                    synchronized(renderCache) { renderCache[cacheKey] = prepared; trimRenderCache() }
                     completeRenderWaiters(cacheKey)
                     waitersCompleted = true
                 }
@@ -1330,7 +1351,7 @@ class ChatAdapter(
                 if (isKnownConfiguration(request.configuration) &&
                     currentRenderKey(chatMessage, request.configuration) == cacheKey
                 ) {
-                    synchronized(renderCache) { renderCache[cacheKey] = prepared }
+                    synchronized(renderCache) { renderCache[cacheKey] = prepared; trimRenderCache() }
                     completeRenderWaiters(cacheKey)
                     waitersCompleted = true
                 }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatFragment.kt
@@ -1529,6 +1529,7 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
         val pinnedBinding = pinnedMessageBinding ?: return
         val overlay = pinnedBinding.pinnedMessageOverlay
         if (message == null || message.id == seenPinnedMessageId) {
+            disposePinnedBadgeRequests()
             overlay.isGone = true
             return
         }
@@ -1556,6 +1557,7 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
         pinnedBinding.pinnedMessageCollapsedPreview.text = message.text
         pinnedBinding.pinnedMessageCollapsedPreview.isVisible = pinnedMessageMinimized
         pinnedBinding.pinnedMessageFooter.isVisible = !pinnedMessageMinimized
+        disposePinnedBadgeRequests()
         renderPinnedMessageBadges(pinnedBinding.pinnedMessagePinnedByBadges, message.pinnedByBadges)
         renderPinnedMessageBadges(pinnedBinding.pinnedMessageSenderBadges, message.senderBadges)
         pinnedBinding.pinnedMessageMinimize.setImageResource(
@@ -1567,9 +1569,12 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
         overlay.isVisible = true
     }
 
-    private fun renderPinnedMessageBadges(container: LinearLayout, badges: List<Badge>) {
+    private fun disposePinnedBadgeRequests() {
         pinnedBadgeRequests.forEach(Disposable::dispose)
         pinnedBadgeRequests.clear()
+    }
+
+    private fun renderPinnedMessageBadges(container: LinearLayout, badges: List<Badge>) {
         container.removeAllViews()
         badges.forEach { badge ->
             val catalogBadge = synchronized(viewModel.globalBadges) {
@@ -3154,8 +3159,7 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
         dropImageRequestGeneration++
         dropImageUrl = null
         dropImageTarget = null
-        pinnedBadgeRequests.forEach(Disposable::dispose)
-        pinnedBadgeRequests.clear()
+        disposePinnedBadgeRequests()
         composerOverlayState = null
         pendingComposerText = null
         lastSlowModeUiState = SlowModeState()

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatFragment.kt
@@ -283,6 +283,11 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
     private var channelPointsIconRequestGeneration = 0
     private var channelPointsIconLoaded = false
     private var channelPointsIconForeground: Int? = null
+    private var dropImageUrl: String? = null
+    private var dropImageTarget: ImageView? = null
+    private var dropImageRequest: Disposable? = null
+    private var dropImageRequestGeneration = 0
+    private var pinnedBadgeRequests = mutableListOf<Disposable>()
     private var channelPointsAccessibilityLabel: String? = null
     private var chatIdentityPopup: ChatIdentityPopup? = null
     private var chatIdentityBadgeRequest: Disposable? = null
@@ -1563,6 +1568,8 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
     }
 
     private fun renderPinnedMessageBadges(container: LinearLayout, badges: List<Badge>) {
+        pinnedBadgeRequests.forEach(Disposable::dispose)
+        pinnedBadgeRequests.clear()
         container.removeAllViews()
         badges.forEach { badge ->
             val catalogBadge = synchronized(viewModel.globalBadges) {
@@ -1588,7 +1595,7 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
                     if (badge.setId == "broadcaster") R.drawable.ic_broadcaster_badge else R.drawable.ic_moderator_badge,
                 )
             } else {
-                requireContext().imageLoader.enqueue(
+                pinnedBadgeRequests += requireContext().imageLoader.enqueue(
                     ImageRequest.Builder(requireContext())
                         .data(url)
                         .diskCachePolicy(CachePolicy.ENABLED)
@@ -2539,19 +2546,41 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
 
     private fun updateDropImage(url: String?) {
         val image = dropImageView ?: return
+        if (dropImageUrl == url && dropImageTarget === image) return
+        disposeDropImageRequest()
+        dropImageUrl = url
+        dropImageTarget = image
+        val requestGeneration = ++dropImageRequestGeneration
         image.setImageDrawable(null)
         image.isVisible = !url.isNullOrBlank()
         if (url.isNullOrBlank()) return
 
         val context = requireContext()
-        context.imageLoader.enqueue(
+        dropImageRequest = context.imageLoader.enqueue(
             ImageRequest.Builder(context)
                 .data(url)
                 .diskCachePolicy(CachePolicy.ENABLED)
                 .crossfade(true)
                 .target(image)
+                .listener(object : ImageRequest.Listener {
+                    override fun onError(request: ImageRequest, result: coil3.request.ErrorResult) {
+                        if (!isCurrentDropImageRequest(url, requestGeneration)) return
+                        image.setImageDrawable(null)
+                    }
+                })
                 .build(),
         )
+    }
+
+    private fun disposeDropImageRequest() {
+        dropImageRequest?.dispose()
+        dropImageRequest = null
+    }
+
+    private fun isCurrentDropImageRequest(url: String, requestGeneration: Int): Boolean {
+        return dropImageView != null &&
+            dropImageUrl == url &&
+            dropImageRequestGeneration == requestGeneration
     }
 
     private fun handleDropClaimResult(result: ChatViewModel.DropClaimResult) {
@@ -3121,6 +3150,12 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
         channelPointsIconUrl = null
         channelPointsIconLoaded = false
         channelPointsIconForeground = null
+        disposeDropImageRequest()
+        dropImageRequestGeneration++
+        dropImageUrl = null
+        dropImageTarget = null
+        pinnedBadgeRequests.forEach(Disposable::dispose)
+        pinnedBadgeRequests.clear()
         composerOverlayState = null
         pendingComposerText = null
         lastSlowModeUiState = SlowModeState()

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatViewModel.kt
@@ -139,13 +139,11 @@ import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.FileInputStream
 import java.io.FileOutputStream
-import java.util.Timer
 import java.util.Locale
 import java.util.concurrent.ConcurrentHashMap
 import java.util.zip.DeflaterOutputStream
 import java.util.zip.InflaterOutputStream
 import javax.net.ssl.X509TrustManager
-import kotlin.concurrent.scheduleAtFixedRate
 import kotlin.time.Instant
 
 internal fun shouldResumeLiveChat(
@@ -525,8 +523,7 @@ class ChatViewModel(
     /** The ongoing prediction only while its betting window is open. */
     val bettablePrediction = MutableStateFlow<Prediction?>(null)
     val predictionSecondsLeft = MutableStateFlow<Int?>(null)
-    var predictionTimer: Timer? = null
-    private var predictionDeadlineJob: Job? = null
+    private var predictionCountdownJob: Job? = null
     private var predictionDeadlineToken: Any? = null
     private val predictionStateStore = PredictionStateStore()
     private val predictionBetEvents = Channel<PredictionBetResult>(Channel.BUFFERED)
@@ -3657,10 +3654,8 @@ class ChatViewModel(
         ongoingPrediction.value = null
         bettablePrediction.value = null
         predictionSecondsLeft.value = null
-        predictionTimer?.cancel()
-        predictionTimer = null
-        predictionDeadlineJob?.cancel()
-        predictionDeadlineJob = null
+        predictionCountdownJob?.cancel()
+        predictionCountdownJob = null
         predictionDeadlineToken = null
         predictionTimeoutJob?.cancel()
         predictionTimeoutJob = null
@@ -3715,10 +3710,8 @@ class ChatViewModel(
     }
 
     private fun updatePredictionTimer(value: Prediction) {
-        predictionTimer?.cancel()
-        predictionTimer = null
-        predictionDeadlineJob?.cancel()
-        predictionDeadlineJob = null
+        predictionCountdownJob?.cancel()
+        predictionCountdownJob = null
         predictionDeadlineToken = null
         if (!PredictionState.isBettingOpen(value)) {
             predictionSecondsLeft.value = null
@@ -3736,40 +3729,47 @@ class ChatViewModel(
         if (remainingMillis != null && remainingMillis > 0L) {
             val deadlineToken = Any()
             predictionDeadlineToken = deadlineToken
-            predictionDeadlineJob = viewModelScope.launch {
-                while (isActive) {
-                    val remaining = endsAt - System.currentTimeMillis()
-                    if (remaining <= 0L) {
-                        predictionStateStore.withLock { current ->
-                            if (predictionDeadlineToken === deadlineToken) {
-                                transitionPredictionToLocked(current)
-                            }
-                        }
-                        return@launch
-                    }
-                    delay(remaining)
-                }
-            }
-            val timer = Timer()
-            predictionTimer = timer
-            timer.scheduleAtFixedRate(1_000, 1_000) {
-                var stopTimer = false
-                predictionStateStore.withLock { current ->
-                    val remaining = endsAt - System.currentTimeMillis()
-                    if (predictionTimer !== timer || current == null) {
-                        stopTimer = true
-                    } else if (remaining <= 0L) {
-                        predictionSecondsLeft.value = null
-                        transitionPredictionToLocked(current)
-                        stopTimer = true
-                    } else {
-                        predictionSecondsLeft.value = ((remaining + 999L) / 1_000L).toInt()
-                    }
-                }
-                if (stopTimer) cancel()
-            }
+            startPredictionCountdown(endsAt, deadlineToken)
         } else if (remainingMillis != null) {
             transitionPredictionToLocked()
+        }
+    }
+
+    private fun startPredictionCountdown(
+        endsAt: Long,
+        deadlineToken: Any,
+    ) {
+        predictionCountdownJob?.cancel()
+        predictionCountdownJob = viewModelScope.launch {
+            while (isActive) {
+                val remainingMs = endsAt - System.currentTimeMillis()
+                if (remainingMs <= 0L) {
+                    predictionSecondsLeft.value = null
+                    predictionStateStore.withLock { current ->
+                        if (predictionDeadlineToken === deadlineToken) {
+                            transitionPredictionToLocked(current)
+                        }
+                    }
+                    break
+                }
+                val remainingSeconds = ((remainingMs + 999L) / 1_000L).toInt()
+                if (predictionSecondsLeft.value != remainingSeconds) {
+                    predictionSecondsLeft.value = remainingSeconds
+                }
+                /*
+                 * Wake at the next visible second boundary.
+                 * We always recalculate from absolute endsAt, therefore delays
+                 * do not accumulate countdown drift.
+                 */
+                val delayMs = remainingMs % 1_000L
+                delay(
+                    if (delayMs == 0L) {
+                        1_000L
+                    } else {
+                        delayMs
+                    }
+                )
+            }
         }
     }
 

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatViewModel.kt
@@ -166,6 +166,31 @@ sealed interface ChatSendResult {
     data class Failure(val message: String) : ChatSendResult
 }
 
+internal fun updatePredictionCountdownState(
+    predictionStateStore: PredictionStateStore,
+    currentDeadlineToken: () -> Any?,
+    deadlineToken: Any,
+    remainingMs: Long,
+    predictionSecondsLeft: MutableStateFlow<Int?>,
+    onExpired: (Prediction?) -> Unit,
+): Boolean = predictionStateStore.withLock { current ->
+    if (currentDeadlineToken() !== deadlineToken) {
+        return@withLock false
+    }
+
+    if (remainingMs <= 0L) {
+        predictionSecondsLeft.value = null
+        onExpired(current)
+        false
+    } else {
+        val remainingSeconds = ((remainingMs + 999L) / 1_000L).toInt()
+        if (predictionSecondsLeft.value != remainingSeconds) {
+            predictionSecondsLeft.value = remainingSeconds
+        }
+        true
+    }
+}
+
 internal fun matchesV2PickerSession(
     active: com.github.andreyasadchy.xtra.ui.chat.v2.session.LiveChatSessionSpec?,
     expectedChannelId: String?,
@@ -3743,18 +3768,17 @@ class ChatViewModel(
         predictionCountdownJob = viewModelScope.launch {
             while (isActive) {
                 val remainingMs = endsAt - System.currentTimeMillis()
-                if (remainingMs <= 0L) {
-                    predictionSecondsLeft.value = null
-                    predictionStateStore.withLock { current ->
-                        if (predictionDeadlineToken === deadlineToken) {
-                            transitionPredictionToLocked(current)
-                        }
-                    }
+                val keepRunning = updatePredictionCountdownState(
+                    predictionStateStore = predictionStateStore,
+                    currentDeadlineToken = { predictionDeadlineToken },
+                    deadlineToken = deadlineToken,
+                    remainingMs = remainingMs,
+                    predictionSecondsLeft = predictionSecondsLeft,
+                    onExpired = ::transitionPredictionToLocked,
+                )
+
+                if (!keepRunning) {
                     break
-                }
-                val remainingSeconds = ((remainingMs + 999L) / 1_000L).toInt()
-                if (predictionSecondsLeft.value != remainingSeconds) {
-                    predictionSecondsLeft.value = remainingSeconds
                 }
                 /*
                  * Wake at the next visible second boundary.

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/StreamCardPresentation.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/StreamCardPresentation.kt
@@ -105,13 +105,17 @@ internal object StreamCardPresentationCache {
     /** Prepares a bounded visible window before it is handed to RecyclerView. */
     fun prewarm(
         context: Context,
-        streams: List<Stream>,
+        itemCount: Int,
+        itemAt: (Int) -> Stream?,
         preferences: FeedUiPreferences,
     ) {
-        val visibleWindow = streams.take(PREWARM_LIMIT)
+        val count = minOf(itemCount, PREWARM_LIMIT)
         // Prewarming only populates the process-local cache. It must not hop
         // back to the main thread or cause a second bind for every card.
-        visibleWindow.forEach { stream -> request(context, stream, preferences) }
+        for (index in 0 until count) {
+            val stream = itemAt(index) ?: continue
+            request(context, stream, preferences)
+        }
     }
 
     private fun build(

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/StreamsAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/StreamsAdapter.kt
@@ -272,6 +272,9 @@ class StreamsAdapter(
                     }
                 } else {
                     boundStream = null
+                    (fragment.requireContext().applicationContext as XtraApp).xtraModule.streamPreviewCoordinator
+                        .detachSurface(previewSurface)
+                    boundPreviewIdentity = null
                     clearUptime()
                     userImage.setImageDrawable(null)
                     userImage.tag = null

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/StreamsAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/StreamsAdapter.kt
@@ -58,7 +58,8 @@ class StreamsAdapter(
                 val preferences = FeedUiPreferencesStore.current(context)
                 StreamCardPresentationCache.prewarm(
                     context = context,
-                    streams = snapshot().items.filterNotNull(),
+                    itemCount = itemCount,
+                    itemAt = { index -> peek(index) },
                     preferences = preferences,
                 )
             }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/StreamsCompactAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/StreamsCompactAdapter.kt
@@ -278,6 +278,9 @@ class StreamsCompactAdapter(
                     }
                 } else {
                     boundStream = null
+                    (fragment.requireContext().applicationContext as XtraApp).xtraModule.streamPreviewCoordinator
+                        .detachSurface(previewSurface)
+                    boundPreviewIdentity = null
                     clearUptime()
                     userImage.setImageDrawable(null)
                     userImage.tag = null

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/StreamsCompactAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/StreamsCompactAdapter.kt
@@ -67,7 +67,8 @@ class StreamsCompactAdapter(
                 val preferences = FeedUiPreferencesStore.current(context)
                 StreamCardPresentationCache.prewarm(
                     context = context,
-                    streams = snapshot().items.filterNotNull(),
+                    itemCount = itemCount,
+                    itemAt = { index -> peek(index) },
                     preferences = preferences,
                 )
             }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/streams/FollowingStreamsListAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/streams/FollowingStreamsListAdapter.kt
@@ -42,7 +42,7 @@ class FollowingStreamsListAdapter(
     fun submitStreams(streams: List<Stream>) {
         val context = fragment.requireContext()
         val preferences = FeedUiPreferencesStore.current(context)
-        StreamCardPresentationCache.prewarm(context, streams, preferences)
+        StreamCardPresentationCache.prewarm(context, streams.size, streams::getOrNull, preferences)
         submitList(streams)
     }
 

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/game/GameMediaFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/game/GameMediaFragment.kt
@@ -13,13 +13,10 @@ import androidx.constraintlayout.helper.widget.Flow
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.content.ContextCompat
 import androidx.core.content.res.use
-import androidx.core.view.ViewCompat
-import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.doOnLayout
 import androidx.core.view.isVisible
 import androidx.core.view.marginBottom
 import androidx.core.view.marginTop
-import androidx.core.view.updateLayoutParams
 import androidx.core.widget.TextViewCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
@@ -54,6 +51,7 @@ import com.github.andreyasadchy.xtra.ui.settings.SettingsActivity
 import com.github.andreyasadchy.xtra.ui.settings.setTabCustomizationLongPress
 import com.github.andreyasadchy.xtra.util.C
 import com.github.andreyasadchy.xtra.util.TwitchApiHelper
+import com.github.andreyasadchy.xtra.util.applyStickyTopSystemBarMargin
 import com.github.andreyasadchy.xtra.util.getAlertDialogBuilder
 import com.github.andreyasadchy.xtra.util.prefs
 import com.github.andreyasadchy.xtra.util.tokenPrefs
@@ -295,13 +293,7 @@ class GameMediaFragment : BaseNetworkFragment(), Scrollable, FragmentHost {
                     }
                 }
             }, false)
-            ViewCompat.setOnApplyWindowInsetsListener(view) { _, windowInsets ->
-                val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout())
-                collapsingToolbar.updateLayoutParams<ViewGroup.MarginLayoutParams> {
-                    topMargin = insets.top
-                }
-                windowInsets
-            }
+            view.applyStickyTopSystemBarMargin(collapsingToolbar)
         }
     }
 

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/game/GameMediaFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/game/GameMediaFragment.kt
@@ -51,7 +51,7 @@ import com.github.andreyasadchy.xtra.ui.settings.SettingsActivity
 import com.github.andreyasadchy.xtra.ui.settings.setTabCustomizationLongPress
 import com.github.andreyasadchy.xtra.util.C
 import com.github.andreyasadchy.xtra.util.TwitchApiHelper
-import com.github.andreyasadchy.xtra.util.applyStickyTopSystemBarMargin
+import com.github.andreyasadchy.xtra.util.applyStableTopSystemBarMargin
 import com.github.andreyasadchy.xtra.util.getAlertDialogBuilder
 import com.github.andreyasadchy.xtra.util.prefs
 import com.github.andreyasadchy.xtra.util.tokenPrefs
@@ -293,7 +293,7 @@ class GameMediaFragment : BaseNetworkFragment(), Scrollable, FragmentHost {
                     }
                 }
             }, false)
-            view.applyStickyTopSystemBarMargin(collapsingToolbar)
+            view.applyStableTopSystemBarMargin(collapsingToolbar)
         }
     }
 

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/game/GamePagerFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/game/GamePagerFragment.kt
@@ -13,13 +13,10 @@ import androidx.constraintlayout.helper.widget.Flow
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.content.ContextCompat
 import androidx.core.content.res.use
-import androidx.core.view.ViewCompat
-import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.doOnLayout
 import androidx.core.view.isVisible
 import androidx.core.view.marginBottom
 import androidx.core.view.marginTop
-import androidx.core.view.updateLayoutParams
 import androidx.core.widget.TextViewCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
@@ -51,6 +48,7 @@ import com.github.andreyasadchy.xtra.ui.search.SearchPagerFragmentDirections
 import com.github.andreyasadchy.xtra.ui.settings.SettingsActivity
 import com.github.andreyasadchy.xtra.ui.settings.setTabCustomizationLongPress
 import com.github.andreyasadchy.xtra.util.C
+import com.github.andreyasadchy.xtra.util.applyStickyTopSystemBarMargin
 import com.github.andreyasadchy.xtra.util.configureForSmoothPaging
 import com.github.andreyasadchy.xtra.util.TwitchApiHelper
 import com.github.andreyasadchy.xtra.util.getAlertDialogBuilder
@@ -300,13 +298,7 @@ class GamePagerFragment : BaseNetworkFragment(), Scrollable, FragmentHost {
                 }
             }.attach()
             tabLayout.setTabCustomizationLongPress(requireContext(), C.UI_GAME_TABS)
-            ViewCompat.setOnApplyWindowInsetsListener(view) { _, windowInsets ->
-                val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout())
-                collapsingToolbar.updateLayoutParams<ViewGroup.MarginLayoutParams> {
-                    topMargin = insets.top
-                }
-                windowInsets
-            }
+            view.applyStickyTopSystemBarMargin(collapsingToolbar)
         }
     }
 

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/game/GamePagerFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/game/GamePagerFragment.kt
@@ -48,7 +48,7 @@ import com.github.andreyasadchy.xtra.ui.search.SearchPagerFragmentDirections
 import com.github.andreyasadchy.xtra.ui.settings.SettingsActivity
 import com.github.andreyasadchy.xtra.ui.settings.setTabCustomizationLongPress
 import com.github.andreyasadchy.xtra.util.C
-import com.github.andreyasadchy.xtra.util.applyStickyTopSystemBarMargin
+import com.github.andreyasadchy.xtra.util.applyStableTopSystemBarMargin
 import com.github.andreyasadchy.xtra.util.configureForSmoothPaging
 import com.github.andreyasadchy.xtra.util.TwitchApiHelper
 import com.github.andreyasadchy.xtra.util.getAlertDialogBuilder
@@ -298,7 +298,7 @@ class GamePagerFragment : BaseNetworkFragment(), Scrollable, FragmentHost {
                 }
             }.attach()
             tabLayout.setTabCustomizationLongPress(requireContext(), C.UI_GAME_TABS)
-            view.applyStickyTopSystemBarMargin(collapsingToolbar)
+            view.applyStableTopSystemBarMargin(collapsingToolbar)
         }
     }
 

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/login/TwitchWebLoginActivity.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/login/TwitchWebLoginActivity.kt
@@ -8,6 +8,7 @@ import android.view.inputmethod.InputMethodManager
 import android.content.Context
 import android.util.Log
 import android.widget.Toast
+import androidx.activity.OnBackPressedCallback
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
@@ -42,6 +43,11 @@ class TwitchWebLoginActivity : AppCompatActivity() {
 
         binding = ActivityTwitchWebLoginBinding.inflate(layoutInflater)
         setContentView(binding.root)
+        onBackPressedDispatcher.addCallback(this, object : OnBackPressedCallback(true) {
+            override fun handleOnBackPressed() {
+                cancel()
+            }
+        })
         geckoView = binding.geckoView
         sessionManager = (application as XtraApp).xtraModule.twitchWebSessionManager
         if (intent.getBooleanExtra(EXTRA_LOGOUT, false)) {
@@ -94,10 +100,6 @@ class TwitchWebLoginActivity : AppCompatActivity() {
     override fun onSupportNavigateUp(): Boolean {
         cancel()
         return true
-    }
-
-    override fun onBackPressed() {
-        cancel()
     }
 
     override fun dispatchKeyEvent(event: KeyEvent): Boolean {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/main/MainActivity.kt
@@ -139,6 +139,8 @@ class MainActivity : AppCompatActivity() {
         const val INTENT_OPEN_OWN_PROFILE = "com.github.andreyasadchy.xtra.OPEN_OWN_PROFILE"
         const val INTENT_OPEN_DROPS = "com.github.andreyasadchy.xtra.OPEN_DROPS"
         const val EXTRA_OPEN_UPDATE_DETAILS = "com.github.andreyasadchy.xtra.OPEN_UPDATE_DETAILS"
+
+        private const val DEEP_LINK_NAV_DEBOUNCE_MS = 500L
     }
 
     private lateinit var binding: ActivityMainBinding
@@ -168,6 +170,8 @@ class MainActivity : AppCompatActivity() {
     private var bottomNavigationDrainPosted = false
     private val bottomNavigationInteractionSource = Any()
     private var keepStateNavigator: KeepStateFragmentNavigator? = null
+    private var lastDeepLinkNavKey: String? = null
+    private var lastDeepLinkNavTime = 0L
     private val isTv: Boolean get() = isTelevision()
 
     private fun rootNavigationView(): NavigationBarView =
@@ -539,7 +543,9 @@ class MainActivity : AppCompatActivity() {
                         if (videoUrl == "") {
                             Toast.makeText(this@MainActivity, R.string.video_not_found, Toast.LENGTH_SHORT).show()
                         } else {
-                            startVideo(Video(), 0, videoUrl = videoUrl)
+                            navigateDeepLinkOnce("videoUrl:$videoUrl") {
+                                startVideo(Video(), 0, videoUrl = videoUrl)
+                            }
                         }
                         viewModel.videoUrl.value = null
                     }
@@ -553,17 +559,21 @@ class MainActivity : AppCompatActivity() {
                     val offset = pair?.second
                     if (video != null) {
                         if (!video.id.isNullOrBlank()) {
-                            (playerFragment as? Media3PlayerFragment)?.also {
-                                if (!isTv) it.minimize()
-                                it.close()
-                                closePlayer()
-                            } ?:
-                            (playerFragment as? PlayerFragment)?.also {
-                                if (!isTv) it.minimize()
-                                it.close()
-                                closePlayer()
+                            navigateDeepLinkOnce("video:${video.id}|$offset") {
+                                (playerFragment as? Media3PlayerFragment)?.also {
+                                    if (!isTv) it.minimize()
+                                    it.close()
+                                    closePlayer()
+                                } ?:
+                                (playerFragment as? PlayerFragment)?.also {
+                                    if (!isTv) it.minimize()
+                                    it.close()
+                                    closePlayer()
+                                }
+                                startVideo(video, offset, offset != null)
                             }
-                            startVideo(video, offset, offset != null)
+                        } else {
+                            Toast.makeText(this@MainActivity, R.string.video_not_found, Toast.LENGTH_SHORT).show()
                         }
                         viewModel.video.value = null
                     }
@@ -575,7 +585,11 @@ class MainActivity : AppCompatActivity() {
                 viewModel.clip.collectLatest { clip ->
                     if (clip != null) {
                         if (!clip.id.isNullOrBlank()) {
-                            startClip(clip)
+                            navigateDeepLinkOnce("clip:${clip.id}") {
+                                startClip(clip)
+                            }
+                        } else {
+                            Toast.makeText(this@MainActivity, R.string.clip_not_found, Toast.LENGTH_SHORT).show()
                         }
                         viewModel.clip.value = null
                     }
@@ -587,15 +601,19 @@ class MainActivity : AppCompatActivity() {
                 viewModel.user.collectLatest { user ->
                     if (user != null) {
                         if (!user.id.isNullOrBlank() || !user.login.isNullOrBlank()) {
-                            leavePlayerForBrowsing()
-                            navController.navigate(
-                                ChannelPagerFragmentDirections.actionGlobalChannelPagerFragment(
-                                    channelId = user.id,
-                                    channelLogin = user.login,
-                                    channelName = user.name,
-                                    channelImage = user.profileImage,
+                            navigateDeepLinkOnce("user:${user.id}|${user.login}") {
+                                leavePlayerForBrowsing()
+                                navController.navigate(
+                                    ChannelPagerFragmentDirections.actionGlobalChannelPagerFragment(
+                                        channelId = user.id,
+                                        channelLogin = user.login,
+                                        channelName = user.name,
+                                        channelImage = user.profileImage,
+                                    )
                                 )
-                            )
+                            }
+                        } else {
+                            Toast.makeText(this@MainActivity, R.string.error_loading_user, Toast.LENGTH_SHORT).show()
                         }
                         viewModel.user.value = null
                     }
@@ -609,14 +627,18 @@ class MainActivity : AppCompatActivity() {
                         val game = pair.first
                         val tag = pair.second
                         if (game != null) {
-                            leavePlayerForBrowsing()
-                            navController.navigate(GamePagerFragmentDirections.actionGlobalGamePagerFragment(
-                                gameId = game.id,
-                                gameSlug = game.slug,
-                                gameName = game.name,
-                                boxArt = game.boxArt,
-                                tags = tag?.let { arrayOf(it) },
-                            ))
+                            navigateDeepLinkOnce("game:${game.id}|${game.slug}|${game.name}|$tag") {
+                                leavePlayerForBrowsing()
+                                navController.navigate(GamePagerFragmentDirections.actionGlobalGamePagerFragment(
+                                    gameId = game.id,
+                                    gameSlug = game.slug,
+                                    gameName = game.name,
+                                    boxArt = game.boxArt,
+                                    tags = tag?.let { arrayOf(it) },
+                                ))
+                            }
+                        } else {
+                            Toast.makeText(this@MainActivity, R.string.game_not_found, Toast.LENGTH_SHORT).show()
                         }
                         viewModel.game.value = null
                     }
@@ -627,12 +649,18 @@ class MainActivity : AppCompatActivity() {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.tag.collectLatest { tag ->
                     if (tag != null) {
-                        leavePlayerForBrowsing()
-                        navController.navigate(
-                            GamesFragmentDirections.actionGlobalGamesFragment(
-                                tags = arrayOf(tag)
-                            )
-                        )
+                        if (!tag.id.isNullOrBlank()) {
+                            navigateDeepLinkOnce("tag:${tag.id}") {
+                                leavePlayerForBrowsing()
+                                navController.navigate(
+                                    GamesFragmentDirections.actionGlobalGamesFragment(
+                                        tags = arrayOf(tag)
+                                    )
+                                )
+                            }
+                        } else {
+                            Toast.makeText(this@MainActivity, R.string.tag_not_found, Toast.LENGTH_SHORT).show()
+                        }
                         viewModel.tag.value = null
                     }
                 }
@@ -1459,6 +1487,22 @@ class MainActivity : AppCompatActivity() {
             (playerFragment as? Media3PlayerFragment)?.minimize()
                 ?: (playerFragment as? PlayerFragment)?.minimize()
         }
+    }
+
+    /**
+     * Deep-link resolutions can fire twice for one user tap (overlapping
+     * loads each post the same result). Ignore an identical navigation that
+     * follows the previous one within a tap window; different targets still
+     * navigate immediately.
+     */
+    private fun navigateDeepLinkOnce(key: String, navigate: () -> Unit) {
+        val now = SystemClock.uptimeMillis()
+        if (key == lastDeepLinkNavKey && now - lastDeepLinkNavTime < DEEP_LINK_NAV_DEBOUNCE_MS) {
+            return
+        }
+        lastDeepLinkNavKey = key
+        lastDeepLinkNavTime = now
+        navigate()
     }
 
     override fun dispatchKeyEvent(event: KeyEvent): Boolean {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/main/MainViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/main/MainViewModel.kt
@@ -252,7 +252,7 @@ class MainViewModel(
                         }
                     } else null
                 }
-                video.value = item to offset
+                video.value = (item ?: Video()) to offset
             }
         }
     }
@@ -296,6 +296,8 @@ class MainViewModel(
     fun loadClip(clipId: String?, networkLibrary: String?, gqlHeaders: Map<String, String>, helixHeaders: Map<String, String>) {
         if (clip.value == null) {
             viewModelScope.launch {
+                // Post a blank Clip (never null) so a failed resolution still
+                // emits and the UI can report it instead of stalling silently.
                 clip.value = try {
                     val response = graphQLRepository.loadQueryClip(networkLibrary, gqlHeaders, clipId!!)
                     response.data!!.clip?.let {
@@ -378,7 +380,7 @@ class MainViewModel(
                             }
                         } else null
                     }
-                }
+                } ?: Clip()
             }
         }
     }
@@ -386,6 +388,8 @@ class MainViewModel(
     fun loadUser(login: String?, networkLibrary: String?, gqlHeaders: Map<String, String>, helixHeaders: Map<String, String>) {
         if (user.value == null) {
             viewModelScope.launch {
+                // Post a blank User (never null) so a failed resolution still
+                // emits and the UI can report it instead of stalling silently.
                 user.value = try {
                     val response = graphQLRepository.loadQueryUser(networkLibrary, gqlHeaders, login = login)
                     response.data!!.user?.let {
@@ -418,7 +422,7 @@ class MainViewModel(
                             null
                         }
                     } else null
-                }
+                } ?: User()
             }
         }
     }
@@ -467,6 +471,8 @@ class MainViewModel(
     fun loadTag(tagId: String, networkLibrary: String?, gqlHeaders: Map<String, String>) {
         if (tag.value == null) {
             viewModelScope.launch {
+                // Post a blank Tag (never null) so a failed resolution still
+                // emits and the UI can report it instead of stalling silently.
                 tag.value = try {
                     val response = graphQLRepository.loadQueryTag(networkLibrary, gqlHeaders, tagId)
                     response.data!!.contentTag?.let {
@@ -487,7 +493,7 @@ class MainViewModel(
                     } catch (e: Exception) {
                         null
                     }
-                }
+                } ?: Tag()
             }
         }
     }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/ExoPlayerFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/ExoPlayerFragment.kt
@@ -261,8 +261,8 @@ class ExoPlayerFragment : PlayerFragment(), ClipEditorDialogFragment.Host {
 
             override fun onIsPlayingChanged(isPlaying: Boolean) {
                 updateProgress()
-                if (canEnterPictureInPicture()) {
-                    requireView().keepScreenOn = isPlaying
+                if (isAdded && view != null) {
+                    requireView().keepScreenOn = isPlaying && canEnterPictureInPicture()
                 }
             }
 

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/Media3Fragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/Media3Fragment.kt
@@ -1617,6 +1617,8 @@ class Media3Fragment : Media3PlayerFragment() {
         qualityRetryJob = null
         qualityRetryAttempts = 0
         pendingQualityCallbacks.clear()
+        resetProgressRenderState()
+        renderedPlaybackChrome = null
         binding.playerControls.root.removeCallbacks(updateProgressAction)
         binding.liveCaptionView.clearCaption()
         logVideoSurfaceBinding("on_destroy_view", player, view?.findViewById(R.id.playerSurface))

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/Media3Fragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/Media3Fragment.kt
@@ -94,6 +94,9 @@ class Media3Fragment : Media3PlayerFragment() {
     private val pendingQualityCallbacks = mutableListOf<() -> Unit>()
     private var nativeCues: List<Cue> = emptyList()
     private var shownLiveCaptionError: String? = null
+    private var renderedPositionSecond = Long.MIN_VALUE
+    private var renderedDurationMs = Long.MIN_VALUE
+    private var renderedPlaybackChrome: PlaybackChromeState? = null
     private val updateProgressAction = Runnable { if (view != null) updateProgress() }
     private val videoOutputOwner = VideoOutputOwner<Player, SurfaceView>(
         attachTarget = { currentPlayer, target -> currentPlayer.setVideoSurfaceView(target) },
@@ -212,20 +215,8 @@ class Media3Fragment : Media3PlayerFragment() {
                         streamRecoveryAttempt = 0
                         clearPlayerError()
                     }
-                    binding.bufferingIndicator.isVisible = playbackState == Player.STATE_BUFFERING
+                    renderPlaybackChrome()
                     val showPlayButton = Util.shouldShowPlayButton(player)
-                    binding.playerControls.playPause.contentDescription = getString(
-                        if (showPlayButton) R.string.player_play else R.string.player_pause_action,
-                    )
-                    if (showPlayButton) {
-                        binding.playerControls.playPause.setImageResource(R.drawable.baseline_play_arrow_black_48)
-                        binding.playerControls.playPause.visibility = View.VISIBLE
-                    } else {
-                        binding.playerControls.playPause.setImageResource(R.drawable.baseline_pause_black_48)
-                        if (videoType == STREAM && !requireContext().isTelevision() && !requireContext().prefs().getBoolean(C.PLAYER_PAUSE, false)) {
-                            binding.playerControls.playPause.visibility = View.GONE
-                        }
-                    }
                     setPipActions(!showPlayButton)
                     updateProgress()
                     controllerAutoHide = !requireContext().isTelevision() && !showPlayButton
@@ -235,20 +226,8 @@ class Media3Fragment : Media3PlayerFragment() {
                 }
 
                 override fun onPlayWhenReadyChanged(playWhenReady: Boolean, reason: Int) {
-                    binding.bufferingIndicator.isVisible = player?.playbackState == Player.STATE_BUFFERING
+                    renderPlaybackChrome()
                     val showPlayButton = Util.shouldShowPlayButton(player)
-                    binding.playerControls.playPause.contentDescription = getString(
-                        if (showPlayButton) R.string.player_play else R.string.player_pause_action,
-                    )
-                    if (showPlayButton) {
-                        binding.playerControls.playPause.setImageResource(R.drawable.baseline_play_arrow_black_48)
-                        binding.playerControls.playPause.visibility = View.VISIBLE
-                    } else {
-                        binding.playerControls.playPause.setImageResource(R.drawable.baseline_pause_black_48)
-                        if (videoType == STREAM && !requireContext().isTelevision() && !requireContext().prefs().getBoolean(C.PLAYER_PAUSE, false)) {
-                            binding.playerControls.playPause.visibility = View.GONE
-                        }
-                    }
                     setPipActions(!showPlayButton)
                     updateProgress()
                     controllerAutoHide = !requireContext().isTelevision() && !showPlayButton
@@ -258,26 +237,9 @@ class Media3Fragment : Media3PlayerFragment() {
                 }
 
                 override fun onAvailableCommandsChanged(availableCommands: Player.Commands) {
-                    val showPlayButton = Util.shouldShowPlayButton(player)
-                    binding.playerControls.playPause.contentDescription = getString(
-                        if (showPlayButton) R.string.player_play else R.string.player_pause_action,
-                    )
-                    if (showPlayButton) {
-                        binding.playerControls.playPause.setImageResource(R.drawable.baseline_play_arrow_black_48)
-                        binding.playerControls.playPause.visibility = View.VISIBLE
-                    } else {
-                        binding.playerControls.playPause.setImageResource(R.drawable.baseline_pause_black_48)
-                        if (videoType == STREAM && !requireContext().isTelevision() && !requireContext().prefs().getBoolean(C.PLAYER_PAUSE, false)) {
-                            binding.playerControls.playPause.visibility = View.GONE
-                        }
-                    }
+                    renderPlaybackChrome()
                     val duration = player?.duration.takeIf { it != androidx.media3.common.C.TIME_UNSET } ?: 0
-                    binding.playerControls.progressBar.setDuration(duration)
-                    binding.playerControls.duration.text = DateUtils.formatElapsedTime(duration / 1000)
-                    binding.playerControls.duration.contentDescription = getString(
-                        R.string.player_duration,
-                        binding.playerControls.duration.text,
-                    )
+                    updateDurationIfNeeded(duration)
                     updateProgress()
                 }
 
@@ -295,12 +257,7 @@ class Media3Fragment : Media3PlayerFragment() {
 
                 override fun onPositionDiscontinuity(oldPosition: Player.PositionInfo, newPosition: Player.PositionInfo, reason: Int) {
                     val duration = player?.duration.takeIf { it != androidx.media3.common.C.TIME_UNSET } ?: 0
-                    binding.playerControls.progressBar.setDuration(duration)
-                    binding.playerControls.duration.text = DateUtils.formatElapsedTime(duration / 1000)
-                    binding.playerControls.duration.contentDescription = getString(
-                        R.string.player_duration,
-                        binding.playerControls.duration.text,
-                    )
+                    updateDurationIfNeeded(duration)
                     updateProgress()
                     if (reason == Player.DISCONTINUITY_REASON_SEEK) {
                         chatFragment?.updatePosition(newPosition.positionMs)
@@ -343,12 +300,7 @@ class Media3Fragment : Media3PlayerFragment() {
 
                 override fun onTimelineChanged(timeline: Timeline, reason: Int) {
                     val duration = player?.duration.takeIf { it != androidx.media3.common.C.TIME_UNSET } ?: 0
-                    binding.playerControls.progressBar.setDuration(duration)
-                    binding.playerControls.duration.text = DateUtils.formatElapsedTime(duration / 1000)
-                    binding.playerControls.duration.contentDescription = getString(
-                        R.string.player_duration,
-                        binding.playerControls.duration.text,
-                    )
+                    updateDurationIfNeeded(duration)
                     updateProgress()
                     if (reason == Player.TIMELINE_CHANGE_REASON_PLAYLIST_CHANGED && !timeline.isEmpty && viewModel.qualities?.find { it.name == AUTO_QUALITY } != null) {
                         viewModel.updateQualities = viewModel.quality?.name != AUDIO_ONLY_QUALITY
@@ -581,19 +533,7 @@ class Media3Fragment : Media3PlayerFragment() {
                     requireView().keepScreenOn = player.isPlaying
                 }
                 updateProgress()
-                val showPlayButton = Util.shouldShowPlayButton(player)
-                binding.playerControls.playPause.contentDescription = getString(
-                    if (showPlayButton) R.string.player_play else R.string.player_pause_action,
-                )
-                if (showPlayButton) {
-                    binding.playerControls.playPause.setImageResource(R.drawable.baseline_play_arrow_black_48)
-                    binding.playerControls.playPause.visibility = View.VISIBLE
-                } else {
-                    binding.playerControls.playPause.setImageResource(R.drawable.baseline_pause_black_48)
-                    if (videoType == STREAM && !requireContext().isTelevision() && !requireContext().prefs().getBoolean(C.PLAYER_PAUSE, false)) {
-                        binding.playerControls.playPause.visibility = View.GONE
-                    }
-                }
+                renderPlaybackChrome()
             }
             if ((isInitialized || !enableNetworkCheck) && !viewModel.started) {
                 startPlayer()
@@ -799,6 +739,7 @@ class Media3Fragment : Media3PlayerFragment() {
 
     private fun startStreamInternal(url: String?, playWhenReady: Boolean?): ListenableFuture<SessionResult>? {
         clearPlayerError()
+        resetProgressRenderState()
         adAvoidanceJob?.cancel()
         adAvoidanceJob = null
         primaryStreamRestoreJob?.cancel()
@@ -841,6 +782,7 @@ class Media3Fragment : Media3PlayerFragment() {
 
     override fun startVideo(url: String?, playbackPosition: Long?, multivariantPlaylist: Boolean) {
         clearPlayerError()
+        resetProgressRenderState()
         player?.let { player ->
             player.trackSelectionParameters = player.trackSelectionParameters.buildUpon().apply {
                 setTrackTypeDisabled(androidx.media3.common.C.TRACK_TYPE_VIDEO, false)
@@ -867,6 +809,7 @@ class Media3Fragment : Media3PlayerFragment() {
 
     override fun startClip(url: String?) {
         clearPlayerError()
+        resetProgressRenderState()
         player?.let { player ->
             if (viewModel.quality?.name == AUDIO_ONLY_QUALITY) {
                 player.trackSelectionParameters = player.trackSelectionParameters.buildUpon().apply {
@@ -899,6 +842,7 @@ class Media3Fragment : Media3PlayerFragment() {
 
     override fun startOfflineVideo(url: String?, position: Long) {
         clearPlayerError()
+        resetProgressRenderState()
         player?.let { player ->
             if (viewModel.quality?.name == AUDIO_ONLY_QUALITY) {
                 player.trackSelectionParameters = player.trackSelectionParameters.buildUpon().apply {
@@ -1040,8 +984,7 @@ class Media3Fragment : Media3PlayerFragment() {
         with(binding.playerControls) {
             if (root.isVisible && !progressBar.isPressed) {
                 val currentPosition = player?.currentPosition ?: 0
-                position.text = DateUtils.formatElapsedTime(currentPosition / 1000)
-                position.contentDescription = getString(R.string.player_position, position.text)
+                updatePositionTextIfNeeded(currentPosition)
                 progressBar.setPosition(currentPosition)
                 progressBar.setBufferedPosition(player?.bufferedPosition ?: 0)
                 root.removeCallbacks(updateProgressAction)
@@ -1056,6 +999,74 @@ class Media3Fragment : Media3PlayerFragment() {
                         root.postDelayed(updateProgressAction, delay)
                     }
                 }
+            }
+        }
+    }
+
+    private data class PlaybackChromeState(
+        val showPlayIcon: Boolean,
+        val buffering: Boolean,
+        val canPause: Boolean,
+    )
+
+    private fun updatePositionTextIfNeeded(positionMs: Long) {
+        val positionSecond = positionMs / 1_000L
+        if (positionSecond == renderedPositionSecond) {
+            return
+        }
+        renderedPositionSecond = positionSecond
+        val formattedPosition = DateUtils.formatElapsedTime(positionSecond)
+        binding.playerControls.position.text = formattedPosition
+        binding.playerControls.position.contentDescription = getString(
+            R.string.player_position,
+            formattedPosition,
+        )
+    }
+
+    private fun updateDurationIfNeeded(durationMs: Long) {
+        if (durationMs == renderedDurationMs) {
+            return
+        }
+        renderedDurationMs = durationMs
+        binding.playerControls.progressBar.setDuration(durationMs)
+        val formattedDuration = DateUtils.formatElapsedTime(durationMs / 1000)
+        binding.playerControls.duration.text = formattedDuration
+        binding.playerControls.duration.contentDescription = getString(
+            R.string.player_duration,
+            formattedDuration,
+        )
+    }
+
+    private fun resetProgressRenderState() {
+        renderedPositionSecond = Long.MIN_VALUE
+        renderedDurationMs = Long.MIN_VALUE
+    }
+
+    private fun renderPlaybackChrome() {
+        val player = player ?: return
+        val showPlayButton = Util.shouldShowPlayButton(player)
+        val buffering = player.playbackState == Player.STATE_BUFFERING
+        val canPause = !(videoType == STREAM && !requireContext().isTelevision() && !requireContext().prefs().getBoolean(C.PLAYER_PAUSE, false))
+        val state = PlaybackChromeState(
+            showPlayIcon = showPlayButton,
+            buffering = buffering,
+            canPause = canPause,
+        )
+        if (state == renderedPlaybackChrome) {
+            return
+        }
+        renderedPlaybackChrome = state
+        binding.bufferingIndicator.isVisible = buffering
+        binding.playerControls.playPause.contentDescription = getString(
+            if (showPlayButton) R.string.player_play else R.string.player_pause_action,
+        )
+        if (showPlayButton) {
+            binding.playerControls.playPause.setImageResource(R.drawable.baseline_play_arrow_black_48)
+            binding.playerControls.playPause.visibility = View.VISIBLE
+        } else {
+            binding.playerControls.playPause.setImageResource(R.drawable.baseline_pause_black_48)
+            if (!canPause) {
+                binding.playerControls.playPause.visibility = View.GONE
             }
         }
     }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/Media3Fragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/Media3Fragment.kt
@@ -59,7 +59,6 @@ import com.github.andreyasadchy.xtra.util.shouldAvoidTwitchAds
 import com.github.andreyasadchy.xtra.util.isTelevision
 import com.google.android.material.snackbar.Snackbar
 import com.google.common.util.concurrent.ListenableFuture
-import com.google.common.util.concurrent.MoreExecutors
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -270,8 +269,8 @@ class Media3Fragment : Media3PlayerFragment() {
 
                 override fun onIsPlayingChanged(isPlaying: Boolean) {
                     updateProgress()
-                    if (canEnterPictureInPicture()) {
-                        requireView().keepScreenOn = isPlaying
+                    if (isAdded && view != null) {
+                        requireView().keepScreenOn = isPlaying && canEnterPictureInPicture()
                     }
                 }
 
@@ -379,7 +378,7 @@ class Media3Fragment : Media3PlayerFragment() {
                                         if (isNetworkAvailable) {
                                             when {
                                                 responseCode == 404 -> {
-                                                    showPlayerError(R.string.stream_ended)
+                                                    showPlayerError(R.string.stream_ended) { restartPlayer() }
                                                 }
                                                 viewModel.useCustomProxy && responseCode >= 400 -> {
                                                     showPlayerError(R.string.proxy_error) { restartPlayer() }
@@ -492,12 +491,13 @@ class Media3Fragment : Media3PlayerFragment() {
             }
             player?.sendCustomCommand(
                 SessionCommand(
-                    PlaybackService.SET_SLEEP_TIMER, Bundle().apply {
-                        putLong(PlaybackService.DURATION, -1L)
-                    }
+                    PlaybackService.GET_SLEEP_TIMER, Bundle.EMPTY
                 ), Bundle.EMPTY
             )?.let { result ->
                 result.addListener({
+                    if (!isAdded || view == null) {
+                        return@addListener
+                    }
                     if (result.get().resultCode == SessionResult.RESULT_SUCCESS) {
                         val endTime = result.get().extras.getLong(PlaybackService.RESULT)
                         if (endTime > 0L) {
@@ -511,7 +511,7 @@ class Media3Fragment : Media3PlayerFragment() {
                             }
                         }
                     }
-                }, MoreExecutors.directExecutor())
+                }, ContextCompat.getMainExecutor(requireContext()))
             }
             if (viewModel.resume) {
                 viewModel.resume = false
@@ -1079,6 +1079,9 @@ class Media3Fragment : Media3PlayerFragment() {
             ), Bundle.EMPTY
         )?.let { result ->
             result.addListener({
+                if (!isAdded || view == null) {
+                    return@addListener
+                }
                 if (result.get().resultCode == SessionResult.RESULT_SUCCESS) {
                     val state = result.get().extras.getBoolean(PlaybackService.RESULT)
                     if (state) {
@@ -1087,7 +1090,7 @@ class Media3Fragment : Media3PlayerFragment() {
                         binding.playerControls.audioCompressor.setImageResource(R.drawable.baseline_audio_compressor_off_24dp)
                     }
                 }
-            }, MoreExecutors.directExecutor())
+            }, ContextCompat.getMainExecutor(requireContext()))
         }
     }
 
@@ -1150,6 +1153,9 @@ class Media3Fragment : Media3PlayerFragment() {
             ), Bundle.EMPTY
         )?.let { result ->
             result.addListener({
+                if (!isAdded || view == null) {
+                    return@addListener
+                }
                 if (result.get().resultCode == SessionResult.RESULT_SUCCESS) {
                     val tags = result.get().extras.getStringArray(PlaybackService.RESULT)?.joinToString("\n")
                     if (!tags.isNullOrBlank()) {
@@ -1171,7 +1177,7 @@ class Media3Fragment : Media3PlayerFragment() {
                         }.show()
                     }
                 }
-            }, MoreExecutors.directExecutor())
+            }, ContextCompat.getMainExecutor(requireContext()))
         }
     }
 
@@ -1362,6 +1368,9 @@ class Media3Fragment : Media3PlayerFragment() {
             Bundle.EMPTY
         )?.let { result ->
             result.addListener({
+                if (!isAdded || view == null) {
+                    return@addListener
+                }
                 if (result.get().resultCode == SessionResult.RESULT_SUCCESS) {
                     val totalDuration = result.get().extras.getLong(PlaybackService.RESULT)
                     val qualities = viewModel.qualities?.filter { !it.url.isNullOrBlank() }
@@ -1388,7 +1397,7 @@ class Media3Fragment : Media3PlayerFragment() {
                         qualityUrls = qualities?.map { it.url.toString() }?.toTypedArray(),
                     ).show(childFragmentManager, null)
                 }
-            }, MoreExecutors.directExecutor())
+            }, ContextCompat.getMainExecutor(requireContext()))
         }
     }
 
@@ -1608,6 +1617,7 @@ class Media3Fragment : Media3PlayerFragment() {
         qualityRetryJob = null
         qualityRetryAttempts = 0
         pendingQualityCallbacks.clear()
+        binding.playerControls.root.removeCallbacks(updateProgressAction)
         binding.liveCaptionView.clearCaption()
         logVideoSurfaceBinding("on_destroy_view", player, view?.findViewById(R.id.playerSurface))
         detachVideoOutput()

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/Media3PlayerFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/Media3PlayerFragment.kt
@@ -3709,8 +3709,11 @@ abstract class Media3PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFr
     override fun onDestroyView() {
         _binding?.playerControls?.root?.let { root ->
             pendingTvFocusRequest?.let(root::removeCallbacks)
+            root.removeCallbacks(controllerHideAction)
         }
         pendingTvFocusRequest = null
+        velocityTracker?.recycle()
+        velocityTracker = null
         xtraModule.liveCaptionManager.resetForPlaybackTransition()
         loadedChannelAvatarUrl = null
         liveRewindDiscoveryJob?.cancel()

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/Media3PlayerFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/Media3PlayerFragment.kt
@@ -180,8 +180,20 @@ abstract class Media3PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFr
     private var uptimeStartedAtMs: Long? = null
     private var liveRewindPendingVodId: String? = null
     private var liveRewindPendingTargetMs: Long? = null
+    private var renderedLiveRewindState: LiveRewindRenderState? = null
     private var lastTvFocusedControl: View? = null
     private var pendingTvFocusRequest: Runnable? = null
+
+    private data class LiveRewindRenderState(
+        val edgeMs: Long,
+        val progressPositionMs: Long?,
+        val positionText: String,
+        val positionDescription: String,
+        val durationText: String,
+        val durationDescription: String,
+        val edgeColor: Int,
+        val liveButtonVisible: Boolean,
+    )
 
     private val backPressedCallback = object : OnBackPressedCallback(true) {
         override fun handleOnBackPressed() {
@@ -2745,6 +2757,7 @@ abstract class Media3PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFr
     protected fun updateLiveRewindProgress() {
         val vod = liveRewindVod ?: return
         if (!isLiveRewindAvailable() || view == null) {
+            renderedLiveRewindState = null
             binding.playerControls.progressBar.visibility = View.GONE
             binding.playerControls.liveButton.visibility = View.GONE
             return
@@ -2780,13 +2793,13 @@ abstract class Media3PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFr
             return
         }
         val edgeMs = freezeLiveEdge(vod.predictedDurationMs(), liveRewindFrozenEdgeMs)
-        binding.playerControls.progressBar.setDuration(edgeMs)
-        if (liveRewindScrubPositionMs == null) {
-            val positionMs = when (livePlaybackMode) {
+        val progressPositionMs = if (liveRewindScrubPositionMs == null) {
+            when (livePlaybackMode) {
                 LivePlaybackMode.Live -> edgeMs
                 is LivePlaybackMode.Rewound -> getCurrentPosition() ?: 0L
             }.coerceIn(0L, edgeMs)
-            binding.playerControls.progressBar.setPosition(positionMs)
+        } else {
+            null
         }
         val displayedPositionMs = liveRewindTimelinePositionMs(
             mode = livePlaybackMode,
@@ -2794,33 +2807,77 @@ abstract class Media3PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFr
             playerPositionMs = getCurrentPosition() ?: 0L,
             scrubPositionMs = liveRewindScrubPositionMs,
         )
-        binding.playerControls.position.visibility = View.VISIBLE
-        binding.playerControls.position.text = DateUtils.formatElapsedTime(0)
-        binding.playerControls.position.contentDescription = getString(
+        val isRewound = livePlaybackMode is LivePlaybackMode.Rewound
+        val positionText = DateUtils.formatElapsedTime(0)
+        val positionDescription = getString(
             R.string.player_position,
-            binding.playerControls.position.text,
+            positionText,
         )
-        binding.playerControls.duration.visibility = View.VISIBLE
-        binding.playerControls.duration.text = DateUtils.formatElapsedTime(displayedPositionMs / 1000L)
-        binding.playerControls.duration.contentDescription = getString(
-            if (livePlaybackMode is LivePlaybackMode.Rewound) R.string.player_position else R.string.player_duration,
-            binding.playerControls.duration.text,
+        val durationText = DateUtils.formatElapsedTime(displayedPositionMs / 1000L)
+        val durationDescription = getString(
+            if (isRewound) R.string.player_position else R.string.player_duration,
+            durationText,
         )
-        binding.playerControls.duration.setCompoundDrawablesRelativeWithIntrinsicBounds(null, null, null, null)
         val edgeColor = requireContext().getColor(
             if (livePlaybackMode is LivePlaybackMode.Live && !liveRewindStreamOffline) R.color.liveStreamRed else R.color.chatStatusDark,
         )
-        binding.playerControls.uptimeIcon.imageTintList = ColorStateList.valueOf(edgeColor)
-        binding.playerControls.liveButton.visibility =
-            if (livePlaybackMode is LivePlaybackMode.Rewound && !liveRewindStreamOffline) {
-                View.VISIBLE
-            } else {
-                View.GONE
-            }
+        val liveButtonVisible = isRewound && !liveRewindStreamOffline
+        val next = LiveRewindRenderState(
+            edgeMs = edgeMs,
+            progressPositionMs = progressPositionMs,
+            positionText = positionText,
+            positionDescription = positionDescription,
+            durationText = durationText,
+            durationDescription = durationDescription,
+            edgeColor = edgeColor,
+            liveButtonVisible = liveButtonVisible,
+        )
+        if (next == renderedLiveRewindState) {
+            return
+        }
+        val previous = renderedLiveRewindState
+        renderedLiveRewindState = next
+        if (previous?.edgeMs != next.edgeMs) {
+            binding.playerControls.progressBar.setDuration(next.edgeMs)
+        }
+        if (next.progressPositionMs != null && previous?.progressPositionMs != next.progressPositionMs) {
+            binding.playerControls.progressBar.setPosition(next.progressPositionMs)
+        }
+        if (previous == null) {
+            binding.playerControls.position.visibility = View.VISIBLE
+            binding.playerControls.duration.visibility = View.VISIBLE
+        }
+        if (previous?.positionText != next.positionText) {
+            binding.playerControls.position.text = next.positionText
+        }
+        if (previous?.positionDescription != next.positionDescription) {
+            binding.playerControls.position.contentDescription = next.positionDescription
+        }
+        if (previous?.durationText != next.durationText) {
+            binding.playerControls.duration.text = next.durationText
+        }
+        if (previous?.durationDescription != next.durationDescription) {
+            binding.playerControls.duration.contentDescription = next.durationDescription
+        }
+        if (previous == null) {
+            binding.playerControls.duration.setCompoundDrawablesRelativeWithIntrinsicBounds(null, null, null, null)
+        }
+        if (previous?.edgeColor != next.edgeColor) {
+            binding.playerControls.uptimeIcon.imageTintList = ColorStateList.valueOf(next.edgeColor)
+        }
+        if (previous?.liveButtonVisible != next.liveButtonVisible) {
+            binding.playerControls.liveButton.visibility =
+                if (next.liveButtonVisible) {
+                    View.VISIBLE
+                } else {
+                    View.GONE
+                }
+        }
     }
 
     private fun updateLiveRewindUi() {
         if (!isLiveRewindAvailable()) {
+            renderedLiveRewindState = null
             setLiveRewindTimelineLayout(false)
             schedulePortraitControlScale()
             binding.playerControls.progressBar.visibility = View.GONE
@@ -2847,6 +2904,7 @@ abstract class Media3PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFr
     }
 
     private fun showLiveRewindPreview(positionMs: Long) {
+        renderedLiveRewindState = null
         val edgeMs = currentLiveEdgeMs()
         binding.playerControls.position.visibility = View.VISIBLE
         binding.playerControls.position.text = formatBehindLive(positionMs, edgeMs)

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/Media3PlayerFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/Media3PlayerFragment.kt
@@ -3712,6 +3712,7 @@ abstract class Media3PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFr
             root.removeCallbacks(controllerHideAction)
         }
         pendingTvFocusRequest = null
+        renderedLiveRewindState = null
         velocityTracker?.recycle()
         velocityTracker = null
         xtraModule.liveCaptionManager.resetForPlaybackTransition()

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/MediaPlayerFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/MediaPlayerFragment.kt
@@ -303,8 +303,8 @@ class MediaPlayerFragment : PlayerFragment() {
                 showController(show = playbackService?.type != BasePlaybackService.STREAM && ended)
             }
             updateProgress()
-            if (canEnterPictureInPicture()) {
-                requireView().keepScreenOn = isPlaying
+            if (isAdded && view != null) {
+                requireView().keepScreenOn = isPlaying && canEnterPictureInPicture()
             }
         }
     }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/PlaybackPersistence.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/PlaybackPersistence.kt
@@ -160,9 +160,15 @@ class PlaybackPersistence internal constructor(
                 true
             }
         }
-        if (shouldQueue && operations.trySend { drainPendingVideoPositions() }.isFailure) {
-            synchronized(videoPositionLock) {
-                videoPositionOperationQueued = false
+        if (!shouldQueue) {
+            return
+        }
+        val operation: suspend () -> Unit = {
+            drainPendingVideoPositions()
+        }
+        if (operations.trySend(operation).isFailure) {
+            scope.launch {
+                operations.send(operation)
             }
         }
     }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/PlaybackService.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/PlaybackService.kt
@@ -231,6 +231,7 @@ class PlaybackService : MediaSessionService() {
                             add(SessionCommand(TOGGLE_PROXY, Bundle.EMPTY))
                             add(SessionCommand(SET_BACKGROUND_PLAYBACK, Bundle.EMPTY))
                             add(SessionCommand(SET_SLEEP_TIMER, Bundle.EMPTY))
+                            add(SessionCommand(GET_SLEEP_TIMER, Bundle.EMPTY))
                             add(SessionCommand(CHECK_ADS, Bundle.EMPTY))
                             add(SessionCommand(GET_QUALITIES, Bundle.EMPTY))
                             add(SessionCommand(GET_DURATION, Bundle.EMPTY))
@@ -528,6 +529,7 @@ class PlaybackService : MediaSessionService() {
                                 val duration = customCommand.customExtras.getLong(DURATION)
                                 val endTime = sleepTimerEndTime
                                 sleepTimer?.cancel()
+                                sleepTimer = null
                                 sleepTimerEndTime = 0L
                                 if (duration > 0L) {
                                     sleepTimer = Timer().apply {
@@ -546,6 +548,11 @@ class PlaybackService : MediaSessionService() {
                                 }
                                 Futures.immediateFuture(SessionResult(SessionResult.RESULT_SUCCESS, Bundle().apply {
                                     putLong(RESULT, endTime)
+                                }))
+                            }
+                            GET_SLEEP_TIMER -> {
+                                Futures.immediateFuture(SessionResult(SessionResult.RESULT_SUCCESS, Bundle().apply {
+                                    putLong(RESULT, sleepTimerEndTime)
                                 }))
                             }
                             CHECK_ADS -> {
@@ -1145,6 +1152,7 @@ class PlaybackService : MediaSessionService() {
         const val TOGGLE_PROXY = "toggleProxy"
         const val SET_BACKGROUND_PLAYBACK = "setBackgroundPlayback"
         const val SET_SLEEP_TIMER = "setSleepTimer"
+        const val GET_SLEEP_TIMER = "getSleepTimer"
         const val CHECK_ADS = "checkAds"
         const val GET_QUALITIES = "getQualities"
         const val GET_DURATION = "getDuration"

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/team/TeamFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/team/TeamFragment.kt
@@ -120,13 +120,18 @@ class TeamFragment : PagedListFragment(), Scrollable {
                     else -> false
                 }
             }
-            var maxTopInset = 0
             ViewCompat.setOnApplyWindowInsetsListener(view) { _, windowInsets ->
-                val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout())
-                if (insets.top > maxTopInset) {
-                    maxTopInset = insets.top
-                    collapsingToolbar.updateLayoutParams<ViewGroup.MarginLayoutParams> {
-                        topMargin = insets.top
+                val top = maxOf(
+                    windowInsets.getInsetsIgnoringVisibility(
+                        WindowInsetsCompat.Type.statusBars()
+                    ).top,
+                    windowInsets.getInsets(
+                        WindowInsetsCompat.Type.displayCutout()
+                    ).top,
+                )
+                collapsingToolbar.updateLayoutParams<ViewGroup.MarginLayoutParams> {
+                    if (topMargin != top) {
+                        topMargin = top
                     }
                 }
                 if (activity.findViewById<LinearLayout>(R.id.navBarContainer)?.isVisible == false) {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/team/TeamFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/team/TeamFragment.kt
@@ -43,6 +43,7 @@ import com.github.andreyasadchy.xtra.ui.team.TeamViewModel.Companion.TeamViewMod
 import com.github.andreyasadchy.xtra.ui.top.TopStreamsFragmentDirections
 import com.github.andreyasadchy.xtra.util.C
 import com.github.andreyasadchy.xtra.util.TwitchApiHelper
+import com.github.andreyasadchy.xtra.util.applyStableTopSystemBarMargin
 import com.github.andreyasadchy.xtra.util.getAlertDialogBuilder
 import com.github.andreyasadchy.xtra.util.prefs
 import com.github.andreyasadchy.xtra.util.tokenPrefs
@@ -120,25 +121,13 @@ class TeamFragment : PagedListFragment(), Scrollable {
                     else -> false
                 }
             }
-            ViewCompat.setOnApplyWindowInsetsListener(view) { _, windowInsets ->
-                val top = maxOf(
-                    windowInsets.getInsetsIgnoringVisibility(
-                        WindowInsetsCompat.Type.statusBars()
-                    ).top,
-                    windowInsets.getInsets(
-                        WindowInsetsCompat.Type.displayCutout()
-                    ).top,
-                )
-                collapsingToolbar.updateLayoutParams<ViewGroup.MarginLayoutParams> {
-                    if (topMargin != top) {
-                        topMargin = top
-                    }
-                }
+            view.applyStableTopSystemBarMargin(collapsingToolbar)
+            ViewCompat.setOnApplyWindowInsetsListener(recyclerViewLayout.recyclerView) { _, windowInsets ->
                 if (activity.findViewById<LinearLayout>(R.id.navBarContainer)?.isVisible == false) {
                     val systemBars = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars())
                     recyclerViewLayout.recyclerView.updatePadding(bottom = systemBars.bottom)
                 }
-                WindowInsetsCompat.CONSUMED
+                windowInsets
             }
         }
         pagingAdapter = TeamMembersAdapter(this) {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/team/TeamFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/team/TeamFragment.kt
@@ -120,10 +120,14 @@ class TeamFragment : PagedListFragment(), Scrollable {
                     else -> false
                 }
             }
+            var maxTopInset = 0
             ViewCompat.setOnApplyWindowInsetsListener(view) { _, windowInsets ->
                 val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout())
-                collapsingToolbar.updateLayoutParams<ViewGroup.MarginLayoutParams> {
-                    topMargin = insets.top
+                if (insets.top > maxTopInset) {
+                    maxTopInset = insets.top
+                    collapsingToolbar.updateLayoutParams<ViewGroup.MarginLayoutParams> {
+                        topMargin = insets.top
+                    }
                 }
                 if (activity.findViewById<LinearLayout>(R.id.navBarContainer)?.isVisible == false) {
                     val systemBars = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars())

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/view/AutoCompleteAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/view/AutoCompleteAdapter.kt
@@ -43,6 +43,9 @@ class AutoCompleteAdapter<T>(
             is Emote -> {
                 view.findViewById<ImageView>(R.id.image)?.let {
                     it.visibility = View.VISIBLE
+                    // Dropdown rows are recycled; clear the previous emote before
+                    // the async load completes so a stale image never flashes.
+                    it.setImageDrawable(null)
                     if (imageLibrary == "0" || (imageLibrary == "1" && !item.format.equals("webp", true))) {
                         context.imageLoader.enqueue(
                             ImageRequest.Builder(context).apply {
@@ -84,7 +87,14 @@ class AutoCompleteAdapter<T>(
                 }
                 view.findViewById<TextView>(R.id.name)?.text = item.name
             }
-            is Chatter -> view.findViewById<TextView>(R.id.name)?.text = item.name
+            is Chatter -> {
+                // A recycled emote row keeps its image; chatter rows have none.
+                view.findViewById<ImageView>(R.id.image)?.let {
+                    it.visibility = View.GONE
+                    it.setImageDrawable(null)
+                }
+                view.findViewById<TextView>(R.id.name)?.text = item.name
+            }
         }
         return view
     }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/ViewExtensions.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/ViewExtensions.kt
@@ -49,25 +49,36 @@ fun ViewPager2.configureForSmoothPaging() {
 /**
  * Offsets a collapsing AppBar child below the status bar/cutout.
  *
- * These pager screens are never immersive themselves, yet transient window
- * states (player fullscreen transitions, PiP) can dispatch a zero top inset
- * that would otherwise strand the collapsed tab strip underneath the status
- * bar with clock/icons overlapping the tabs. Keep the largest inset seen for
- * this view lifetime so a stale zero can never shrink the offset; the value
- * resets with the view. Errs toward a slightly larger gap, never overlap.
+ * Uses the stable status-bar geometry, which is reported even while the
+ * bar is temporarily hidden (player fullscreen transitions, PiP), so a
+ * transient zero inset can never strand the collapsed tab strip underneath
+ * the status bar. Legitimate geometry changes such as portrait to
+ * landscape rotation are still applied.
  */
-fun View.applyStickyTopSystemBarMargin(target: View) {
-    var maxTop = 0
+fun View.applyStableTopSystemBarMargin(target: View) {
     ViewCompat.setOnApplyWindowInsetsListener(this) { _, windowInsets ->
-        val top = windowInsets.getInsets(
-            WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout()
-        ).top
-        if (top > maxTop) {
-            maxTop = top
-            target.updateLayoutParams<ViewGroup.MarginLayoutParams> {
+        val statusBarTop = windowInsets
+            .getInsetsIgnoringVisibility(
+                WindowInsetsCompat.Type.statusBars()
+            )
+            .top
+
+        val cutoutTop = windowInsets
+            .getInsets(
+                WindowInsetsCompat.Type.displayCutout()
+            )
+            .top
+
+        val top = maxOf(statusBarTop, cutoutTop)
+
+        target.updateLayoutParams<ViewGroup.MarginLayoutParams> {
+            if (topMargin != top) {
                 topMargin = top
             }
         }
+
         windowInsets
     }
+
+    ViewCompat.requestApplyInsets(this)
 }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/ViewExtensions.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/ViewExtensions.kt
@@ -2,6 +2,10 @@ package com.github.andreyasadchy.xtra.util
 
 import android.graphics.Rect
 import android.view.View
+import android.view.ViewGroup
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updateLayoutParams
 import androidx.recyclerview.widget.RecyclerView
 import androidx.viewpager2.widget.ViewPager2
 
@@ -40,4 +44,30 @@ fun ViewPager2.configureForSmoothPaging() {
         setHasFixedSize(true)
     }
     reduceDragSensitivity()
+}
+
+/**
+ * Offsets a collapsing AppBar child below the status bar/cutout.
+ *
+ * These pager screens are never immersive themselves, yet transient window
+ * states (player fullscreen transitions, PiP) can dispatch a zero top inset
+ * that would otherwise strand the collapsed tab strip underneath the status
+ * bar with clock/icons overlapping the tabs. Keep the largest inset seen for
+ * this view lifetime so a stale zero can never shrink the offset; the value
+ * resets with the view. Errs toward a slightly larger gap, never overlap.
+ */
+fun View.applyStickyTopSystemBarMargin(target: View) {
+    var maxTop = 0
+    ViewCompat.setOnApplyWindowInsetsListener(this) { _, windowInsets ->
+        val top = windowInsets.getInsets(
+            WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout()
+        ).top
+        if (top > maxTop) {
+            maxTop = top
+            target.updateLayoutParams<ViewGroup.MarginLayoutParams> {
+                topMargin = top
+            }
+        }
+        windowInsets
+    }
 }

--- a/app/src/main/res/layout/fragment_chat.xml
+++ b/app/src/main/res/layout/fragment_chat.xml
@@ -196,7 +196,8 @@
         <LinearLayout
             android:id="@+id/messageView"
             android:layout_width="match_parent"
-            android:layout_height="48dp"
+            android:layout_height="wrap_content"
+            android:minHeight="48dp"
             android:baselineAligned="false"
             android:orientation="horizontal"
             android:visibility="gone"

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -571,6 +571,9 @@
     <string name="loaded_cached_ffz_emotes">عواطف FFZ المحملة مؤقتًا</string>
     <string name="find_unlisted_video">ابحث عن فيديو غير مدرج</string>
     <string name="video_not_found">لم يتم العثور على الفيديو</string>
+    <string name="clip_not_found">لم يتم العثور على المقطع</string>
+    <string name="game_not_found">لم يتم العثور على اللعبة</string>
+    <string name="tag_not_found">لم يتم العثور على العلامة</string>
     <string name="recent_messages_api_url">عنوان URL لواجهة برمجة التطبيقات للرسائل الأخيرة</string>
     <string name="access_local_network_title">منح إذن الشبكة المحلية</string>
     <string name="access_local_network_desc">مطلوب للاتصال بالوكلاء المحليين</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -1273,6 +1273,9 @@
     <string name="loaded_cached_ffz_emotes">Načtené emotikony FFZ z mezipaměti</string>
     <string name="find_unlisted_video">Najít neveřejné video</string>
     <string name="video_not_found">Video nenalezeno</string>
+    <string name="clip_not_found">Klip nenalezen</string>
+    <string name="game_not_found">Hra nenalezena</string>
+    <string name="tag_not_found">Štítek nenalezen</string>
     <string name="recent_messages_api_url">Adresa URL rozhraní API posledních zpráv</string>
     <string name="access_local_network_title">Udělte oprávnění k místní síti</string>
     <string name="access_local_network_desc">Vyžadováno pro připojení k místním serverům proxy</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -571,6 +571,9 @@
     <string name="loaded_cached_ffz_emotes">Geladene zwischengespeicherte FFZ-Emotes</string>
     <string name="find_unlisted_video">Nicht gelistete Videos finden</string>
     <string name="video_not_found">Video nicht gefunden</string>
+    <string name="clip_not_found">Clip nicht gefunden</string>
+    <string name="game_not_found">Spiel nicht gefunden</string>
+    <string name="tag_not_found">Schlagwort nicht gefunden</string>
     <string name="recent_messages_api_url">API-URL für aktuelle Nachrichten</string>
     <string name="access_local_network_title">Berechtigung für lokales Netzwerk erteilen</string>
     <string name="access_local_network_desc">Erforderlich für die Verbindung zu lokalen Proxys</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -576,6 +576,9 @@
     <string name="loaded_cached_ffz_emotes">Gestos FFZ cargados en caché</string>
     <string name="find_unlisted_video">Buscar video no listado</string>
     <string name="video_not_found">Video no encontrado</string>
+    <string name="clip_not_found">Clip no encontrado</string>
+    <string name="game_not_found">Juego no encontrado</string>
+    <string name="tag_not_found">Etiqueta no encontrada</string>
     <string name="recent_messages_api_url">URL de API de mensajes recientes</string>
     <string name="access_local_network_title">Otorgar permiso de red local</string>
     <string name="access_local_network_desc">Requerido para conectarse a servidores proxy locales</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -571,6 +571,9 @@
     <string name="loaded_cached_ffz_emotes">Émoticônes FFZ en cache chargées</string>
     <string name="find_unlisted_video">Rechercher une vidéo non répertoriée</string>
     <string name="video_not_found">Vidéo introuvable</string>
+    <string name="clip_not_found">Clip introuvable</string>
+    <string name="game_not_found">Jeu introuvable</string>
+    <string name="tag_not_found">Balise introuvable</string>
     <string name="recent_messages_api_url">URL de l\'API des messages récents</string>
     <string name="access_local_network_title">Accorder l\'autorisation du réseau local</string>
     <string name="access_local_network_desc">Requis pour la connexion aux proxys locaux</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -571,6 +571,9 @@
     <string name="loaded_cached_ffz_emotes">Cargáronse emocións FFZ almacenadas na caché</string>
     <string name="find_unlisted_video">Busca vídeo non listado</string>
     <string name="video_not_found">Non se atopou o vídeo</string>
+    <string name="clip_not_found">Non se atopou o clip</string>
+    <string name="game_not_found">Non se atopou o xogo</string>
+    <string name="tag_not_found">Non se atopou a etiqueta</string>
     <string name="recent_messages_api_url">URL da API de mensaxes recentes</string>
     <string name="access_local_network_title">Concede permiso de rede local</string>
     <string name="access_local_network_desc">Necesario para conectarse a proxies locais</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -572,6 +572,9 @@
     <string name="loaded_cached_ffz_emotes">Memuat emote FFZ yang di-cache</string>
     <string name="find_unlisted_video">Temukan video yang tidak terdaftar</string>
     <string name="video_not_found">Video tidak ditemukan</string>
+    <string name="clip_not_found">Klip tidak ditemukan</string>
+    <string name="game_not_found">Game tidak ditemukan</string>
+    <string name="tag_not_found">Tag tidak ditemukan</string>
     <string name="recent_messages_api_url">URL API pesan terbaru</string>
     <string name="access_local_network_title">Berikan izin jaringan lokal</string>
     <string name="access_local_network_desc">Diperlukan untuk terhubung ke proxy lokal</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -571,6 +571,9 @@
     <string name="loaded_cached_ffz_emotes">Emote FFZ caricate nella cache</string>
     <string name="find_unlisted_video">Trova video non in elenco</string>
     <string name="video_not_found">Video non trovato</string>
+    <string name="clip_not_found">Clip non trovato</string>
+    <string name="game_not_found">Gioco non trovato</string>
+    <string name="tag_not_found">Tag non trovato</string>
     <string name="recent_messages_api_url">URL API messaggi recenti</string>
     <string name="access_local_network_title">Concedi l\'autorizzazione alla rete locale</string>
     <string name="access_local_network_desc">Necessario per la connessione ai proxy locali</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -571,6 +571,9 @@
     <string name="loaded_cached_ffz_emotes">キャッシュされたFFZエモートをロード</string>
     <string name="find_unlisted_video">限定公開のビデオを検索</string>
     <string name="video_not_found">ビデオが見つかりません</string>
+    <string name="clip_not_found">クリップが見つかりません</string>
+    <string name="game_not_found">ゲームが見つかりません</string>
+    <string name="tag_not_found">タグが見つかりません</string>
     <string name="recent_messages_api_url">最近のメッセージ API URL</string>
     <string name="access_local_network_title">ローカル ネットワーク許可の付与</string>
     <string name="access_local_network_desc">ローカル プロキシへの接続に必要</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -1248,6 +1248,9 @@
     <string name="loaded_cached_ffz_emotes">Wczytane emotikony FFZ z pamięci podręcznej</string>
     <string name="find_unlisted_video">Znajdź niepubliczny film</string>
     <string name="video_not_found">Nie znaleziono filmu</string>
+    <string name="clip_not_found">Nie znaleziono klipu</string>
+    <string name="game_not_found">Nie znaleziono gry</string>
+    <string name="tag_not_found">Nie znaleziono tagu</string>
     <string name="recent_messages_api_url">URL API ostatnich wiadomości</string>
     <string name="access_local_network_title">Udziel uprawnień do sieci lokalnej</string>
     <string name="access_local_network_desc">Wymagane do połączenia z lokalnymi serwerami proxy</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -571,6 +571,9 @@
     <string name="loaded_cached_ffz_emotes">Emotes FFZ em cache carregados</string>
     <string name="find_unlisted_video">Encontrar vídeo não listado</string>
     <string name="video_not_found">Vídeo não encontrado</string>
+    <string name="clip_not_found">Clipe não encontrado</string>
+    <string name="game_not_found">Jogo não encontrado</string>
+    <string name="tag_not_found">Tag não encontrada</string>
     <string name="recent_messages_api_url">Mensagens recentes URL da API</string>
     <string name="access_local_network_title">Conceder permissão de rede local</string>
     <string name="access_local_network_desc">Necessário para conexão com proxies locais</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -571,6 +571,9 @@
     <string name="loaded_cached_ffz_emotes">Загруженные кэшированные смайлы FFZ</string>
     <string name="find_unlisted_video">Найти видео, не включенное в список</string>
     <string name="video_not_found">Видео не найдено</string>
+    <string name="clip_not_found">Клип не найден</string>
+    <string name="game_not_found">Игра не найдена</string>
+    <string name="tag_not_found">Тег не найден</string>
     <string name="recent_messages_api_url">URL-адрес API последних сообщений</string>
     <string name="access_local_network_title">Предоставить разрешение локальной сети</string>
     <string name="access_local_network_desc">Требуется для подключения к локальным прокси-серверам</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -1273,6 +1273,9 @@
     <string name="loaded_cached_ffz_emotes">Načítané emoty FFZ uložené vo vyrovnávacej pamäti</string>
     <string name="find_unlisted_video">Nájdite nezaradené video</string>
     <string name="video_not_found">Video sa nenašlo</string>
+    <string name="clip_not_found">Klip sa nenašiel</string>
+    <string name="game_not_found">Hra sa nenašla</string>
+    <string name="tag_not_found">Značka sa nenašla</string>
     <string name="recent_messages_api_url">Adresa URL rozhrania API posledných správ</string>
     <string name="access_local_network_title">Udeľte povolenie na lokálnu sieť</string>
     <string name="access_local_network_desc">Vyžaduje sa na pripojenie k miestnym serverom proxy</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -572,6 +572,9 @@
     <string name="loaded_cached_ffz_emotes">Önbelleğe alınmış FFZ ifadeleri yüklendi</string>
     <string name="find_unlisted_video">Listelenmemiş videoyu bul</string>
     <string name="video_not_found">Video bulunamadı</string>
+    <string name="clip_not_found">Klip bulunamadı</string>
+    <string name="game_not_found">Oyun bulunamadı</string>
+    <string name="tag_not_found">Etiket bulunamadı</string>
     <string name="recent_messages_api_url">Son mesajlar API URL\'si</string>
     <string name="access_local_network_title">Yerel ağ izni verin</string>
     <string name="access_local_network_desc">Yerel proxy\'lere bağlanmak için gereklidir</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -571,6 +571,9 @@
     <string name="loaded_cached_ffz_emotes">已加载缓存的 FFZ 表情</string>
     <string name="find_unlisted_video">查找未列出的视频</string>
     <string name="video_not_found">未找到视频</string>
+    <string name="clip_not_found">未找到剪辑</string>
+    <string name="game_not_found">未找到游戏</string>
+    <string name="tag_not_found">未找到标签</string>
     <string name="recent_messages_api_url">最近消息 API URL</string>
     <string name="access_local_network_title">授予本地网络权限</string>
     <string name="access_local_network_desc">需要连接到本地代理</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -571,6 +571,9 @@
     <string name="loaded_cached_ffz_emotes">載入快取的 FFZ 表情</string>
     <string name="find_unlisted_video">尋找未列出的視頻</string>
     <string name="video_not_found">找不到視頻</string>
+    <string name="clip_not_found">找不到剪輯</string>
+    <string name="game_not_found">找不到遊戲</string>
+    <string name="tag_not_found">找不到標籤</string>
     <string name="recent_messages_api_url">最近訊息 API URL</string>
     <string name="access_local_network_title">授予本地網路權限</string>
     <string name="access_local_network_desc">連接到本地代理所需</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1571,6 +1571,9 @@
     <string name="loaded_cached_ffz_emotes">Loaded cached FFZ emotes</string>
     <string name="find_unlisted_video">Find unlisted video</string>
     <string name="video_not_found">Video not found</string>
+    <string name="clip_not_found">Clip not found</string>
+    <string name="game_not_found">Game not found</string>
+    <string name="tag_not_found">Tag not found</string>
     <string name="recent_messages_api_url">Recent messages API URL</string>
     <string name="access_local_network_title">Grant local network permission</string>
     <string name="access_local_network_desc">Required for connecting to local proxies</string>

--- a/app/src/test/java/com/github/andreyasadchy/xtra/util/chat/PredictionStateTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/util/chat/PredictionStateTest.kt
@@ -1,6 +1,8 @@
 package com.github.andreyasadchy.xtra.util.chat
 
 import com.github.andreyasadchy.xtra.model.chat.Prediction
+import com.github.andreyasadchy.xtra.ui.chat.updatePredictionCountdownState
+import kotlinx.coroutines.flow.MutableStateFlow
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -13,6 +15,56 @@ import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 
 class PredictionStateTest {
+    @Test
+    fun stalePredictionCountdownCannotOverwriteNewDeadline() {
+        listOf(9_000L, -1L).forEach { staleRemainingMs ->
+            val store = PredictionStateStore()
+            val secondsLeft = MutableStateFlow<Int?>(11)
+            val tokenA = Any()
+            val tokenB = Any()
+            var activeToken: Any? = tokenA
+            val replacementReady = CountDownLatch(1)
+            val releaseReplacement = CountDownLatch(1)
+            val staleReady = CountDownLatch(1)
+            val executor = Executors.newFixedThreadPool(2)
+
+            try {
+                val replacementFuture = executor.submit<Boolean> {
+                    store.withLock {
+                        activeToken = tokenB
+                        secondsLeft.value = 22
+                        replacementReady.countDown()
+                        releaseReplacement.await(2, TimeUnit.SECONDS)
+                    }
+                }
+                assertTrue(replacementReady.await(2, TimeUnit.SECONDS))
+
+                val staleFuture = executor.submit<Boolean> {
+                    staleReady.countDown()
+                    updatePredictionCountdownState(
+                        predictionStateStore = store,
+                        currentDeadlineToken = { activeToken },
+                        deadlineToken = tokenA,
+                        remainingMs = staleRemainingMs,
+                        predictionSecondsLeft = secondsLeft,
+                        onExpired = {
+                            throw AssertionError("stale countdown must not expire the replacement")
+                        },
+                    )
+                }
+                assertTrue(staleReady.await(2, TimeUnit.SECONDS))
+                releaseReplacement.countDown()
+
+                assertFalse(staleFuture.get(2, TimeUnit.SECONDS))
+                assertTrue(replacementFuture.get(2, TimeUnit.SECONDS))
+                assertEquals(22, secondsLeft.value)
+            } finally {
+                releaseReplacement.countDown()
+                executor.shutdownNow()
+            }
+        }
+    }
+
     @Test
     fun parsesHermesBeginWithColoredOutcomes() {
         val prediction = PubSubUtils.onPredictionUpdate(


### PR DESCRIPTION
## Playback performance pass + review follow-ups

Two bodies of work, 12 commits, all verified on-device (Pixel emulator, API 35) with `assembleDebug` + `testDebugUnitTest` green.

### Perf pass
- `perf: reuse proxy networking resources` — cache derived OkHttp proxy clients and proxy `HttpEngine`/`CronetEngine` instances per proxy config instead of rebuilding them per playback-token request. Auth/backend selection unchanged; engines stay process-scoped.
- `perf: avoid redundant Media3 player text and chrome rendering` — position label rewrites only on second change, duration label only on duration change (progress cadence untouched); one idempotent renderer for the repeated play/pause/buffering derivation.
- `perf: consolidate prediction countdown scheduling` — one `viewModelScope` coroutine instead of Timer thread + deadline Job; stale-token guard preserved.
- `perf: make chat render cache trimming deterministic` — explicit stale-entry trim after inserts instead of the linear scan in `removeEldestEntry`.
- `perf: bound stream-card prewarming work` — bounded indexed access (`peek`, max 32) instead of snapshotting all loaded pages.
- `fix: guarantee queued playback position flushes` — suspending-send fallback when the channel refuses the coalesced drain.
- `perf: avoid redundant live-rewind view writes` — 500ms ticker kept; unchanged view properties are no longer reassigned (rendering only, no state-machine skips).

### Review follow-ups (all reproduced or code-verified first)
- `fix: keep collapsed pager tabs below the status bar` — collapsing AppBar tab strips (channel/game/media/team) could strand a stale zero top inset and slide under the status clock; keep the largest inset seen per view lifetime.
- `fix(player)` — MediaSession callbacks that touch views run on the main executor with lifecycle guards; posted runnables removed + velocity tracker recycled in `onDestroyView`; screen stays on only while video-capable playback is playing; read-only `GET_SLEEP_TIMER` replaces the cancelling query; 404 stream-end gains a retry action.
- `fix(nav)` — failed deep-link resolutions (video/clip/user/game/tag) toast instead of stalling silently; identical back-to-back navigations within a tap window are ignored.
- `fix(chat/feed)` — drop-image/pinned-badge Coil requests tracked with dispose + dedupe; autocomplete rows cleared so chatter rows never show stale emote images; preview surface detached on null placeholder binds; chat input grows past 48dp for large fonts.
- `fix(login)` — `OnBackPressedDispatcher` instead of deprecated `onBackPressed`.

### Verification
Cold start, session restore, Browse/Overview/Search/Settings, channel page, stream + clip playback, live chat, profile popout, VOD lists, player maximize/minimize, landscape fullscreen, bogus-link toast, good-link navigation, stream-ended state. No crashes in logcat.
