### PR TITLE
Fix false chat mention highlights

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatHighlightSettings.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatHighlightSettings.kt
@@ -12,6 +12,32 @@ import com.github.andreyasadchy.xtra.util.tokenPrefs
 internal const val DEFAULT_CHAT_HIGHLIGHT_COLOR: Int = 0x80680E0E.toInt()
 
 private val CHAT_HIGHLIGHT_COLOR_PATTERN = Regex("#(?:[0-9a-fA-F]{6}|[0-9a-fA-F]{8})")
+private val CHAT_HIGHLIGHT_URL_PATTERN = Regex(
+    """(?i)(?<![\p{L}\p{N}_])(?:(?:https?://|www\.)[^\s<>()]+|(?:[\p{L}\p{N}_-]+\.)+[a-z]{2,}(?:/[^\s<>()]*)?)""",
+)
+
+internal class ChatMentionMatcher(
+    viewerLogin: String?,
+    matchWithoutAt: Boolean,
+) {
+    internal val viewerLogin: String? = viewerLogin?.trim()?.takeIf { it.isNotEmpty() }
+    private val pattern = this.viewerLogin?.let { login ->
+        val prefix = if (matchWithoutAt) "@?" else "@"
+        Regex(
+            "(?<![\\p{L}\\p{N}_])$prefix${Regex.escape(login)}(?![\\p{L}\\p{N}_])",
+            RegexOption.IGNORE_CASE,
+        )
+    }
+
+    fun contains(text: String?): Boolean {
+        val value = text?.takeIf { it.isNotEmpty() } ?: return false
+        val mentionPattern = pattern ?: return false
+        val urlRanges = CHAT_HIGHLIGHT_URL_PATTERN.findAll(value).map { it.range }.toList()
+        return mentionPattern.findAll(value).any { mention ->
+            urlRanges.none { url -> mention.range.first <= url.last && mention.range.last >= url.first }
+        }
+    }
+}
 
 data class ChatHighlightSettings(
     val highlightReplies: Boolean = true,
@@ -20,7 +46,12 @@ data class ChatHighlightSettings(
     val color: Int = DEFAULT_CHAT_HIGHLIGHT_COLOR,
     val viewerId: String? = null,
     val viewerLogin: String? = null,
-)
+) {
+    /** The matcher is rebuilt with each new immutable settings instance, not per chat row. */
+    internal val mentionMatcher: ChatMentionMatcher by lazy {
+        ChatMentionMatcher(viewerLogin, matchMentionsWithoutAt)
+    }
+}
 
 internal fun resolveChatHighlightSettings(context: Context): ChatHighlightSettings {
     val preferences = context.prefs()
@@ -49,16 +80,8 @@ internal fun parseChatHighlightColor(value: String?): Int? {
 
 internal fun containsChatViewerMention(
     text: String?,
-    viewerLogin: String?,
-    matchWithoutAt: Boolean,
-): Boolean {
-    val login = viewerLogin?.trim()?.takeIf { it.isNotEmpty() } ?: return false
-    val prefix = if (matchWithoutAt) "@?" else "@"
-    return Regex(
-        "(?<![\\p{L}\\p{N}_])$prefix${Regex.escape(login)}(?![\\p{L}\\p{N}_])",
-        RegexOption.IGNORE_CASE,
-    ).containsMatchIn(text.orEmpty())
-}
+    matcher: ChatMentionMatcher,
+): Boolean = matcher.contains(text)
 
 internal fun matchesChatViewer(
     id: String?,
@@ -74,6 +97,7 @@ internal fun matchesChatViewer(
 internal fun shouldHighlightLegacyChatMessage(
     message: LegacyChatMessage,
     settings: ChatHighlightSettings,
+    mentionDetected: Boolean? = null,
 ): Boolean {
     if (message.type != LegacyChatMessage.USER_MESSAGE) return false
     if (settings.viewerId.isNullOrBlank() && settings.viewerLogin.isNullOrBlank()) return false
@@ -82,11 +106,8 @@ internal fun shouldHighlightLegacyChatMessage(
     val reply = settings.highlightReplies && message.reply?.let {
         matchesChatViewer(null, it.userLogin, it.userName, settings)
     } == true
-    val mention = settings.highlightMentions && containsChatViewerMention(
-        message.message,
-        settings.viewerLogin,
-        settings.matchMentionsWithoutAt,
-    )
+    val mention = settings.highlightMentions && (mentionDetected
+        ?: containsChatViewerMention(message.message, settings.mentionMatcher))
     return reply || mention
 }
 
@@ -106,19 +127,8 @@ internal fun shouldHighlightV2ChatMessage(
         if (!isExplicit && !settings.matchMentionsWithoutAt) return@any false
         matchesChatViewer(mention.userId, mention.login, null, settings)
     }
-    val rawText = message.rawText ?: message.segments.joinToString(separator = "") { segment ->
-        when (segment) {
-            is ChatSegment.Text -> segment.text
-            is ChatSegment.Mention -> segment.text
-            is ChatSegment.Emote -> segment.fallbackText
-            is ChatSegment.Gif -> segment.fallbackText
-            is ChatSegment.Cheermote -> segment.text
-        }
-    }
-    val textMention = settings.highlightMentions && containsChatViewerMention(
-        rawText,
-        settings.viewerLogin,
-        settings.matchMentionsWithoutAt,
-    )
+    val textMention = settings.highlightMentions && message.segments
+        .filterIsInstance<ChatSegment.Text>()
+        .any { containsChatViewerMention(it.text, settings.mentionMatcher) }
     return reply || structuredMention || textMention
 }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/MessageClickedChatAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/MessageClickedChatAdapter.kt
@@ -200,32 +200,6 @@ class MessageClickedChatAdapter(
         )
     }
 
-    fun updateBackground(chatMessage: ChatMessage, item: TextView) {
-        val highlightSettings = resolveChatHighlightSettings(item.context)
-        if (chatMessage.isHighlightedMessage()) {
-            item.setBackgroundResource(R.drawable.bg_chat_highlight)
-        } else if (chatMessage.isWatchStreakNotice()) {
-            item.setBackgroundResource(R.drawable.bg_chat_watch_streak)
-        } else if (chatMessage.message.isNullOrBlank()) {
-            item.setBackgroundResource(0)
-        } else {
-            when {
-                chatMessage.isFirst && firstMsgVisibility < 2 -> item.setBackgroundResource(R.color.chatMessageFirst)
-                chatMessage.reward?.id != null && firstMsgVisibility < 2 -> item.setBackgroundResource(R.color.chatMessageReward)
-                chatMessage.systemMsg != null || chatMessage.msgId != null -> item.setBackgroundResource(R.color.chatMessageNotice)
-                shouldHighlightLegacyChatMessage(chatMessage, highlightSettings) ->
-                    item.setBackgroundColor(highlightSettings.color)
-                else -> item.setBackgroundResource(0)
-            }
-        }
-        (item.text as? Spannable)?.let { view ->
-            view.getSpans<NamePaintImageSpan>().forEach {
-                it.backgroundColor = (item.background as? ColorDrawable)?.color
-                view.setSpan(it, view.getSpanStart(it), view.getSpanEnd(it), SPAN_EXCLUSIVE_EXCLUSIVE)
-            }
-        }
-    }
-
     fun updateTranslation(chatMessage: ChatMessage, item: TextView, previousTranslation: String?) {
         (item.text as? SpannableString)?.let { text ->
             val builder = SpannableStringBuilder()

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/MessageClickedDialog.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/MessageClickedDialog.kt
@@ -145,9 +145,7 @@ class MessageClickedDialog : BottomSheetDialogFragment() {
                                 if (!it.id.isNullOrBlank()) message.id == it.id else message === it
                             }.takeIf { it != -1 }
                         }?.let {
-                            (recyclerView.layoutManager?.findViewByPosition(it) as? TextView)?.let {
-                                adapter.updateBackground(previousSelectedMessage, it)
-                            } ?: adapter.notifyItemChanged(it)
+                            adapter.notifyItemChanged(it)
                         }
                     }
                 }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ReplyClickedChatAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ReplyClickedChatAdapter.kt
@@ -139,32 +139,6 @@ class ReplyClickedChatAdapter(
         )
     }
 
