### PR TITLE
Fix chat-v2 asset-first rendering

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -60,8 +60,21 @@ jobs:
           cache-provider: basic
       - name: Build for CodeQL
         # CodeQL only needs a compilable release graph; publishing validates the real ID.
-        # Bytecode tracing makes the Kotlin compiler's default daemon heap unreliable.
-        run: ./gradlew assembleRelease "-PtwitchPublicClientId=codeql-placeholder" "-Pkotlin.daemon.jvmargs=-Xmx4g"
+        # CodeQL tracing increases packaging memory pressure, so keep the build single-worker.
+        shell: bash
+        run: |
+          set -euo pipefail
+          build_args=(
+            "-PtwitchPublicClientId=codeql-placeholder"
+          )
+          # AGP can leave its incremental packaging worker in a bad state after
+          # CodeQL interrupts or traces a packaging task. Retry without daemon
+          # or configuration-cache state before treating the build as broken.
+          if ./gradlew --no-daemon --no-configuration-cache --max-workers=1 assembleRelease "${build_args[@]}"; then
+            exit 0
+          fi
+          ./gradlew --stop || true
+          ./gradlew --no-daemon --no-configuration-cache --max-workers=1 assembleRelease "${build_args[@]}"
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@4c0873ef8656cb3c50b3f42fb63bc1ade0cfa827 # v4
         with:

--- a/app/src/androidTest/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatMessageTextViewTest.kt
+++ b/app/src/androidTest/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatMessageTextViewTest.kt
@@ -1,14 +1,20 @@
 package com.github.andreyasadchy.xtra.ui.chat.v2
 
 import android.content.Context
+import android.content.ComponentName
+import android.content.Intent
+import android.app.Activity
 import android.graphics.Canvas
 import android.graphics.Color
 import android.graphics.Bitmap
+import android.graphics.LinearGradient
 import android.graphics.Paint
 import android.graphics.PixelFormat
 import android.graphics.drawable.Animatable
 import android.graphics.drawable.Drawable
 import android.text.Spanned
+import android.text.TextPaint
+import android.text.style.CharacterStyle
 import android.text.style.ClickableSpan
 import android.text.style.ForegroundColorSpan
 import android.text.style.ReplacementSpan
@@ -19,6 +25,7 @@ import android.view.MotionEvent
 import android.view.ViewConfiguration
 import android.widget.FrameLayout
 import com.github.andreyasadchy.xtra.ui.chat.v2.assets.ChatAssetLoader
+import com.github.andreyasadchy.xtra.ui.chat.v2.assets.ChatAssetLoadException
 import com.github.andreyasadchy.xtra.ui.chat.v2.assets.ChatAssetRepository
 import com.github.andreyasadchy.xtra.ui.chat.v2.assets.ChatAssetState
 import com.github.andreyasadchy.xtra.ui.chat.v2.assets.ChatImageHandle
@@ -31,13 +38,19 @@ import com.github.andreyasadchy.xtra.ui.chat.v2.presentation.ChatPiece
 import com.github.andreyasadchy.xtra.ui.chat.v2.presentation.ChatRowUiModel
 import com.github.andreyasadchy.xtra.ui.chat.v2.ui.ChatMessageTextView
 import com.github.andreyasadchy.xtra.ui.chat.v2.ui.ChatTimelineAdapter
+import com.github.andreyasadchy.xtra.ui.chat.v2.preview.ChatClipPreviewRepository
+import com.github.andreyasadchy.xtra.ui.chat.v2.preview.ChatClipPreview
+import com.github.andreyasadchy.xtra.ui.chat.v2.preview.ChatClipPreviewLink
 import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatAssetProvider
+import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatNamePaint
 import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatEmoteScope
 import com.github.andreyasadchy.xtra.ui.chat.resolveChatSizing
 import com.github.andreyasadchy.xtra.util.C
 import com.github.andreyasadchy.xtra.util.prefs
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.core.app.ActivityScenario
 import androidx.test.platform.app.InstrumentationRegistry
+import androidx.core.view.doOnPreDraw
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
@@ -48,7 +61,9 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
@@ -93,37 +108,619 @@ class ChatMessageTextViewTest {
     }
 
     @Test
