### PR TITLE
Fix CLEARCHAT moderation notices

### DIFF
--- a/.github/scripts/check-resources.py
+++ b/.github/scripts/check-resources.py
@@ -156,6 +156,9 @@ INTENTIONAL_FALLBACK_RESOURCES = {
     # translations are reviewed by native speakers.
     "chat_clip_playing",
     "chat_clip_clipped_by",
+    # User-targeted moderation notices use the default English wording until
+    # translations are reviewed by native speakers.
+    "chat_clear_user",
     # Prediction result display settings ship with the default English resources
     # until their translations are reviewed by native speakers.
     "prediction_result_duration",

--- a/app/src/main/java/com/github/andreyasadchy/xtra/XtraModule.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/XtraModule.kt
@@ -758,6 +758,16 @@ class XtraModule(application: Application) {
                         joinedMessage = appContext.getString(R.string.chat_join).format(spec.channelLogin),
                         messageDeletedMessage = appContext.getString(R.string.chat_message_deleted),
                         chatClearedMessage = appContext.getString(R.string.chat_clear),
+                        chatTimeoutMessage = { login, seconds ->
+                            appContext.getString(R.string.chat_timeout).format(
+                                login,
+                                TwitchApiHelper.getDurationFromSeconds(appContext, seconds.toString()).orEmpty(),
+                            )
+                        },
+                        chatBanMessage = { login -> appContext.getString(R.string.chat_ban).format(login) },
+                        chatUserMessagesClearedMessage = { login ->
+                            appContext.getString(R.string.chat_clear_user).format(login)
+                        },
                     ),
                     trustManager = trustManager,
                     createSubscription = { headers, userId, type, sessionId ->

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatViewModel.kt
@@ -3995,7 +3995,7 @@ class ChatViewModel(
             }
         }
 
-        override suspend fun onClearChat(event: JSONObject, timestamp: String?) {
+        override suspend fun onClearChat(event: JSONObject, timestamp: String?, notificationId: String?) {
             if (showClearChat) {
                 onMessage(EventSubUtils.parseClearChat(applicationContext, event, timestamp))
             }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/domain/ChatEvent.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/domain/ChatEvent.kt
@@ -2,6 +2,12 @@ package com.github.andreyasadchy.xtra.ui.chat.v2.domain
 
 import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatDecorationUpdate
 
+enum class ChatUserClearReason {
+    TIMEOUT,
+    BAN,
+    MESSAGES_CLEARED,
+}
+
 sealed interface ChatEvent {
     val eventId: String?
     val receivedAtMs: Long
@@ -12,7 +18,15 @@ sealed interface ChatEvent {
         override val receivedAtMs: Long = System.currentTimeMillis(),
     ) : ChatEvent
     data class Delete(val messageId: ChatMessageId, override val eventId: String?, override val receivedAtMs: Long) : ChatEvent
-    data class ClearUser(val userId: String, override val eventId: String?, override val receivedAtMs: Long) : ChatEvent
+    data class ClearUser(
+        val userId: String?,
+        override val eventId: String?,
+        override val receivedAtMs: Long,
+        val userLogin: String? = null,
+        val userName: String? = null,
+        val reason: ChatUserClearReason = ChatUserClearReason.MESSAGES_CLEARED,
+        val timeoutSeconds: Int? = null,
+    ) : ChatEvent
     data class Clear(override val eventId: String?, override val receivedAtMs: Long) : ChatEvent
     data class SettingsUpdated(
         val channelId: String,

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/session/ChatTimelineStore.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/session/ChatTimelineStore.kt
@@ -16,7 +16,6 @@ sealed interface TimelineOperation {
     data class Append(val items: List<ChatMessage>) : TimelineOperation
     data class Prepend(val items: List<ChatMessage>) : TimelineOperation
     data class Delete(val id: ChatMessageId, val atMs: Long) : TimelineOperation
-    data class ClearUser(val userId: String, val atMs: Long) : TimelineOperation
     data class Clear(val atMs: Long) : TimelineOperation
     data class Replace(val items: List<ChatMessage>) : TimelineOperation
     class RequestSnapshot(val result: CompletableDeferred<List<ChatMessage>>) : TimelineOperation
@@ -42,7 +41,6 @@ class ChatTimelineStore(
             // These tombstones belong to the active generation. Replace(emptyList()) is the
             // processor's generation boundary and resets them before a new channel is accepted.
             val deletedMessageIds = LinkedHashSet<ChatMessageId>(MODERATION_TOMBSTONE_LIMIT)
-            val clearedUsersAt = LinkedHashMap<String, Long>(MODERATION_TOMBSTONE_LIMIT, 0.75f, true)
             var globallyClearedAt: Long? = null
             for (operation in operations) {
                 when (operation) {
@@ -55,31 +53,19 @@ class ChatTimelineStore(
                         continue
                     }
                     is TimelineOperation.Append -> operation.items.forEach { item ->
-                        if (isSuppressed(item, deletedMessageIds, clearedUsersAt, globallyClearedAt)) continue
+                        if (isSuppressed(item, deletedMessageIds, globallyClearedAt)) continue
                         if (isDuplicateReward(item, items)) continue
                         if (ids.add(item.id)) items.addLast(item)
                     }
                     is TimelineOperation.Prepend -> operation.items.asReversed().forEach { item ->
-                        if (isSuppressed(item, deletedMessageIds, clearedUsersAt, globallyClearedAt)) continue
+                        if (isSuppressed(item, deletedMessageIds, globallyClearedAt)) continue
                         if (isDuplicateReward(item, items)) continue
                         if (ids.add(item.id)) items.addFirst(item)
                     }
                     is TimelineOperation.Delete -> {
                         deletedMessageIds.add(operation.id)
-                        trimModerationTombstones(deletedMessageIds, clearedUsersAt)
+                        trimModerationTombstones(deletedMessageIds)
                         if (ids.remove(operation.id)) items.removeIf { it.id == operation.id }
-                    }
-                    is TimelineOperation.ClearUser -> {
-                        val previous = clearedUsersAt[operation.userId]
-                        if (previous == null || operation.atMs > previous) {
-                            clearedUsersAt[operation.userId] = operation.atMs
-                        }
-                        trimModerationTombstones(deletedMessageIds, clearedUsersAt)
-                        items.removeIf { item ->
-                            val removed = item.user?.id == operation.userId
-                            if (removed) ids.remove(item.id)
-                            removed
-                        }
                     }
                     is TimelineOperation.Clear -> {
                         val previous = globallyClearedAt
@@ -91,13 +77,12 @@ class ChatTimelineStore(
                     is TimelineOperation.Replace -> {
                         items.clear(); ids.clear()
                         deletedMessageIds.clear()
-                        clearedUsersAt.clear()
                         globallyClearedAt = null
                         operation.items.takeLast(maxSize).forEach { if (ids.add(it.id)) items.addLast(it) }
                     }
                     is TimelineOperation.Reconcile -> {
                         val merged = (items.toList() + operation.recent.filterNot {
-                            isSuppressed(it, deletedMessageIds, clearedUsersAt, globallyClearedAt)
+                            isSuppressed(it, deletedMessageIds, globallyClearedAt)
                         })
                             .distinctBy { it.id }
                             .sortedBy { it.timestampMs }
@@ -117,13 +102,11 @@ class ChatTimelineStore(
     private fun isSuppressed(
         message: ChatMessage,
         deletedMessageIds: Set<ChatMessageId>,
-        clearedUsersAt: Map<String, Long>,
         globallyClearedAt: Long?,
     ): Boolean {
         if (message.id in deletedMessageIds) return true
         if (globallyClearedAt?.let { message.timestampMs <= it } == true) return true
-        val userId = message.user?.id ?: return false
-        return clearedUsersAt[userId]?.let { message.timestampMs <= it } == true
+        return false
     }
 
     /** Hermes and chat.message can describe the same redemption without sharing an ID. */
@@ -149,13 +132,9 @@ class ChatTimelineStore(
 
     private fun trimModerationTombstones(
         deletedMessageIds: LinkedHashSet<ChatMessageId>,
-        clearedUsersAt: LinkedHashMap<String, Long>,
     ) {
         while (deletedMessageIds.size > MODERATION_TOMBSTONE_LIMIT) {
             deletedMessageIds.remove(deletedMessageIds.first())
-        }
-        while (clearedUsersAt.size > MODERATION_TOMBSTONE_LIMIT) {
-            clearedUsersAt.remove(clearedUsersAt.entries.iterator().next().key)
         }
     }
 
@@ -183,11 +162,14 @@ class ChatTimelineStore(
             is ChatEvent.Message -> apply(TimelineOperation.Append(listOf(event.message)))
             is ChatEvent.Notice -> apply(TimelineOperation.Append(listOf(event.message)))
             is ChatEvent.Delete -> apply(TimelineOperation.Delete(event.messageId, event.receivedAtMs))
-            is ChatEvent.ClearUser -> apply(TimelineOperation.ClearUser(event.userId, event.receivedAtMs))
+            // Legacy Xtra keeps a user's existing messages visible after moderation. The
+            // transport emits the notice separately; user clears do not mutate this timeline.
+            is ChatEvent.ClearUser -> Unit
             is ChatEvent.Clear -> apply(TimelineOperation.Clear(event.receivedAtMs))
             is ChatEvent.SettingsUpdated -> Unit
             is ChatEvent.DecorationUpdated -> Unit
             is ChatEvent.TransportDisconnected -> Unit
         }
     }
+
 }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/transport/TwitchChatEventParser.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/transport/TwitchChatEventParser.kt
@@ -13,6 +13,7 @@ import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessageId
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessageKind
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatReply
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatSegment
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatUserClearReason
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatUser
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.SharedChatSource
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.TwitchChatMessageType
@@ -53,9 +54,18 @@ object TwitchChatEventParser {
             receivedAtMs = timestamp(message.tags["tmi-sent-ts"]),
         )
         "CLEARCHAT" -> {
-            val userId = message.tags["target-user-id"]
-            if (!userId.isNullOrBlank()) {
-                ChatEvent.ClearUser(userId, message.tags["target-user-id"], timestamp(message.tags["tmi-sent-ts"]))
+            val userId = message.tags["target-user-id"]?.takeIf { it.isNotBlank() }
+            val userLogin = message.params.getOrNull(1)?.takeIf { it.isNotBlank() }
+            if (userId != null || userLogin != null) {
+                val timeoutSeconds = message.tags["ban-duration"]?.toIntOrNull()?.takeIf { it > 0 }
+                ChatEvent.ClearUser(
+                    userId = userId,
+                    eventId = message.tags["tmi-sent-ts"] ?: userLogin,
+                    receivedAtMs = timestamp(message.tags["tmi-sent-ts"]),
+                    userLogin = userLogin,
+                    reason = if (timeoutSeconds != null) ChatUserClearReason.TIMEOUT else ChatUserClearReason.BAN,
+                    timeoutSeconds = timeoutSeconds,
+                )
             } else {
                 ChatEvent.Clear(message.tags["id"], timestamp(message.tags["tmi-sent-ts"]))
             }
@@ -144,14 +154,23 @@ object TwitchChatEventParser {
         )
     }
 
-    fun fromEventSubClear(event: JSONObject, timestamp: String?): ChatEvent {
+    fun fromEventSubClear(event: JSONObject, timestamp: String?, notificationId: String? = null): ChatEvent {
         val receivedAt = parseTimestamp(timestamp)
+        val eventId = notificationId?.takeIf { it.isNotBlank() }
         val messageId = event.optString("message_id").takeIf { it.isNotBlank() }
         val userId = event.optString("target_user_id").takeIf { it.isNotBlank() }
+        val userLogin = event.optString("target_user_login").takeIf { it.isNotBlank() }
+        val userName = event.optString("target_user_name").takeIf { it.isNotBlank() }
         return when {
             messageId != null -> ChatEvent.Delete(ChatMessageId(messageId), messageId, receivedAt)
-            userId != null -> ChatEvent.ClearUser(userId, userId, receivedAt)
-            else -> ChatEvent.Clear(null, receivedAt)
+            userId != null || userLogin != null -> ChatEvent.ClearUser(
+                userId = userId,
+                eventId = eventId ?: "${userId ?: userLogin}-$receivedAt",
+                receivedAtMs = receivedAt,
+                userLogin = userLogin,
+                userName = userName,
+            )
+            else -> ChatEvent.Clear(eventId, receivedAt)
         }
     }
 

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/transport/TwitchChatTransport.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/transport/TwitchChatTransport.kt
@@ -5,6 +5,7 @@ import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessage
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessageId
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessageKind
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatSessionKey
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatUserClearReason
 import com.github.andreyasadchy.xtra.util.chat.ChatReadWebSocket
 import com.github.andreyasadchy.xtra.util.chat.ChatUtils
 import com.github.andreyasadchy.xtra.util.chat.EventSubWebSocket
@@ -64,6 +65,9 @@ data class TwitchChatTransportConfig(
     val joinedMessage: String? = null,
     val messageDeletedMessage: String? = null,
     val chatClearedMessage: String? = null,
+    val chatTimeoutMessage: ((String, Int) -> String)? = null,
+    val chatBanMessage: ((String) -> String)? = null,
+    val chatUserMessagesClearedMessage: ((String) -> String)? = null,
 )
 
 /**
@@ -121,10 +125,7 @@ class TwitchChatTransport(
                 override suspend fun onClearChat(message: ChatUtils.IRCMessage) {
                     TwitchChatEventParser.fromIrc(message, config.channelId)?.let { event ->
                         send(event)
-                        if (config.showClearChat) {
-                            val eventKey = message.tags["tmi-sent-ts"] ?: System.nanoTime().toString()
-                            systemMessage(session, "clear-$eventKey", config.chatClearedMessage)?.let { flowScope.send(it) }
-                        }
+                        moderationSystemMessage(session, event)?.let { flowScope.send(it) }
                     }
                 }
 
@@ -193,20 +194,16 @@ class TwitchChatTransport(
                     flowScope.send(TwitchChatEventParser.fromEventSub(event, timestamp, notice = true))
                 }
 
-                override suspend fun onClearChat(event: org.json.JSONObject, timestamp: String?) {
-                    val clearEvent = TwitchChatEventParser.fromEventSubClear(event, timestamp)
+                override suspend fun onClearChat(event: org.json.JSONObject, timestamp: String?, notificationId: String?) {
+                    val clearEvent = TwitchChatEventParser.fromEventSubClear(event, timestamp, notificationId)
                     flowScope.send(clearEvent)
-                    if (config.showClearChat) {
-                        systemMessage(session, "clear-${clearEvent.eventId ?: timestamp ?: System.nanoTime()}", config.chatClearedMessage)?.let { flowScope.send(it) }
-                    }
+                    moderationSystemMessage(session, clearEvent)?.let { flowScope.send(it) }
                 }
 
-                override suspend fun onClearUserMessages(event: org.json.JSONObject, timestamp: String?) {
-                    val clearEvent = TwitchChatEventParser.fromEventSubClear(event, timestamp)
+                override suspend fun onClearUserMessages(event: org.json.JSONObject, timestamp: String?, notificationId: String?) {
+                    val clearEvent = TwitchChatEventParser.fromEventSubClear(event, timestamp, notificationId)
                     flowScope.send(clearEvent)
-                    if (config.showClearChat) {
-                        systemMessage(session, "clear-user-${clearEvent.eventId ?: timestamp ?: System.nanoTime()}", config.chatClearedMessage)?.let { flowScope.send(it) }
-                    }
+                    moderationSystemMessage(session, clearEvent)?.let { flowScope.send(it) }
                 }
 
                 override suspend fun onMessageDelete(event: org.json.JSONObject, timestamp: String?) {
@@ -403,13 +400,44 @@ class TwitchChatTransport(
         )
     }
 
-    private fun systemMessage(session: ChatSessionKey, suffix: String, text: String?): ChatEvent.Message? =
+    private fun moderationSystemMessage(session: ChatSessionKey, event: ChatEvent): ChatEvent.Message? {
+        if (!config.showClearChat) return null
+        val text = when (event) {
+            is ChatEvent.Clear -> config.chatClearedMessage
+            is ChatEvent.ClearUser -> {
+                val target = event.userName ?: event.userLogin ?: event.userId ?: return null
+                when (event.reason) {
+                    ChatUserClearReason.TIMEOUT -> event.timeoutSeconds?.let { seconds ->
+                        config.chatTimeoutMessage?.invoke(target, seconds)
+                    } ?: config.chatUserMessagesClearedMessage?.invoke(target)
+                    ChatUserClearReason.BAN -> config.chatBanMessage?.invoke(target)
+                        ?: config.chatUserMessagesClearedMessage?.invoke(target)
+                    ChatUserClearReason.MESSAGES_CLEARED -> config.chatUserMessagesClearedMessage?.invoke(target)
+                }
+            }
+            else -> null
+        }
+        val prefix = if (event is ChatEvent.ClearUser) "clear-user" else "clear"
+        return systemMessage(
+            session = session,
+            suffix = "$prefix-${event.eventId ?: event.receivedAtMs}",
+            text = text,
+            timestampMs = event.receivedAtMs + 1,
+        )
+    }
+
+    private fun systemMessage(
+        session: ChatSessionKey,
+        suffix: String,
+        text: String?,
+        timestampMs: Long? = null,
+    ): ChatEvent.Message? =
         text?.takeIf { it.isNotBlank() }?.let {
             ChatEvent.Message(
                 message = ChatMessage(
                     id = ChatMessageId("system-$suffix-${session.generation}"),
                     channelId = config.channelId,
-                    timestampMs = System.currentTimeMillis(),
+                    timestampMs = timestampMs ?: System.currentTimeMillis(),
                     user = null,
                     badges = emptyList(),
                     segments = emptyList(),

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/chat/EventSubWebSocket.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/chat/EventSubWebSocket.kt
@@ -332,8 +332,8 @@ class EventSubWebSocket(
         suspend fun onChatMessage(event: JSONObject, timestamp: String?) {}
         suspend fun onChannelPointsRewardRedemption(event: JSONObject, timestamp: String?) {}
         suspend fun onUserNotice(event: JSONObject, timestamp: String?) {}
-        suspend fun onClearChat(event: JSONObject, timestamp: String?) {}
-        suspend fun onClearUserMessages(event: JSONObject, timestamp: String?) {}
+        suspend fun onClearChat(event: JSONObject, timestamp: String?, notificationId: String?) {}
+        suspend fun onClearUserMessages(event: JSONObject, timestamp: String?, notificationId: String?) {}
         suspend fun onMessageDelete(event: JSONObject, timestamp: String?) {}
         suspend fun onRoomState(event: JSONObject, timestamp: String?) {}
         suspend fun onStreamOnline(event: JSONObject, timestamp: String?) {}
@@ -378,8 +378,8 @@ class EventSubWebSocket(
                                     "channel.chat.message" -> listener.onChatMessage(event, timestamp)
                                     "channel.channel_points_custom_reward_redemption.add" -> listener.onChannelPointsRewardRedemption(event, timestamp)
                                     "channel.chat.notification" -> listener.onUserNotice(event, timestamp)
-                                    "channel.chat.clear" -> listener.onClearChat(event, timestamp)
-                                    "channel.chat.clear_user_messages" -> listener.onClearUserMessages(event, timestamp)
+                                    "channel.chat.clear" -> listener.onClearChat(event, timestamp, messageId)
+                                    "channel.chat.clear_user_messages" -> listener.onClearUserMessages(event, timestamp, messageId)
                                     "channel.chat.message_delete" -> listener.onMessageDelete(event, timestamp)
                                     "channel.chat_settings.update" -> listener.onRoomState(event, timestamp)
                                     "stream.online" -> listener.onStreamOnline(event, timestamp)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -729,6 +729,7 @@
     <string name="chat_join">Welcome to %s\'s chat room!</string>
     <string name="copy_clip">Copy to clipboard</string>
     <string name="chat_clear">Chat has been cleared by a moderator.</string>
+    <string name="chat_clear_user">Messages from %s have been cleared by a moderator.</string>
     <string name="chat_timeout">%1$s has been timed out for %2$s.</string>
     <string name="chat_ban">%s has been permanently banned.</string>
     <string name="chat_clearmsg">Message deleted from %1$s\: %2$s</string>

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatTimelineArchitectureTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatTimelineArchitectureTest.kt
@@ -6,6 +6,7 @@ import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessageId
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessageKind
 import com.github.andreyasadchy.xtra.ui.chat.v2.session.ChatEventProcessor
 import com.github.andreyasadchy.xtra.ui.chat.v2.session.ChatTimelineStore
+import com.github.andreyasadchy.xtra.ui.chat.v2.transport.TwitchChatEventParser
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel
@@ -13,7 +14,9 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.withTimeout
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import org.json.JSONObject
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
 import org.junit.Test
 
 class ChatTimelineArchitectureTest {
@@ -132,13 +135,34 @@ class ChatTimelineArchitectureTest {
     }
 
     @Test
-    fun deletionClearUserAndClearAreCanonicalOperations() = runBlocking {
+    fun deletionAndRoomClearAreCanonicalOperations() = runBlocking {
         val scope = CoroutineScope(Dispatchers.Default)
         val store = ChatTimelineStore(scope, maxSize = 600)
         store.apply(com.github.andreyasadchy.xtra.ui.chat.v2.session.TimelineOperation.Append(listOf(message(1, "u1"), message(2, "u2"), message(3, "u1"))))
         store.apply(com.github.andreyasadchy.xtra.ui.chat.v2.session.TimelineOperation.Delete(ChatMessageId("2"), atMs = 4))
-        store.apply(com.github.andreyasadchy.xtra.ui.chat.v2.session.TimelineOperation.ClearUser("u1", atMs = 4))
+        assertEquals(listOf("1", "3"), store.snapshot().map { it.id.value })
+        store.apply(com.github.andreyasadchy.xtra.ui.chat.v2.session.TimelineOperation.Clear(atMs = 5))
         assertEquals(emptyList<String>(), store.snapshot().map { it.id.value })
+        scope.cancel()
+    }
+
+    @Test
+    fun clearUserWithMissingUserIdPreservesExistingMessages() = runBlocking {
+        val scope = CoroutineScope(Dispatchers.Default)
+        val store = ChatTimelineStore(scope, maxSize = 600)
+        val userMessage = message(1).copy(
+            user = com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatUser(null, "viewer", "Viewer", null),
+        )
+        store.apply(com.github.andreyasadchy.xtra.ui.chat.v2.session.TimelineOperation.Append(listOf(userMessage)))
+        store.accept(
+            ChatEvent.ClearUser(
+                userId = null,
+                eventId = "viewer",
+                receivedAtMs = 2,
+                userLogin = "VIEWER",
+            ),
+        )
+        assertEquals(listOf("1"), store.snapshot().map { it.id.value })
         scope.cancel()
     }
 
@@ -158,7 +182,7 @@ class ChatTimelineArchitectureTest {
     }
 
     @Test
-    fun repeatedClearUserEventsAreBothApplied() = runBlocking {
+    fun clearUserEventsPreserveExistingAndFutureMessages() = runBlocking {
         val scope = CoroutineScope(Dispatchers.Default)
         val store = ChatTimelineStore(scope, maxSize = 600)
         val processor = ChatEventProcessor(scope, store)
@@ -168,12 +192,12 @@ class ChatTimelineArchitectureTest {
         awaitSnapshot(store) { it.lastOrNull()?.id?.value == "1" }
 
         processor.submit(key, ChatEvent.ClearUser("u1", eventId = "u1", receivedAtMs = 2))
-        awaitSnapshot(store) { it.isEmpty() }
+        assertEquals(listOf("1"), awaitSnapshot(store) { it.size == 1 }.map { it.id.value })
         processor.submit(key, ChatEvent.Message(message(3, "u1"), receivedAtMs = 3))
-        awaitSnapshot(store) { it.lastOrNull()?.id?.value == "3" }
+        assertEquals(listOf("1", "3"), awaitSnapshot(store) { it.size == 2 }.map { it.id.value })
 
         processor.submit(key, ChatEvent.ClearUser("u1", eventId = "u1", receivedAtMs = 4))
-        assertEquals(emptyList<String>(), awaitSnapshot(store) { it.isEmpty() }.map { it.id.value })
+        assertEquals(listOf("1", "3"), awaitSnapshot(store) { it.size == 2 }.map { it.id.value })
         scope.cancel()
     }
 
@@ -196,7 +220,7 @@ class ChatTimelineArchitectureTest {
     }
 
     @Test
-    fun clearedUserMessagesDoNotReturnFromStaleReconciliation() = runBlocking {
+    fun clearUserDoesNotSuppressStaleReconciliation() = runBlocking {
         val scope = CoroutineScope(Dispatchers.Default)
         val store = ChatTimelineStore(scope, maxSize = 600)
         val processor = ChatEventProcessor(scope, store)
@@ -206,10 +230,10 @@ class ChatTimelineArchitectureTest {
         oldMessages.forEach { processor.submit(key, ChatEvent.Message(it, receivedAtMs = it.timestampMs)) }
         awaitSnapshot(store) { it.size == 2 }
         processor.submit(key, ChatEvent.ClearUser("u1", eventId = "u1", receivedAtMs = 3))
-        awaitSnapshot(store) { it.isEmpty() }
+        assertEquals(listOf("1", "2"), awaitSnapshot(store) { it.size == 2 }.map { it.id.value })
 
         processor.reconcile(key, oldMessages)
-        assertEquals(emptyList<String>(), store.snapshot().map { it.id.value })
+        assertEquals(listOf("1", "2"), store.snapshot().map { it.id.value })
         scope.cancel()
     }
 
@@ -228,6 +252,69 @@ class ChatTimelineArchitectureTest {
 
         processor.reconcile(key, oldMessages)
         assertEquals(emptyList<String>(), store.snapshot().map { it.id.value })
+        scope.cancel()
+    }
+
+    @Test
+    fun repeatedEventSubUserClearsKeepBothModerationNotices() = runBlocking {
+        val scope = CoroutineScope(Dispatchers.Default)
+        val store = ChatTimelineStore(scope, maxSize = 600)
+        val processor = ChatEventProcessor(scope, store)
+        val key = com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatSessionKey("channel", 1)
+        val payload = JSONObject(
+            """{"target_user_id":"u1","target_user_login":"viewer","target_user_name":"Viewer"}""",
+        )
+        val firstClear = TwitchChatEventParser.fromEventSubClear(
+            payload,
+            "2026-09-01T12:00:00Z",
+            notificationId = "clear-1",
+        ) as ChatEvent.ClearUser
+        val secondClear = TwitchChatEventParser.fromEventSubClear(
+            payload,
+            "2026-09-01T12:00:00Z",
+            notificationId = "clear-2",
+        ) as ChatEvent.ClearUser
+        val firstNotice = moderationNotice(firstClear)
+        val secondNotice = moderationNotice(secondClear)
+        processor.activate(key)
+
+        processor.submit(key, ChatEvent.Message(message(1, "u1"), receivedAtMs = 1))
+        awaitSnapshot(store) { it.size == 1 }
+        processor.submit(key, firstClear)
+        processor.submit(key, ChatEvent.Message(firstNotice, eventId = firstNotice.id.value, receivedAtMs = firstNotice.timestampMs))
+        assertEquals(
+            listOf("1", firstNotice.id.value),
+            awaitSnapshot(store) { it.size == 2 }.map { it.id.value },
+        )
+
+        processor.submit(key, secondClear)
+        processor.submit(key, ChatEvent.Message(secondNotice, eventId = secondNotice.id.value, receivedAtMs = secondNotice.timestampMs))
+        assertEquals(
+            listOf("1", firstNotice.id.value, secondNotice.id.value),
+            awaitSnapshot(store) { it.size == 3 }.map { it.id.value },
+        )
+        assertNotEquals(firstNotice.id, secondNotice.id)
+        scope.cancel()
+    }
+
+    @Test
+    fun roomClearNoticeRemainsVisibleAfterClearOperation() = runBlocking {
+        val scope = CoroutineScope(Dispatchers.Default)
+        val store = ChatTimelineStore(scope, maxSize = 600)
+        val processor = ChatEventProcessor(scope, store)
+        val key = com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatSessionKey("channel", 1)
+        processor.activate(key)
+        processor.submit(key, ChatEvent.Clear(eventId = "clear", receivedAtMs = 3))
+        awaitSnapshot(store) { it.isEmpty() }
+
+        val notice = message(4).copy(
+            id = ChatMessageId("system-clear-1"),
+            kind = ChatMessageKind.SYSTEM,
+            systemText = "Chat has been cleared by a moderator.",
+        )
+        processor.submit(key, ChatEvent.Message(notice, eventId = notice.id.value, receivedAtMs = 4))
+
+        assertEquals(listOf("system-clear-1"), awaitSnapshot(store) { it.isNotEmpty() }.map { it.id.value })
         scope.cancel()
     }
 
@@ -270,6 +357,14 @@ class ChatTimelineArchitectureTest {
         badges = emptyList(),
         segments = emptyList(),
         kind = ChatMessageKind.CHAT,
+    )
+
+    private fun moderationNotice(event: ChatEvent.ClearUser) = message(0).copy(
+        id = ChatMessageId("system-clear-user-${event.eventId}-1"),
+        timestampMs = event.receivedAtMs + 1,
+        user = null,
+        kind = ChatMessageKind.SYSTEM,
+        systemText = "Messages from Viewer have been cleared by a moderator.",
     )
 
     private suspend fun snapshotAfter(store: ChatTimelineStore, id: String): List<ChatMessage> {

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/TwitchChatEventParserTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/TwitchChatEventParserTest.kt
@@ -3,6 +3,7 @@ package com.github.andreyasadchy.xtra.ui.chat.v2
 import com.github.andreyasadchy.xtra.R
 import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatCatalogSnapshot
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatEvent
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatUserClearReason
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatReward
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.HIGHLIGHTED_MESSAGE_REWARD_TYPE
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatSegment
@@ -15,10 +16,79 @@ import com.github.andreyasadchy.xtra.util.chat.ChatUtils
 import com.github.andreyasadchy.xtra.util.chat.PubSubUtils
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class TwitchChatEventParserTest {
+    @Test
+    fun ircClearchatDistinguishesTimeoutBanAndRoomClear() {
+        val timeout = TwitchChatEventParser.fromIrc(
+            ChatUtils.parseIRCMessage(
+                "@target-user-id=42;ban-duration=600;tmi-sent-ts=1000 :mod!mod@mod.tmi.twitch.tv CLEARCHAT #channel :viewer",
+            ),
+            "channel-id",
+        ) as ChatEvent.ClearUser
+        assertEquals("42", timeout.userId)
+        assertEquals("viewer", timeout.userLogin)
+        assertEquals(ChatUserClearReason.TIMEOUT, timeout.reason)
+        assertEquals(600, timeout.timeoutSeconds)
+
+        val ban = TwitchChatEventParser.fromIrc(
+            ChatUtils.parseIRCMessage(
+                "@tmi-sent-ts=1001 :mod!mod@mod.tmi.twitch.tv CLEARCHAT #channel :viewer",
+            ),
+            "channel-id",
+        ) as ChatEvent.ClearUser
+        assertEquals(ChatUserClearReason.BAN, ban.reason)
+        assertEquals("viewer", ban.userLogin)
+
+        val roomClear = TwitchChatEventParser.fromIrc(
+            ChatUtils.parseIRCMessage(
+                "@tmi-sent-ts=1002 :tmi.twitch.tv CLEARCHAT #channel",
+            ),
+            "channel-id",
+        )
+        assertTrue(roomClear is ChatEvent.Clear)
+    }
+
+    @Test
+    fun eventSubUserClearCarriesTargetIdentityWithoutCallingItABan() {
+        val event = TwitchChatEventParser.fromEventSubClear(
+            JSONObject(
+                """{"target_user_id":"42","target_user_login":"viewer","target_user_name":"Viewer"}""",
+            ),
+            "2026-09-01T12:00:00Z",
+        ) as ChatEvent.ClearUser
+
+        assertEquals("42", event.userId)
+        assertEquals("viewer", event.userLogin)
+        assertEquals("Viewer", event.userName)
+        assertEquals(ChatUserClearReason.MESSAGES_CLEARED, event.reason)
+        assertTrue(event.eventId?.startsWith("42-") == true)
+    }
+
+    @Test
+    fun repeatedEventSubUserClearsUseNotificationIdsForDistinctNotices() {
+        val payload = JSONObject(
+            """{"target_user_id":"42","target_user_login":"viewer","target_user_name":"Viewer"}""",
+        )
+        val first = TwitchChatEventParser.fromEventSubClear(
+            payload,
+            "2026-09-01T12:00:00Z",
+            notificationId = "clear-1",
+        ) as ChatEvent.ClearUser
+        val second = TwitchChatEventParser.fromEventSubClear(
+            payload,
+            "2026-09-01T12:00:00Z",
+            notificationId = "clear-2",
+        ) as ChatEvent.ClearUser
+
+        assertEquals("clear-1", first.eventId)
+        assertEquals("clear-2", second.eventId)
+        assertNotEquals(first.eventId, second.eventId)
+    }
+
     @Test
     fun eventSubKeepsStructuredFragmentsAndCurrentMessageMetadata() {
         val gifUrl = "https://clips-media-assets2.twitch.tv/gif?token=keep-exactly"


### PR DESCRIPTION
Correctly distinguish room clears from user timeouts and bans. Preserve the existing timeout/ban visibility setting and special notice styling.