-    fun updateBackground(chatMessage: ChatMessage, item: TextView) {
-        val highlightSettings = resolveChatHighlightSettings(item.context)
-        if (chatMessage.isHighlightedMessage()) {
-            item.setBackgroundResource(R.drawable.bg_chat_highlight)
-        } else if (chatMessage.isWatchStreakNotice()) {
-            item.setBackgroundResource(R.drawable.bg_chat_watch_streak)
-        } else if (chatMessage.message.isNullOrBlank()) {
-            item.setBackgroundResource(0)
-        } else {
-            when {
-                chatMessage.isFirst && firstMsgVisibility < 2 -> item.setBackgroundResource(R.color.chatMessageFirst)
-                chatMessage.reward?.id != null && firstMsgVisibility < 2 -> item.setBackgroundResource(R.color.chatMessageReward)
-                chatMessage.systemMsg != null || chatMessage.msgId != null -> item.setBackgroundResource(R.color.chatMessageNotice)
-                shouldHighlightLegacyChatMessage(chatMessage, highlightSettings) ->
-                    item.setBackgroundColor(highlightSettings.color)
-                else -> item.setBackgroundResource(0)
-            }
-        }
-        (item.text as? Spannable)?.let { view ->
-            view.getSpans<NamePaintImageSpan>().forEach {
-                it.backgroundColor = (item.background as? ColorDrawable)?.color
-                view.setSpan(it, view.getSpanStart(it), view.getSpanEnd(it), SPAN_EXCLUSIVE_EXCLUSIVE)
-            }
-        }
-    }
-
     fun updateTranslation(chatMessage: ChatMessage, item: TextView, previousTranslation: String?) {
         (item.text as? SpannableString)?.let { text ->
             val builder = SpannableStringBuilder()

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ReplyClickedDialog.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ReplyClickedDialog.kt
@@ -99,9 +99,7 @@ class ReplyClickedDialog : BottomSheetDialogFragment() {
                         synchronized(adapter.messages) {
                             adapter.messages.indexOf(it).takeIf { it != -1 }
                         }?.let {
-                            (recyclerView.layoutManager?.findViewByPosition(it) as? TextView)?.let {
-                                adapter.updateBackground(previousSelectedMessage, it)
-                            } ?: adapter.notifyItemChanged(it)
+                            adapter.notifyItemChanged(it)
                         }
                     }
                 }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/chat/ChatAdapterUtils.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/chat/ChatAdapterUtils.kt
@@ -55,6 +55,7 @@ import com.github.andreyasadchy.xtra.ui.view.CenteredImageSpan
 import com.github.andreyasadchy.xtra.ui.view.NamePaintImageSpan
 import com.github.andreyasadchy.xtra.ui.view.NamePaintSpan
 import com.github.andreyasadchy.xtra.ui.chat.ChatHighlightSettings
+import com.github.andreyasadchy.xtra.ui.chat.ChatMentionMatcher
 import com.github.andreyasadchy.xtra.ui.chat.shouldHighlightLegacyChatMessage
 import com.github.andreyasadchy.xtra.util.TwitchApiHelper
 import java.text.NumberFormat
@@ -247,7 +248,7 @@ object ChatAdapterUtils {
         var translated = false
         var backgroundResource = 0
         var backgroundColor: Int? = null
-        val highlightMatch = shouldHighlightLegacyChatMessage(chatMessage, highlightSettings)
+        var highlightMatch = shouldHighlightLegacyChatMessage(chatMessage, highlightSettings)
         var builderIndex = 0
         val badgeVisibility = chatBadgeVisibility(showBadges, showSTVBadges, showNamePaints, showPersonalEmotes)
         when {
@@ -686,8 +687,9 @@ object ChatAdapterUtils {
                     if (chatMessage.isAction) {
                         builder.setSpan(ForegroundColorSpan(color), builderIndex, builderIndex + chatMessage.message.length, SPAN_EXCLUSIVE_EXCLUSIVE)
                     }
-                    val result = prepareEmotes(chatMessage, chatMessage.message, builder, builderIndex, images, imageClick, useReadableColors, isLightTheme, enableOverlayEmotes, useBoldNames, loggedInUser, chatUrl, savedColors, localTwitchEmotes, showPersonalEmotes, personalEmoteSets, stvUser, thirdPartyEmotes, cheerEmotes, savedLocalTwitchEmotes, savedLocalCheerEmotes, savedLocalEmotes, indexes)
+                    val result = prepareEmotes(chatMessage, chatMessage.message, builder, builderIndex, images, imageClick, useReadableColors, isLightTheme, enableOverlayEmotes, useBoldNames, loggedInUser, chatUrl, savedColors, localTwitchEmotes, showPersonalEmotes, personalEmoteSets, stvUser, thirdPartyEmotes, cheerEmotes, savedLocalTwitchEmotes, savedLocalCheerEmotes, savedLocalEmotes, indexes, highlightSettings.mentionMatcher)
                     wasMentioned = result
+                    highlightMatch = shouldHighlightLegacyChatMessage(chatMessage, highlightSettings, mentionDetected = wasMentioned)
                     builderIndex = builder.length
                 }
                 if (chatMessage.translatedMessage != null) {
@@ -1176,7 +1178,7 @@ object ChatAdapterUtils {
         return ColorUtils.HSLToColor(colorArray)
     }
 
-    private fun prepareEmotes(chatMessage: ChatMessage, message: String, builder: SpannableStringBuilder, startIndex: Int, images: ArrayList<Image>, imageClick: ((String?, String?, String?, Boolean?, Int?, Boolean?, String?) -> Unit)?, useReadableColors: Boolean, isLightTheme: Boolean, enableOverlayEmotes: Boolean, useBoldNames: Boolean, loggedInUser: String?, chatUrl: String?, savedColors: HashMap<String, Int>, localTwitchEmotes: List<TwitchEmote>, showPersonalEmotes: Boolean, personalEmoteSets: Map<String, List<Emote>>, stvUser: STVUser?, thirdPartyEmotes: List<Emote>, cheerEmotes: List<CheerEmote>, savedLocalTwitchEmotes: MutableMap<String, ByteArray>, savedLocalCheerEmotes: MutableMap<String, ByteArray>, savedLocalEmotes: MutableMap<String, ByteArray>, catalogIndexes: ChatCatalogIndexes): Boolean {
+    private fun prepareEmotes(chatMessage: ChatMessage, message: String, builder: SpannableStringBuilder, startIndex: Int, images: ArrayList<Image>, imageClick: ((String?, String?, String?, Boolean?, Int?, Boolean?, String?) -> Unit)?, useReadableColors: Boolean, isLightTheme: Boolean, enableOverlayEmotes: Boolean, useBoldNames: Boolean, loggedInUser: String?, chatUrl: String?, savedColors: HashMap<String, Int>, localTwitchEmotes: List<TwitchEmote>, showPersonalEmotes: Boolean, personalEmoteSets: Map<String, List<Emote>>, stvUser: STVUser?, thirdPartyEmotes: List<Emote>, cheerEmotes: List<CheerEmote>, savedLocalTwitchEmotes: MutableMap<String, ByteArray>, savedLocalCheerEmotes: MutableMap<String, ByteArray>, savedLocalEmotes: MutableMap<String, ByteArray>, catalogIndexes: ChatCatalogIndexes, mentionMatcher: ChatMentionMatcher? = null): Boolean {
         var wasMentioned = false
         try {
             var builderIndex = startIndex
@@ -1404,9 +1406,10 @@ object ChatAdapterUtils {
                 if (value.startsWith('@') && useBoldNames) {
                     builder.setSpan(StyleSpan(Typeface.BOLD), builderIndex, builderIndex + value.length, SPAN_EXCLUSIVE_EXCLUSIVE)
                 }
+                val matchesViewer = mentionMatcher?.contains(value)
+                    ?: (!loggedInUser.isNullOrBlank() && value.contains(loggedInUser, true))
                 if (!wasMentioned &&
-                    !loggedInUser.isNullOrBlank() &&
-                    value.contains(loggedInUser, true) &&
+                    matchesViewer &&
                     chatMessage.userId != null &&
                     chatMessage.userLogin != loggedInUser
                 ) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1364,7 +1364,7 @@
     <string name="chat_highlight_mentions">Highlight mentions of me</string>
     <string name="chat_highlight_mentions_without_at">Match mentions without @</string>
     <string name="chat_highlight_color">Highlight color</string>
-    <string name="chat_highlight_color_summary">Enter #RRGGBB or #AARRGGBB.</string>
+    <string name="chat_highlight_color_summary">Enter #RRGGBB for the default translucent highlight, or #AARRGGBB to set opacity.</string>
     <string name="chat_highlight_color_hint">#80680E0E</string>
     <string name="chat_highlight_color_invalid">Enter a color as #RRGGBB or #AARRGGBB.</string>
     <string name="replying_to_message">Replying to %1$s\: %2$s</string>

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/ChatHighlightSettingsTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/ChatHighlightSettingsTest.kt
@@ -1,0 +1,76 @@
+package com.github.andreyasadchy.xtra.ui.chat
+
+import com.github.andreyasadchy.xtra.model.chat.ChatMessage as LegacyChatMessage
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatAssetKey
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatAssetSpec
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessage
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessageId
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessageKind
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatSegment
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatUser
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ChatHighlightSettingsTest {
+
+    private val settings = ChatHighlightSettings(viewerLogin = "someuser")
+
+    @Test
+    fun `plain text mentions highlight in both renderers`() {
+        assertTrue(shouldHighlightLegacyChatMessage(legacyMessage("hello someuser"), settings))
+        assertTrue(shouldHighlightV2ChatMessage(v2Message(ChatSegment.Text("hello someuser")), settings))
+    }
+
+    @Test
+    fun `mentions inside urls do not highlight`() {
+        listOf(
+            "https://twitch.tv/someuser",
+            "example.com/someuser",
+        ).forEach { text ->
+            assertFalse(shouldHighlightLegacyChatMessage(legacyMessage(text), settings))
+            assertFalse(shouldHighlightV2ChatMessage(v2Message(ChatSegment.Text(text)), settings))
+        }
+    }
+
+    @Test
+    fun `emote fallback text is not treated as a mention in v2`() {
+        val emote = ChatSegment.Emote(
+            asset = ChatAssetSpec(ChatAssetKey("test-emote"), sourceWidth = 1, sourceHeight = 1, targetHeight = 1),
+            fallbackText = "someuser",
+            animated = false,
+        )
+
+        assertFalse(shouldHighlightV2ChatMessage(v2MessageWithRawText("someuser", emote), settings))
+        assertTrue(shouldHighlightV2ChatMessage(v2Message(emote, ChatSegment.Text("someuser")), settings))
+    }
+
+    @Test
+    fun `bare name matching can be disabled`() {
+        val noBareNames = settings.copy(matchMentionsWithoutAt = false)
+
+        assertFalse(shouldHighlightLegacyChatMessage(legacyMessage("hello someuser"), noBareNames))
+        assertFalse(shouldHighlightV2ChatMessage(v2Message(ChatSegment.Text("hello someuser")), noBareNames))
+        assertTrue(shouldHighlightV2ChatMessage(v2Message(ChatSegment.Text("hello @someuser")), noBareNames))
+    }
+
+    private fun legacyMessage(text: String) = LegacyChatMessage(
+        type = LegacyChatMessage.USER_MESSAGE,
+        userId = "other-id",
+        userLogin = "other-user",
+        message = text,
+    )
+
+    private fun v2Message(vararg segments: ChatSegment) = ChatMessage(
+        id = ChatMessageId("message-id"),
+        channelId = "channel-id",
+        timestampMs = 0L,
+        user = ChatUser(id = "other-id", login = "other-user", displayName = "Other User", color = null),
+        badges = emptyList(),
+        segments = segments.toList(),
+        kind = ChatMessageKind.CHAT,
+    )
+
+    private fun v2MessageWithRawText(rawText: String, vararg segments: ChatSegment) =
+        v2Message(*segments).copy(rawText = rawText)
+}


### PR DESCRIPTION
Fixes false personal highlights for usernames found in URLs and emote text. Caches the mention matcher with chat highlight settings, keeps legacy emote handling token-aware, clarifies six-digit highlight color opacity, and adds regression tests.