-    fun fallbackTextReflowsToCompactAssetWidthWhenLoaded() = runBlocking {
+    fun pendingAssetKeepsFinalGeometryAndRowIsNotExposed() = runBlocking {
         val context = InstrumentationRegistry.getInstrumentation().targetContext
-        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
         val asset = CompletableDeferred<ChatImageHandle?>()
         val repository = ChatAssetRepository(scope, ChatAssetLoader { asset.await() })
-        val view = TestTextView(context, repository)
+        val attached = attachView(repository)
+        val view = attached.view
         val spec = ChatAssetSpec(ChatAssetKey("missing"), 20, 20, 28)
         lateinit var span: ReplacementSpan
-        runOnMain {
-            view.bind(row(spec, username = "login", fallback = "OMEGALUL"))
-            val spanned = view.text as Spanned
-            val usernameColor = spanned.getSpans(0, 5, ForegroundColorSpan::class.java).single().foregroundColor
-            assertNotEquals(Color.WHITE, usernameColor)
-            assertTrue(view.text.toString().contains("login"))
-            span = spanned.getSpans(0, spanned.length, ReplacementSpan::class.java).single()
-            val metrics = Paint.FontMetricsInt()
-            assertTrue(span.getSize(Paint(), spanned, 0, 1, metrics) > spec.compositionWidth)
-            assertTrue(metrics.descent - metrics.ascent >= spec.compositionHeight)
-            draw(span, spanned, metrics)
+        try {
+            runOnMain {
+                view.bind(row(spec, username = "login", fallback = "OMEGALUL"))
+                val spanned = view.text as Spanned
+                val usernameColor = spanned.getSpans(0, 5, ForegroundColorSpan::class.java).single().foregroundColor
+                assertNotEquals(Color.WHITE, usernameColor)
+                assertEquals(0f, view.alpha)
+                span = spanned.getSpans(0, spanned.length, ReplacementSpan::class.java).single()
+                val metrics = Paint.FontMetricsInt()
+                assertEquals(spec.compositionWidth, span.getSize(Paint(), spanned, 0, 1, metrics))
+                assertTrue(metrics.descent - metrics.ascent >= spec.compositionHeight)
+                assertFalse(hasVisiblePixels(draw(span, spanned, metrics)))
+            }
+            asset.complete(ChatImageHandle { SolidDrawable(Color.RED) })
+            withTimeout(2_000) {
+                while (repository.peek(spec.key) !is ChatAssetState.Ready) delay(1)
+            }
+            awaitPreDraw(view)
+            runOnMain {
+                val spanned = view.text as Spanned
+                val metrics = Paint.FontMetricsInt()
+                assertEquals(1f, view.alpha)
+                assertEquals(spec.compositionWidth, span.getSize(Paint(), spanned, 0, 1, metrics))
+                assertTrue(containsColor(draw(span, spanned, metrics), Color.RED))
+            }
+        } finally {
+            attached.close()
+            scope.cancel()
         }
-        asset.complete(ChatImageHandle { SolidDrawable(Color.RED) })
-        withTimeout(2_000) {
-            while (repository.peek(spec.key) !is ChatAssetState.Ready) delay(1)
+    }
+
+    @Test
+    fun failedBadgeNeverDrawsItsName() = runBlocking {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val repository = ChatAssetRepository(scope, ChatAssetLoader { throw ChatAssetLoadException(404) })
+        val attached = attachView(repository)
+        val view = attached.view
+        val spec = ChatAssetSpec(ChatAssetKey("badge"), 18, 18, 18)
+        try {
+            runOnMain { view.bind(badgeRow(spec, "subscriber")) }
+            awaitPresentationTerminal(repository, listOf(spec.key))
+            awaitPreDraw(view)
+            runOnMain {
+                val spanned = view.text as Spanned
+                val span = spanned.getSpans(0, spanned.length, ReplacementSpan::class.java).single()
+                assertEquals(1f, view.alpha)
+                assertEquals(spec.compositionWidth, span.getSize(Paint(), spanned, 0, 1, Paint.FontMetricsInt()))
+                assertFalse(hasVisiblePixels(draw(span, spanned, Paint.FontMetricsInt())))
+            }
+        } finally {
+            attached.close()
+            scope.cancel()
         }
-        runOnMain {
-            val spanned = view.text as Spanned
-            val metrics = Paint.FontMetricsInt()
-            assertEquals(spec.compositionWidth, span.getSize(Paint(), spanned, 0, 1, metrics))
-            draw(span, spanned, metrics)
+    }
+
+    @Test
+    fun failedEmoteUsesTextOnlyAfterFailure() = runBlocking {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val releaseFailure = CompletableDeferred<Unit>()
+        val repository = ChatAssetRepository(scope, ChatAssetLoader {
+            releaseFailure.await()
+            throw ChatAssetLoadException(404)
+        })
+        val attached = attachView(repository)
+        val view = attached.view
+        val spec = ChatAssetSpec(ChatAssetKey("failed-emote"), 20, 20, 28)
+        lateinit var span: ReplacementSpan
+        try {
+            runOnMain {
+                view.bind(row(spec, fallback = "OMEGALUL"))
+                val spanned = view.text as Spanned
+                span = spanned.getSpans(0, spanned.length, ReplacementSpan::class.java).single()
+                assertEquals(0f, view.alpha)
+                assertFalse(hasVisiblePixels(draw(span, spanned, Paint.FontMetricsInt())))
+            }
+
+            releaseFailure.complete(Unit)
+            awaitPresentationTerminal(repository, listOf(spec.key))
+            awaitPreDraw(view)
+            runOnMain {
+                val spanned = view.text as Spanned
+                assertEquals(1f, view.alpha)
+                assertTrue(span.getSize(Paint(), spanned, 0, 1, Paint.FontMetricsInt()) >= spec.compositionWidth)
+                assertTrue(hasVisiblePixels(draw(span, spanned, Paint.FontMetricsInt())))
+            }
+        } finally {
+            attached.close()
+            scope.cancel()
         }
-        scope.cancel()
+    }
+
+    @Test
+    fun rowRevealsOnlyAfterAllInitialAssetsSettle() = runBlocking {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val first = CompletableDeferred<ChatImageHandle?>()
+        val second = CompletableDeferred<ChatImageHandle?>()
+        val repository = ChatAssetRepository(scope, ChatAssetLoader { key ->
+            when (key.value) {
+                "first" -> first.await()
+                "second" -> {
+                    second.await()
+                    throw ChatAssetLoadException(404)
+                }
+                else -> null
+            }
+        })
+        val attached = attachView(repository)
+        val view = attached.view
+        val firstSpec = ChatAssetSpec(ChatAssetKey("first"), 20, 20, 28)
+        val secondSpec = ChatAssetSpec(ChatAssetKey("second"), 20, 20, 28)
+        val row = ChatRowUiModel(
+            id = ChatMessageId("two-assets"),
+            channelId = "channel",
+            timestampText = null,
+            pieces = listOf(
+                ChatPiece.Emote(firstSpec, "FIRST"),
+                ChatPiece.Emote(secondSpec, "SECOND"),
+            ),
+            background = 0xff101010.toInt(),
+            accessibilityText = "two assets",
+            reply = null,
+            source = null,
+            isAction = false,
+        )
+        try {
+            runOnMain {
+                view.bind(row)
+                assertEquals(0f, view.alpha)
+            }
+
+            first.complete(ChatImageHandle { SolidDrawable(Color.RED) })
+            awaitSettled(repository, listOf(firstSpec.key))
+            awaitPreDraw(view)
+            runOnMain { assertEquals(0f, view.alpha) }
+
+            second.complete(null)
+            awaitPresentationTerminal(repository, listOf(secondSpec.key))
+            awaitPreDraw(view)
+            runOnMain { assertEquals(1f, view.alpha) }
+        } finally {
+            attached.close()
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun retryableFailureKeepsInitialRowHiddenUntilRecovery() = runBlocking {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val firstFailed = CompletableDeferred<Unit>()
+        val secondStarted = CompletableDeferred<Unit>()
+        val secondRelease = CompletableDeferred<Unit>()
+        val attempts = AtomicInteger()
+        val repository = ChatAssetRepository(
+            scope = scope,
+            loader = ChatAssetLoader {
+                if (attempts.incrementAndGet() == 1) {
+                    firstFailed.complete(Unit)
+                    null
+                } else {
+                    secondStarted.complete(Unit)
+                    secondRelease.await()
+                    ChatImageHandle { SolidDrawable(Color.RED) }
+                }
+            },
+        )
+        val attached = attachView(repository)
+        val view = attached.view
+        val spec = ChatAssetSpec(ChatAssetKey("retryable"), 20, 20, 28)
+        try {
+            runOnMain { view.bind(row(spec, fallback = "OMEGALUL")) }
+            firstFailed.await()
+            withTimeout(2_000) {
+                while (repository.peek(spec.key) !is ChatAssetState.Failed) delay(1)
+            }
+            awaitPreDraw(view)
+            runOnMain {
+                val spanned = view.text as Spanned
+                val span = spanned.getSpans(0, spanned.length, ReplacementSpan::class.java).single()
+                assertEquals(0f, view.alpha)
+                assertFalse(hasVisiblePixels(draw(span, spanned, Paint.FontMetricsInt())))
+            }
+
+            withTimeout(3_000) { secondStarted.await() }
+            awaitPreDraw(view)
+            runOnMain {
+                val spanned = view.text as Spanned
+                val span = spanned.getSpans(0, spanned.length, ReplacementSpan::class.java).single()
+                assertEquals(0f, view.alpha)
+                assertFalse(hasVisiblePixels(draw(span, spanned, Paint.FontMetricsInt())))
+            }
+
+            secondRelease.complete(Unit)
+            withTimeout(2_000) {
+                while (repository.peek(spec.key) !is ChatAssetState.Ready) delay(1)
+            }
+            awaitPreDraw(view)
+            runOnMain { assertEquals(1f, view.alpha) }
+        } finally {
+            attached.close()
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun sameKeyRebindKeepsTheExistingAssetLoad() = runBlocking {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val release = CompletableDeferred<ChatImageHandle?>()
+        val loads = AtomicInteger()
+        val repository = ChatAssetRepository(scope, ChatAssetLoader {
+            loads.incrementAndGet()
+            release.await()
+        })
+        val attached = attachView(repository)
+        val view = attached.view
+        val spec = ChatAssetSpec(ChatAssetKey("same-key"), 20, 20, 28)
+        try {
+            val row = row(spec)
+            runOnMain {
+                view.bind(row)
+                assertEquals(1, repository.observerCount(spec.key))
+                view.bind(row)
+                assertEquals(1, repository.observerCount(spec.key))
+            }
+            withTimeout(2_000) { while (loads.get() < 1) delay(1) }
+            assertEquals(1, loads.get())
+            release.complete(ChatImageHandle { SolidDrawable(Color.RED) })
+            withTimeout(2_000) {
+                while (repository.peek(spec.key) !is ChatAssetState.Ready) delay(1)
+            }
+        } finally {
+            attached.close()
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun revealedRowDoesNotChangeDuringALaterRetry() = runBlocking {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val retryStarted = CompletableDeferred<Unit>()
+        val retryRelease = CompletableDeferred<Unit>()
+        val attempts = AtomicInteger()
+        val repository = ChatAssetRepository(scope, ChatAssetLoader {
+            if (attempts.incrementAndGet() == 1) throw ChatAssetLoadException(404)
+            retryStarted.complete(Unit)
+            retryRelease.await()
+            ChatImageHandle { SolidDrawable(Color.RED) }
+        })
+        val attached = attachView(repository)
+        val view = attached.view
+        val spec = ChatAssetSpec(ChatAssetKey("latched"), 20, 20, 28)
+        try {
+            runOnMain { view.bind(row(spec, fallback = "OMEGALUL")) }
+            awaitPresentationTerminal(repository, listOf(spec.key))
+            awaitPreDraw(view)
+            runOnMain {
+                assertEquals(1f, view.alpha)
+                val spanned = view.text as Spanned
+                val span = spanned.getSpans(0, spanned.length, ReplacementSpan::class.java).single()
+                assertTrue(hasVisiblePixels(draw(span, spanned, Paint.FontMetricsInt())))
+            }
+
+            repository.invalidate(setOf(spec.key))
+            retryStarted.await()
+            awaitPreDraw(view)
+            runOnMain {
+                assertEquals(1f, view.alpha)
+                val spanned = view.text as Spanned
+                val span = spanned.getSpans(0, spanned.length, ReplacementSpan::class.java).single()
+                assertTrue(hasVisiblePixels(draw(span, spanned, Paint.FontMetricsInt())))
+            }
+
+            retryRelease.complete(Unit)
+            withTimeout(2_000) {
+                while (repository.peek(spec.key) !is ChatAssetState.Ready) delay(1)
+            }
+            awaitPreDraw(view)
+            runOnMain { assertEquals(1f, view.alpha) }
+        } finally {
+            attached.close()
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun recycledRowGetsANewInitialGate() = runBlocking {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val first = CompletableDeferred<ChatImageHandle?>()
+        val second = CompletableDeferred<ChatImageHandle?>()
+        val repository = ChatAssetRepository(scope, ChatAssetLoader { key ->
+            if (key.value == "first-row") first.await() else second.await()
+        })
+        val attached = attachView(repository)
+        val view = attached.view
+        try {
+            val firstSpec = ChatAssetSpec(ChatAssetKey("first-row"), 20, 20, 28)
+            val secondSpec = ChatAssetSpec(ChatAssetKey("second-row"), 20, 20, 28)
+            runOnMain {
+                view.bind(row(firstSpec))
+                assertEquals(0f, view.alpha)
+                view.recycle()
+                view.bind(row(secondSpec))
+                assertEquals(0f, view.alpha)
+            }
+            second.complete(ChatImageHandle { SolidDrawable(Color.RED) })
+            withTimeout(2_000) {
+                while (repository.peek(secondSpec.key) !is ChatAssetState.Ready) delay(1)
+            }
+            awaitPreDraw(view)
+            runOnMain { assertEquals(1f, view.alpha) }
+        } finally {
+            attached.close()
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun clipRowReservesGeometryAndWaitsForMetadataAndThumbnail() = runBlocking {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val releaseMetadata = CompletableDeferred<ChatClipPreview?>()
+        val releaseThumbnail = CompletableDeferred<ChatImageHandle?>()
+        val clipRepository = ChatClipPreviewRepository(scope) { releaseMetadata.await() }
+        val assetRepository = ChatAssetRepository(scope, ChatAssetLoader { releaseThumbnail.await() })
+        val attached = attachView(assetRepository, clipRepository)
+        val view = attached.view
+        val link = ChatClipPreviewLink("clip-slug", "https://clips.twitch.tv/clip-slug")
+        val row = ChatRowUiModel(
+            id = ChatMessageId("clip-row"),
+            channelId = "channel",
+            timestampText = null,
+            pieces = listOf(ChatPiece.Text(link.url)),
+            background = 0xff101010.toInt(),
+            accessibilityText = link.url,
+            reply = null,
+            source = null,
+            isAction = false,
+            clipPreviews = listOf(link),
+        )
+        try {
+            runOnMain {
+                view.bind(row)
+                assertEquals(0f, view.alpha)
+            }
+            awaitPreDraw(view)
+            val reservedHeight = view.measuredHeight
+            releaseMetadata.complete(ChatClipPreview(
+                title = "clip",
+                broadcasterName = "broadcaster",
+                creatorName = "creator",
+                thumbnailUrl = "thumbnail",
+                gameName = "game",
+                durationSeconds = 30,
+                createdAt = null,
+            ))
+            withTimeout(2_000) {
+                while (assetRepository.peek(ChatAssetKey("thumbnail")) is ChatAssetState.Missing) delay(1)
+            }
+            awaitPreDraw(view)
+            runOnMain {
+                assertEquals(0f, view.alpha)
+                assertEquals(reservedHeight, view.measuredHeight)
+            }
+            releaseThumbnail.complete(ChatImageHandle { SolidDrawable(Color.RED) })
+            withTimeout(2_000) {
+                while (assetRepository.peek(ChatAssetKey("thumbnail")) !is ChatAssetState.Ready) delay(1)
+            }
+            awaitPreDraw(view)
+            runOnMain {
+                assertEquals(1f, view.alpha)
+                assertEquals(reservedHeight, view.measuredHeight)
+            }
+        } finally {
+            attached.close()
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun failedCompositeLatchesOnlyItsComposition() = runBlocking {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val repository = ChatAssetRepository(scope, ChatAssetLoader { key ->
+            if (key.value == "A") ChatImageHandle { SolidDrawable(Color.RED) }
+            else throw ChatAssetLoadException(404)
+        })
+        val attached = attachView(repository)
+        val view = attached.view
+        val plain = ChatAssetSpec(ChatAssetKey("A"), 20, 20, 28)
+        val composite = plain.copy(
+            overlays = listOf(ChatAssetSpec(ChatAssetKey("B"), 20, 20, 28)),
+        )
+        val row = ChatRowUiModel(
+            id = ChatMessageId("composite-latch"),
+            channelId = "channel",
+            timestampText = null,
+            pieces = listOf(
+                ChatPiece.Emote(plain, "A"),
+                ChatPiece.Emote(composite, "A+B"),
+            ),
+            background = 0xff101010.toInt(),
+            accessibilityText = "A A+B",
+            reply = null,
+            source = null,
+            isAction = false,
+        )
+        try {
+            runOnMain { view.bind(row) }
+            awaitPresentationTerminal(repository, listOf(plain.key, composite.overlays.single().key))
+            awaitPreDraw(view)
+            runOnMain {
+                val spanned = view.text as Spanned
+                val spans = spanned.getSpans(0, spanned.length, ReplacementSpan::class.java)
+                    .sortedBy { spanned.getSpanStart(it) }
+                assertEquals(2, spans.size)
+                assertTrue(containsColor(draw(spans[0], spanned, Paint.FontMetricsInt()), Color.RED))
+                assertTrue(hasVisiblePixels(draw(spans[1], spanned, Paint.FontMetricsInt())))
+            }
+        } finally {
+            attached.close()
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun failedNamePaintDoesNotChangeWhenItsImageRecovers() = runBlocking {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val retryStarted = CompletableDeferred<Unit>()
+        val retryRelease = CompletableDeferred<Unit>()
+        val attempts = AtomicInteger()
+        val key = ChatAssetKey("paint")
+        val repository = ChatAssetRepository(scope, ChatAssetLoader {
+            if (attempts.incrementAndGet() == 1) throw ChatAssetLoadException(404)
+            retryStarted.complete(Unit)
+            retryRelease.await()
+            ChatImageHandle { SolidDrawable(Color.RED) }
+        })
+        val attached = attachView(repository)
+        val view = attached.view
+        val row = ChatRowUiModel(
+            id = ChatMessageId("paint-latch"),
+            channelId = "channel",
+            timestampText = null,
+            pieces = listOf(
+                ChatPiece.Username(
+                    value = "painted",
+                    color = Color.WHITE,
+                    paint = ChatNamePaint(colors = listOf(Color.RED, Color.BLUE), imageUrl = key.value),
+                ),
+            ),
+            background = 0xff101010.toInt(),
+            accessibilityText = "painted",
+            reply = null,
+            source = null,
+            isAction = false,
+        )
+        try {
+            runOnMain { view.bind(row) }
+            awaitPresentationTerminal(repository, listOf(key))
+            awaitPreDraw(view)
+            fun nameShader() = runOnMainValue {
+                val spanned = view.text as Spanned
+                spanned.getSpans(0, 7, CharacterStyle::class.java).mapNotNull { span ->
+                    TextPaint().also(span::updateDrawState).shader
+                }.first()
+            }
+            val initialShader = nameShader()
+            assertEquals(LinearGradient::class.java, initialShader.javaClass)
+
+            repository.invalidate(setOf(key))
+            retryStarted.await()
+            awaitPreDraw(view)
+            val retryShader = nameShader()
+            assertEquals(LinearGradient::class.java, retryShader.javaClass)
+
+            retryRelease.complete(Unit)
+            withTimeout(2_000) { while (repository.peek(key) !is ChatAssetState.Ready) delay(1) }
+            awaitPreDraw(view)
+            val recoveredShader = nameShader()
+            assertEquals(LinearGradient::class.java, recoveredShader.javaClass)
+        } finally {
+            attached.close()
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun failedClipMetadataRevealsWithoutBlankCard() = runBlocking {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val clipRepository = ChatClipPreviewRepository(scope) { null }
+        val assetRepository = ChatAssetRepository(scope, ChatAssetLoader { null })
+        val attached = attachView(assetRepository, clipRepository)
+        val view = attached.view
+        val link = ChatClipPreviewLink("failed-clip", "https://clips.twitch.tv/failed-clip")
+        try {
+            runOnMain { view.bind(textRow(link.url, ChatMessageId("failed-clip-row")).copy(clipPreviews = listOf(link))) }
+            withTimeout(2_000) {
+                while (clipRepository.peekState(link.slug) !is com.github.andreyasadchy.xtra.ui.chat.v2.preview.ChatClipPreviewState.Ready) delay(1)
+            }
+            awaitPreDraw(view)
+            runOnMain {
+                assertEquals(1f, view.alpha)
+                assertEquals(400, view.measuredHeight)
+            }
+        } finally {
+            attached.close()
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun failedClipMetadataDoesNotGrowLaterOnSameBinding() = runBlocking {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val loads = AtomicInteger()
+        val clipRepository = ChatClipPreviewRepository(scope) {
+            if (loads.incrementAndGet() == 1) null else ChatClipPreview(
+                title = "clip",
+                broadcasterName = "broadcaster",
+                creatorName = "creator",
+                thumbnailUrl = null,
+                gameName = null,
+                durationSeconds = null,
+                createdAt = null,
+            )
+        }
+        val assetRepository = ChatAssetRepository(scope, ChatAssetLoader { null })
+        val attached = attachView(assetRepository, clipRepository)
+        val view = attached.view
+        val link = ChatClipPreviewLink("retry-clip", "https://clips.twitch.tv/retry-clip")
+        try {
+            runOnMain { view.bind(textRow(link.url, ChatMessageId("retry-clip-row")).copy(clipPreviews = listOf(link))) }
+            withTimeout(2_000) {
+                while (clipRepository.peekState(link.slug) !is com.github.andreyasadchy.xtra.ui.chat.v2.preview.ChatClipPreviewState.Ready) delay(1)
+            }
+            awaitPreDraw(view)
+            var failedHeight = 0
+            runOnMain { failedHeight = view.measuredHeight }
+            runOnMain { view.setRenderingActive(false); view.setRenderingActive(true) }
+            withTimeout(2_000) { while (loads.get() < 2) delay(1) }
+            awaitPreDraw(view)
+            runOnMain {
+                assertEquals(1f, view.alpha)
+                assertEquals(failedHeight, view.measuredHeight)
+            }
+        } finally {
+            attached.close()
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun failedClipThumbnailDoesNotChangeWhenItsImageRecovers() = runBlocking {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val clipRepository = ChatClipPreviewRepository(scope) {
+            ChatClipPreview(
+                title = "clip",
+                broadcasterName = "broadcaster",
+                creatorName = "creator",
+                thumbnailUrl = "thumbnail",
+                gameName = null,
+                durationSeconds = null,
+                createdAt = null,
+            )
+        }
+        val retryStarted = CompletableDeferred<Unit>()
+        val retryRelease = CompletableDeferred<Unit>()
+        val attempts = AtomicInteger()
+        val thumbnailKey = ChatAssetKey("thumbnail")
+        val assetRepository = ChatAssetRepository(scope, ChatAssetLoader {
+            if (attempts.incrementAndGet() == 1) throw ChatAssetLoadException(404)
+            retryStarted.complete(Unit)
+            retryRelease.await()
+            ChatImageHandle { SolidDrawable(Color.RED) }
+        })
+        val attached = attachView(assetRepository, clipRepository)
+        val view = attached.view
+        val link = ChatClipPreviewLink("thumbnail-clip", "https://clips.twitch.tv/thumbnail-clip")
+        try {
+            runOnMain { view.bind(textRow(link.url, ChatMessageId("thumbnail-clip-row")).copy(clipPreviews = listOf(link))) }
+            awaitPresentationTerminal(assetRepository, listOf(thumbnailKey))
+            awaitPreDraw(view)
+            val initial = runOnMainResult {
+                Bitmap.createBitmap(view.width, view.height, Bitmap.Config.ARGB_8888).also { view.draw(Canvas(it)) }
+            }
+
+            assetRepository.invalidate(setOf(thumbnailKey))
+            retryStarted.await()
+            awaitPreDraw(view)
+            val duringRetry = runOnMainResult {
+                Bitmap.createBitmap(view.width, view.height, Bitmap.Config.ARGB_8888).also { view.draw(Canvas(it)) }
+            }
+            assertTrue(initial.sameAs(duringRetry))
+
+            retryRelease.complete(Unit)
+            withTimeout(2_000) { while (assetRepository.peek(thumbnailKey) !is ChatAssetState.Ready) delay(1) }
+            awaitPreDraw(view)
+            val recovered = runOnMainResult {
+                Bitmap.createBitmap(view.width, view.height, Bitmap.Config.ARGB_8888).also { view.draw(Canvas(it)) }
+            }
+            assertTrue(initial.sameAs(recovered))
+        } finally {
+            attached.close()
+            scope.cancel()
+        }
     }
 
     @Test
@@ -498,6 +1095,30 @@ class ChatMessageTextViewTest {
         source = null, isAction = false,
     )
 
+    private fun badgeRow(spec: ChatAssetSpec, name: String) = ChatRowUiModel(
+        id = ChatMessageId("badge-row"),
+        channelId = "channel",
+        timestampText = null,
+        pieces = listOf(
+            ChatPiece.Badge(
+                spec,
+                ChatEmoteInteraction(
+                    id = "badge-id",
+                    name = name,
+                    url = spec.key.value,
+                    animated = false,
+                    provider = ChatAssetProvider.TWITCH,
+                    scope = null,
+                ),
+            ),
+        ),
+        background = 0xff101010.toInt(),
+        accessibilityText = name,
+        reply = null,
+        source = null,
+        isAction = false,
+    )
+
     private fun textRow(value: String, id: ChatMessageId = ChatMessageId("text")) = ChatRowUiModel(
         id = id, channelId = "channel", timestampText = null,
         pieces = listOf(ChatPiece.Text(value)),
@@ -512,6 +1133,15 @@ class ChatMessageTextViewTest {
         return bitmap
     }
 
+    private fun hasVisiblePixels(bitmap: Bitmap): Boolean {
+        for (x in 0 until bitmap.width) {
+            for (y in 0 until bitmap.height) {
+                if (bitmap.getPixel(x, y) != Color.TRANSPARENT) return true
+            }
+        }
+        return false
+    }
+
     private fun awaitSettled(repository: ChatAssetRepository, keys: List<ChatAssetKey>) = runBlocking {
         withTimeout(2_000) {
             while (keys.any { repository.peek(it) is ChatAssetState.Missing || repository.peek(it) is ChatAssetState.Loading }) {
@@ -520,11 +1150,31 @@ class ChatMessageTextViewTest {
         }
     }
 
+    private fun awaitPresentationTerminal(repository: ChatAssetRepository, keys: List<ChatAssetKey>) = runBlocking {
+        withTimeout(2_000) {
+            while (keys.any { key ->
+                    when (val state = repository.peek(key)) {
+                        ChatAssetState.Missing,
+                        ChatAssetState.Loading -> true
+                        is ChatAssetState.Ready -> false
+                        is ChatAssetState.Failed -> !state.isPresentationTerminal
+                    }
+                }
+            ) delay(1)
+        }
+    }
+
     private fun ChatAssetSpec.allKeysForTest(): List<ChatAssetKey> =
         listOf(key) + overlays.flatMap { it.allKeysForTest() }
 
     private fun runOnMainResult(block: () -> Bitmap): Bitmap {
         var result: Bitmap? = null
+        runOnMain { result = block() }
+        return checkNotNull(result)
+    }
+
+    private fun <T> runOnMainValue(block: () -> T): T {
+        var result: T? = null
         runOnMain { result = block() }
         return checkNotNull(result)
     }
@@ -541,7 +1191,49 @@ class ChatMessageTextViewTest {
     private fun runOnMain(block: () -> Unit) =
         InstrumentationRegistry.getInstrumentation().runOnMainSync(block)
 
-    private class TestTextView(context: Context, repository: ChatAssetRepository) : ChatMessageTextView(context, repository) {
+    private fun awaitPreDraw(view: View) {
+        val drawn = CountDownLatch(1)
+        runOnMain {
+            view.doOnPreDraw { drawn.countDown() }
+            view.requestLayout()
+            view.invalidate()
+        }
+        assertTrue(drawn.await(2, TimeUnit.SECONDS))
+    }
+
+    private fun attachView(
+        repository: ChatAssetRepository,
+        clipPreviews: ChatClipPreviewRepository? = null,
+    ): AttachedTestView {
+        val targetContext = InstrumentationRegistry.getInstrumentation().targetContext
+        val scenario = ActivityScenario.launch<ChatMessageTextViewTestActivity>(
+            Intent().setComponent(ComponentName(targetContext, ChatMessageTextViewTestActivity::class.java)),
+        )
+        lateinit var view: TestTextView
+        scenario.onActivity { activity ->
+            view = TestTextView(activity, repository, clipPreviews)
+            activity.root.addView(view, FrameLayout.LayoutParams(600, 400))
+        }
+        return AttachedTestView(scenario, view)
+    }
+
+    private data class AttachedTestView(
+        val scenario: ActivityScenario<ChatMessageTextViewTestActivity>,
+        val view: TestTextView,
+    ) {
+        fun close() {
+            InstrumentationRegistry.getInstrumentation().runOnMainSync {
+                view.recycle()
+                (view.context as Activity).finish()
+            }
+        }
+    }
+
+    private class TestTextView(
+        context: Context,
+        repository: ChatAssetRepository,
+        clipPreviews: ChatClipPreviewRepository? = null,
+    ) : ChatMessageTextView(context, repository, clipPreviews) {
         fun attachedForTest() = onAttachedToWindow()
         fun detachedForTest() = onDetachedFromWindow()
         fun verifyForTest(drawable: Drawable) = verifyDrawable(drawable)

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <application>
+        <activity
+            android:name="com.github.andreyasadchy.xtra.ui.chat.v2.ChatMessageTextViewTestActivity"
+            android:exported="true" />
+    </application>
+</manifest>

--- a/app/src/debug/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatMessageTextViewTestActivity.kt
+++ b/app/src/debug/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatMessageTextViewTestActivity.kt
@@ -1,0 +1,17 @@
+package com.github.andreyasadchy.xtra.ui.chat.v2
+
+import android.app.Activity
+import android.os.Bundle
+import android.widget.FrameLayout
+
+/** A debug-only host used by renderer instrumentation tests. */
+class ChatMessageTextViewTestActivity : Activity() {
+    lateinit var root: FrameLayout
+        private set
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        root = FrameLayout(this)
+        setContentView(root)
+    }
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatFragment.kt
@@ -920,6 +920,7 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
                                         },
                                 )
                             },
+                            rewardCatalogSettled = viewModel.channelPointCatalogSettled,
                             decorationCatalog = merge(
                                 viewModel.thirdPartyEmotesUpdated,
                                 viewModel.updateUserMessages.map { Unit },

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatViewModel.kt
@@ -644,6 +644,8 @@ class ChatViewModel(
     )
     val translateAllMessages = MutableStateFlow<Boolean?>(null)
     val channelPoints = MutableStateFlow<ChannelPoints?>(null)
+    /** The first channel-point metadata request has completed for the active channel. */
+    val channelPointCatalogSettled = MutableStateFlow(false)
     private var highlightedMessageReward: ChannelPointRewardInfo? = null
     val watchStreak = MutableStateFlow<WatchStreak?>(null)
     private val channelPointRedemptionEvents = Channel<ChannelPointRedemptionResult>(Channel.BUFFERED)
@@ -1946,6 +1948,7 @@ class ChatViewModel(
             channelPointsBalanceState = channelPointsBalanceReducer.reset()
             channelPoints.value = null
         }
+        channelPointCatalogSettled.value = false
     }
 
     private fun applyChannelPointsBalanceEvent(event: ChannelPointsBalanceEvent): Boolean {
@@ -2468,6 +2471,7 @@ class ChatViewModel(
         delayMillis: Long = 0L,
     ) {
         if (channelLogin.isNullOrBlank()) {
+            channelPointCatalogSettled.value = true
             return
         }
         val expectedChannelId = activeChannelId
@@ -2481,7 +2485,13 @@ class ChatViewModel(
                     return@launch
                 }
                 updateChannelPoints(response, requestRevision)
+                channelPointCatalogSettled.value = true
+            } catch (error: CancellationException) {
+                throw error
             } catch (_: Exception) {
+                if (activeChannelId == expectedChannelId && activeChannelLogin == channelLogin) {
+                    channelPointCatalogSettled.value = true
+                }
             }
         }
     }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/assets/ChatAssetState.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/assets/ChatAssetState.kt
@@ -7,7 +7,11 @@ sealed interface ChatAssetState {
     data object Missing : ChatAssetState
     data object Loading : ChatAssetState
     data class Ready(val image: ChatImageHandle) : ChatAssetState
-    data class Failed(val nextRetryAtMs: Long, val attempts: Int, val permanentUntilMs: Long? = null) : ChatAssetState
+    data class Failed(val nextRetryAtMs: Long, val attempts: Int, val permanentUntilMs: Long? = null) : ChatAssetState {
+        /** The row may expose its failure fallback only after this state is stable enough. */
+        val isPresentationTerminal: Boolean
+            get() = permanentUntilMs != null || attempts >= 3
+    }
 }
 
 fun interface ChatImageHandle { fun newDrawable(): Drawable }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/catalog/ChatCatalogRepository.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/catalog/ChatCatalogRepository.kt
@@ -55,9 +55,21 @@ data class ChatCatalogLoadResult(
         get() = twitch == null || sevenTv == null || sevenTv.hasFailedScope ||
                 bttv == null || bttv.hasFailedScope || ffz == null || ffz.hasFailedScope ||
                 badges == null || cheermotes == null
+
+    fun hasFailedProviderIgnoringBadges(): Boolean = twitch == null || sevenTv == null || sevenTv.hasFailedScope ||
+            bttv == null || bttv.hasFailedScope || ffz == null || ffz.hasFailedScope || cheermotes == null
 }
 
-fun interface ChatCatalogSource { suspend fun load(): ChatCatalogLoadResult }
+fun interface ChatCatalogSource {
+    suspend fun load(): ChatCatalogLoadResult
+
+    /** True when Twitch badges are published independently of the aggregate catalog request. */
+    val hasIndependentBadgeProvider: Boolean
+        get() = false
+
+    /** Returns the Twitch badge result as soon as that provider finishes. */
+    suspend fun loadBadges(): ChatCatalogProviderUpdate<Map<String, ChatCatalogBadge>>? = null
+}
 
 /** A last-good cache. A provider is absent from a result when its refresh failed. */
 interface ChatCatalogCache {
@@ -85,6 +97,8 @@ class ChatCatalogRepository(
     /** Catalog data and local-cache hydration are published atomically. */
     val state: StateFlow<ChatCatalogState> = _state.asStateFlow()
     private var refreshJob: Job? = null
+    private var badgeRefreshJob: Job? = null
+    private var badgeRefreshGeneration: Long? = null
     private var generation = 0L
     private var closed = false
     private var cacheJob: Job? = null
@@ -254,6 +268,8 @@ class ChatCatalogRepository(
                                 _state.value = ChatCatalogState(
                                     cached.withRuntimeDecorations(runtimeDecorations),
                                     hydrated = true,
+                                    badgesSettled = currentState.badgesSettled || cached.badges.isNotEmpty(),
+                                    structuralCatalogSettled = currentState.structuralCatalogSettled,
                                     refreshFailed = currentState.refreshFailed,
                                     thirdPartyRefreshFailed = currentState.thirdPartyRefreshFailed,
                                 )
@@ -276,11 +292,16 @@ class ChatCatalogRepository(
                                     _state.value = ChatCatalogState(
                                         merged.copy(revision = current.revision + 1),
                                         hydrated = true,
+                                        badgesSettled = currentState.badgesSettled || cached.badges.isNotEmpty(),
+                                        structuralCatalogSettled = currentState.structuralCatalogSettled,
                                         refreshFailed = currentState.refreshFailed,
                                         thirdPartyRefreshFailed = currentState.thirdPartyRefreshFailed,
                                     )
                                 } else {
-                                    _state.value = currentState.copy(hydrated = true)
+                                    _state.value = currentState.copy(
+                                        hydrated = true,
+                                        badgesSettled = currentState.badgesSettled || cached.badges.isNotEmpty(),
+                                    )
                                 }
                             }
                         } else {
@@ -296,6 +317,8 @@ class ChatCatalogRepository(
         if (closed) return
         val requestGeneration = ++generation
         refreshJob?.cancel()
+        badgeRefreshJob?.cancel()
+        badgeRefreshGeneration = null
         refreshJob = launchRefresh(requestGeneration, attempt = 1, delayMs = 0L)
     }
 
@@ -303,6 +326,9 @@ class ChatCatalogRepository(
     @Synchronized fun pause() {
         refreshJob?.cancel()
         refreshJob = null
+        badgeRefreshJob?.cancel()
+        badgeRefreshJob = null
+        badgeRefreshGeneration = null
         personalEmoteSetJobs.values.forEach(Job::cancel)
         personalEmoteSetJobs.clear()
     }
@@ -313,12 +339,22 @@ class ChatCatalogRepository(
         cacheJob = null
         refreshJob?.cancel()
         refreshJob = null
+        badgeRefreshJob?.cancel()
+        badgeRefreshJob = null
+        badgeRefreshGeneration = null
         personalEmoteSetJobs.values.forEach(Job::cancel)
         personalEmoteSetJobs.clear()
     }
 
     private fun launchRefresh(requestGeneration: Long, attempt: Int, delayMs: Long): Job = scope.launch {
         if (delayMs > 0) wait(delayMs)
+        if (source.hasIndependentBadgeProvider &&
+            badgeRefreshGeneration != requestGeneration &&
+            badgeRefreshJob?.isActive != true
+        ) {
+            badgeRefreshGeneration = requestGeneration
+            badgeRefreshJob = launchBadgeRefresh(requestGeneration, attempt, delayMs = 0L)
+        }
         val result = try {
             source.load()
         } catch (e: CancellationException) {
@@ -329,8 +365,14 @@ class ChatCatalogRepository(
         synchronized(this@ChatCatalogRepository) {
             if (closed || requestGeneration != generation) return@synchronized
             if (result == null || !result.hasSuccessfulProvider) {
-                if (!_state.value.refreshFailed || !_state.value.thirdPartyRefreshFailed) {
+                if (!_state.value.refreshFailed ||
+                    !_state.value.thirdPartyRefreshFailed ||
+                    (!source.hasIndependentBadgeProvider && !_state.value.badgesSettled) ||
+                    !_state.value.structuralCatalogSettled
+                ) {
                     _state.value = _state.value.copy(
+                        badgesSettled = _state.value.badgesSettled || !source.hasIndependentBadgeProvider,
+                        structuralCatalogSettled = true,
                         refreshFailed = true,
                         thirdPartyRefreshFailed = true,
                     )
@@ -370,7 +412,13 @@ class ChatCatalogRepository(
             val nextState = ChatCatalogState(
                 next,
                 hydrated = currentState.hydrated,
-                refreshFailed = result.hasFailedProvider,
+                badgesSettled = currentState.badgesSettled || !source.hasIndependentBadgeProvider,
+                structuralCatalogSettled = true,
+                refreshFailed = if (source.hasIndependentBadgeProvider) {
+                    result.hasFailedProviderIgnoringBadges()
+                } else {
+                    result.hasFailedProvider
+                },
                 thirdPartyRefreshFailed = result.hasFailedThirdPartyProvider,
             )
             if (changed) {
@@ -378,14 +426,56 @@ class ChatCatalogRepository(
                 enqueuePersistence(next)
             } else if (
                 currentState.refreshFailed != nextState.refreshFailed ||
-                currentState.thirdPartyRefreshFailed != nextState.thirdPartyRefreshFailed
+                currentState.thirdPartyRefreshFailed != nextState.thirdPartyRefreshFailed ||
+                currentState.badgesSettled != nextState.badgesSettled ||
+                currentState.structuralCatalogSettled != nextState.structuralCatalogSettled
             ) {
                 _state.value = nextState
             }
-            refreshJob = if (result.hasFailedProvider) {
+            val aggregateFailed = if (source.hasIndependentBadgeProvider) {
+                result.hasFailedProviderIgnoringBadges()
+            } else {
+                result.hasFailedProvider
+            }
+            refreshJob = if (aggregateFailed) {
                 launchRefresh(requestGeneration, attempt + 1, retryDelay(attempt))
             } else {
                 null
+            }
+        }
+    }
+
+    private fun launchBadgeRefresh(requestGeneration: Long, attempt: Int, delayMs: Long): Job = scope.launch {
+        if (delayMs > 0) wait(delayMs)
+        val result = try {
+            source.loadBadges()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (_: Throwable) {
+            null
+        }
+        synchronized(this@ChatCatalogRepository) {
+            if (closed || requestGeneration != generation) return@synchronized
+            if (result != null) {
+                networkProvidersObserved = networkProvidersObserved + Provider.BADGES
+                val currentState = _state.value
+                val current = currentState.snapshot
+                val next = current.copy(
+                    revision = current.revision + 1,
+                    badges = result.value,
+                )
+                _state.value = currentState.copy(
+                    snapshot = next,
+                    badgesSettled = true,
+                )
+                enqueuePersistence(next)
+                badgeRefreshJob = null
+            } else {
+                _state.value = _state.value.copy(
+                    badgesSettled = true,
+                    refreshFailed = true,
+                )
+                badgeRefreshJob = launchBadgeRefresh(requestGeneration, attempt + 1, retryDelay(attempt))
             }
         }
     }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/catalog/ChatCatalogSnapshot.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/catalog/ChatCatalogSnapshot.kt
@@ -166,6 +166,12 @@ data class ChatCatalogSnapshot(
 data class ChatCatalogState(
     val snapshot: ChatCatalogSnapshot,
     val hydrated: Boolean,
+    val badgesSettled: Boolean = false,
+    /** True after the first aggregate structural-catalog attempt returns. */
+    val structuralCatalogSettled: Boolean = false,
     val refreshFailed: Boolean = false,
     val thirdPartyRefreshFailed: Boolean = false,
 )
+
+internal fun ChatCatalogState.isReadyForChatPublication(showBadges: Boolean): Boolean =
+    hydrated && structuralCatalogSettled && (!showBadges || badgesSettled)

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/catalog/TwitchChatCatalogSource.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/catalog/TwitchChatCatalogSource.kt
@@ -38,6 +38,8 @@ class TwitchChatCatalogSource(
 ) : ChatCatalogSource {
     private val context = context.applicationContext
 
+    override val hasIndependentBadgeProvider: Boolean = true
+
     suspend fun loadPersonalEmoteSet(setId: String): Map<String, ChatCatalogEmote> {
         return PersonalEmoteSetCache.get(setId) {
             val network = context.prefs().getString(C.NETWORK_LIBRARY, C.OKHTTP)
@@ -61,13 +63,6 @@ class TwitchChatCatalogSource(
             val sevenTv = async { if (context.prefs().getBoolean(C.CHAT_ENABLE_STV, true)) loadSevenTv(network, useWebp) else emptyProviderUpdate() }
             val bttv = async { if (context.prefs().getBoolean(C.CHAT_ENABLE_BTTV, true)) loadBttv(network, useWebp) else emptyProviderUpdate() }
             val ffz = async { if (context.prefs().getBoolean(C.CHAT_ENABLE_FFZ, true)) loadFfz(network, useWebp) else emptyProviderUpdate() }
-            val badges = async { provider {
-                val global = GlobalChatCatalogCache.get(GlobalCatalogKey.TWITCH_BADGES) {
-                    playerRepository.loadGlobalBadges(network, helix, gql, "4")
-                }
-                val channel = playerRepository.loadChannelBadges(network, helix, gql, channelId, channelLogin, "4")
-                (global + channel).associateBy { "${it.setId}:${it.version}" }.mapValues { (_, badge) -> badge.toCatalog() }
-            } }
             val cheermotes = async { provider {
                 playerRepository.loadCheerEmotes(
                     network,
@@ -83,9 +78,21 @@ class TwitchChatCatalogSource(
                 sevenTv = sevenTv.await(),
                 bttv = bttv.await(),
                 ffz = ffz.await(),
-                badges = badges.await(),
                 cheermotes = cheermotes.await(),
             )
+        }
+    }
+
+    override suspend fun loadBadges(): ChatCatalogProviderUpdate<Map<String, ChatCatalogBadge>>? = withContext(Dispatchers.IO) {
+        val network = context.prefs().getString(C.NETWORK_LIBRARY, C.OKHTTP)
+        val helix = TwitchApiHelper.getHelixHeaders(context)
+        val gql = TwitchApiHelper.getGQLHeaders(context, true)
+        provider {
+            val global = GlobalChatCatalogCache.get(GlobalCatalogKey.TWITCH_BADGES) {
+                playerRepository.loadGlobalBadges(network, helix, gql, "4")
+            }
+            val channel = playerRepository.loadChannelBadges(network, helix, gql, channelId, channelLogin, "4")
+            (global + channel).associateBy { "${it.setId}:${it.version}" }.mapValues { (_, badge) -> badge.toCatalog() }
         }
     }
 

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/domain/ChatReward.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/domain/ChatReward.kt
@@ -10,6 +10,9 @@ data class ChatReward(
 /** GQL automatic reward type for the Highlight My Message redemption. */
 const val HIGHLIGHTED_MESSAGE_REWARD_TYPE = "SEND_HIGHLIGHTED_MESSAGE"
 
+fun ChatMessage.requiresInitialRewardMetadata(): Boolean =
+    rewardId != null || twitchType == TwitchChatMessageType.Highlighted
+
 /**
  * Runtime channel-point metadata. Custom rewards are keyed by reward ID while
  * automatic (built-in) rewards are keyed by their upper-cased GQL type, since

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/presentation/ChatPresentationSnapshot.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/presentation/ChatPresentationSnapshot.kt
@@ -1,0 +1,111 @@
+package com.github.andreyasadchy.xtra.ui.chat.v2.presentation
+
+import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatCatalogSnapshot
+import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatCatalogBadge
+import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatCatalogCheermote
+import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatCatalogEmote
+import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatNamePaint
+import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatUserDecoration
+import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ScopedEmoteCatalog
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessage
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessageId
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatReward
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatSessionKey
+
+/**
+ * Keeps structural catalog inputs stable for every message already published in a session.
+ *
+ * Catalog retries and live decoration updates are allowed to improve the presentation of new
+ * messages. They must not insert a new span into an existing row, because the row may already
+ * have been revealed by the atomic asset gate.
+ */
+internal class ChatPresentationSnapshot {
+    private var sessionKey: ChatSessionKey? = null
+    private val catalogsByMessage = HashMap<ChatMessageId, FrozenCatalog>()
+
+    @Synchronized
+    fun catalogsFor(
+        key: ChatSessionKey,
+        messages: List<ChatMessage>,
+        catalog: ChatCatalogSnapshot,
+        captureBadges: Boolean = true,
+    ): List<ChatCatalogSnapshot> {
+        if (sessionKey != key) {
+            sessionKey = key
+            catalogsByMessage.clear()
+        }
+        val messageIds = messages.asSequence().map(ChatMessage::id).toSet()
+        catalogsByMessage.keys.retainAll(messageIds)
+        return messages.map { message ->
+            val frozen = catalogsByMessage[message.id]
+            if (frozen == null) {
+                val created = FrozenCatalog.from(catalog, captureBadges)
+                catalogsByMessage[message.id] = created
+                created.toCatalog(catalog)
+            } else {
+                if (captureBadges) frozen.captureBadges(catalog)
+                frozen.toCatalog(catalog)
+            }
+        }
+    }
+
+    @Synchronized
+    fun clear() {
+        sessionKey = null
+        catalogsByMessage.clear()
+    }
+
+    private class FrozenCatalog(
+        private val twitch: Map<String, ChatCatalogEmote>,
+        private val sevenTv: ScopedEmoteCatalog,
+        private val sevenTvChannelSetId: String?,
+        private val bttv: ScopedEmoteCatalog,
+        private val ffz: ScopedEmoteCatalog,
+        private var badges: Map<String, ChatCatalogBadge>?,
+        private val cheermotes: Map<String, ChatCatalogCheermote>,
+        private val userDecorations: Map<String, ChatUserDecoration>,
+        private val namePaints: Map<String, ChatNamePaint>,
+        private val sevenTvBadges: Map<String, ChatCatalogBadge>,
+        private val channelPointRewards: Map<String, ChatReward>,
+        private val automaticChannelPointRewards: Map<String, ChatReward>,
+        private val channelPointRewardsRevision: Int,
+    ) {
+        fun captureBadges(catalog: ChatCatalogSnapshot) {
+            if (badges == null) badges = catalog.badges
+        }
+
+        fun toCatalog(current: ChatCatalogSnapshot): ChatCatalogSnapshot = current.copy(
+            twitch = twitch,
+            sevenTv = sevenTv,
+            sevenTvChannelSetId = sevenTvChannelSetId,
+            bttv = bttv,
+            ffz = ffz,
+            badges = badges ?: current.badges,
+            cheermotes = cheermotes,
+            userDecorations = userDecorations,
+            namePaints = namePaints,
+            sevenTvBadges = sevenTvBadges,
+            channelPointRewards = channelPointRewards,
+            automaticChannelPointRewards = automaticChannelPointRewards,
+            channelPointRewardsRevision = channelPointRewardsRevision,
+        )
+
+        companion object {
+            fun from(catalog: ChatCatalogSnapshot, captureBadges: Boolean): FrozenCatalog = FrozenCatalog(
+                twitch = catalog.twitch,
+                sevenTv = catalog.sevenTv,
+                sevenTvChannelSetId = catalog.sevenTvChannelSetId,
+                bttv = catalog.bttv,
+                ffz = catalog.ffz,
+                badges = catalog.badges.takeIf { captureBadges },
+                cheermotes = catalog.cheermotes,
+                userDecorations = catalog.userDecorations,
+                namePaints = catalog.namePaints,
+                sevenTvBadges = catalog.sevenTvBadges,
+                channelPointRewards = catalog.channelPointRewards,
+                automaticChannelPointRewards = catalog.automaticChannelPointRewards,
+                channelPointRewardsRevision = catalog.channelPointRewardsRevision,
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/presentation/ChatRowCompiler.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/presentation/ChatRowCompiler.kt
@@ -137,9 +137,8 @@ class ChatRowCompiler(
             }
             if (showBadges && !specialNotice) message.badges
                 .filter { it.setId.isNotBlank() && it.versionId.isNotBlank() }
-                .forEach { badge ->
-                    add(ChatPiece.Badge(badgeSpec(badge, catalog), badgeInteraction(badge, catalog)))
-                }
+                .mapNotNull { badge -> badgePiece(badge, catalog) }
+                .forEach(::add)
             if (showThirdPartyBadges && !specialNotice) {
                 message.user?.id?.let(catalog.userDecorations::get)?.badgeId?.let { badgeId ->
                     catalog.sevenTvBadges[badgeId]?.let { badge ->
@@ -413,18 +412,23 @@ class ChatRowCompiler(
         )
     }
 
-    private fun badgeSpec(badge: ChatBadgeRef, catalog: ChatCatalogSnapshot): ChatAssetSpec =
-        (catalog.badges[badge.catalogKey]?.asset ?: badge.asset).scaledTo(badgeHeightPx)
+    private fun badgePiece(badge: ChatBadgeRef, catalog: ChatCatalogSnapshot): ChatPiece.Badge? {
+        val definition = catalog.badges[badge.catalogKey] ?: return null
+        val assetKey = definition.asset.key.value
+        if (!assetKey.startsWith("http://", ignoreCase = true) &&
+            !assetKey.startsWith("https://", ignoreCase = true)
+        ) return null
 
-    private fun badgeInteraction(badge: ChatBadgeRef, catalog: ChatCatalogSnapshot): ChatEmoteInteraction {
-        val definition = catalog.badges[badge.catalogKey]
-        return ChatEmoteInteraction(
-            id = badge.versionId,
-            name = definition?.info ?: badge.info ?: badge.setId,
-            url = definition?.asset?.key?.value ?: badge.asset.key.value,
-            animated = false,
-            provider = com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatAssetProvider.TWITCH,
-            scope = null,
+        return ChatPiece.Badge(
+            asset = definition.asset.scaledTo(badgeHeightPx),
+            interaction = ChatEmoteInteraction(
+                id = badge.versionId,
+                name = definition.info ?: badge.info ?: badge.setId,
+                url = definition.asset.key.value,
+                animated = false,
+                provider = com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatAssetProvider.TWITCH,
+                scope = null,
+            ),
         )
     }
 

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/preview/ChatClipPreviewRepository.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/preview/ChatClipPreviewRepository.kt
@@ -39,6 +39,12 @@ data class ChatClipPreviewLink(
     }
 }
 
+sealed interface ChatClipPreviewState {
+    data object Missing : ChatClipPreviewState
+    data object Loading : ChatClipPreviewState
+    data class Ready(val preview: ChatClipPreview?) : ChatClipPreviewState
+}
+
 /** Formats a clip duration the way Twitch does (`m:ss`, `h:mm:ss` past an hour). */
 fun formatClipDuration(durationSeconds: Int?): String? {
     if (durationSeconds == null || durationSeconds < 0) return null
@@ -64,19 +70,26 @@ class ChatClipPreviewRepository(
     private val loader: suspend (String) -> ChatClipPreview?,
 ) {
     private val cache = HashMap<String, ChatClipPreview>()
+    private val states = HashMap<String, ChatClipPreviewState>()
     private val listeners = HashMap<String, MutableSet<() -> Unit>>()
     private val loading = HashSet<String>()
 
     @Synchronized
     fun peek(slug: String): ChatClipPreview? = cache[slug]
 
+    @Synchronized
+    fun peekState(slug: String): ChatClipPreviewState = states[slug] ?: ChatClipPreviewState.Missing
+
     fun observe(slug: String, listener: () -> Unit) {
         val shouldLoad: Boolean
         val cached: Boolean
         synchronized(this) {
-            listeners.getOrPut(slug) { LinkedHashSet() }.add(listener)
+            val slugListeners = listeners.getOrPut(slug) { LinkedHashSet() }
+            val alreadyObserved = listener in slugListeners
+            slugListeners.add(listener)
             cached = cache.containsKey(slug)
-            shouldLoad = !cached && loading.add(slug)
+            shouldLoad = !cached && !alreadyObserved && loading.add(slug)
+            if (shouldLoad) states[slug] = ChatClipPreviewState.Loading
         }
         if (cached) listener()
         if (shouldLoad) {
@@ -86,6 +99,7 @@ class ChatClipPreviewRepository(
                     // A failed request must remain retryable when the same clip is seen again.
                     if (preview != null) cache[slug] = preview
                     loading.remove(slug)
+                    states[slug] = ChatClipPreviewState.Ready(preview)
                     listeners[slug]?.toList().orEmpty()
                 }
                 callbacks.forEach { it() }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatMessageTextView.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatMessageTextView.kt
@@ -36,6 +36,7 @@ import android.widget.TextView
 import android.util.TypedValue
 import android.util.AttributeSet
 import androidx.core.content.ContextCompat
+import androidx.core.view.doOnPreDraw
 import androidx.appcompat.widget.AppCompatTextView
 import com.github.andreyasadchy.xtra.R
 import com.github.andreyasadchy.xtra.XtraApp
@@ -52,6 +53,7 @@ import com.github.andreyasadchy.xtra.ui.chat.v2.presentation.ChatRowBackground
 import com.github.andreyasadchy.xtra.ui.chat.v2.preview.ChatClipPreviewLink
 import com.github.andreyasadchy.xtra.ui.chat.v2.preview.ChatClipPreview
 import com.github.andreyasadchy.xtra.ui.chat.v2.preview.ChatClipPreviewRepository
+import com.github.andreyasadchy.xtra.ui.chat.v2.preview.ChatClipPreviewState
 import com.github.andreyasadchy.xtra.ui.chat.v2.preview.formatClipDuration
 import com.github.andreyasadchy.xtra.ui.chat.v2.preview.parseClipTimestamp
 import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatNamePaint
@@ -96,8 +98,10 @@ open class ChatMessageTextView private constructor(
     private val drawableHandles = HashMap<ChatAssetKey, Any>()
     private val assetInvalidator: () -> Unit = {
         post {
+            latchTerminalAssetFailures()
             requestLayout()
             postInvalidateOnAnimation()
+            maybeRevealInitialAssetFrame()
         }
     }
     private val clipMetadataInvalidator: () -> Unit = {
@@ -105,9 +109,17 @@ open class ChatMessageTextView private constructor(
             refreshClipPreviewAssets()
             requestLayout()
             postInvalidateOnAnimation()
+            maybeRevealInitialAssetFrame()
         }
     }
-    private val clipThumbnailInvalidator: () -> Unit = { postInvalidateOnAnimation() }
+    private val clipThumbnailInvalidator: () -> Unit = {
+        post {
+            latchTerminalAssetFailures()
+            requestLayout()
+            postInvalidateOnAnimation()
+            maybeRevealInitialAssetFrame()
+        }
+    }
     private var renderingActive = true
     private var animateGifs = true
     private var boundMessageId: ChatMessageId? = null
@@ -126,6 +138,13 @@ open class ChatMessageTextView private constructor(
     private var touchMoved = false
     private var clipPreviewSlugs = emptySet<String>()
     private var clipPreviewAssetKeys = emptySet<ChatAssetKey>()
+    private var awaitingInitialAssetFrame = false
+    private var revealOnPreDrawPosted = false
+    private var initialAssetSpecs = emptyList<ChatAssetSpec>()
+    private var initialDirectAssetKeys = emptySet<ChatAssetKey>()
+    private val latchedFailedCompositionKeys = HashSet<String>()
+    private val latchedFailedDirectKeys = HashSet<ChatAssetKey>()
+    private val latchedFailedClipMetadataSlugs = HashSet<String>()
 
     fun setInteractionCallbacks(
         onMessageLongClick: ((ChatMessageId) -> Unit)?,
@@ -173,20 +192,25 @@ open class ChatMessageTextView private constructor(
     }
 
     private fun bindRow(row: ChatRowUiModel) {
+        val sameRevealedMessage = boundMessageId == row.id && !awaitingInitialAssetFrame
+        if (!sameRevealedMessage) {
+            awaitingInitialAssetFrame = true
+            alpha = 0f
+            latchedFailedCompositionKeys.clear()
+            latchedFailedDirectKeys.clear()
+            latchedFailedClipMetadataSlugs.clear()
+        }
         boundMessageId = row.id
         longPressConsumed = false
         longPressRunnable?.let(mainHandler::removeCallbacks)
         longPressRunnable = null
         isLongClickable = onMessageLongClick != null
-        keys.forEach { assets.removeObserver(it, assetInvalidator) }
-        clipPreviewSlugs.forEach { slug -> clipPreviews?.removeObserver(slug, clipMetadataInvalidator) }
-        clipPreviewAssetKeys.forEach { assets.removeObserver(it, clipThumbnailInvalidator) }
-        clipPreviewSlugs = emptySet()
-        clipPreviewAssetKeys = emptySet()
+        val oldKeys = keys
+        val oldClipPreviewSlugs = clipPreviewSlugs
         drawables.values.forEach { it.stopIfNeeded(); it.callback = null }
         drawables.clear()
         drawableHandles.clear()
-        keys = row.pieces.flatMap { piece ->
+        val newKeys = row.pieces.flatMap { piece ->
             buildList {
                 val spec = when (piece) {
                     is ChatPiece.Badge -> piece.asset
@@ -202,9 +226,32 @@ open class ChatMessageTextView private constructor(
                 }
             }
         }.toSet()
-        keys.forEach { assets.observe(it, assetInvalidator) }
-        clipPreviewSlugs = row.clipPreviews.map { it.slug }.toSet()
-        clipPreviewSlugs.forEach { slug -> clipPreviews?.observe(slug, clipMetadataInvalidator) }
+        oldKeys.filterNot(newKeys::contains).forEach { assets.removeObserver(it, assetInvalidator) }
+        newKeys.filterNot(oldKeys::contains).forEach { assets.observe(it, assetInvalidator) }
+        keys = newKeys
+        initialAssetSpecs = row.pieces.mapNotNull { piece ->
+            when (piece) {
+                is ChatPiece.Badge -> piece.asset
+                is ChatPiece.RewardIcon -> piece.asset
+                is ChatPiece.Emote -> piece.asset
+                is ChatPiece.Cheermote -> piece.asset
+                is ChatPiece.Gif -> piece.asset
+                else -> null
+            }
+        }
+        initialDirectAssetKeys = row.pieces.mapNotNull { piece ->
+            (piece as? ChatPiece.Username)?.paint?.imageUrl
+                ?.takeIf { it.isNotBlank() }
+                ?.let(::ChatAssetKey)
+        }.toSet()
+        val newClipPreviewSlugs = row.clipPreviews.map { it.slug }.toSet()
+        oldClipPreviewSlugs.filterNot(newClipPreviewSlugs::contains).forEach { slug ->
+            clipPreviews?.removeObserver(slug, clipMetadataInvalidator)
+        }
+        newClipPreviewSlugs.filterNot(oldClipPreviewSlugs::contains).forEach { slug ->
+            clipPreviews?.observe(slug, clipMetadataInvalidator)
+        }
+        clipPreviewSlugs = newClipPreviewSlugs
         refreshClipPreviewAssets()
         when (row.backgroundStyle) {
             ChatRowBackground.NORMAL -> setBackgroundColor(row.background)
@@ -259,12 +306,41 @@ open class ChatMessageTextView private constructor(
                 is ChatPiece.Source -> appendStyled(output, "[${piece.value}] ", piece.color)
                 is ChatPiece.Icon -> appendIcon(output, piece)
                 is ChatPiece.Mention -> appendStyled(output, piece.value, null)
-                is ChatPiece.Badge -> appendAsset(output, piece.asset, piece.interaction?.name ?: "badge", piece.interaction)
-                is ChatPiece.RewardIcon -> appendAsset(output, piece.asset, piece.fallback)
-                is ChatPiece.Emote -> appendAsset(output, piece.asset, piece.fallback, piece.interaction)
-                is ChatPiece.Gif -> appendAsset(output, piece.asset, piece.fallback, gifInteraction = piece.interaction)
+                is ChatPiece.Badge -> appendAsset(
+                    output,
+                    piece.asset,
+                    fallback = "",
+                    fallbackMode = ChatAssetFallbackMode.NONE,
+                    interaction = piece.interaction,
+                )
+                is ChatPiece.RewardIcon -> appendAsset(
+                    output,
+                    piece.asset,
+                    piece.fallback,
+                    fallbackMode = ChatAssetFallbackMode.NONE,
+                )
+                is ChatPiece.Emote -> appendAsset(
+                    output,
+                    piece.asset,
+                    piece.fallback,
+                    fallbackMode = ChatAssetFallbackMode.TEXT_ON_FAILURE,
+                    interaction = piece.interaction,
+                )
+                is ChatPiece.Gif -> appendAsset(
+                    output,
+                    piece.asset,
+                    piece.fallback,
+                    fallbackMode = ChatAssetFallbackMode.TEXT_ON_FAILURE,
+                    gifInteraction = piece.interaction,
+                )
                 is ChatPiece.Cheermote -> {
-                    appendAsset(output, piece.asset, piece.bits.toString(), piece.interaction)
+                    appendAsset(
+                        output,
+                        piece.asset,
+                        piece.bits.toString(),
+                        fallbackMode = ChatAssetFallbackMode.NONE,
+                        interaction = piece.interaction,
+                    )
                     appendStyled(output, " ${piece.bits}", piece.color)
                 }
             }
@@ -300,12 +376,94 @@ open class ChatMessageTextView private constructor(
         if (row.isAction) output.setSpan(StyleSpan(android.graphics.Typeface.ITALIC), 0, output.length, 0)
         contentDescription = row.accessibilityText
         text = output
+        maybeRevealInitialAssetFrame()
+    }
+
+    private fun maybeRevealInitialAssetFrame() {
+        if (!awaitingInitialAssetFrame) return
+
+        latchFailedClipMetadata()
+
+        val hasPendingAsset = (keys + clipPreviewAssetKeys).any { key ->
+            when (val state = assets.peek(key)) {
+                ChatAssetState.Missing,
+                ChatAssetState.Loading -> true
+
+                is ChatAssetState.Ready -> false
+                is ChatAssetState.Failed -> !state.isPresentationTerminal
+            }
+        }
+        if (hasPendingAsset) return
+        if (clipPreviewSlugs.any { slug ->
+                when (clipPreviews?.peekState(slug)) {
+                    ChatClipPreviewState.Missing,
+                    ChatClipPreviewState.Loading -> true
+                    is ChatClipPreviewState.Ready,
+                    null -> false
+                }
+            }
+        ) return
+
+        if (!isAttachedToWindow || revealOnPreDrawPosted) return
+        revealOnPreDrawPosted = true
+        doOnPreDraw {
+            revealOnPreDrawPosted = false
+            revealInitialAssetFrameIfReady()
+        }
+    }
+
+    private fun revealInitialAssetFrameIfReady() {
+        if (!awaitingInitialAssetFrame) return
+        latchFailedClipMetadata()
+        val hasPendingAsset = (keys + clipPreviewAssetKeys).any { key ->
+            when (val state = assets.peek(key)) {
+                ChatAssetState.Missing,
+                ChatAssetState.Loading -> true
+
+                is ChatAssetState.Ready -> false
+                is ChatAssetState.Failed -> !state.isPresentationTerminal
+            }
+        }
+        if (hasPendingAsset || clipPreviewSlugs.any { slug ->
+                when (clipPreviews?.peekState(slug)) {
+                    ChatClipPreviewState.Missing,
+                    ChatClipPreviewState.Loading -> true
+                    is ChatClipPreviewState.Ready,
+                    null -> false
+                }
+            }
+        ) return
+
+        latchTerminalAssetFailures()
+
+        awaitingInitialAssetFrame = false
+        alpha = 1f
+    }
+
+    private fun latchTerminalAssetFailures() {
+        initialAssetSpecs
+            .filter { assetRenderState(it) == ChatAssetRenderState.FAILED }
+            .forEach { latchedFailedCompositionKeys += it.compositionKey }
+        (initialDirectAssetKeys + clipPreviewAssetKeys).forEach { key ->
+            val state = assets.peek(key)
+            if (state is ChatAssetState.Failed && state.isPresentationTerminal) {
+                latchedFailedDirectKeys += key
+            }
+        }
+    }
+
+    private fun latchFailedClipMetadata() {
+        val failed = clipPreviewSlugs.filter { slug ->
+            clipPreviews?.peekState(slug) == ChatClipPreviewState.Ready(null)
+        }
+        if (latchedFailedClipMetadataSlugs.addAll(failed)) requestLayout()
     }
 
     private fun refreshClipPreviewAssets() {
         val nextKeys = boundRow?.clipPreviews.orEmpty().mapNotNull { link ->
             clipPreviews?.peek(link.slug)?.thumbnailUrl?.takeIf { it.isNotBlank() }?.let(::ChatAssetKey)
         }.toSet()
+        initialDirectAssetKeys = (initialDirectAssetKeys - clipPreviewAssetKeys) + nextKeys
         clipPreviewAssetKeys.filterNot(nextKeys::contains).forEach { assets.removeObserver(it, clipThumbnailInvalidator) }
         if (isAttachedToWindow && renderingActive) {
             nextKeys.filterNot(clipPreviewAssetKeys::contains).forEach { assets.observe(it, clipThumbnailInvalidator) }
@@ -315,12 +473,15 @@ open class ChatMessageTextView private constructor(
 
     private fun resolvedClipPreviews(): List<Pair<ChatClipPreviewLink, ChatClipPreview>> =
         boundRow?.clipPreviews.orEmpty().mapNotNull { link ->
+            if (link.slug in latchedFailedClipMetadataSlugs) return@mapNotNull null
             clipPreviews?.peek(link.slug)?.let { preview -> link to preview }
         }
 
     override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
         super.onMeasure(widthMeasureSpec, heightMeasureSpec)
-        val count = resolvedClipPreviews().size
+        // Reserve parsed clip-card geometry before metadata arrives. The row remains hidden until
+        // metadata and its thumbnail reach a terminal state, so metadata cannot reflow a visible row.
+        val count = boundRow?.clipPreviews?.count { it.slug !in latchedFailedClipMetadataSlugs } ?: 0
         if (count == 0) return
         val extra = count * clipPreviewBlockHeight() + count * clipPreviewGap()
         setMeasuredDimension(measuredWidth, measuredHeight + extra)
@@ -370,7 +531,8 @@ open class ChatMessageTextView private constructor(
             val spec = com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatAssetSpec(
                 ChatAssetKey(imageUrl), 16, 9, (thumbBottom - thumbTop).toInt(),
             )
-            drawableFor(ChatAssetKey(imageUrl), spec)?.let { drawable ->
+            val key = ChatAssetKey(imageUrl)
+            if (!isDirectAssetFailureLatched(key)) drawableFor(key, spec)?.let { drawable ->
                 drawable.setBounds(thumbLeft.toInt(), thumbTop.toInt(), thumbRight.toInt(), thumbBottom.toInt())
                 drawable.draw(canvas)
             }
@@ -588,7 +750,12 @@ open class ChatMessageTextView private constructor(
         val start = output.length
         appendStyled(output, piece.value + piece.separator, piece.color, piece.bold)
         piece.paint?.let { paintSpec ->
-            output.setSpan(ChatNamePaintSpan(paintSpec, assets), start, start + piece.value.length, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+            output.setSpan(
+                ChatNamePaintSpan(paintSpec, assets, ::isDirectAssetFailureLatched),
+                start,
+                start + piece.value.length,
+                Spanned.SPAN_EXCLUSIVE_EXCLUSIVE,
+            )
         }
     }
 
@@ -638,6 +805,7 @@ open class ChatMessageTextView private constructor(
         output: SpannableStringBuilder,
         spec: ChatAssetSpec,
         fallback: String,
+        fallbackMode: ChatAssetFallbackMode,
         interaction: ChatEmoteInteraction? = null,
         gifInteraction: ChatGifInteraction? = null,
     ) {
@@ -649,7 +817,8 @@ open class ChatMessageTextView private constructor(
                 spec,
                 fallback,
                 { drawableLayersFor(spec) },
-                { spec.flatten().all { assets.peek(it.key) is ChatAssetState.Ready } },
+                { assetRenderState(spec) },
+                fallbackMode,
             ),
             start,
             end,
@@ -715,8 +884,35 @@ open class ChatMessageTextView private constructor(
         keys = emptySet()
         clipPreviewSlugs = emptySet()
         clipPreviewAssetKeys = emptySet()
+        initialAssetSpecs = emptyList()
+        initialDirectAssetKeys = emptySet()
+        latchedFailedCompositionKeys.clear()
+        latchedFailedDirectKeys.clear()
+        latchedFailedClipMetadataSlugs.clear()
         text = null
+        boundMessageId = null
+        boundRow = null
+        awaitingInitialAssetFrame = false
+        revealOnPreDrawPosted = false
+        alpha = 1f
     }
+
+    private fun assetRenderState(spec: ChatAssetSpec): ChatAssetRenderState {
+        val flattened = spec.flatten()
+        if (spec.compositionKey in latchedFailedCompositionKeys) return ChatAssetRenderState.FAILED
+        val states = flattened.map { assets.peek(it.key) }
+        return when {
+            states.all { it is ChatAssetState.Ready } -> ChatAssetRenderState.READY
+            states.any {
+                it === ChatAssetState.Missing ||
+                    it === ChatAssetState.Loading ||
+                    it is ChatAssetState.Failed && !it.isPresentationTerminal
+            } -> ChatAssetRenderState.PENDING
+            else -> ChatAssetRenderState.FAILED
+        }
+    }
+
+    private fun isDirectAssetFailureLatched(key: ChatAssetKey): Boolean = key in latchedFailedDirectKeys
 
     /** Stops asset callbacks while the containing chat surface is hidden. */
     fun setRenderingActive(active: Boolean) {
@@ -726,6 +922,10 @@ open class ChatMessageTextView private constructor(
             if (isAttachedToWindow) keys.forEach { assets.observe(it, assetInvalidator) }
             if (isAttachedToWindow) clipPreviewSlugs.forEach { slug -> clipPreviews?.observe(slug, clipMetadataInvalidator) }
             if (isAttachedToWindow) clipPreviewAssetKeys.forEach { assets.observe(it, clipThumbnailInvalidator) }
+            if (isAttachedToWindow) {
+                refreshClipPreviewAssets()
+                maybeRevealInitialAssetFrame()
+            }
             if (isAttachedToWindow) {
                 drawables.values.forEach { drawable ->
                     drawable.callback = this
@@ -756,6 +956,8 @@ open class ChatMessageTextView private constructor(
             keys.forEach { assets.observe(it, assetInvalidator) }
             clipPreviewSlugs.forEach { slug -> clipPreviews?.observe(slug, clipMetadataInvalidator) }
             clipPreviewAssetKeys.forEach { assets.observe(it, clipThumbnailInvalidator) }
+            refreshClipPreviewAssets()
+            maybeRevealInitialAssetFrame()
             drawables.values.forEach { drawable ->
                 drawable.callback = this
                 if (animateGifs) drawable.startIfNeeded()
@@ -786,9 +988,21 @@ private fun ChatAssetSpec.flatten(): List<ChatAssetSpec> = buildList {
 
 private data class DrawableLayer(val spec: ChatAssetSpec, val drawable: Drawable)
 
+private enum class ChatAssetRenderState {
+    PENDING,
+    READY,
+    FAILED,
+}
+
+private enum class ChatAssetFallbackMode {
+    NONE,
+    TEXT_ON_FAILURE,
+}
+
 private class ChatNamePaintSpan(
     private val paintSpec: ChatNamePaint,
     private val assets: ChatAssetRepository,
+    private val isFailureLatched: (ChatAssetKey) -> Boolean,
 ) : CharacterStyle() {
     private var imageHandle: Any? = null
     private var imageShader: Shader? = null
@@ -797,7 +1011,12 @@ private class ChatNamePaintSpan(
         textPaint.clearShadowLayer()
         val imageUrl = paintSpec.imageUrl?.takeIf { it.isNotBlank() }
         if (imageUrl != null) {
-            val handle = (assets.peek(ChatAssetKey(imageUrl)) as? ChatAssetState.Ready)?.image
+            val key = ChatAssetKey(imageUrl)
+            val handle = if (isFailureLatched(key)) {
+                null
+            } else {
+                (assets.peek(key) as? ChatAssetState.Ready)?.image
+            }
             if (handle !== imageHandle) {
                 imageHandle = handle
                 imageShader = (handle?.newDrawable() as? BitmapDrawable)?.bitmap?.let { bitmap ->
@@ -857,7 +1076,8 @@ private class ChatAssetSpan(
     private val spec: ChatAssetSpec,
     private val fallback: String,
     private val drawables: () -> List<DrawableLayer>?,
-    private val isReady: () -> Boolean,
+    private val renderState: () -> ChatAssetRenderState,
+    private val fallbackMode: ChatAssetFallbackMode,
 ) : ReplacementSpan() {
     override fun getSize(paint: Paint, text: CharSequence, start: Int, end: Int, fm: Paint.FontMetricsInt?): Int {
         val height = spec.compositionHeight
@@ -873,10 +1093,44 @@ private class ChatAssetSpan(
                 fm.bottom = fm.descent
             }
         }
-        return if (isReady()) spec.compositionWidth else maxOf(spec.compositionWidth, fallbackWidth(paint))
+        return if (renderState() == ChatAssetRenderState.FAILED &&
+            fallbackMode == ChatAssetFallbackMode.TEXT_ON_FAILURE
+        ) {
+            maxOf(spec.compositionWidth, fallbackWidth(paint))
+        } else {
+            spec.compositionWidth
+        }
     }
 
     override fun draw(canvas: Canvas, text: CharSequence, start: Int, end: Int, x: Float, top: Int, y: Int, bottom: Int, paint: Paint) {
+        when (renderState()) {
+            ChatAssetRenderState.PENDING -> return
+            ChatAssetRenderState.FAILED if fallbackMode == ChatAssetFallbackMode.NONE -> return
+            ChatAssetRenderState.READY -> drawReady(canvas, x, top, bottom)
+            ChatAssetRenderState.FAILED -> drawFallback(canvas, x, top, bottom, paint)
+        }
+    }
+
+    private fun drawReady(canvas: Canvas, x: Float, top: Int, bottom: Int) {
+        val images = drawables() ?: return
+        val centerY = (top + bottom) / 2f
+        val rect = RectF(
+            x,
+            centerY - spec.compositionHeight / 2f,
+            x + spec.compositionWidth,
+            centerY + spec.compositionHeight / 2f,
+        )
+        images.forEach { layer ->
+            val width = layer.spec.computedWidth
+            val height = layer.spec.targetHeight
+            val left = rect.centerX() - width / 2f
+            val layerRect = RectF(left, rect.centerY() - height / 2f, left + width, rect.centerY() + height / 2f)
+            layer.drawable.setBounds(layerRect.left.toInt(), layerRect.top.toInt(), layerRect.right.toInt(), layerRect.bottom.toInt())
+            layer.drawable.draw(canvas)
+        }
+    }
+
+    private fun drawFallback(canvas: Canvas, x: Float, top: Int, bottom: Int, paint: Paint) {
         val oldColor = paint.color
         val oldStyle = paint.style
         val oldTextSize = paint.textSize
@@ -884,34 +1138,14 @@ private class ChatAssetSpan(
         val centerY = (top + bottom) / 2f
         val label = fallback.trim().ifEmpty { "?" }
         val fallbackPaint = fallbackPaint(paint)
-        val images = drawables()
-        val reservedWidth = if (images != null) {
-            spec.compositionWidth
-        } else {
-            maxOf(spec.compositionWidth, fallbackPaint.measureText(label).roundToInt())
-        }
+        val reservedWidth = maxOf(spec.compositionWidth, fallbackPaint.measureText(label).roundToInt())
         val rect = RectF(x, centerY - spec.compositionHeight / 2f, x + reservedWidth, centerY + spec.compositionHeight / 2f)
-        if (images != null) {
-            images.forEach { layer ->
-                val width = layer.spec.computedWidth
-                val height = layer.spec.targetHeight
-                val left = rect.centerX() - width / 2f
-                val layerRect = RectF(left, rect.centerY() - height / 2f, left + width, rect.centerY() + height / 2f)
-                layer.drawable.setBounds(layerRect.left.toInt(), layerRect.top.toInt(), layerRect.right.toInt(), layerRect.bottom.toInt())
-                layer.drawable.draw(canvas)
-            }
-        } else {
-            // Keep the original token readable while the image is loading or retrying. The
-            // Reserve enough room for the original token while the image is unavailable. A
-            // fake pill suggests that an image exists when it does not and was especially
-            // confusing for missing badge URLs.
-            paint.color = oldColor
-            paint.style = Paint.Style.FILL
-            paint.textAlign = Paint.Align.CENTER
-            paint.textSize = fallbackPaint.textSize
-            val baseline = rect.centerY() - (paint.ascent() + paint.descent()) / 2f
-            canvas.drawText(label, rect.centerX(), baseline, paint)
-        }
+        paint.color = oldColor
+        paint.style = Paint.Style.FILL
+        paint.textAlign = Paint.Align.CENTER
+        paint.textSize = fallbackPaint.textSize
+        val baseline = rect.centerY() - (paint.ascent() + paint.descent()) / 2f
+        canvas.drawText(label, rect.centerX(), baseline, paint)
         paint.color = oldColor
         paint.style = oldStyle
         paint.textSize = oldTextSize

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatV2RendererController.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatV2RendererController.kt
@@ -10,10 +10,14 @@ import com.github.andreyasadchy.xtra.ui.chat.v2.assets.ChatAssetRepository
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessageId
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessage
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatRewardCatalog
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.requiresInitialRewardMetadata
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatEmoteInteraction
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatGifInteraction
 import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatDecorationSnapshot
+import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatCatalogState
+import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.isReadyForChatPublication
 import com.github.andreyasadchy.xtra.ui.chat.v2.presentation.ChatColorResolver
+import com.github.andreyasadchy.xtra.ui.chat.v2.presentation.ChatPresentationSnapshot
 import com.github.andreyasadchy.xtra.ui.chat.v2.presentation.ChatPresentationResolver
 import com.github.andreyasadchy.xtra.ui.chat.v2.presentation.ChatRowCompiler
 import com.github.andreyasadchy.xtra.ui.chat.v2.presentation.ChatRowUiModel
@@ -92,6 +96,7 @@ class ChatV2RendererController(
     private val onMessageLongClick: (ChatMessage) -> Unit = {},
     private val profilePopoutGesture: ChatProfilePopoutGesture = ChatProfilePopoutGesture.HOLD,
     private val rewardCatalog: Flow<ChatRewardCatalog> = flowOf(ChatRewardCatalog()),
+    private val rewardCatalogSettled: Flow<Boolean> = flowOf(true),
     private val decorationCatalog: Flow<ChatDecorationSnapshot> = flowOf(ChatDecorationSnapshot()),
     private val onEmoteClick: (ChatEmoteInteraction) -> Unit = {},
     private val onGifClick: (ChatGifInteraction) -> Unit = {},
@@ -134,6 +139,7 @@ class ChatV2RendererController(
     private var previousTailId: ChatMessageId? = null
     private var latestRows: List<ChatRowUiModel> = emptyList()
     private var latestPublication: PresentationPublication? = null
+    private val presentationSnapshot = ChatPresentationSnapshot()
     private val rendererVisible = MutableStateFlow(true)
     private var translateAllMessages = translateAllMessages
     private val requestedTranslationIds = HashSet<ChatMessageId>()
@@ -204,6 +210,7 @@ class ChatV2RendererController(
         previousIds = null
         previousTailId = null
         currentKey = null
+        presentationSnapshot.clear()
         requestedTranslationIds.clear()
     }
 
@@ -296,8 +303,16 @@ class ChatV2RendererController(
     private suspend fun compileCurrent(publication: PresentationPublication): List<ChatRowUiModel> {
         while (true) {
             val compiler = presentation.snapshot()
+            val catalogs = presentationSnapshot.catalogsFor(
+                publication.key,
+                publication.messages,
+                publication.catalog,
+                captureBadges = renderStyle.showBadges,
+            )
             val rows = withContext(Dispatchers.Default) {
-                publication.messages.map { compiler.resolve(it, publication.catalog) }
+                publication.messages.zip(catalogs).map { (message, catalog) ->
+                    compiler.resolve(message, catalog)
+                }
             }
             if (presentation.isCurrent(compiler)) return rows
         }
@@ -351,9 +366,16 @@ class ChatV2RendererController(
             session.attachUi(),
             catalog.state,
             rewardCatalog,
+            rewardCatalogSettled,
             decorationCatalog,
-        ) { snapshot, catalogState, rewards, decorations ->
-            if (!catalogState.hydrated) {
+        ) { snapshot, catalogState, rewards, rewardsSettled, decorations ->
+            if (!isReadyForChatPublication(
+                    catalogState = catalogState,
+                    showBadges = renderStyle.showBadges,
+                    messages = snapshot.messages,
+                    rewardCatalogSettled = rewardsSettled,
+                )
+            ) {
                 null
             } else {
                 PresentationPublication(
@@ -379,3 +401,11 @@ class ChatV2RendererController(
         val catalog: com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatCatalogSnapshot,
     )
 }
+
+internal fun isReadyForChatPublication(
+    catalogState: ChatCatalogState,
+    showBadges: Boolean,
+    messages: List<ChatMessage>,
+    rewardCatalogSettled: Boolean,
+): Boolean = catalogState.isReadyForChatPublication(showBadges) &&
+    (rewardCatalogSettled || messages.none { it.requiresInitialRewardMetadata() })

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatCatalogRepositoryTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatCatalogRepositoryTest.kt
@@ -1,6 +1,7 @@
 package com.github.andreyasadchy.xtra.ui.chat.v2
 
 import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatCatalogCache
+import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatCatalogBadge
 import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatCatalogEmote
 import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatCatalogLoadResult
 import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatCatalogProviderUpdate
@@ -14,8 +15,14 @@ import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ExpiringSingleFlightCach
 import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ScopeUpdate
 import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ScopedEmoteCatalog
 import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatAssetProvider
+import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.isReadyForChatPublication
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatAssetKey
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatAssetSpec
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessage
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessageId
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessageKind
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatSegment
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatSessionKey
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
@@ -28,14 +35,427 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 import kotlinx.coroutines.awaitCancellation
+import com.github.andreyasadchy.xtra.ui.chat.v2.presentation.ChatPiece
+import com.github.andreyasadchy.xtra.ui.chat.v2.presentation.ChatPresentationSnapshot
+import com.github.andreyasadchy.xtra.ui.chat.v2.presentation.ChatRowCompiler
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
 
 class ChatCatalogRepositoryTest {
+    @Test
+    fun hydratedAloneDoesNotSettleInitialBadgeAttempt() = runBlocking {
+        val release = CompletableDeferred<Unit>()
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val repository = ChatCatalogRepository(
+            scope = scope,
+            source = ChatCatalogSource {
+                release.await()
+                ChatCatalogLoadResult(badges = ChatCatalogProviderUpdate(emptyMap()))
+            },
+        )
+
+        assertTrue(repository.state.value.hydrated)
+        assertFalse(repository.state.value.badgesSettled)
+        repository.refresh()
+        delay(20)
+        assertFalse(repository.state.value.badgesSettled)
+
+        release.complete(Unit)
+        withTimeout(1_000) { while (!repository.state.value.badgesSettled) delay(1) }
+        repository.close()
+        scope.cancel()
+    }
+
+    @Test
+    fun independentBadgeSettlementDoesNotWaitForUnrelatedProviders() = runBlocking {
+        val aggregateStarted = CompletableDeferred<Unit>()
+        val releaseUnrelatedProviders = CompletableDeferred<Unit>()
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val repository = ChatCatalogRepository(
+            scope = scope,
+            source = object : ChatCatalogSource {
+                override val hasIndependentBadgeProvider = true
+
+                override suspend fun loadBadges() = ChatCatalogProviderUpdate(emptyMap<String, ChatCatalogBadge>())
+
+                override suspend fun load(): ChatCatalogLoadResult {
+                    aggregateStarted.complete(Unit)
+                    releaseUnrelatedProviders.await()
+                    return ChatCatalogLoadResult(
+                        twitch = ChatCatalogProviderUpdate(emptyMap()),
+                        sevenTv = ChatCatalogProviderUpdate(emptyMap()),
+                        bttv = ChatCatalogProviderUpdate(emptyMap()),
+                        ffz = ChatCatalogProviderUpdate(emptyMap()),
+                        cheermotes = ChatCatalogProviderUpdate(emptyMap()),
+                    )
+                }
+            },
+        )
+
+        repository.refresh()
+        aggregateStarted.await()
+        withTimeout(1_000) {
+            while (!repository.state.value.badgesSettled) delay(1)
+        }
+        assertFalse(repository.state.value.structuralCatalogSettled)
+        assertFalse(repository.state.value.isReadyForChatPublication(showBadges = true))
+
+        releaseUnrelatedProviders.complete(Unit)
+        withTimeout(1_000) {
+            while (!repository.state.value.structuralCatalogSettled) delay(1)
+        }
+        assertTrue(repository.state.value.isReadyForChatPublication(showBadges = true))
+        repository.close()
+        scope.cancel()
+    }
+
+    @Test
+    fun initialThirdPartyAttemptCompletesBeforeFirstPublication() = runBlocking {
+        val aggregateStarted = CompletableDeferred<Unit>()
+        val releaseAggregate = CompletableDeferred<Unit>()
+        val omegalul = emote("OMEGALUL", ChatAssetProvider.SEVEN_TV)
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val repository = ChatCatalogRepository(
+            scope = scope,
+            source = object : ChatCatalogSource {
+                override val hasIndependentBadgeProvider = true
+
+                override suspend fun loadBadges() = ChatCatalogProviderUpdate(emptyMap<String, ChatCatalogBadge>())
+
+                override suspend fun load(): ChatCatalogLoadResult {
+                    aggregateStarted.complete(Unit)
+                    releaseAggregate.await()
+                    return ChatCatalogLoadResult(
+                        twitch = ChatCatalogProviderUpdate(emptyMap()),
+                        sevenTv = ChatCatalogProviderUpdate(mapOf(omegalul.name to omegalul)),
+                        bttv = ChatCatalogProviderUpdate(emptyMap()),
+                        ffz = ChatCatalogProviderUpdate(emptyMap()),
+                        cheermotes = ChatCatalogProviderUpdate(emptyMap()),
+                    )
+                }
+            },
+        )
+        repository.refresh()
+        aggregateStarted.await()
+        withTimeout(1_000) {
+            while (!repository.state.value.badgesSettled) delay(1)
+        }
+
+        assertFalse(repository.state.value.structuralCatalogSettled)
+        assertFalse(repository.state.value.isReadyForChatPublication(showBadges = true))
+
+        releaseAggregate.complete(Unit)
+        withTimeout(1_000) {
+            while (!repository.state.value.isReadyForChatPublication(showBadges = true)) delay(1)
+        }
+        val message = ChatMessage(
+            id = ChatMessageId("omegalul"),
+            channelId = "channel",
+            timestampMs = 1L,
+            user = null,
+            badges = emptyList(),
+            segments = listOf(ChatSegment.Text("OMEGALUL")),
+            kind = ChatMessageKind.CHAT,
+        )
+        val row = ChatRowCompiler().compile(
+            message,
+            ChatPresentationSnapshot().catalogsFor(
+                ChatSessionKey("channel", 1L),
+                listOf(message),
+                repository.state.value.snapshot,
+            ).single(),
+        )
+        assertTrue(row.pieces.any { it is ChatPiece.Emote })
+
+        repository.close()
+        scope.cancel()
+    }
+
+    @Test
+    fun successfulBadgesAreNotRestartedByAggregateRetries() = runBlocking {
+        val releaseFirstAggregate = CompletableDeferred<Unit>()
+        val secondAggregateStarted = CompletableDeferred<Unit>()
+        val badgeCalls = AtomicInteger()
+        val aggregateCalls = AtomicInteger()
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val repository = ChatCatalogRepository(
+            scope = scope,
+            source = object : ChatCatalogSource {
+                override val hasIndependentBadgeProvider = true
+
+                override suspend fun loadBadges(): ChatCatalogProviderUpdate<Map<String, ChatCatalogBadge>> {
+                    badgeCalls.incrementAndGet()
+                    return ChatCatalogProviderUpdate(emptyMap())
+                }
+
+                override suspend fun load(): ChatCatalogLoadResult {
+                    if (aggregateCalls.incrementAndGet() == 1) {
+                        releaseFirstAggregate.await()
+                    } else {
+                        secondAggregateStarted.complete(Unit)
+                        awaitCancellation()
+                    }
+                    return ChatCatalogLoadResult(twitch = ChatCatalogProviderUpdate(emptyMap()))
+                }
+            },
+            wait = { delay(1) },
+        )
+
+        repository.refresh()
+        withTimeout(1_000) {
+            while (!repository.state.value.badgesSettled) delay(1)
+        }
+        assertEquals(1, badgeCalls.get())
+
+        releaseFirstAggregate.complete(Unit)
+        secondAggregateStarted.await()
+        assertEquals(1, badgeCalls.get())
+
+        repository.close()
+        scope.cancel()
+    }
+
+    @Test
+    fun badgesOnlyCacheDoesNotSettleStructuralCatalog() = runBlocking {
+        val releaseNetwork = CompletableDeferred<Unit>()
+        val badge = ChatCatalogBadge(
+            name = "subscriber:1",
+            asset = ChatAssetSpec(ChatAssetKey("https://cdn.example.test/subscriber.png"), 18, 18, 18),
+            provider = ChatAssetProvider.TWITCH,
+            setId = "subscriber",
+            versionId = "1",
+        )
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val repository = ChatCatalogRepository(
+            scope = scope,
+            source = ChatCatalogSource {
+                releaseNetwork.await()
+                ChatCatalogLoadResult(
+                    twitch = ChatCatalogProviderUpdate(emptyMap()),
+                    sevenTv = ChatCatalogProviderUpdate(emptyMap()),
+                    bttv = ChatCatalogProviderUpdate(emptyMap()),
+                    ffz = ChatCatalogProviderUpdate(emptyMap()),
+                    cheermotes = ChatCatalogProviderUpdate(emptyMap()),
+                )
+            },
+            cache = object : ChatCatalogCache {
+                override suspend fun read() = ChatCatalogSnapshot(
+                    revision = 4,
+                    badges = mapOf("subscriber:1" to badge),
+                )
+
+                override suspend fun write(snapshot: ChatCatalogSnapshot) = Unit
+            },
+        )
+
+        repository.refresh()
+        withTimeout(1_000) {
+            while (!repository.state.value.hydrated || !repository.state.value.badgesSettled) delay(1)
+        }
+        assertTrue(repository.state.value.snapshot.badges.isNotEmpty())
+        assertFalse(repository.state.value.structuralCatalogSettled)
+        assertFalse(repository.state.value.isReadyForChatPublication(showBadges = true))
+
+        releaseNetwork.complete(Unit)
+        withTimeout(1_000) {
+            while (!repository.state.value.structuralCatalogSettled) delay(1)
+        }
+        assertTrue(repository.state.value.isReadyForChatPublication(showBadges = true))
+        repository.close()
+        scope.cancel()
+    }
+
+    @Test
+    fun badgeCacheWrittenBeforeAggregateCannotBypassNextColdStart() = runBlocking {
+        val badge = ChatCatalogBadge(
+            name = "subscriber:1",
+            asset = ChatAssetSpec(ChatAssetKey("https://cdn.example.test/subscriber.png"), 18, 18, 18),
+            provider = ChatAssetProvider.TWITCH,
+            setId = "subscriber",
+            versionId = "1",
+        )
+        val persisted = AtomicReference<ChatCatalogSnapshot?>()
+        val cache = object : ChatCatalogCache {
+            override suspend fun read(): ChatCatalogSnapshot? = persisted.get()
+
+            override suspend fun write(snapshot: ChatCatalogSnapshot) {
+                persisted.set(snapshot)
+            }
+        }
+        val firstAggregateRelease = CompletableDeferred<Unit>()
+        val firstScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val firstRepository = ChatCatalogRepository(
+            scope = firstScope,
+            source = object : ChatCatalogSource {
+                override val hasIndependentBadgeProvider = true
+
+                override suspend fun loadBadges() = ChatCatalogProviderUpdate(mapOf("subscriber:1" to badge))
+
+                override suspend fun load(): ChatCatalogLoadResult {
+                    firstAggregateRelease.await()
+                    return ChatCatalogLoadResult(
+                        twitch = ChatCatalogProviderUpdate(emptyMap()),
+                        sevenTv = ChatCatalogProviderUpdate(emptyMap()),
+                        bttv = ChatCatalogProviderUpdate(emptyMap()),
+                        ffz = ChatCatalogProviderUpdate(emptyMap()),
+                        cheermotes = ChatCatalogProviderUpdate(emptyMap()),
+                    )
+                }
+            },
+            cache = cache,
+        )
+        firstRepository.refresh()
+        withTimeout(1_000) {
+            while (persisted.get()?.badges.isNullOrEmpty()) delay(1)
+        }
+        assertFalse(firstRepository.state.value.structuralCatalogSettled)
+        firstRepository.close()
+        firstScope.cancel()
+
+        val secondAggregateRelease = CompletableDeferred<Unit>()
+        val secondScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val secondRepository = ChatCatalogRepository(
+            scope = secondScope,
+            source = object : ChatCatalogSource {
+                override val hasIndependentBadgeProvider = true
+
+                override suspend fun loadBadges() = ChatCatalogProviderUpdate(mapOf("subscriber:1" to badge))
+
+                override suspend fun load(): ChatCatalogLoadResult {
+                    secondAggregateRelease.await()
+                    return ChatCatalogLoadResult(
+                        twitch = ChatCatalogProviderUpdate(emptyMap()),
+                        sevenTv = ChatCatalogProviderUpdate(emptyMap()),
+                        bttv = ChatCatalogProviderUpdate(emptyMap()),
+                        ffz = ChatCatalogProviderUpdate(emptyMap()),
+                        cheermotes = ChatCatalogProviderUpdate(emptyMap()),
+                    )
+                }
+            },
+            cache = cache,
+        )
+        secondRepository.refresh()
+        withTimeout(1_000) {
+            while (!secondRepository.state.value.hydrated || !secondRepository.state.value.badgesSettled) delay(1)
+        }
+        assertFalse(secondRepository.state.value.structuralCatalogSettled)
+        assertFalse(secondRepository.state.value.isReadyForChatPublication(showBadges = true))
+
+        secondAggregateRelease.complete(Unit)
+        withTimeout(1_000) {
+            while (!secondRepository.state.value.structuralCatalogSettled) delay(1)
+        }
+        secondRepository.close()
+        secondScope.cancel()
+    }
+
+    @Test
+    fun successfulInitialCatalogAttemptSettlesBadges() = runBlocking {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val repository = ChatCatalogRepository(
+            scope = scope,
+            source = ChatCatalogSource {
+                ChatCatalogLoadResult(badges = ChatCatalogProviderUpdate(emptyMap()))
+            },
+        )
+
+        repository.refresh()
+        withTimeout(1_000) { while (!repository.state.value.badgesSettled) delay(1) }
+        assertTrue(repository.state.value.badgesSettled)
+        assertTrue(repository.state.value.structuralCatalogSettled)
+        repository.close()
+        scope.cancel()
+    }
+
+    @Test
+    fun failedInitialCatalogAttemptSettlesBadgesAndRetryKeepsItSettled() = runBlocking {
+        val retryStarted = CompletableDeferred<Unit>()
+        val releaseRetry = CompletableDeferred<Unit>()
+        val attempts = AtomicInteger()
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val repository = ChatCatalogRepository(
+            scope = scope,
+            source = ChatCatalogSource {
+                if (attempts.incrementAndGet() == 1) {
+                    throw IllegalStateException("catalog unavailable")
+                }
+                retryStarted.complete(Unit)
+                releaseRetry.await()
+                ChatCatalogLoadResult(badges = ChatCatalogProviderUpdate(emptyMap()))
+            },
+            wait = { delayMs ->
+                if (delayMs == 1_000L) retryStarted.complete(Unit)
+            },
+        )
+
+        repository.refresh()
+        withTimeout(1_000) { while (!repository.state.value.badgesSettled) delay(1) }
+        assertTrue(repository.state.value.badgesSettled)
+        assertTrue(repository.state.value.structuralCatalogSettled)
+        withTimeout(1_500) { retryStarted.await() }
+        assertTrue(repository.state.value.badgesSettled)
+
+        releaseRetry.complete(Unit)
+        repository.close()
+        scope.cancel()
+    }
+
+    @Test
+    fun failedInitialThirdPartyAttemptSettlesStructuralCatalog() = runBlocking {
+        val retryStarted = CompletableDeferred<Unit>()
+        val releaseRetry = CompletableDeferred<Unit>()
+        val attempts = AtomicInteger()
+        val recovered = emote("OMEGALUL", ChatAssetProvider.SEVEN_TV)
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val repository = ChatCatalogRepository(
+            scope = scope,
+            source = ChatCatalogSource {
+                if (attempts.incrementAndGet() == 1) {
+                    ChatCatalogLoadResult(
+                        twitch = ChatCatalogProviderUpdate(emptyMap()),
+                        badges = ChatCatalogProviderUpdate(emptyMap()),
+                    )
+                } else {
+                    retryStarted.complete(Unit)
+                    releaseRetry.await()
+                    ChatCatalogLoadResult(
+                        twitch = ChatCatalogProviderUpdate(emptyMap()),
+                        sevenTv = ChatCatalogProviderUpdate(mapOf(recovered.name to recovered)),
+                        bttv = ChatCatalogProviderUpdate(emptyMap()),
+                        ffz = ChatCatalogProviderUpdate(emptyMap()),
+                        cheermotes = ChatCatalogProviderUpdate(emptyMap()),
+                        badges = ChatCatalogProviderUpdate(emptyMap()),
+                    )
+                }
+            },
+            wait = { delayMs ->
+                if (delayMs == 1_000L) retryStarted.complete(Unit)
+            },
+        )
+
+        repository.refresh()
+        withTimeout(1_000) {
+            while (!repository.state.value.structuralCatalogSettled) delay(1)
+        }
+        assertTrue(repository.state.value.isReadyForChatPublication(showBadges = true))
+        withTimeout(1_000) { retryStarted.await() }
+        assertTrue(repository.state.value.structuralCatalogSettled)
+
+        releaseRetry.complete(Unit)
+        withTimeout(1_000) {
+            while (repository.state.value.snapshot.sevenTv[recovered.name] != recovered) delay(1)
+        }
+        assertTrue(repository.state.value.structuralCatalogSettled)
+
+        repository.close()
+        scope.cancel()
+    }
+
     @Test
     fun singleFlightCacheKeepsDifferentProviderKeysParallelAndJoinsDuplicates() = runBlocking {
         val cache = ExpiringSingleFlightCache<String>()
@@ -533,7 +953,7 @@ class ChatCatalogRepositoryTest {
     }
 
     @Test
-    fun pendingRefreshDoesNotDiscardCacheHydration() = runBlocking {
+    fun cachedThirdPartyCatalogHydratesBeforeStructuralSettlement() = runBlocking {
         val cacheReadStarted = CompletableDeferred<Unit>()
         val releaseCacheRead = CompletableDeferred<Unit>()
         val releaseNetwork = CompletableDeferred<Unit>()
@@ -573,8 +993,13 @@ class ChatCatalogRepositoryTest {
             while (repository.state.value.snapshot.revision != cached.revision) delay(1)
         }
         assertEquals(cached.sevenTv, repository.state.value.snapshot.sevenTv)
+        assertFalse(repository.state.value.structuralCatalogSettled)
 
         releaseNetwork.complete(Unit)
+        withTimeout(1_000) {
+            while (!repository.state.value.structuralCatalogSettled) delay(1)
+        }
+        assertTrue(repository.state.value.structuralCatalogSettled)
         repository.close()
         scope.cancel()
     }
@@ -620,7 +1045,98 @@ class ChatCatalogRepositoryTest {
         withTimeout(1_000) {
             while (repository.state.value.snapshot.bttv["cached"] != cachedBttv) delay(1)
         }
+        assertTrue(repository.state.value.structuralCatalogSettled)
         assertEquals(networkSevenTv, repository.state.value.snapshot.sevenTv["network"])
+
+        repository.close()
+        scope.cancel()
+    }
+
+    @Test
+    fun lateCacheHydrationPreservesSuccessfulStructuralSettlement() = runBlocking {
+        val cacheReadStarted = CompletableDeferred<Unit>()
+        val releaseCacheRead = CompletableDeferred<Unit>()
+        val cachedBttv = emote("cached-bttv", ChatAssetProvider.BTTV)
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val repository = ChatCatalogRepository(
+            scope = scope,
+            source = ChatCatalogSource {
+                ChatCatalogLoadResult(
+                    sevenTv = ChatCatalogProviderUpdate(emptyMap()),
+                    // Other providers remain eligible for the late cache merge.
+                )
+            },
+            cache = object : ChatCatalogCache {
+                override suspend fun read(): ChatCatalogSnapshot {
+                    cacheReadStarted.complete(Unit)
+                    releaseCacheRead.await()
+                    return ChatCatalogSnapshot(
+                        revision = 4,
+                        bttv = ScopedEmoteCatalog(global = mapOf("cached" to cachedBttv)),
+                    )
+                }
+
+                override suspend fun write(snapshot: ChatCatalogSnapshot) = Unit
+            },
+            wait = { awaitCancellation() },
+        )
+
+        cacheReadStarted.await()
+        repository.refresh()
+        withTimeout(1_000) {
+            while (!repository.state.value.structuralCatalogSettled) delay(1)
+        }
+        assertTrue(repository.state.value.structuralCatalogSettled)
+
+        releaseCacheRead.complete(Unit)
+        withTimeout(1_000) {
+            while (repository.state.value.snapshot.bttv["cached"] != cachedBttv) delay(1)
+        }
+        assertTrue(repository.state.value.structuralCatalogSettled)
+
+        repository.close()
+        scope.cancel()
+    }
+
+    @Test
+    fun lateCacheHydrationPreservesFailedFirstAttemptSettlement() = runBlocking {
+        val cacheReadStarted = CompletableDeferred<Unit>()
+        val releaseCacheRead = CompletableDeferred<Unit>()
+        val cachedBttv = emote("cached-bttv", ChatAssetProvider.BTTV)
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val repository = ChatCatalogRepository(
+            scope = scope,
+            source = ChatCatalogSource {
+                throw IllegalStateException("initial catalog failure")
+            },
+            cache = object : ChatCatalogCache {
+                override suspend fun read(): ChatCatalogSnapshot {
+                    cacheReadStarted.complete(Unit)
+                    releaseCacheRead.await()
+                    return ChatCatalogSnapshot(
+                        revision = 4,
+                        bttv = ScopedEmoteCatalog(global = mapOf("cached" to cachedBttv)),
+                    )
+                }
+
+                override suspend fun write(snapshot: ChatCatalogSnapshot) = Unit
+            },
+            wait = { awaitCancellation() },
+        )
+
+        cacheReadStarted.await()
+        repository.refresh()
+        withTimeout(1_000) {
+            while (!repository.state.value.structuralCatalogSettled) delay(1)
+        }
+        assertTrue(repository.state.value.structuralCatalogSettled)
+
+        releaseCacheRead.complete(Unit)
+        withTimeout(1_000) {
+            while (repository.state.value.snapshot.bttv["cached"] != cachedBttv) delay(1)
+        }
+        assertTrue(repository.state.value.structuralCatalogSettled)
+        assertTrue(repository.state.value.isReadyForChatPublication(showBadges = false))
 
         repository.close()
         scope.cancel()

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatDomainPresentationTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatDomainPresentationTest.kt
@@ -522,10 +522,22 @@ class ChatDomainPresentationTest {
         val message = message(ChatSegment.Emote(base, "Kappa", false)).copy(
             badges = listOf(ChatBadgeRef("subscriber", "1", "Subscriber")),
         )
+        val catalog = ChatCatalogSnapshot(
+            1,
+            badges = mapOf(
+                "subscriber:1" to ChatCatalogBadge(
+                    name = "subscriber:1",
+                    asset = ChatAssetSpec(ChatAssetKey("https://cdn.example.test/subscriber.png"), 18, 18, 18),
+                    provider = ChatAssetProvider.TWITCH,
+                    setId = "subscriber",
+                    versionId = "1",
+                ),
+            ),
+        )
         val resolver = ChatPresentationResolver(ChatRowCompiler(emoteHeightPx = 14, badgeHeightPx = 9))
-        val compact = resolver.resolve(message, ChatCatalogSnapshot(1))
+        val compact = resolver.resolve(message, catalog)
         resolver.replaceCompiler(ChatRowCompiler(emoteHeightPx = 56, badgeHeightPx = 36))
-        val large = resolver.resolve(message, ChatCatalogSnapshot(1))
+        val large = resolver.resolve(message, catalog)
 
         assertEquals(14, compact.pieces.filterIsInstance<ChatPiece.Emote>().single().asset.targetHeight)
         assertEquals(9, compact.pieces.filterIsInstance<ChatPiece.Badge>().single().asset.targetHeight)
@@ -589,13 +601,39 @@ class ChatDomainPresentationTest {
     }
 
     @Test
-    fun badgeIdentityAndGeometryExistBeforeBadgeCatalogLoads() {
+    fun twitchBadgesRequireResolvedHttpAssets() {
         val badge = ChatBadgeRef("subscriber", "12", "Subscriber")
-        val row = ChatPresentationResolver().resolve(message(ChatSegment.Text("hi")).copy(badges = listOf(badge)), ChatCatalogSnapshot(0))
-        val piece = row.pieces.filterIsInstance<ChatPiece.Badge>().single()
-        assertEquals("twitch-badge:subscriber:12", piece.asset.key.value)
+        val missing = ChatPresentationResolver().resolve(
+            message(ChatSegment.Text("hi")).copy(badges = listOf(badge)),
+            ChatCatalogSnapshot(0),
+        )
+        assertTrue(missing.pieces.none { it is ChatPiece.Badge })
+
+        val resolvedDefinition = ChatCatalogBadge(
+            name = "subscriber:12",
+            asset = ChatAssetSpec(ChatAssetKey("https://cdn.example.test/subscriber.png"), 18, 18, 18),
+            provider = ChatAssetProvider.TWITCH,
+            setId = "subscriber",
+            versionId = "12",
+            info = "Subscriber",
+        )
+        val resolved = ChatPresentationResolver().resolve(
+            message(ChatSegment.Text("hi")).copy(badges = listOf(badge)),
+            ChatCatalogSnapshot(1, badges = mapOf(badge.catalogKey to resolvedDefinition)),
+        )
+        val piece = resolved.pieces.filterIsInstance<ChatPiece.Badge>().single()
+        assertTrue(piece.asset.key.value.startsWith("https://"))
         assertEquals(18, piece.asset.targetHeight)
         assertEquals(ChatAssetProvider.TWITCH, piece.interaction?.provider)
+
+        val pseudo = resolvedDefinition.copy(
+            asset = resolvedDefinition.asset.copy(key = ChatAssetKey("twitch-badge:subscriber:12")),
+        )
+        val invalid = ChatPresentationResolver().resolve(
+            message(ChatSegment.Text("hi")).copy(badges = listOf(badge)),
+            ChatCatalogSnapshot(2, badges = mapOf(badge.catalogKey to pseudo)),
+        )
+        assertTrue(invalid.pieces.none { it is ChatPiece.Badge })
     }
 
     @Test

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatV2PublicationSemanticsTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatV2PublicationSemanticsTest.kt
@@ -3,11 +3,102 @@ package com.github.andreyasadchy.xtra.ui.chat.v2
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessage
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessageId
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessageKind
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatReward
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatAssetKey
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatAssetSpec
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatBadgeRef
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatSessionKey
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatUser
+import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatAssetProvider
+import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatCatalogBadge
+import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatCatalogEmote
+import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatCatalogSnapshot
+import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatCatalogState
+import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatNamePaint
+import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatUserDecoration
+import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ScopedEmoteCatalog
+import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.isReadyForChatPublication
+import com.github.andreyasadchy.xtra.ui.chat.v2.presentation.ChatPresentationSnapshot
+import com.github.andreyasadchy.xtra.ui.chat.v2.presentation.ChatPiece
+import com.github.andreyasadchy.xtra.ui.chat.v2.presentation.ChatRowCompiler
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatSegment
 import com.github.andreyasadchy.xtra.ui.chat.v2.ui.countNewLiveMessages
+import com.github.andreyasadchy.xtra.ui.chat.v2.ui.isReadyForChatPublication as isPresentationReady
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class ChatV2PublicationSemanticsTest {
+    @Test
+    fun badgeSettlementGatesOnlyBadgeEnabledPublication() {
+        val unsettled = ChatCatalogState(
+            ChatCatalogSnapshot(0),
+            hydrated = true,
+            badgesSettled = false,
+            structuralCatalogSettled = false,
+        )
+        val structural = unsettled.copy(structuralCatalogSettled = true)
+        val settled = structural.copy(badgesSettled = true)
+
+        assertEquals(false, unsettled.isReadyForChatPublication(showBadges = true))
+        assertEquals(false, structural.isReadyForChatPublication(showBadges = true))
+        assertEquals(true, settled.isReadyForChatPublication(showBadges = true))
+        assertEquals(false, unsettled.isReadyForChatPublication(showBadges = false))
+        assertEquals(true, structural.isReadyForChatPublication(showBadges = false))
+    }
+
+    @Test
+    fun rewardMessageWaitsForInitialRewardMetadata() {
+        val state = ChatCatalogState(
+            snapshot = ChatCatalogSnapshot(0),
+            hydrated = true,
+            badgesSettled = true,
+            structuralCatalogSettled = true,
+        )
+        val rewardMessage = message("reward", 1L).copy(rewardId = "reward-id")
+        val ordinaryMessage = message("ordinary", 2L)
+
+        assertEquals(
+            false,
+            isPresentationReady(state, showBadges = true, messages = listOf(rewardMessage), rewardCatalogSettled = false),
+        )
+        assertEquals(
+            true,
+            isPresentationReady(state, showBadges = true, messages = listOf(rewardMessage), rewardCatalogSettled = true),
+        )
+        assertEquals(
+            true,
+            isPresentationReady(state, showBadges = true, messages = listOf(ordinaryMessage), rewardCatalogSettled = false),
+        )
+
+        val resolvedCatalog = state.snapshot.copy(
+            channelPointRewards = mapOf(
+                "reward-id" to ChatReward("Super Reward", cost = 1_000, imageUrl = "https://cdn.example/reward.png"),
+            ),
+        )
+        val resolvedRow = ChatRowCompiler().compile(rewardMessage, resolvedCatalog)
+        assertTrue(resolvedRow.pieces.any { it is ChatPiece.RewardIcon })
+    }
+
+    @Test
+    fun failedInitialRewardLoadDoesNotBlockForever() {
+        val state = ChatCatalogState(
+            snapshot = ChatCatalogSnapshot(0),
+            hydrated = true,
+            badgesSettled = true,
+            structuralCatalogSettled = true,
+        )
+        val rewardMessage = message("reward", 1L).copy(rewardId = "missing-reward")
+
+        assertEquals(
+            true,
+            isPresentationReady(state, showBadges = true, messages = listOf(rewardMessage), rewardCatalogSettled = true),
+        )
+        val row = ChatRowCompiler().compile(rewardMessage, ChatCatalogSnapshot(0))
+        assertTrue(row.pieces.none { it is ChatPiece.RewardIcon })
+        assertTrue(row.pieces.any { it is ChatPiece.Text })
+    }
+
     @Test
     fun recoveredOlderHistoryDoesNotCountAsNewLiveMessages() {
         val visible = (100..200).map(::message)
@@ -53,6 +144,187 @@ class ChatV2PublicationSemanticsTest {
         )
     }
 
+    @Test
+    fun recoveredBadgesDoNotRetrofitAlreadyPublishedMessages() {
+        val session = ChatSessionKey("channel", 1L)
+        val badge = ChatBadgeRef("subscriber", "1")
+        val first = message("first", 1L, badge)
+        val second = message("second", 2L, badge)
+        val compiler = ChatRowCompiler()
+        val presentation = ChatPresentationSnapshot()
+        val failedCatalog = ChatCatalogSnapshot(revision = 1)
+        val recoveredCatalog = failedCatalog.copy(
+            revision = 2,
+            badges = mapOf(
+                badge.catalogKey to ChatCatalogBadge(
+                    name = "subscriber",
+                    asset = ChatAssetSpec(ChatAssetKey("https://cdn.example/subscriber.png"), 18, 18, 18),
+                    provider = ChatAssetProvider.TWITCH,
+                    setId = badge.setId,
+                    versionId = badge.versionId,
+                ),
+            ),
+        )
+
+        val firstRow = compiler.compile(first, presentation.catalogsFor(session, listOf(first), failedCatalog).single())
+        val existingRowAfterRecovery = compiler.compile(
+            first,
+            presentation.catalogsFor(session, listOf(first), recoveredCatalog).single(),
+        )
+        val newRowAfterRecovery = compiler.compile(
+            second,
+            presentation.catalogsFor(session, listOf(first, second), recoveredCatalog).last(),
+        )
+
+        assertTrue(firstRow.pieces.none { it is ChatPiece.Badge })
+        assertEquals(firstRow, existingRowAfterRecovery)
+        assertTrue(newRowAfterRecovery.pieces.any { it is ChatPiece.Badge })
+    }
+
+    @Test
+    fun thirdPartyCatalogRecoveryDoesNotRetrofitExistingMessage() {
+        val session = ChatSessionKey("channel", 2L)
+        val first = message("first", 1L).copy(segments = listOf(ChatSegment.Text("OMEGALUL")))
+        val second = message("second", 2L).copy(segments = listOf(ChatSegment.Text("OMEGALUL")))
+        val emote = ChatCatalogEmote(
+            name = "OMEGALUL",
+            asset = ChatAssetSpec(ChatAssetKey("https://cdn.example/omegalul.png"), 28, 28, 28),
+            provider = ChatAssetProvider.SEVEN_TV,
+            animated = false,
+        )
+        val emptyCatalog = ChatCatalogSnapshot(revision = 1)
+        val recoveredCatalog = emptyCatalog.copy(
+            revision = 2,
+            sevenTv = ScopedEmoteCatalog(global = mapOf(emote.name to emote)),
+        )
+        val compiler = ChatRowCompiler()
+        val presentation = ChatPresentationSnapshot()
+
+        val firstRow = compiler.compile(
+            first,
+            presentation.catalogsFor(session, listOf(first), emptyCatalog).single(),
+        )
+        val existingRowAfterRecovery = compiler.compile(
+            first,
+            presentation.catalogsFor(session, listOf(first), recoveredCatalog).single(),
+        )
+        val newRowAfterRecovery = compiler.compile(
+            second,
+            presentation.catalogsFor(session, listOf(first, second), recoveredCatalog).last(),
+        )
+
+        assertTrue(firstRow.pieces.none { it is ChatPiece.Emote })
+        assertEquals(firstRow, existingRowAfterRecovery)
+        assertTrue(newRowAfterRecovery.pieces.any { it is ChatPiece.Emote })
+    }
+
+    @Test
+    fun lateSevenTvBadgeDoesNotRetrofitExistingMessage() {
+        val session = ChatSessionKey("channel", 3L)
+        val user = ChatUser("user", "user", "User", null)
+        val first = message("first", 1L).copy(user = user)
+        val second = message("second", 2L).copy(user = user)
+        val badge = ChatCatalogBadge(
+            name = "late-badge",
+            asset = ChatAssetSpec(ChatAssetKey("https://cdn.example/late-badge.png"), 18, 18, 18),
+            provider = ChatAssetProvider.SEVEN_TV,
+            setId = "late-badge",
+            versionId = "1",
+        )
+        val emptyCatalog = ChatCatalogSnapshot(revision = 1)
+        val recoveredCatalog = emptyCatalog.copy(
+            revision = 2,
+            userDecorations = mapOf(user.id!! to ChatUserDecoration(badgeId = "late-badge")),
+            sevenTvBadges = mapOf("late-badge" to badge),
+        )
+        val compiler = ChatRowCompiler()
+        val presentation = ChatPresentationSnapshot()
+
+        val firstRow = compiler.compile(
+            first,
+            presentation.catalogsFor(session, listOf(first), emptyCatalog).single(),
+        )
+        val existingRowAfterRecovery = compiler.compile(
+            first,
+            presentation.catalogsFor(session, listOf(first), recoveredCatalog).single(),
+        )
+        val newRowAfterRecovery = compiler.compile(
+            second,
+            presentation.catalogsFor(session, listOf(first, second), recoveredCatalog).last(),
+        )
+
+        assertTrue(firstRow.pieces.none { it is ChatPiece.Badge })
+        assertEquals(firstRow, existingRowAfterRecovery)
+        assertTrue(newRowAfterRecovery.pieces.any { it is ChatPiece.Badge })
+    }
+
+    @Test
+    fun lateNamePaintDoesNotRetrofitExistingMessage() {
+        val session = ChatSessionKey("channel", 4L)
+        val user = ChatUser("user", "user", "User", null)
+        val first = message("first", 1L).copy(user = user)
+        val second = message("second", 2L).copy(user = user)
+        val paint = ChatNamePaint(colors = listOf(0xffff00ff.toInt(), 0xff9146ff.toInt()))
+        val emptyCatalog = ChatCatalogSnapshot(revision = 1)
+        val recoveredCatalog = emptyCatalog.copy(
+            revision = 2,
+            userDecorations = mapOf(user.id!! to ChatUserDecoration(paintId = "late-paint")),
+            namePaints = mapOf("late-paint" to paint),
+        )
+        val compiler = ChatRowCompiler()
+        val presentation = ChatPresentationSnapshot()
+
+        val firstUsername = compiler.compile(
+            first,
+            presentation.catalogsFor(session, listOf(first), emptyCatalog).single(),
+        ).pieces.filterIsInstance<ChatPiece.Username>().single()
+        val existingUsernameAfterRecovery = compiler.compile(
+            first,
+            presentation.catalogsFor(session, listOf(first), recoveredCatalog).single(),
+        ).pieces.filterIsInstance<ChatPiece.Username>().single()
+        val newUsernameAfterRecovery = compiler.compile(
+            second,
+            presentation.catalogsFor(session, listOf(first, second), recoveredCatalog).last(),
+        ).pieces.filterIsInstance<ChatPiece.Username>().single()
+
+        assertEquals(null, firstUsername.paint)
+        assertEquals(firstUsername, existingUsernameAfterRecovery)
+        assertEquals(paint, newUsernameAfterRecovery.paint)
+    }
+
+    @Test
+    fun badgesDisabledAtColdStartCanBeEnabledLater() {
+        val session = ChatSessionKey("channel", 5L)
+        val badge = ChatBadgeRef("subscriber", "1")
+        val message = message("first", 1L, badge)
+        val emptyCatalog = ChatCatalogSnapshot(revision = 1)
+        val recoveredCatalog = emptyCatalog.copy(
+            revision = 2,
+            badges = mapOf(
+                badge.catalogKey to ChatCatalogBadge(
+                    name = "subscriber",
+                    asset = ChatAssetSpec(ChatAssetKey("https://cdn.example/subscriber.png"), 18, 18, 18),
+                    provider = ChatAssetProvider.TWITCH,
+                    setId = badge.setId,
+                    versionId = badge.versionId,
+                ),
+            ),
+        )
+        val presentation = ChatPresentationSnapshot()
+
+        val disabledRow = ChatRowCompiler(showBadges = false).compile(
+            message,
+            presentation.catalogsFor(session, listOf(message), emptyCatalog, captureBadges = false).single(),
+        )
+        val enabledRow = ChatRowCompiler(showBadges = true).compile(
+            message,
+            presentation.catalogsFor(session, listOf(message), recoveredCatalog, captureBadges = true).single(),
+        )
+
+        assertTrue(disabledRow.pieces.none { it is ChatPiece.Badge })
+        assertTrue(enabledRow.pieces.any { it is ChatPiece.Badge })
+    }
+
     private fun message(index: Int) = ChatMessage(
         id = ChatMessageId(index.toString()),
         channelId = "channel",
@@ -69,6 +341,16 @@ class ChatV2PublicationSemanticsTest {
         timestampMs = timestampMs,
         user = null,
         badges = emptyList(),
+        segments = emptyList(),
+        kind = ChatMessageKind.CHAT,
+    )
+
+    private fun message(id: String, timestampMs: Long, badge: ChatBadgeRef) = ChatMessage(
+        id = ChatMessageId(id),
+        channelId = "channel",
+        timestampMs = timestampMs,
+        user = ChatUser("user-$id", id, id, null),
+        badges = listOf(badge),
         segments = emptyList(),
         kind = ChatMessageKind.CHAT,
     )


### PR DESCRIPTION
Fix chat-v2's first visible frame.

The visual fallback and reflow regression came from c18536b, which made pending assets render fallback text and widened spans until images arrived. Twitch badge names could therefore appear before usernames.

The renderer also had a catalog-hydration race: hydrated did not mean the Twitch badge provider had finished, so cold startup could publish rows with unresolved pseudo badge assets while unrelated providers were still loading. Badge settlement is independent. The first structural catalog attempt now settles separately from badge loading, and reward-dependent messages wait for the first reward metadata result. Each published message freezes every structural catalog input, so provider recovery can improve new messages without retrofitting existing rows.

This adds a first-visible-frame invariant. Rows stay transparent until initially required assets are terminal. Pending assets keep final geometry and draw nothing. Failed decorative assets are omitted, while failed semantic emotes and GIFs use text only after failure is known. Retryable failures remain pending, revealed failures are latched, same-message rebinds retain in-flight loads, and clip rows reserve their parsed geometry before reveal.

Validation:
- :app:testDebugUnitTest
- :app:connectedDebugAndroidTest with ChatMessageTextViewTest (27 cases on xtra-phone-api35)
- :app:assembleRelease with the CI placeholder client ID
- CodeQL Java/Kotlin and Actions analysis were green before this follow-up
- xtra-phone-api35 cold-cache live-chat smoke and 10-second screen recording, with visible badge/emote imagery and no badge-name fallback text


The structural baseline is session-scoped. Disk cache hydration can provide badge and catalog maps immediately, but only the current aggregate provider attempt can settle structural publication, so a badge-only cache cannot freeze an incomplete first batch.
