### PR TITLE
Use Twitch badges in pinned chat messages

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/model/chat/PinnedChatMessage.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/model/chat/PinnedChatMessage.kt
@@ -9,4 +9,6 @@ data class PinnedChatMessage(
     val senderColor: String? = null,
     val senderBadges: List<Badge> = emptyList(),
     val sentAt: Long? = null,
+    val startsAt: Long? = null,
+    val endsAt: Long? = null,
 )

--- a/app/src/main/java/com/github/andreyasadchy/xtra/model/gql/chat/PinnedChatMessageResponse.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/model/gql/chat/PinnedChatMessageResponse.kt
@@ -31,6 +31,8 @@ class PinnedChatMessageResponse(
     @Serializable
     class Node(
         val id: String? = null,
+        val startsAt: String? = null,
+        val endsAt: String? = null,
         val pinnedBy: User? = null,
         val pinnedMessage: Message? = null,
     )
@@ -41,6 +43,13 @@ class PinnedChatMessageResponse(
         val displayName: String? = null,
         val login: String? = null,
         val chatColor: String? = null,
+        val displayBadges: List<Badge>? = null,
+    )
+
+    @Serializable
+    class Badge(
+        val setID: String? = null,
+        val version: String? = null,
     )
 
     @Serializable

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/GraphQLRepository.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/GraphQLRepository.kt
@@ -167,11 +167,17 @@ class GraphQLRepository(
                     edges {
                         node {
                             id
+                            startsAt
+                            endsAt
                             pinnedBy {
                                 id
                                 displayName
                                 login
                                 chatColor
+                                displayBadges(channelID: ${'$'}channelId) {
+                                    setID
+                                    version
+                                }
                             }
                             pinnedMessage {
                                 sentAt
@@ -180,6 +186,10 @@ class GraphQLRepository(
                                     displayName
                                     login
                                     chatColor
+                                    displayBadges(channelID: ${'$'}channelId) {
+                                        setID
+                                        version
+                                    }
                                 }
                                 content {
                                     text

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatFragment.kt
@@ -124,6 +124,9 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import java.util.Locale
 import kotlin.math.max
@@ -288,6 +291,7 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
     private var dropImageRequest: Disposable? = null
     private var dropImageRequestGeneration = 0
     private var pinnedBadgeRequests = mutableListOf<Disposable>()
+    private var pinnedMessageTimerJob: Job? = null
     private var channelPointsAccessibilityLabel: String? = null
     private var chatIdentityPopup: ChatIdentityPopup? = null
     private var chatIdentityBadgeRequest: Disposable? = null
@@ -629,6 +633,7 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
         val pinnedBinding = pinnedMessageBinding ?: return
         pinnedBinding.pinnedMessageSeen.setOnClickListener {
             seenPinnedMessageId = displayedPinnedMessageId
+            pinnedMessageTimerJob?.cancel()
             pinnedBinding.pinnedMessageOverlay.isGone = true
         }
         pinnedBinding.pinnedMessageMinimize.setOnClickListener {
@@ -1529,7 +1534,9 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
         val pinnedBinding = pinnedMessageBinding ?: return
         val overlay = pinnedBinding.pinnedMessageOverlay
         if (message == null || message.id == seenPinnedMessageId) {
+            pinnedMessageTimerJob?.cancel()
             disposePinnedBadgeRequests()
+            pinnedBinding.pinnedMessageProgress.isGone = true
             overlay.isGone = true
             return
         }
@@ -1567,6 +1574,7 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
             if (pinnedMessageMinimized) R.string.pinned_message_expand else R.string.pinned_message_minimize,
         )
         overlay.isVisible = true
+        schedulePinnedMessageTimer(message)
     }
 
     private fun disposePinnedBadgeRequests() {
@@ -1583,7 +1591,8 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
                 viewModel.channelBadges.firstOrNull { it.setId == badge.setId && it.version == badge.version }
             }
             val url = catalogBadge?.url2x ?: catalogBadge?.url1x
-            if (url.isNullOrBlank() && badge.setId !in setOf("moderator", "broadcaster")) return@forEach
+            val fallbackDrawable = pinnedChatBadgeFallbackResource(badge.setId)
+            if (url.isNullOrBlank() && fallbackDrawable == null) return@forEach
             val density = resources.displayMetrics.density
             val image = ImageView(requireContext()).apply {
                 layoutParams = LinearLayout.LayoutParams(
@@ -1593,12 +1602,10 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
                     marginEnd = (3 * density).toInt()
                 }
                 scaleType = ImageView.ScaleType.CENTER_INSIDE
-                contentDescription = badge.setId
+                contentDescription = catalogBadge?.title ?: badge.setId
             }
             if (url.isNullOrBlank()) {
-                image.setImageResource(
-                    if (badge.setId == "broadcaster") R.drawable.ic_broadcaster_badge else R.drawable.ic_moderator_badge,
-                )
+                image.setImageResource(fallbackDrawable!!)
             } else {
                 pinnedBadgeRequests += requireContext().imageLoader.enqueue(
                     ImageRequest.Builder(requireContext())
@@ -1612,6 +1619,36 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
             container.addView(image)
         }
         container.isVisible = container.childCount > 0
+    }
+
+    private fun schedulePinnedMessageTimer(message: PinnedChatMessage) {
+        pinnedMessageTimerJob?.cancel()
+        val startsAt = message.startsAt
+        val endsAt = message.endsAt
+        val progress = pinnedMessageBinding?.pinnedMessageProgress ?: return
+        if (startsAt == null || endsAt == null || endsAt <= startsAt) {
+            progress.progress = 0
+            progress.isGone = true
+            return
+        }
+        val duration = endsAt - startsAt
+        pinnedMessageTimerJob = viewLifecycleOwner.lifecycleScope.launch {
+            while (isActive && displayedPinnedMessageId == message.id) {
+                val remaining = endsAt - System.currentTimeMillis()
+                if (remaining <= 0L) {
+                    pinnedMessageBinding?.pinnedMessageOverlay?.isGone = true
+                    pinnedMessageBinding?.pinnedMessageProgress?.isGone = true
+                    break
+                }
+                val currentBinding = pinnedMessageBinding ?: break
+                currentBinding.pinnedMessageProgress.progress =
+                    ((remaining.toDouble() / duration) * 1000.0)
+                        .coerceIn(0.0, 1000.0)
+                        .toInt()
+                currentBinding.pinnedMessageProgress.isVisible = true
+                delay(1_000L)
+            }
+        }
     }
 
     private fun updatePinnedMessageOverlayWidth() {
@@ -3138,6 +3175,8 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
     }
 
     override fun onDestroyView() {
+        pinnedMessageTimerJob?.cancel()
+        pinnedMessageTimerJob = null
         pinnedMessageBinding = null
         captureActiveOverlayState()
         chatV2ViewportState = chatV2Renderer?.state ?: chatV2ViewportState

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatViewModel.kt
@@ -46,6 +46,7 @@ import com.github.andreyasadchy.xtra.model.chat.TwitchBadge
 import com.github.andreyasadchy.xtra.model.chat.TwitchEmote
 import com.github.andreyasadchy.xtra.model.chat.VideoChatMessage
 import com.github.andreyasadchy.xtra.model.gql.chat.ChannelPointContextResponse
+import com.github.andreyasadchy.xtra.model.gql.chat.PinnedChatMessageResponse
 import com.github.andreyasadchy.xtra.model.gql.chat.WatchStreakResponse
 import com.github.andreyasadchy.xtra.model.ui.ChannelPoints
 import com.github.andreyasadchy.xtra.model.ui.ChannelPointReward as ChannelPointRewardInfo
@@ -272,6 +273,15 @@ internal fun shouldStartLegacyChatWriteTransport(
         isLoggedIn &&
         !(startMessageTransport && useEventSubChat) &&
         (hasGqlToken || hasHelixToken && !useApiChatMessages)
+
+private fun PinnedChatMessageResponse.User?.toChatBadges(): List<Badge>? {
+    val displayBadges = this?.displayBadges ?: return null
+    return displayBadges.mapNotNull { badge ->
+        val setId = badge.setID?.takeIf(String::isNotBlank) ?: return@mapNotNull null
+        val version = badge.version?.takeIf(String::isNotBlank) ?: return@mapNotNull null
+        Badge(setId, version)
+    }
+}
 
 @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
 class ChatViewModel(
@@ -2410,19 +2420,21 @@ class ChatViewModel(
                                         (senderLogin != null && message.userLogin.equals(senderLogin, true))
                                 }
                             }
-                            val roleBadge = Badge(
-                                setId = if (it.pinnedBy?.id == expectedChannelId) "broadcaster" else "moderator",
-                                version = "1",
-                            )
                             if (text.isBlank() || pinnedBy.isNullOrBlank()) null else PinnedChatMessage(
                                 id = it.id!!,
                                 pinnedBy = pinnedBy,
-                                pinnedByBadges = listOf(roleBadge),
+                                pinnedByBadges = it.pinnedBy.toChatBadges().orEmpty(),
                                 text = text,
                                 sender = senderName,
                                 senderColor = sender?.chatColor ?: it.pinnedBy?.chatColor,
-                                senderBadges = chatMessage?.badges.orEmpty(),
+                                senderBadges = sender.toChatBadges() ?: chatMessage?.badges.orEmpty(),
                                 sentAt = it.pinnedMessage?.sentAt?.let { value ->
+                                    runCatching { java.time.Instant.parse(value).toEpochMilli() }.getOrNull()
+                                },
+                                startsAt = it.startsAt?.let { value ->
+                                    runCatching { java.time.Instant.parse(value).toEpochMilli() }.getOrNull()
+                                },
+                                endsAt = it.endsAt?.let { value ->
                                     runCatching { java.time.Instant.parse(value).toEpochMilli() }.getOrNull()
                                 },
                             )

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/PinnedChatBadgeFallback.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/PinnedChatBadgeFallback.kt
@@ -1,0 +1,9 @@
+package com.github.andreyasadchy.xtra.ui.chat
+
+import com.github.andreyasadchy.xtra.R
+
+internal fun pinnedChatBadgeFallbackResource(setId: String): Int? = when (setId) {
+    "moderator" -> R.drawable.ic_moderator_badge
+    "broadcaster" -> R.drawable.ic_broadcaster_badge
+    else -> null
+}

--- a/app/src/main/res/layout/view_pinned_chat_message.xml
+++ b/app/src/main/res/layout/view_pinned_chat_message.xml
@@ -11,9 +11,9 @@
     android:focusable="true"
     android:orientation="vertical"
     android:paddingStart="8dp"
-    android:paddingTop="5dp"
+    android:paddingTop="8dp"
     android:paddingEnd="8dp"
-    android:paddingBottom="5dp"
+    android:paddingBottom="8dp"
     android:visibility="gone"
     tools:visibility="visible">
 
@@ -21,12 +21,12 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:gravity="center_vertical"
-        android:minHeight="28dp"
+        android:minHeight="32dp"
         android:orientation="horizontal">
 
         <ImageView
-            android:layout_width="16dp"
-            android:layout_height="16dp"
+            android:layout_width="18dp"
+            android:layout_height="18dp"
             android:importantForAccessibility="no"
             android:src="@drawable/ic_push_pin"
             app:tint="?attr/colorOnSurfaceVariant" />
@@ -44,6 +44,7 @@
             android:id="@+id/pinnedMessagePinnedByBadges"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_marginStart="4dp"
             android:gravity="center_vertical"
             android:orientation="horizontal" />
 
@@ -56,7 +57,8 @@
             android:ellipsize="end"
             android:maxLines="1"
             android:textAppearance="?attr/textAppearanceBodySmall"
-            android:textColor="?attr/colorOnSurface"
+            android:textColor="?attr/colorPrimary"
+            android:textStyle="bold"
             tools:text="Heuto" />
 
         <ImageButton
@@ -88,10 +90,10 @@
         android:id="@+id/pinnedMessageText"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="1dp"
+        android:layout_marginTop="5dp"
         android:ellipsize="end"
         android:maxLines="4"
-        android:textAppearance="?attr/textAppearanceBodyLarge"
+        android:textAppearance="?attr/textAppearanceTitleLarge"
         android:textColor="?attr/colorOnSurface"
         android:textStyle="bold"
         tools:text="Asmon is aware of the JD Vance briefing" />
@@ -111,7 +113,7 @@
         android:id="@+id/pinnedMessageFooter"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="3dp"
+        android:layout_marginTop="6dp"
         android:gravity="center_vertical"
         android:minHeight="20dp"
         android:orientation="horizontal">

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/PinnedChatBadgeFallbackTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/PinnedChatBadgeFallbackTest.kt
@@ -1,0 +1,17 @@
+package com.github.andreyasadchy.xtra.ui.chat
+
+import com.github.andreyasadchy.xtra.R
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class PinnedChatBadgeFallbackTest {
+
+    @Test
+    fun `only Twitch authority badges have local fallbacks`() {
+        assertEquals(R.drawable.ic_moderator_badge, pinnedChatBadgeFallbackResource("moderator"))
+        assertEquals(R.drawable.ic_broadcaster_badge, pinnedChatBadgeFallbackResource("broadcaster"))
+        assertNull(pinnedChatBadgeFallbackResource("subscriber"))
+        assertNull(pinnedChatBadgeFallbackResource("unknown"))
+    }
+}


### PR DESCRIPTION
Use Twitch-provided badge data in pinned chat messages and show their optional pin expiry.