### PR TITLE
Fix Chat Identity badge semantics

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/model/chat/ChatIdentity.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/model/chat/ChatIdentity.kt
@@ -18,6 +18,15 @@ data class ChatIdentityCampaignReward(
     val title: String?,
     val description: String?,
     val imageUrl: String?,
+    val earnableUntil: String? = null,
+)
+
+data class ChatIdentityCampaignBadge(
+    val key: ChatIdentityBadgeKey,
+    val title: String?,
+    val description: String?,
+    val imageUrl: String,
+    val owned: Boolean,
 )
 
 data class ChatIdentityCampaign(
@@ -27,13 +36,19 @@ data class ChatIdentityCampaign(
     val imageUrl: String?,
     val earnedBadges: Int,
     val totalBadges: Int,
+    val brand: String? = null,
+    val game: String? = null,
     val rewards: List<ChatIdentityCampaignReward> = emptyList(),
+    val badges: List<ChatIdentityCampaignBadge> = emptyList(),
+    val startsAt: String? = null,
+    val endsAt: String? = null,
+    val rewardCampaignIds: List<String> = emptyList(),
 )
 
 data class ChatIdentityData(
     val displayName: String,
     val nameColor: String?,
-    val effectiveBadges: List<ChatIdentityBadge>,
+    val displayBadges: List<ChatIdentityBadge>,
     val availableGlobalBadges: List<ChatIdentityBadge>,
     val selectedGlobalBadge: ChatIdentityBadge?,
     val subscriberBadge: ChatIdentityBadge?,
@@ -41,6 +56,7 @@ data class ChatIdentityData(
     val selectedChannelBadge: ChatIdentityBadge?,
     val isSubscribed: Boolean,
     val canUseCustomNameColor: Boolean = false,
+    val subscriptionMonths: Int? = null,
     val campaigns: List<ChatIdentityCampaign> = emptyList(),
 )
 
@@ -75,13 +91,15 @@ val TWITCH_STANDARD_CHAT_COLORS = listOf(
 data class ChatIdentityState(
     val loading: Boolean = false,
     val loadedChannelId: String? = null,
+    val loadedViewerId: String? = null,
     val displayName: String = "",
     val nameColor: String? = null,
-    val effectiveBadge: ChatIdentityBadge? = null,
+    val displayBadges: List<ChatIdentityBadge> = emptyList(),
     val globalBadges: List<ChatIdentityBadge> = emptyList(),
     val selectedGlobalBadge: ChatIdentityBadgeKey? = null,
     val subscriberBadge: ChatIdentityBadge? = null,
     val isSubscribed: Boolean = false,
+    val subscriptionMonths: Int? = null,
     val channelBadges: List<ChatIdentityBadge> = emptyList(),
     val useCustomChannelBadge: Boolean = false,
     val selectedChannelBadge: ChatIdentityBadgeKey? = null,
@@ -94,9 +112,60 @@ data class ChatIdentityState(
     val error: String? = null,
 )
 
-fun ChatIdentityState.effectiveBadge(): ChatIdentityBadge? {
-    if (useCustomChannelBadge && selectedChannelBadge != null) {
-        channelBadges.firstOrNull { it.key == selectedChannelBadge }?.let { return it }
+fun ChatIdentityState.selectedVanityBadge(): ChatIdentityBadge? {
+    if (useCustomChannelBadge) {
+        selectedChannelBadge?.let { key ->
+            channelBadges.firstOrNull { it.key == key }?.let { return it }
+        }
     }
-    return globalBadges.firstOrNull { it.key == selectedGlobalBadge } ?: effectiveBadge
+
+    return selectedGlobalBadge?.let { key ->
+        globalBadges.firstOrNull { it.key == key }
+    }
 }
+
+fun ChatIdentityBadge.isSubscriptionSlotBadge(): Boolean =
+    key.setId.equals("subscriber", ignoreCase = true) ||
+        key.setId.equals("founder", ignoreCase = true)
+
+internal fun ChatIdentityData.toState(channelId: String, viewerId: String? = null): ChatIdentityState {
+    val selectableSelectedGlobalBadge = selectedGlobalBadge
+        ?.takeUnless(ChatIdentityBadge::isSubscriptionSlotBadge)
+    val selectableSelectedChannelBadge = selectedChannelBadge
+        ?.takeUnless(ChatIdentityBadge::isSubscriptionSlotBadge)
+    val selectableGlobalBadges = (availableGlobalBadges + listOfNotNull(selectedGlobalBadge))
+        .filterNot(ChatIdentityBadge::isSubscriptionSlotBadge)
+        .distinctBy { it.key }
+    return ChatIdentityState(
+        loadedChannelId = channelId,
+        loadedViewerId = viewerId,
+        displayName = displayName,
+        nameColor = nameColor,
+        displayBadges = displayBadges,
+        globalBadges = selectableGlobalBadges,
+        selectedGlobalBadge = selectableSelectedGlobalBadge?.key,
+        subscriberBadge = subscriberBadge,
+        isSubscribed = isSubscribed,
+        subscriptionMonths = subscriptionMonths,
+        channelBadges = channelBadges
+            .filterNot(ChatIdentityBadge::isSubscriptionSlotBadge)
+            .distinctBy { it.key },
+        useCustomChannelBadge = selectableSelectedChannelBadge != null,
+        selectedChannelBadge = selectableSelectedChannelBadge?.key,
+        campaigns = campaigns,
+        canUseCustomNameColor = canUseCustomNameColor,
+        badgeSelectionAvailable = true,
+        channelBadgeOverrideAvailable = true,
+    )
+}
+
+internal fun ChatIdentityState.selectGlobalBadgeOptimistically(
+    badge: ChatIdentityBadge?,
+): ChatIdentityState = copy(selectedGlobalBadge = badge?.key)
+
+internal fun ChatIdentityState.selectChannelBadgeOptimistically(
+    badge: ChatIdentityBadge?,
+): ChatIdentityState = copy(
+    useCustomChannelBadge = badge != null,
+    selectedChannelBadge = badge?.key,
+)

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/GraphQLChatIdentity.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/GraphQLChatIdentity.kt
@@ -3,6 +3,7 @@ package com.github.andreyasadchy.xtra.repository
 import com.github.andreyasadchy.xtra.model.chat.ChatIdentityBadge
 import com.github.andreyasadchy.xtra.model.chat.ChatIdentityBadgeKey
 import com.github.andreyasadchy.xtra.model.chat.ChatIdentityData
+import com.github.andreyasadchy.xtra.model.chat.isSubscriptionSlotBadge
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
@@ -15,6 +16,8 @@ import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonObject
+import kotlinx.coroutines.CancellationException
+import kotlinx.serialization.json.intOrNull
 
 /**
  * Full-document operations verified against Twitch's current web Chat Identity chunks.
@@ -33,18 +36,21 @@ internal const val CHAT_IDENTITY_QUERY = """
             setID
             version
             title
+            description
             imageURL(size: QUADRUPLE)
           }
           availableBadges {
             setID
             version
             title
+            description
             imageURL(size: QUADRUPLE)
           }
           displayBadges {
             setID
             version
             title
+            description
             imageURL(size: QUADRUPLE)
           }
         }
@@ -62,12 +68,14 @@ internal const val CHAT_IDENTITY_QUERY = """
           setID
           version
           title
+          description
           imageURL(size: QUADRUPLE)
         }
         availableBadges {
           setID
           version
           title
+          description
           imageURL(size: QUADRUPLE)
         }
       }
@@ -82,6 +90,7 @@ internal const val CHAT_EARNED_BADGES_CHANNEL_DATA_QUERY = """
           setID
           version
           title
+          description
           imageURL(size: QUADRUPLE)
         }
       }
@@ -89,6 +98,22 @@ internal const val CHAT_EARNED_BADGES_CHANNEL_DATA_QUERY = """
 """
 
 internal const val CHAT_EARNED_BADGES_INITIAL_SUB_STATUS_QUERY = """
+    query Chat_EarnedBadges_InitialSubStatus(${'$'}channelLogin: String!) {
+      user(login: ${'$'}channelLogin) {
+        id
+        self {
+          subscriptionBenefit {
+            id
+          }
+          subscriptionTenure(tenureMethod: CUMULATIVE) {
+            months
+          }
+        }
+      }
+    }
+"""
+
+internal const val CHAT_EARNED_BADGES_INITIAL_SUB_STATUS_LEGACY_QUERY = """
     query Chat_EarnedBadges_InitialSubStatus(${'$'}channelLogin: String!) {
       user(login: ${'$'}channelLogin) {
         id
@@ -197,11 +222,7 @@ suspend fun GraphQLRepository.loadChatIdentity(
         throw ChatIdentityGraphQlException("Chat Identity returned an unexpected viewer")
     }
 
-    val effectiveBadges = identity.objectOrNull("channel")
-        ?.objectOrNull("self")
-        ?.arrayOrEmpty("displayBadges")
-        ?.mapNotNull(::parseChatIdentityBadge)
-        .orEmpty()
+    val displayBadges = ChatIdentityCampaignParser.parseDisplayBadges(identity)
     val channelSelf = identity.objectOrNull("channel")?.objectOrNull("self")
     val availableGlobalBadges = currentUser.arrayOrEmpty("availableBadges")
         .mapNotNull(::parseChatIdentityBadge)
@@ -225,32 +246,77 @@ suspend fun GraphQLRepository.loadChatIdentity(
         ?.mapNotNull(::parseChatIdentityBadge)
         .orEmpty()
 
-    val subStatus = executeRawOperation(
+    val subscription = loadSubscriptionStatus(
         networkLibrary = networkLibrary,
         headers = headers,
-        operationName = "Chat_EarnedBadges_InitialSubStatus",
-        query = CHAT_EARNED_BADGES_INITIAL_SUB_STATUS_QUERY,
-        variables = buildJsonObject { put("channelLogin", channelLogin) },
-    ).dataOrThrow("Chat_EarnedBadges_InitialSubStatus")
-        .objectOrNull("user")
-        ?.objectOrNull("self")
-        ?.objectOrNull("subscriptionBenefit")
+        channelLogin = channelLogin,
+    )
+    val displayedSubscriptionBadge = displayBadges.firstOrNull { it.isSubscriptionSlotBadge() }
+    val subscriptionBadge = displayedSubscriptionBadge
+        ?: earned.firstOrNull { it.isSubscriptionSlotBadge() }
 
     return ChatIdentityData(
         displayName = currentUser.stringOrNull("displayName")
             ?: currentUser.stringOrNull("login").orEmpty(),
         nameColor = currentUser.stringOrNull("chatColor"),
-        effectiveBadges = effectiveBadges,
+        displayBadges = displayBadges,
         availableGlobalBadges = availableGlobalBadges,
-        selectedGlobalBadge = selectedGlobalBadge,
-        subscriberBadge = earned.firstOrNull { it.isSubscriberBadge() },
+        selectedGlobalBadge = selectedGlobalBadge?.takeUnless { it.isSubscriptionSlotBadge() },
+        subscriberBadge = subscriptionBadge,
         channelBadges = (availableChannelBadges + listOfNotNull(selectedChannelBadge) + earned)
-            .filterNot { it.isSubscriberBadge() }
+            .filterNot { it.isSubscriptionSlotBadge() }
             .distinctBy { it.key },
-        selectedChannelBadge = selectedChannelBadge,
-        isSubscribed = subStatus != null,
+        selectedChannelBadge = selectedChannelBadge?.takeUnless { it.isSubscriptionSlotBadge() },
+        isSubscribed = subscription?.isSubscribed == true || displayedSubscriptionBadge != null,
         canUseCustomNameColor = currentUser.booleanOrNull("hasPrime") == true ||
             currentUser.objectOrNull("turboStatus")?.booleanOrNull("hasActiveTurbo") == true,
+        subscriptionMonths = subscription?.months,
+    )
+}
+
+private data class SubscriptionStatus(
+    val isSubscribed: Boolean,
+    val months: Int?,
+)
+
+private suspend fun GraphQLRepository.loadSubscriptionStatus(
+    networkLibrary: String?,
+    headers: Map<String, String>,
+    channelLogin: String,
+): SubscriptionStatus? {
+    val result = try {
+        executeRawOperation(
+            networkLibrary = networkLibrary,
+            headers = headers,
+            operationName = "Chat_EarnedBadges_InitialSubStatus",
+            query = CHAT_EARNED_BADGES_INITIAL_SUB_STATUS_QUERY,
+            variables = buildJsonObject { put("channelLogin", channelLogin) },
+        ).dataOrThrow("Chat_EarnedBadges_InitialSubStatus")
+    } catch (error: CancellationException) {
+        throw error
+    } catch (_: Exception) {
+        // subscriptionTenure is optional. Retry the stable subscription-only query when Twitch
+        // removes or changes that field, so a tenure schema change cannot hide Chat Identity.
+        try {
+            executeRawOperation(
+                networkLibrary = networkLibrary,
+                headers = headers,
+                operationName = "Chat_EarnedBadges_InitialSubStatus",
+                query = CHAT_EARNED_BADGES_INITIAL_SUB_STATUS_LEGACY_QUERY,
+                variables = buildJsonObject { put("channelLogin", channelLogin) },
+            ).dataOrThrow("Chat_EarnedBadges_InitialSubStatus")
+        } catch (error: CancellationException) {
+            throw error
+        } catch (_: Exception) {
+            return null
+        }
+    }
+    val self = result.objectOrNull("user")?.objectOrNull("self")
+    return SubscriptionStatus(
+        isSubscribed = self?.objectOrNull("subscriptionBenefit") != null,
+        months = self?.objectOrNull("subscriptionTenure")
+            ?.intOrNull("months")
+            ?.takeIf { it > 0 },
     )
 }
 
@@ -380,13 +446,10 @@ private fun parseChatIdentityBadge(element: JsonElement): ChatIdentityBadge? {
     return ChatIdentityBadge(
         key = ChatIdentityBadgeKey(setId, version),
         title = badge.stringOrNull("title"),
-        description = null,
+        description = badge.stringOrNull("description"),
         imageUrl = imageUrl,
     )
 }
-
-private fun ChatIdentityBadge.isSubscriberBadge(): Boolean =
-    key.setId.contains("subscriber", ignoreCase = true)
 
 private fun JsonObject.objectOrNull(name: String): JsonObject? =
     this[name]?.jsonObjectOrNull()
@@ -403,4 +466,9 @@ private fun JsonElement.jsonArrayOrNull(): JsonArray? =
 private fun JsonObject.stringOrNull(name: String): String? =
     this[name]?.takeUnless { it is JsonNull }?.let {
         runCatching { it.jsonPrimitive.contentOrNull }.getOrNull()
+    }
+
+private fun JsonObject.intOrNull(name: String): Int? =
+    this[name]?.takeUnless { it is JsonNull }?.let {
+        runCatching { it.jsonPrimitive.intOrNull }.getOrNull()
     }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/GraphQLChatIdentityCampaigns.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/GraphQLChatIdentityCampaigns.kt
@@ -1,0 +1,444 @@
+package com.github.andreyasadchy.xtra.repository
+
+import android.os.SystemClock
+import com.github.andreyasadchy.xtra.model.chat.ChatIdentityBadge
+import com.github.andreyasadchy.xtra.model.chat.ChatIdentityBadgeKey
+import com.github.andreyasadchy.xtra.model.chat.ChatIdentityCampaign
+import com.github.andreyasadchy.xtra.model.chat.ChatIdentityCampaignBadge
+import com.github.andreyasadchy.xtra.model.chat.ChatIdentityCampaignReward
+import com.github.andreyasadchy.xtra.model.chat.isSubscriptionSlotBadge
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import org.json.JSONArray
+import org.json.JSONObject
+import java.text.Normalizer
+import java.time.Instant
+import java.util.Locale
+
+/** The web operation used by Twitch's Chat Identity active collections section. */
+internal const val CHAT_IDENTITY_CAMPAIGNS_QUERY = """
+    query ViewerDropsDashboard(${'$'}fetchRewardCampaigns: Boolean!) {
+      currentUser {
+        id
+      }
+      rewardCampaignsAvailableToUser @include(if: ${'$'}fetchRewardCampaigns) {
+        id
+        name
+        brand
+        startsAt
+        endsAt
+        status
+        summary
+        isSitewide
+        game {
+          id
+          displayName
+        }
+        image {
+          image1xURL
+        }
+        unlockRequirements {
+          minuteWatchedGoal
+          subsGoal
+        }
+        rewards {
+          id
+          name
+          earnableUntil
+          thumbnailImage {
+            image1xURL
+          }
+          bannerImage {
+            image1xURL
+          }
+        }
+      }
+    }
+"""
+
+/** The global badge catalog used by the bounded campaign-to-badge reconciliation fallback. */
+internal const val CHAT_IDENTITY_GLOBAL_BADGE_CATALOG_QUERY = """
+    query ChatIdentityGlobalBadgeCatalog {
+      badges {
+        id
+        setID
+        version
+        title
+        description
+        imageURL(size: QUADRUPLE)
+      }
+    }
+"""
+
+private data class RewardCampaign(
+    val id: String,
+    val name: String,
+    val brand: String?,
+    val startsAt: String?,
+    val endsAt: String?,
+    val status: String?,
+    val gameName: String?,
+    val imageUrl: String?,
+    val rewards: List<ChatIdentityCampaignReward>,
+)
+
+private data class CatalogBadge(
+    val key: ChatIdentityBadgeKey,
+    val title: String?,
+    val description: String?,
+    val imageUrl: String,
+)
+
+/**
+ * Twitch exposes reward containers here, not necessarily the chat badges in a collection.
+ * Keep that distinction explicit and only show a card after badge metadata gives us a strong
+ * relationship to the reward campaign.
+ */
+internal object ChatIdentityCampaignParser {
+    internal fun hasUsableActiveRewardCampaigns(body: String, now: Instant): Boolean =
+        parseRewardCampaigns(body)?.any { it.isActiveAt(now) } == true
+
+    fun parse(
+        rewardCampaignsBody: String,
+        badgeCatalogBody: String,
+        ownedBadges: Set<ChatIdentityBadgeKey>,
+        now: Instant,
+    ): List<ChatIdentityCampaign>? {
+        val rewardCampaigns = parseRewardCampaigns(rewardCampaignsBody) ?: return null
+        val badgeCatalog = parseBadgeCatalog(badgeCatalogBody) ?: return null
+        return project(rewardCampaigns, badgeCatalog, ownedBadges, now)
+    }
+
+    internal fun parseDisplayBadges(body: JsonObject): List<ChatIdentityBadge> =
+        body.optObject("channel")
+            ?.optObject("self")
+            ?.optArray("displayBadges")
+            .orEmpty()
+            .mapNotNull { parseBadge(it) }
+
+    private fun parseRewardCampaigns(body: String): List<RewardCampaign>? {
+        val root = runCatching { JSONObject(body) }.getOrNull() ?: return null
+        if (root.hasErrors()) return null
+        val data = root.optJSONObject("data") ?: return null
+        if (!data.has("rewardCampaignsAvailableToUser")) return null
+        val campaigns = data.optJSONArray("rewardCampaignsAvailableToUser") ?: return emptyList()
+        return buildList {
+            for (index in 0 until campaigns.length()) {
+                val campaign = campaigns.optJSONObject(index) ?: continue
+                val id = campaign.optionalString("id") ?: continue
+                val name = campaign.optionalString("name") ?: continue
+                add(
+                    RewardCampaign(
+                        id = id,
+                        name = name,
+                        brand = campaign.optionalString("brand"),
+                        startsAt = campaign.optionalString("startsAt"),
+                        endsAt = campaign.optionalString("endsAt"),
+                        status = campaign.optionalString("status"),
+                        gameName = campaign.optJSONObject("game")?.optionalString("displayName"),
+                        imageUrl = campaign.optJSONObject("image")?.optionalString("image1xURL"),
+                        rewards = parseRewards(campaign.optJSONArray("rewards")),
+                    ),
+                )
+            }
+        }
+    }
+
+    private fun parseBadgeCatalog(body: String): List<CatalogBadge>? {
+        val root = runCatching { JSONObject(body) }.getOrNull() ?: return null
+        if (root.hasErrors()) return null
+        val data = root.optJSONObject("data") ?: return null
+        if (!data.has("badges")) return null
+        val badges = data.optJSONArray("badges") ?: return emptyList()
+        return buildList {
+            for (index in 0 until badges.length()) {
+                val badge = badges.optJSONObject(index) ?: continue
+                val setId = badge.optionalString("setID") ?: continue
+                val version = badge.optionalString("version") ?: continue
+                val imageUrl = badge.optionalString("imageURL") ?: continue
+                add(
+                    CatalogBadge(
+                        key = ChatIdentityBadgeKey(setId, version),
+                        title = badge.optionalString("title"),
+                        description = badge.optionalString("description"),
+                        imageUrl = imageUrl,
+                    ),
+                )
+            }
+        }
+    }
+
+    private fun project(
+        campaigns: List<RewardCampaign>,
+        catalog: List<CatalogBadge>,
+        ownedBadges: Set<ChatIdentityBadgeKey>,
+        now: Instant,
+    ): List<ChatIdentityCampaign> {
+        val activeCampaigns = campaigns.filter { it.isActiveAt(now) }
+        val grouped = activeCampaigns
+            .groupBy(::logicalCampaignKey)
+            .filterKeys(String::isNotBlank)
+        if (grouped.isEmpty()) return emptyList()
+
+        val matchedGroups = catalog.associateWith { badge ->
+            grouped.keys.filter { key -> grouped.getValue(key).any { badge.matches(it) } }
+        }
+        val ambiguousGroups = matchedGroups.values
+            .filter { it.size > 1 }
+            .flatten()
+            .toSet()
+
+        return grouped.mapNotNull { (logicalKey, sourceCampaigns) ->
+            if (logicalKey in ambiguousGroups) return@mapNotNull null
+            val badges = matchedGroups.asSequence()
+                .filter { (_, matches) -> matches.singleOrNull() == logicalKey }
+                .map { (badge, _) ->
+                    ChatIdentityCampaignBadge(
+                        key = badge.key,
+                        title = badge.title,
+                        description = badge.description,
+                        imageUrl = badge.imageUrl,
+                        owned = badge.key in ownedBadges,
+                    )
+                }
+                .distinctBy { it.key }
+                .toList()
+            if (badges.isEmpty()) return@mapNotNull null
+
+            val rewards = sourceCampaigns.asSequence()
+                .flatMap { it.rewards.asSequence() }
+                .distinctBy { it.id }
+                .toList()
+            ChatIdentityCampaign(
+                id = logicalKey,
+                title = sourceCampaigns.first().name,
+                subtitle = sourceCampaigns.first().brand ?: sourceCampaigns.first().gameName,
+                imageUrl = sourceCampaigns.firstNotNullOfOrNull { it.imageUrl },
+                earnedBadges = badges.count { it.owned },
+                totalBadges = badges.size,
+                brand = sourceCampaigns.first().brand,
+                game = sourceCampaigns.first().gameName,
+                rewards = rewards,
+                badges = badges,
+                startsAt = sourceCampaigns.mapNotNull { it.startsAt }.minOrNull(),
+                endsAt = sourceCampaigns.mapNotNull { it.endsAt }.maxOrNull(),
+                rewardCampaignIds = sourceCampaigns.map { it.id }.distinct(),
+            )
+        }.sortedBy { it.title.lowercase(Locale.ROOT) }
+    }
+
+    private fun logicalCampaignKey(campaign: RewardCampaign): String {
+        val name = normalize(campaign.name)
+        if (name.isBlank()) return ""
+        val brand = normalize(campaign.brand)
+        val game = normalize(campaign.gameName)
+        return if (brand.isNotBlank()) {
+            "$brand|$name"
+        } else if (game.isNotBlank()) {
+            "$name|game:$game"
+        } else {
+            "name:$name"
+        }
+    }
+
+    private fun RewardCampaign.isActiveAt(now: Instant): Boolean {
+        val normalizedStatus = status?.trim()?.uppercase(Locale.ROOT)
+        if (normalizedStatus in setOf("EXPIRED", "ENDED", "COMPLETE", "COMPLETED")) return false
+        val starts = startsAt?.toInstantOrNull()
+        val ends = endsAt?.toInstantOrNull()
+        if (starts != null && starts > now) return false
+        if (ends != null && ends <= now) return false
+        return true
+    }
+
+    private fun CatalogBadge.matches(campaign: RewardCampaign): Boolean {
+        val description = normalize(description)
+        if (description.isBlank()) return false
+        val name = normalize(campaign.name)
+        if (name.isBlank()) return false
+        if (description.contains(name)) return true
+        val nameTerms = meaningfulTerms(name)
+        if (nameTerms.size < 2) return false
+        if (!nameTerms.all(description::contains)) return false
+        val brandTerms = meaningfulTerms(normalize(campaign.brand))
+        return brandTerms.isEmpty() || brandTerms.all(description::contains)
+    }
+
+    private fun parseRewards(rewards: JSONArray?): List<ChatIdentityCampaignReward> =
+        buildList {
+            if (rewards == null) return@buildList
+            for (index in 0 until rewards.length()) {
+                val reward = rewards.optJSONObject(index) ?: continue
+                val id = reward.optionalString("id") ?: continue
+                add(
+                    ChatIdentityCampaignReward(
+                        id = id,
+                        title = reward.optionalString("name"),
+                        description = null,
+                        imageUrl = reward.optJSONObject("bannerImage")?.optionalString("image1xURL")
+                            ?: reward.optJSONObject("thumbnailImage")?.optionalString("image1xURL"),
+                        earnableUntil = reward.optionalString("earnableUntil"),
+                    ),
+                )
+            }
+        }
+
+    private fun parseBadge(element: kotlinx.serialization.json.JsonElement): ChatIdentityBadge? {
+        val badge = element.jsonObjectOrNull() ?: return null
+        val setId = badge.stringOrNull("setID") ?: return null
+        val version = badge.stringOrNull("version") ?: return null
+        val imageUrl = badge.stringOrNull("imageURL") ?: return null
+        return ChatIdentityBadge(
+            key = ChatIdentityBadgeKey(setId, version),
+            title = badge.stringOrNull("title"),
+            description = badge.stringOrNull("description"),
+            imageUrl = imageUrl,
+        )
+    }
+
+    private fun meaningfulTerms(value: String?): List<String> = value.orEmpty()
+        .split(' ')
+        .filter { it.length >= 3 }
+        .filterNot { it in setOf("and", "for", "the", "with") }
+
+    private fun normalize(value: String?): String = Normalizer.normalize(
+        value.orEmpty(),
+        Normalizer.Form.NFD,
+    ).replace("\\p{M}+".toRegex(), "")
+        .lowercase(Locale.ROOT)
+        .replace("[^a-z0-9]+".toRegex(), " ")
+        .trim()
+
+    private fun String.toInstantOrNull(): Instant? = runCatching { Instant.parse(this) }.getOrNull()
+
+    private fun JSONObject.hasErrors(): Boolean = optJSONArray("errors")?.length()?.let { it > 0 } == true
+
+    private fun JSONObject.optionalString(vararg keys: String): String? = keys.firstNotNullOfOrNull { key ->
+        if (!has(key) || isNull(key)) null else optString(key).takeIf(String::isNotBlank)
+    }
+
+    private fun JsonObject.optObject(name: String): JsonObject? =
+        this[name]?.jsonObjectOrNull()
+
+    private fun JsonObject.optArray(name: String): List<kotlinx.serialization.json.JsonElement>? =
+        this[name]?.jsonArrayOrNull()?.toList()
+
+    private fun kotlinx.serialization.json.JsonElement.jsonObjectOrNull(): JsonObject? =
+        runCatching { jsonObject }.getOrNull()
+
+    private fun kotlinx.serialization.json.JsonElement.jsonArrayOrNull(): kotlinx.serialization.json.JsonArray? =
+        runCatching { jsonArray }.getOrNull()
+
+    private fun JsonObject.stringOrNull(name: String): String? =
+        this[name]?.let { runCatching { it.jsonPrimitive.content }.getOrNull() }
+}
+
+internal class ChatIdentityCampaignRepository private constructor(
+    private val networkLoader: suspend (
+        networkLibrary: String?,
+        headers: Map<String, String>,
+        ownedBadges: List<ChatIdentityBadge>,
+    ) -> List<ChatIdentityCampaign>,
+    private val elapsedRealtime: () -> Long,
+) {
+    constructor(graphQLRepository: GraphQLRepository) : this(
+        networkLoader = { networkLibrary, headers, ownedBadges ->
+            graphQLRepository.loadChatIdentityCampaigns(
+                networkLibrary = networkLibrary,
+                headers = headers,
+                ownedBadges = ownedBadges,
+            )
+        },
+        elapsedRealtime = SystemClock::elapsedRealtime,
+    )
+
+    private data class CacheEntry(
+        val viewerId: String,
+        val loadedAtElapsedRealtime: Long,
+        val campaigns: List<ChatIdentityCampaign>,
+    )
+
+    private val mutex = Mutex()
+    private var cache: CacheEntry? = null
+
+    suspend fun load(
+        viewerId: String,
+        networkLibrary: String?,
+        headers: Map<String, String>,
+        ownedBadges: List<ChatIdentityBadge>,
+    ): List<ChatIdentityCampaign> = mutex.withLock {
+        val now = elapsedRealtime()
+        cache?.takeIf {
+            it.viewerId == viewerId && now - it.loadedAtElapsedRealtime < CACHE_TTL_MS
+        }?.let { return@withLock it.campaigns }
+
+        val campaigns = try {
+            networkLoader(networkLibrary, headers, ownedBadges)
+        } catch (error: CancellationException) {
+            throw error
+        } catch (_: Exception) {
+            emptyList()
+        }
+        cache = CacheEntry(viewerId, now, campaigns)
+        campaigns
+    }
+
+    fun clear() {
+        cache = null
+    }
+
+    companion object {
+        internal fun forTesting(
+            networkLoader: suspend (
+                networkLibrary: String?,
+                headers: Map<String, String>,
+                ownedBadges: List<ChatIdentityBadge>,
+            ) -> List<ChatIdentityCampaign>,
+            elapsedRealtime: () -> Long = { 0L },
+        ): ChatIdentityCampaignRepository = ChatIdentityCampaignRepository(networkLoader, elapsedRealtime)
+
+        private const val CACHE_TTL_MS = 3 * 60 * 1000L
+    }
+}
+
+private suspend fun GraphQLRepository.loadChatIdentityCampaigns(
+    networkLibrary: String?,
+    headers: Map<String, String>,
+    ownedBadges: List<ChatIdentityBadge>,
+): List<ChatIdentityCampaign> {
+    val campaignsBody = executeRawOperation(
+        networkLibrary = networkLibrary,
+        headers = headers,
+        operationName = "ViewerDropsDashboard",
+        query = CHAT_IDENTITY_CAMPAIGNS_QUERY,
+        variables = kotlinx.serialization.json.buildJsonObject {
+            put("fetchRewardCampaigns", true)
+        },
+    ).toString()
+    val now = Instant.now()
+    if (!ChatIdentityCampaignParser.hasUsableActiveRewardCampaigns(campaignsBody, now)) {
+        return emptyList()
+    }
+    val badgeCatalogBody = executeRawOperation(
+        networkLibrary = networkLibrary,
+        headers = headers,
+        operationName = "ChatIdentityGlobalBadgeCatalog",
+        query = CHAT_IDENTITY_GLOBAL_BADGE_CATALOG_QUERY,
+    ).toString()
+    return ChatIdentityCampaignParser.parse(
+        rewardCampaignsBody = campaignsBody,
+        badgeCatalogBody = badgeCatalogBody,
+        ownedBadges = ownedBadges
+            .filterNot(ChatIdentityBadge::isSubscriptionSlotBadge)
+            .map { it.key }
+            .toSet(),
+        now = now,
+    ) ?: emptyList()
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatFragment.kt
@@ -56,7 +56,7 @@ import com.github.andreyasadchy.xtra.model.chat.ChatMessage
 import com.github.andreyasadchy.xtra.model.chat.ChatIdentityState
 import com.github.andreyasadchy.xtra.model.chat.NamePaint
 import com.github.andreyasadchy.xtra.model.chat.STVBadge
-import com.github.andreyasadchy.xtra.model.chat.effectiveBadge
+import com.github.andreyasadchy.xtra.model.chat.selectedVanityBadge
 import com.github.andreyasadchy.xtra.model.chat.Emote
 import com.github.andreyasadchy.xtra.model.chat.Poll
 import com.github.andreyasadchy.xtra.model.chat.PollVoteState
@@ -2007,7 +2007,8 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
 
     private fun updateChatIdentityTrigger(state: ChatIdentityState) {
         val icon = _binding?.chatIdentity ?: return
-        val badge = state.effectiveBadge()
+        val badge = state.displayBadges.firstOrNull()
+            ?: state.takeIf { !it.loading && it.displayName.isNotBlank() }?.selectedVanityBadge()
         if (badge?.imageUrl.isNullOrBlank()) {
             chatIdentityBadgeRequest?.dispose()
             chatIdentityBadgeRequest = null

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatIdentityPopup.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatIdentityPopup.kt
@@ -40,7 +40,6 @@ import com.github.andreyasadchy.xtra.util.PlayerUiGeometry
 import com.github.andreyasadchy.xtra.model.chat.ChatIdentityBadge
 import com.github.andreyasadchy.xtra.model.chat.ChatIdentityCampaign
 import com.github.andreyasadchy.xtra.model.chat.ChatIdentityState
-import com.github.andreyasadchy.xtra.model.chat.effectiveBadge
 import com.github.andreyasadchy.xtra.util.getAlertDialogBuilder
 import com.google.android.material.color.MaterialColors
 import com.google.android.material.materialswitch.MaterialSwitch
@@ -131,17 +130,28 @@ class ChatIdentityPopup(
         )
 
         clearImageRequests()
-        val previewBadge = content.findViewById<ImageView>(R.id.chatIdentityPreviewBadge)
-        previewBadge.setImageDrawable(null)
-        state.effectiveBadge()?.let { badge ->
-            previewBadge.isVisible = true
-            enqueueImage(badge.imageUrl, previewBadge)
-        } ?: run { previewBadge.isVisible = false }
+        renderPreviewBadges(content, state.displayBadges)
 
         renderCampaigns(content, state.campaigns)
         renderGlobalBadges(content, state)
         renderChannelBadges(content, state)
         renderColors(content, state)
+    }
+
+    private fun renderPreviewBadges(content: View, badges: List<ChatIdentityBadge>) {
+        val container = content.findViewById<LinearLayout>(R.id.chatIdentityPreviewBadges)
+        container.removeAllViews()
+        container.isVisible = badges.isNotEmpty()
+        badges.forEachIndexed { index, badge ->
+            val image = ImageView(context).apply {
+                contentDescription = null
+                scaleType = ImageView.ScaleType.FIT_CENTER
+            }
+            container.addView(image, LinearLayout.LayoutParams(context.dp(24), context.dp(24)).apply {
+                if (index != badges.lastIndex) rightMargin = context.dp(3)
+            })
+            enqueueImage(badge.imageUrl, image)
+        }
     }
 
     private fun renderGlobalBadges(content: View, state: ChatIdentityState) {
@@ -174,6 +184,7 @@ class ChatIdentityPopup(
             context.getString(R.string.chat_identity_channel_description, channelDisplayName)
         val subscriberContainer = content.findViewById<LinearLayout>(R.id.chatIdentitySubscriberBadge)
         subscriberContainer.removeAllViews()
+        val subscriptionStatus = content.findViewById<TextView>(R.id.chatIdentitySubscriptionStatus)
         if (state.isSubscribed && state.subscriberBadge != null) {
             val tile = createBadgeTile(
                 parent = subscriberContainer,
@@ -189,15 +200,13 @@ class ChatIdentityPopup(
                 setPadding(context.dp(8), 0, 0, 0)
             }, LinearLayout.LayoutParams(0, LinearLayout.LayoutParams.WRAP_CONTENT, 1f))
             subscriberContainer.isVisible = true
-            content.findViewById<TextView>(R.id.chatIdentitySubscriptionStatus).text = ""
+            renderSubscriptionStatus(subscriptionStatus, state)
         } else if (state.isSubscribed) {
             subscriberContainer.isVisible = false
-            content.findViewById<TextView>(R.id.chatIdentitySubscriptionStatus)
-                .setText(R.string.chat_identity_subscriber_badge_unavailable)
+            renderSubscriptionStatus(subscriptionStatus, state)
         } else {
             subscriberContainer.isVisible = false
-            content.findViewById<TextView>(R.id.chatIdentitySubscriptionStatus)
-                .setText(R.string.chat_identity_not_subscribed)
+            subscriptionStatus.setText(R.string.chat_identity_not_subscribed)
         }
 
         val customSwitch = content.findViewById<MaterialSwitch>(R.id.chatIdentityCustomBadgeSwitch)
@@ -354,6 +363,28 @@ class ChatIdentityPopup(
             orientation = LinearLayout.VERTICAL
             isVisible = false
         }
+        if (campaign.badges.isNotEmpty()) {
+            rewards.addView(TextView(context).apply {
+                text = context.getString(R.string.chat_identity_campaign_badges)
+                setTypeface(typeface, android.graphics.Typeface.BOLD)
+                setPadding(0, context.dp(6), 0, context.dp(2))
+            })
+            campaign.badges.forEach { badge ->
+                val row = LinearLayout(context).apply {
+                    gravity = Gravity.CENTER_VERTICAL
+                    alpha = if (badge.owned) 1f else 0.55f
+                    contentDescription = badge.title
+                }
+                val image = ImageView(context).apply { scaleType = ImageView.ScaleType.CENTER_INSIDE }
+                row.addView(image, LinearLayout.LayoutParams(context.dp(36), context.dp(36)))
+                enqueueImage(badge.imageUrl, image)
+                row.addView(TextView(context).apply {
+                    text = listOfNotNull(badge.title, badge.description).joinToString("\n")
+                    setPadding(context.dp(8), context.dp(4), 0, context.dp(4))
+                }, LinearLayout.LayoutParams(0, LinearLayout.LayoutParams.WRAP_CONTENT, 1f))
+                rewards.addView(row)
+            }
+        }
         campaign.rewards.forEach { reward ->
             val row = LinearLayout(context).apply { gravity = Gravity.CENTER_VERTICAL }
             reward.imageUrl?.let { imageUrl ->
@@ -382,6 +413,19 @@ class ChatIdentityPopup(
         header.setOnClickListener { setExpanded(!rewards.isVisible) }
         card.addView(root)
         return card
+    }
+
+    private fun renderSubscriptionStatus(status: TextView, state: ChatIdentityState) {
+        val months = state.subscriptionMonths
+        if (months != null && months > 0) {
+            status.text = context.resources.getQuantityString(
+                R.plurals.user_card_subscribed_months,
+                months,
+                months,
+            )
+        } else {
+            status.setText(R.string.user_card_subscribed)
+        }
     }
 
     private fun addBadgeTile(

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatViewModel.kt
@@ -23,7 +23,9 @@ import com.github.andreyasadchy.xtra.model.chat.ChannelPointReward
 import com.github.andreyasadchy.xtra.model.chat.ChatMessage
 import com.github.andreyasadchy.xtra.model.chat.ChatIdentityState
 import com.github.andreyasadchy.xtra.model.chat.ChatIdentityBadge
-import com.github.andreyasadchy.xtra.model.chat.effectiveBadge
+import com.github.andreyasadchy.xtra.model.chat.selectChannelBadgeOptimistically
+import com.github.andreyasadchy.xtra.model.chat.selectGlobalBadgeOptimistically
+import com.github.andreyasadchy.xtra.model.chat.toState
 import com.github.andreyasadchy.xtra.model.chat.Chatter
 import com.github.andreyasadchy.xtra.model.chat.CheerEmote
 import com.github.andreyasadchy.xtra.model.chat.Emote
@@ -61,6 +63,7 @@ import com.github.andreyasadchy.xtra.model.ui.WatchStreak
 import com.github.andreyasadchy.xtra.model.ui.WatchStreakReward
 import com.github.andreyasadchy.xtra.model.ui.WatchStreakShareResult
 import com.github.andreyasadchy.xtra.repository.GraphQLRepository
+import com.github.andreyasadchy.xtra.repository.ChatIdentityCampaignRepository
 import com.github.andreyasadchy.xtra.repository.HelixRepository
 import com.github.andreyasadchy.xtra.repository.PlayerRepository
 import com.github.andreyasadchy.xtra.repository.loadChatIdentity
@@ -409,8 +412,15 @@ class ChatViewModel(
         private set
 
     private data class CachedChatIdentity(
+        val viewerId: String,
         val loadedAtElapsedRealtime: Long,
         val state: ChatIdentityState,
+        val campaignsLoaded: Boolean,
+    )
+
+    private data class ChatIdentityCampaignLoadKey(
+        val viewerId: String,
+        val channelId: String,
     )
 
     data class ChatSnapshot(
@@ -516,7 +526,10 @@ class ChatViewModel(
     private var loggedInUserId: String? = null
     private var loggedInUserLogin: String? = null
     private val chatIdentityCache = mutableMapOf<String, CachedChatIdentity>()
+    private val chatIdentityCampaignRepository = ChatIdentityCampaignRepository(graphQLRepository)
     private var chatIdentityLoadJob: Job? = null
+    private var chatIdentityCampaignLoadJob: Job? = null
+    private var chatIdentityCampaignLoadKey: ChatIdentityCampaignLoadKey? = null
     private val chatIdentityMutationMutex = Mutex()
     private val _chatIdentityState = MutableStateFlow(ChatIdentityState())
     val chatIdentityState: StateFlow<ChatIdentityState> = _chatIdentityState
@@ -678,21 +691,41 @@ class ChatViewModel(
     fun ensureChatIdentityLoaded(channelId: String?, channelLogin: String?) {
         if (channelId.isNullOrBlank() || channelLogin.isNullOrBlank()) return
         val viewerId = applicationContext.tokenPrefs().getString(C.USER_ID, null)
-        if (viewerId.isNullOrBlank()) return
-        val cached = chatIdentityCache[channelId]
+        if (viewerId.isNullOrBlank()) {
+            chatIdentityCache.clear()
+            chatIdentityCampaignRepository.clear()
+            cancelChatIdentityCampaignLoad()
+            _chatIdentityState.value = ChatIdentityState(loadedChannelId = channelId)
+            return
+        }
+        val cached = chatIdentityCache[channelId]?.takeIf { it.viewerId == viewerId }
         val now = SystemClock.elapsedRealtime()
         if (cached != null && now - cached.loadedAtElapsedRealtime < CHAT_IDENTITY_CACHE_TTL_MS) {
             _chatIdentityState.value = cached.state
+            if (!cached.campaignsLoaded) {
+                scheduleChatIdentityCampaignLoad(
+                    viewerId = viewerId,
+                    channelId = channelId,
+                    ownedBadges = cached.state.globalBadges,
+                )
+            }
             return
         }
-        if (chatIdentityLoadJob?.isActive == true && _chatIdentityState.value.loadedChannelId == channelId) {
+        if (chatIdentityLoadJob?.isActive == true &&
+            _chatIdentityState.value.loadedChannelId == channelId &&
+            _chatIdentityState.value.loadedViewerId == viewerId
+        ) {
             return
         }
         chatIdentityLoadJob?.cancel()
-        val previous = _chatIdentityState.value.takeIf { it.loadedChannelId == channelId }
+        cancelChatIdentityCampaignLoad()
+        val previous = _chatIdentityState.value.takeIf {
+            it.loadedChannelId == channelId && it.loadedViewerId == viewerId
+        }
         _chatIdentityState.value = (previous ?: ChatIdentityState(loadedChannelId = channelId)).copy(
             loading = true,
             loadedChannelId = channelId,
+            loadedViewerId = viewerId,
             error = null,
         )
         chatIdentityLoadJob = viewModelScope.launch {
@@ -705,10 +738,60 @@ class ChatViewModel(
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
-                if (_chatIdentityState.value.loadedChannelId == channelId) {
+                if (_chatIdentityState.value.loadedChannelId == channelId &&
+                    _chatIdentityState.value.loadedViewerId == viewerId
+                ) {
                     _chatIdentityState.update { it.copy(loading = false, error = e.message) }
                 }
                 chatIdentityErrors.tryEmit(e.message ?: applicationContext.getString(R.string.chat_identity_load_failed))
+            }
+        }
+    }
+
+    private fun cancelChatIdentityCampaignLoad() {
+        chatIdentityCampaignLoadJob?.cancel()
+        chatIdentityCampaignLoadJob = null
+        chatIdentityCampaignLoadKey = null
+    }
+
+    private fun scheduleChatIdentityCampaignLoad(
+        viewerId: String,
+        channelId: String,
+        ownedBadges: List<ChatIdentityBadge>,
+    ) {
+        val key = ChatIdentityCampaignLoadKey(viewerId, channelId)
+        if (chatIdentityCampaignLoadJob?.isActive == true && chatIdentityCampaignLoadKey == key) {
+            return
+        }
+        chatIdentityCampaignLoadJob?.cancel()
+        chatIdentityCampaignLoadKey = key
+        chatIdentityCampaignLoadJob = viewModelScope.launch {
+            try {
+                val campaigns = chatIdentityCampaignRepository.load(
+                    viewerId = viewerId,
+                    networkLibrary = applicationContext.prefs().getString(C.NETWORK_LIBRARY, C.OKHTTP),
+                    headers = TwitchApiHelper.getGQLHeaders(applicationContext, true),
+                    ownedBadges = ownedBadges,
+                )
+                val cached = chatIdentityCache[channelId]
+                    ?.takeIf { it.viewerId == viewerId }
+                if (cached != null) {
+                    val campaignState = cached.state.copy(campaigns = campaigns)
+                    chatIdentityCache[channelId] = cached.copy(
+                        state = campaignState,
+                        campaignsLoaded = true,
+                    )
+                    if (_chatIdentityState.value.loadedChannelId == channelId &&
+                        _chatIdentityState.value.loadedViewerId == viewerId
+                    ) {
+                        _chatIdentityState.update { it.copy(campaigns = campaigns) }
+                    }
+                }
+            } finally {
+                if (chatIdentityCampaignLoadKey == key) {
+                    chatIdentityCampaignLoadJob = null
+                    chatIdentityCampaignLoadKey = null
+                }
             }
         }
     }
@@ -723,6 +806,10 @@ class ChatViewModel(
         viewModelScope.launch {
             chatIdentityMutationMutex.withLock {
                 val before = _chatIdentityState.value
+                if (before.mutationInProgress ||
+                    before.loadedChannelId != channelId ||
+                    before.loadedViewerId != viewerId
+                ) return@withLock
                 _chatIdentityState.value = before.copy(
                     nameColor = normalized,
                     mutationInProgress = true,
@@ -738,12 +825,17 @@ class ChatViewModel(
                 } catch (e: CancellationException) {
                     throw e
                 } catch (e: Exception) {
-                    if (_chatIdentityState.value.loadedChannelId == channelId) {
+                    if (_chatIdentityState.value.loadedChannelId == channelId &&
+                        _chatIdentityState.value.loadedViewerId == viewerId
+                    ) {
                         _chatIdentityState.value = before.copy(mutationInProgress = false, error = e.message)
                     }
                     chatIdentityErrors.tryEmit(e.message ?: applicationContext.getString(R.string.chat_identity_update_failed))
                 } finally {
-                    if (_chatIdentityState.value.loadedChannelId == channelId && _chatIdentityState.value.mutationInProgress) {
+                    if (_chatIdentityState.value.loadedChannelId == channelId &&
+                        _chatIdentityState.value.loadedViewerId == viewerId &&
+                        _chatIdentityState.value.mutationInProgress
+                    ) {
                         _chatIdentityState.update { it.copy(mutationInProgress = false) }
                     }
                 }
@@ -753,7 +845,7 @@ class ChatViewModel(
 
     fun setChatIdentityGlobalBadge(badge: ChatIdentityBadge?) {
         mutateChatIdentityPreference(
-            optimistic = { state -> state.copy(selectedGlobalBadge = badge?.key) },
+            optimistic = { state -> state.selectGlobalBadgeOptimistically(badge) },
             request = {
                 graphQLRepository.setGlobalChatBadge(
                     networkLibrary = applicationContext.prefs().getString(C.NETWORK_LIBRARY, C.OKHTTP),
@@ -768,10 +860,7 @@ class ChatViewModel(
         val channelId = _chatIdentityState.value.loadedChannelId ?: activeChannelId ?: return
         mutateChatIdentityPreference(
             optimistic = { state ->
-                state.copy(
-                    useCustomChannelBadge = badge != null,
-                    selectedChannelBadge = badge?.key,
-                )
+                state.selectChannelBadgeOptimistically(badge)
             },
             request = {
                 graphQLRepository.setChannelChatBadge(
@@ -806,7 +895,10 @@ class ChatViewModel(
         viewModelScope.launch {
             chatIdentityMutationMutex.withLock {
                 val before = _chatIdentityState.value
-                if (before.mutationInProgress || before.loadedChannelId != channelId) return@withLock
+                if (before.mutationInProgress ||
+                    before.loadedChannelId != channelId ||
+                    before.loadedViewerId != viewerId
+                ) return@withLock
                 _chatIdentityState.value = optimistic(before).copy(
                     mutationInProgress = true,
                     error = null,
@@ -817,12 +909,17 @@ class ChatViewModel(
                 } catch (e: CancellationException) {
                     throw e
                 } catch (e: Exception) {
-                    if (_chatIdentityState.value.loadedChannelId == channelId) {
+                    if (_chatIdentityState.value.loadedChannelId == channelId &&
+                        _chatIdentityState.value.loadedViewerId == viewerId
+                    ) {
                         _chatIdentityState.value = before.copy(mutationInProgress = false, error = e.message)
                     }
                     chatIdentityErrors.tryEmit(e.message ?: applicationContext.getString(R.string.chat_identity_update_failed))
                 } finally {
-                    if (_chatIdentityState.value.loadedChannelId == channelId && _chatIdentityState.value.mutationInProgress) {
+                    if (_chatIdentityState.value.loadedChannelId == channelId &&
+                        _chatIdentityState.value.loadedViewerId == viewerId &&
+                        _chatIdentityState.value.mutationInProgress
+                    ) {
                         _chatIdentityState.update { it.copy(mutationInProgress = false) }
                     }
                 }
@@ -835,40 +932,38 @@ class ChatViewModel(
         channelId: String,
         channelLogin: String,
     ) {
-        val data = graphQLRepository.loadChatIdentity(
+        val gqlHeaders = TwitchApiHelper.getGQLHeaders(applicationContext, true)
+        val baseData = graphQLRepository.loadChatIdentity(
             networkLibrary = applicationContext.prefs().getString(C.NETWORK_LIBRARY, C.OKHTTP),
-            headers = TwitchApiHelper.getGQLHeaders(applicationContext, true),
+            headers = gqlHeaders,
             viewerId = viewerId,
             channelId = channelId,
             channelLogin = channelLogin,
         )
-        val effectiveBadge = data.effectiveBadges.firstOrNull()
-        val globalBadges = (
-            data.availableGlobalBadges +
-                listOfNotNull(data.selectedGlobalBadge)
-            )
-            .distinctBy { it.key }
-        val state = ChatIdentityState(
-            loadedChannelId = channelId,
-            displayName = data.displayName,
-            nameColor = data.nameColor,
-            effectiveBadge = effectiveBadge,
-            globalBadges = globalBadges,
-            selectedGlobalBadge = data.selectedGlobalBadge?.key,
-            subscriberBadge = data.subscriberBadge,
-            isSubscribed = data.isSubscribed,
-            channelBadges = data.channelBadges,
-            useCustomChannelBadge = data.selectedChannelBadge != null,
-            selectedChannelBadge = data.selectedChannelBadge?.key,
-            campaigns = data.campaigns,
-            badgeSelectionAvailable = true,
-            channelBadgeOverrideAvailable = true,
-            canUseCustomNameColor = data.canUseCustomNameColor,
+        val existingCampaigns = _chatIdentityState.value
+            .takeIf {
+                it.loadedChannelId == channelId && it.loadedViewerId == viewerId
+            }
+            ?.campaigns
+            .orEmpty()
+        val state = baseData.toState(channelId = channelId, viewerId = viewerId)
+            .copy(campaigns = existingCampaigns)
+        chatIdentityCache[channelId] = CachedChatIdentity(
+            viewerId = viewerId,
+            loadedAtElapsedRealtime = SystemClock.elapsedRealtime(),
+            state = state,
+            campaignsLoaded = false,
         )
-        chatIdentityCache[channelId] = CachedChatIdentity(SystemClock.elapsedRealtime(), state)
-        if (_chatIdentityState.value.loadedChannelId == channelId) {
+        if (_chatIdentityState.value.loadedChannelId == channelId &&
+            _chatIdentityState.value.loadedViewerId == viewerId
+        ) {
             _chatIdentityState.value = state
         }
+        scheduleChatIdentityCampaignLoad(
+            viewerId = viewerId,
+            channelId = channelId,
+            ownedBadges = baseData.availableGlobalBadges,
+        )
     }
 
     fun startLive(
@@ -2885,9 +2980,20 @@ class ChatViewModel(
         val sessionToken = predictionSessionToken
         started = true
         _connectionState.value = ConnectionState.CONNECTING
-        if (_chatIdentityState.value.loadedChannelId != channelId) {
+        val currentIdentityViewerId = applicationContext.tokenPrefs().getString(C.USER_ID, null)
+        if (_chatIdentityState.value.loadedChannelId != channelId ||
+            _chatIdentityState.value.loadedViewerId != currentIdentityViewerId
+        ) {
             chatIdentityLoadJob?.cancel()
-            _chatIdentityState.value = ChatIdentityState(loadedChannelId = channelId)
+            cancelChatIdentityCampaignLoad()
+            if (_chatIdentityState.value.loadedViewerId != currentIdentityViewerId) {
+                chatIdentityCache.clear()
+                chatIdentityCampaignRepository.clear()
+            }
+            _chatIdentityState.value = ChatIdentityState(
+                loadedChannelId = channelId,
+                loadedViewerId = currentIdentityViewerId,
+            )
         }
         activeChannelId = channelId
         activeChannelLogin = channelLogin
@@ -3275,6 +3381,14 @@ class ChatViewModel(
         lastWatchStreakReconciliationElapsedRealtime = null
         activeChannelId = null
         activeChannelLogin = null
+        if (applicationContext.tokenPrefs().getString(C.USER_ID, null).isNullOrBlank()) {
+            chatIdentityLoadJob?.cancel()
+            chatIdentityLoadJob = null
+            cancelChatIdentityCampaignLoad()
+            chatIdentityCache.clear()
+            chatIdentityCampaignRepository.clear()
+            _chatIdentityState.value = ChatIdentityState()
+        }
         v2LiveChannelId = null
         v2LiveChannelLogin = null
         pinnedChatRefreshJob?.cancel()

--- a/app/src/main/res/layout/popup_chat_identity.xml
+++ b/app/src/main/res/layout/popup_chat_identity.xml
@@ -95,13 +95,13 @@
                 android:gravity="center_vertical"
                 android:orientation="horizontal">
 
-                <ImageView
-                    android:id="@+id/chatIdentityPreviewBadge"
-                    android:layout_width="24dp"
+                <LinearLayout
+                    android:id="@+id/chatIdentityPreviewBadges"
+                    android:layout_width="wrap_content"
                     android:layout_height="24dp"
                     android:layout_marginEnd="6dp"
-                    android:contentDescription="@null"
-                    android:scaleType="fitCenter"
+                    android:gravity="center_vertical"
+                    android:orientation="horizontal"
                     android:visibility="gone" />
 
                 <TextView

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1769,7 +1769,8 @@
     <string name="chat_identity_campaign_collapse" translatable="false">Collapse campaign</string>
     <string name="chat_identity_campaign_chevron_collapsed" translatable="false">&#9662;</string>
     <string name="chat_identity_campaign_chevron_expanded" translatable="false">&#9652;</string>
-    <string name="chat_identity_campaign_progress" translatable="false">%1$d/%2$d</string>
+    <string name="chat_identity_campaign_badges" translatable="false">Badges</string>
+    <string name="chat_identity_campaign_progress" translatable="false">%1$d/%2$d Badges</string>
     <string name="chat_identity_badge_selected" translatable="false">%1$s, selected</string>
     <string name="chat_identity_badge_title_hex" translatable="false">%1$s (%2$s)</string>
     <string name="chat_identity_subscriber_badge_unavailable" translatable="false">No subscriber badge is currently available.</string>

--- a/app/src/test/java/com/github/andreyasadchy/xtra/model/chat/ChatIdentitySemanticsTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/model/chat/ChatIdentitySemanticsTest.kt
@@ -1,0 +1,160 @@
+package com.github.andreyasadchy.xtra.model.chat
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ChatIdentitySemanticsTest {
+    private val subscriber = badge("subscriber", "12")
+    private val founder = badge("founder", "0")
+    private val moderator = badge("moderator", "1")
+    private val broadcaster = badge("broadcaster", "1")
+    private val globalVanity = badge("global-vanity", "pikachu")
+    private val channelVanity = badge("channel-vanity", "1")
+
+    @Test
+    fun `subscriber and global vanity keep server order for composer and preview`() {
+        val state = state(
+            displayBadges = listOf(subscriber, globalVanity),
+            globalBadges = listOf(globalVanity),
+            selectedGlobalBadge = globalVanity.key,
+        )
+
+        assertEquals(subscriber, state.displayBadges.firstOrNull())
+        assertEquals(listOf(subscriber, globalVanity), state.displayBadges)
+        assertEquals(globalVanity, state.selectedVanityBadge())
+    }
+
+    @Test
+    fun `custom channel vanity does not replace subscription slot`() {
+        val state = state(
+            displayBadges = listOf(subscriber, channelVanity),
+            channelBadges = listOf(channelVanity),
+            useCustomChannelBadge = true,
+            selectedChannelBadge = channelVanity.key,
+        )
+
+        assertEquals(subscriber, state.displayBadges.first())
+        assertEquals(listOf(subscriber, channelVanity), state.displayBadges)
+        assertEquals(channelVanity, state.selectedVanityBadge())
+    }
+
+    @Test
+    fun `turning custom override off selects global vanity only`() {
+        val state = state(
+            displayBadges = listOf(subscriber, globalVanity),
+            globalBadges = listOf(globalVanity),
+            selectedGlobalBadge = globalVanity.key,
+            channelBadges = listOf(channelVanity),
+            useCustomChannelBadge = false,
+            selectedChannelBadge = channelVanity.key,
+        )
+
+        assertEquals(globalVanity, state.selectedVanityBadge())
+        assertEquals(subscriber, state.displayBadges.first())
+    }
+
+    @Test
+    fun `server display list is the composer source without subscription`() {
+        val state = state(displayBadges = listOf(moderator, globalVanity))
+
+        assertEquals(moderator, state.displayBadges.first())
+        assertEquals(listOf(moderator, globalVanity), state.displayBadges)
+    }
+
+    @Test
+    fun `server authority and subscription order is preserved exactly`() {
+        val displayBadges = listOf(broadcaster, moderator, subscriber, globalVanity)
+        val state = state(displayBadges = displayBadges)
+
+        assertEquals(displayBadges, state.displayBadges)
+        assertEquals(broadcaster, state.displayBadges.first())
+    }
+
+    @Test
+    fun `founder is the subscription slot badge`() {
+        assertTrue(founder.isSubscriptionSlotBadge())
+        assertFalse(globalVanity.isSubscriptionSlotBadge())
+
+        val data = data(displayBadges = listOf(founder), earnedBadges = emptyList())
+        assertEquals(founder, data.subscriberBadge)
+    }
+
+    @Test
+    fun `earned founder without displayed subscription does not imply active subscription`() {
+        val data = data(displayBadges = emptyList(), earnedBadges = listOf(founder))
+
+        assertEquals(founder, data.subscriberBadge)
+        assertFalse(data.isSubscribed)
+    }
+
+    @Test
+    fun `subscription remains visible when no vanity is selected`() {
+        val state = state(displayBadges = listOf(subscriber))
+
+        assertEquals(subscriber, state.displayBadges.first())
+        assertNull(state.selectedVanityBadge())
+    }
+
+    @Test
+    fun `server refresh replaces display list while optimistic selection changes only preference`() {
+        val before = state(displayBadges = listOf(subscriber, globalVanity))
+        val optimistic = before.selectGlobalBadgeOptimistically(channelVanity)
+        val refreshed = data(displayBadges = listOf(subscriber, channelVanity))
+            .toState(channelId = "channel", viewerId = "viewer")
+
+        assertEquals(channelVanity.key, optimistic.selectedGlobalBadge)
+        assertEquals(before.displayBadges, optimistic.displayBadges)
+        assertEquals(listOf(subscriber, channelVanity), refreshed.displayBadges)
+    }
+
+    @Test
+    fun `subscription tenure is optional`() {
+        assertEquals(1, data(subscriptionMonths = 1).subscriptionMonths)
+        assertEquals(12, data(subscriptionMonths = 12).subscriptionMonths)
+        assertNull(data(subscriptionMonths = null).subscriptionMonths)
+    }
+
+    private fun state(
+        displayBadges: List<ChatIdentityBadge> = emptyList(),
+        globalBadges: List<ChatIdentityBadge> = emptyList(),
+        selectedGlobalBadge: ChatIdentityBadgeKey? = null,
+        channelBadges: List<ChatIdentityBadge> = emptyList(),
+        useCustomChannelBadge: Boolean = false,
+        selectedChannelBadge: ChatIdentityBadgeKey? = null,
+    ) = ChatIdentityState(
+        displayBadges = displayBadges,
+        globalBadges = globalBadges,
+        selectedGlobalBadge = selectedGlobalBadge,
+        channelBadges = channelBadges,
+        useCustomChannelBadge = useCustomChannelBadge,
+        selectedChannelBadge = selectedChannelBadge,
+    )
+
+    private fun data(
+        displayBadges: List<ChatIdentityBadge> = emptyList(),
+        earnedBadges: List<ChatIdentityBadge> = emptyList(),
+        subscriptionMonths: Int? = null,
+    ) = ChatIdentityData(
+        displayName = "viewer",
+        nameColor = null,
+        displayBadges = displayBadges,
+        availableGlobalBadges = emptyList(),
+        selectedGlobalBadge = null,
+        subscriberBadge = displayBadges.firstOrNull { it.isSubscriptionSlotBadge() }
+            ?: earnedBadges.firstOrNull { it.isSubscriptionSlotBadge() },
+        channelBadges = earnedBadges.filterNot { it.isSubscriptionSlotBadge() },
+        selectedChannelBadge = null,
+        isSubscribed = displayBadges.any { it.isSubscriptionSlotBadge() },
+        subscriptionMonths = subscriptionMonths,
+    )
+
+    private fun badge(setId: String, version: String) = ChatIdentityBadge(
+        key = ChatIdentityBadgeKey(setId, version),
+        title = setId,
+        description = null,
+        imageUrl = "https://example.com/$setId-$version.png",
+    )
+}

--- a/app/src/test/java/com/github/andreyasadchy/xtra/repository/ChatIdentityCampaignsTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/repository/ChatIdentityCampaignsTest.kt
@@ -1,0 +1,184 @@
+package com.github.andreyasadchy.xtra.repository
+
+import com.github.andreyasadchy.xtra.model.chat.ChatIdentityBadge
+import com.github.andreyasadchy.xtra.model.chat.ChatIdentityBadgeKey
+import com.github.andreyasadchy.xtra.model.chat.ChatIdentityCampaign
+import com.github.andreyasadchy.xtra.model.chat.ChatIdentityState
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.time.Instant
+
+class ChatIdentityCampaignsTest {
+    private val now = Instant.parse("2026-09-05T00:00:00Z")
+
+    @Test
+    fun `display badge parser retains every badge and description`() {
+        val body = Json.parseToJsonElement(
+            """
+            {"channel":{"self":{"displayBadges":[
+              {"setID":"subscriber","version":"1","title":"Subscriber","description":"sub","imageURL":"sub.png"},
+              {"setID":"vanity","version":"pikachu","title":"Pikachu","description":"vanity","imageURL":"pika.png"}
+            ]}}}
+            """.trimIndent(),
+        ).jsonObject
+
+        val badges = ChatIdentityCampaignParser.parseDisplayBadges(body)
+
+        assertEquals(listOf("subscriber", "vanity"), badges.map { it.key.setId })
+        assertEquals("vanity", badges[1].description)
+    }
+
+    @Test
+    fun `duplicate reward mechanics become one four badge collection with one owned`() {
+        val campaigns = parse(owned = setOf(ChatIdentityBadgeKey("first-partners", "pichu")))
+
+        assertEquals(1, campaigns.size)
+        assertEquals("First Partners Collection", campaigns.single().title)
+        assertEquals("Pokémon", campaigns.single().subtitle)
+        assertEquals(1, campaigns.single().earnedBadges)
+        assertEquals(4, campaigns.single().totalBadges)
+        assertEquals(2, campaigns.single().rewardCampaignIds.size)
+        assertEquals(2, campaigns.single().rewards.size)
+    }
+
+    @Test
+    fun `collection progress supports zero and complete ownership`() {
+        assertEquals(0, parse(emptySet()).single().earnedBadges)
+        assertEquals(
+            4,
+            parse(
+                setOf("pichu", "bulbasaur", "charmander", "squirtle")
+                    .map { ChatIdentityBadgeKey("first-partners", it) }
+                    .toSet(),
+            ).single().earnedBadges,
+        )
+    }
+
+    @Test
+    fun `no active campaigns produces no chat identity cards`() {
+        val expired = fixture("chat_identity_campaigns.json")
+            .replace("\"endsAt\": \"2026-12-31T23:59:59Z\"", "\"endsAt\": \"2026-01-02T00:00:00Z\"")
+        val result = ChatIdentityCampaignParser.parse(
+            rewardCampaignsBody = expired,
+            badgeCatalogBody = fixture("chat_identity_badges.json"),
+            ownedBadges = emptySet(),
+            now = now,
+        )
+
+        assertEquals(emptyList<Any>(), result)
+    }
+
+    @Test
+    fun `badge catalog is only needed after an active dashboard campaign is found`() {
+        assertTrue(
+            ChatIdentityCampaignParser.hasUsableActiveRewardCampaigns(
+                body = fixture("chat_identity_campaigns.json"),
+                now = now,
+            ),
+        )
+        assertFalse(
+            ChatIdentityCampaignParser.hasUsableActiveRewardCampaigns(
+                body = fixture("chat_identity_campaigns.json")
+                    .replace("\"endsAt\": \"2026-12-31T23:59:59Z\"", "\"endsAt\": \"2026-01-02T00:00:00Z\""),
+                now = now,
+            ),
+        )
+        assertFalse(
+            ChatIdentityCampaignParser.hasUsableActiveRewardCampaigns(
+                body = "{\"data\":{}}",
+                now = now,
+            ),
+        )
+    }
+
+    @Test
+    fun `campaign schema failure is isolated`() {
+        assertNull(
+            ChatIdentityCampaignParser.parse(
+                rewardCampaignsBody = "{\"data\":{}}",
+                badgeCatalogBody = fixture("chat_identity_badges.json"),
+                ownedBadges = emptySet(),
+                now = now,
+            ),
+        )
+    }
+
+    @Test
+    fun `delayed campaign loading does not change the already available base identity`() = runBlocking {
+        val started = CompletableDeferred<Unit>()
+        val release = CompletableDeferred<List<ChatIdentityCampaign>>()
+        val repository = ChatIdentityCampaignRepository.forTesting(
+            networkLoader = { _, _, _ ->
+                started.complete(Unit)
+                release.await()
+            },
+        )
+        val baseState = ChatIdentityState(
+            displayName = "viewer",
+            displayBadges = listOf(
+                ChatIdentityBadge(
+                    key = ChatIdentityBadgeKey("subscriber", "1"),
+                    title = "Subscriber",
+                    description = null,
+                    imageUrl = "subscriber.png",
+                ),
+            ),
+        )
+        val load = async {
+            repository.load(
+                viewerId = "viewer",
+                networkLibrary = null,
+                headers = emptyMap(),
+                ownedBadges = emptyList(),
+            )
+        }
+
+        started.await()
+        assertEquals("viewer", baseState.displayName)
+        assertEquals("subscriber", baseState.displayBadges.single().key.setId)
+        assertFalse(load.isCompleted)
+
+        release.complete(emptyList())
+        assertEquals(emptyList<ChatIdentityCampaign>(), load.await())
+    }
+
+    @Test
+    fun `campaign loader failure is cached as an empty optional result`() = runBlocking {
+        var calls = 0
+        val repository = ChatIdentityCampaignRepository.forTesting(
+            networkLoader = { _, _, _ ->
+                calls += 1
+                error("campaign endpoint unavailable")
+            },
+        )
+
+        assertEquals(
+            emptyList<ChatIdentityCampaign>(),
+            repository.load("viewer", null, emptyMap(), emptyList()),
+        )
+        assertEquals(
+            emptyList<ChatIdentityCampaign>(),
+            repository.load("viewer", null, emptyMap(), emptyList()),
+        )
+        assertEquals(1, calls)
+    }
+
+    private fun parse(owned: Set<ChatIdentityBadgeKey>): List<com.github.andreyasadchy.xtra.model.chat.ChatIdentityCampaign> =
+        ChatIdentityCampaignParser.parse(
+            rewardCampaignsBody = fixture("chat_identity_campaigns.json"),
+            badgeCatalogBody = fixture("chat_identity_badges.json"),
+            ownedBadges = owned,
+            now = now,
+        )!!
+
+    private fun fixture(name: String): String =
+        javaClass.getResource("/twitch_gql/$name")!!.readText()
+}

--- a/app/src/test/resources/twitch_gql/chat_identity_badges.json
+++ b/app/src/test/resources/twitch_gql/chat_identity_badges.json
@@ -1,0 +1,46 @@
+{
+  "data": {
+    "badges": [
+      {
+        "id": "pichu",
+        "setID": "first-partners",
+        "version": "pichu",
+        "title": "Pichu",
+        "description": "Chat badge earned through the Pokémon First Partners Collection.",
+        "imageURL": "https://example.com/pichu.png"
+      },
+      {
+        "id": "bulbasaur",
+        "setID": "first-partners",
+        "version": "bulbasaur",
+        "title": "Bulbasaur",
+        "description": "Chat badge earned through the Pokémon First Partners Collection.",
+        "imageURL": "https://example.com/bulbasaur.png"
+      },
+      {
+        "id": "charmander",
+        "setID": "first-partners",
+        "version": "charmander",
+        "title": "Charmander",
+        "description": "Chat badge earned through the Pokémon First Partners Collection.",
+        "imageURL": "https://example.com/charmander.png"
+      },
+      {
+        "id": "squirtle",
+        "setID": "first-partners",
+        "version": "squirtle",
+        "title": "Squirtle",
+        "description": "Chat badge earned through the Pokémon First Partners Collection.",
+        "imageURL": "https://example.com/squirtle.png"
+      },
+      {
+        "id": "unrelated",
+        "setID": "other-collection",
+        "version": "1",
+        "title": "Other",
+        "description": "Chat badge earned through another collection.",
+        "imageURL": "https://example.com/other.png"
+      }
+    ]
+  }
+}

--- a/app/src/test/resources/twitch_gql/chat_identity_campaigns.json
+++ b/app/src/test/resources/twitch_gql/chat_identity_campaigns.json
@@ -1,0 +1,51 @@
+{
+  "data": {
+    "currentUser": { "id": "viewer" },
+    "rewardCampaignsAvailableToUser": [
+      {
+        "id": "reward-poke-ball",
+        "name": "First Partners Collection",
+        "brand": "Pokémon",
+        "startsAt": "2026-01-01T00:00:00Z",
+        "endsAt": "2026-12-31T23:59:59Z",
+        "status": "ACTIVE",
+        "summary": "Collect Pokémon chat badges",
+        "isSitewide": true,
+        "game": { "id": "pokemon", "displayName": "Pokémon" },
+        "image": { "image1xURL": "https://example.com/pokemon.png" },
+        "unlockRequirements": { "minuteWatchedGoal": 0, "subsGoal": 0 },
+        "rewards": [
+          {
+            "id": "poke-ball",
+            "name": "Poké Ball",
+            "earnableUntil": "2026-12-31T23:59:59Z",
+            "thumbnailImage": { "image1xURL": "https://example.com/poke-ball.png" },
+            "bannerImage": { "image1xURL": "https://example.com/poke-ball-banner.png" }
+          }
+        ]
+      },
+      {
+        "id": "reward-great-ball",
+        "name": "First Partners Collection",
+        "brand": "Pokémon",
+        "startsAt": "2026-01-01T00:00:00Z",
+        "endsAt": "2026-12-31T23:59:59Z",
+        "status": "ACTIVE",
+        "summary": "Collect more Pokémon chat badges",
+        "isSitewide": true,
+        "game": { "id": "pokemon", "displayName": "Pokémon" },
+        "image": { "image1xURL": "https://example.com/pokemon.png" },
+        "unlockRequirements": { "minuteWatchedGoal": 0, "subsGoal": 0 },
+        "rewards": [
+          {
+            "id": "great-ball",
+            "name": "Great Ball",
+            "earnableUntil": "2026-12-31T23:59:59Z",
+            "thumbnailImage": { "image1xURL": "https://example.com/great-ball.png" },
+            "bannerImage": { "image1xURL": "https://example.com/great-ball-banner.png" }
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Chat Identity now follows Twitch's ordered badge list, so subscriber and vanity badges display together. Active badge collections use campaign data without affecting the rest of identity loading.