### PR TITLE
Reduce sustained chat rendering work

### DIFF
--- a/app/src/androidTest/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatMessageTextViewTest.kt
+++ b/app/src/androidTest/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatMessageTextViewTest.kt
@@ -782,6 +782,29 @@ class ChatMessageTextViewTest {
     }
 
     @Test
+    fun modelDisabledAnimationStaysStoppedWhenGlobalAnimationIsEnabled() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+        lateinit var animated: RecordingAnimatedDrawable
+        val repository = ChatAssetRepository(scope, ChatAssetLoader {
+            ChatImageHandle { RecordingAnimatedDrawable().also { animated = it } }
+        })
+        val view = TestTextView(context, repository)
+        val spec = ChatAssetSpec(ChatAssetKey("model-disabled-animation"), 20, 20, 28)
+
+        runOnMain {
+            view.setAnimateGifs(true)
+            view.bind(row(spec, animated = false))
+            val spanned = view.text as Spanned
+            val span = spanned.getSpans(0, spanned.length, ReplacementSpan::class.java).single()
+            draw(span, spanned, Paint.FontMetricsInt())
+            view.attachedForTest()
+            assertEquals(0, animated.startCount)
+        }
+        scope.cancel()
+    }
+
+    @Test
     fun adapterAppliesRuntimeAnimationSettingToReboundRows() {
         val context = InstrumentationRegistry.getInstrumentation().targetContext
         val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
@@ -1085,11 +1108,12 @@ class ChatMessageTextViewTest {
         username: String? = null,
         interaction: ChatEmoteInteraction? = null,
         fallback: String = ":asset:",
+        animated: Boolean = true,
     ) = ChatRowUiModel(
         id = ChatMessageId("row"), channelId = "channel", timestampText = null,
         pieces = buildList {
             username?.let { add(ChatPiece.Username(it, 0xffff8a80.toInt())) }
-            add(ChatPiece.Emote(spec, fallback, interaction = interaction))
+            add(ChatPiece.Emote(spec, fallback, animated = animated, interaction = interaction))
         },
         background = 0xff101010.toInt(), accessibilityText = "row", reply = null,
         source = null, isAction = false,

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/catalog/ChatCatalogSnapshot.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/catalog/ChatCatalogSnapshot.kt
@@ -90,6 +90,7 @@ data class ChatCatalogBadge(
 data class ChatCatalogCheermote(
     val asset: ChatAssetSpec,
     val color: Int?,
+    val animated: Boolean = false,
 )
 
 data class ChatNamePaint(

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/catalog/TwitchChatCatalogSource.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/catalog/TwitchChatCatalogSource.kt
@@ -239,21 +239,6 @@ class TwitchChatCatalogSource(
         )
     }
 
-    private fun CheerEmote.toCatalog(): Pair<String, ChatCatalogCheermote>? {
-        val url = url4x ?: url3x ?: url2x ?: url1x ?: return null
-        val key = "twitch-cheer:$name:$minBits"
-        val color = color?.let { value -> runCatching { Color.parseColor(value) }.getOrNull() }
-        return key to ChatCatalogCheermote(
-            asset = ChatAssetSpec(
-                key = ChatAssetKey(url),
-                sourceWidth = 28,
-                sourceHeight = 28,
-                targetHeight = 28,
-            ),
-            color = color,
-        )
-    }
-
     private suspend fun <T> scopeUpdate(
         channel: Boolean,
         emptyValue: T? = null,
@@ -315,6 +300,22 @@ class TwitchChatCatalogSource(
     } catch (_: Throwable) {
         null
     }
+}
+
+internal fun CheerEmote.toCatalog(): Pair<String, ChatCatalogCheermote>? {
+    val url = url4x ?: url3x ?: url2x ?: url1x ?: return null
+    val key = "twitch-cheer:$name:$minBits"
+    val color = color?.let { value -> runCatching { Color.parseColor(value) }.getOrNull() }
+    return key to ChatCatalogCheermote(
+        asset = ChatAssetSpec(
+            key = ChatAssetKey(url),
+            sourceWidth = 28,
+            sourceHeight = 28,
+            targetHeight = 28,
+        ),
+        color = color,
+        animated = isAnimated,
+    )
 }
 
 private enum class GlobalCatalogKey {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/presentation/ChatRowCompiler.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/presentation/ChatRowCompiler.kt
@@ -347,7 +347,7 @@ class ChatRowCompiler(
                                     id = segment.asset.key.value,
                                     name = segment.text,
                                     url = catalogCheermote?.asset?.key?.value ?: segment.asset.key.value,
-                                    animated = false,
+                                    animated = catalogCheermote?.animated == true,
                                     provider = com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatAssetProvider.TWITCH,
                                     scope = null,
                                 ),
@@ -491,6 +491,7 @@ class ChatRowCompiler(
         val previous = output.lastOrNull() as? ChatSegment.Emote ?: return false
         output[output.lastIndex] = previous.copy(
             asset = previous.asset.copy(overlays = previous.asset.overlays + modifier.asset),
+            animated = previous.animated || modifier.animated,
         )
         return true
     }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatMessageTextView.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatMessageTextView.kt
@@ -30,6 +30,7 @@ import android.graphics.Typeface
 import android.view.Gravity
 import android.os.Handler
 import android.os.Looper
+import android.os.Trace
 import android.view.MotionEvent
 import android.view.ViewConfiguration
 import android.widget.TextView
@@ -40,8 +41,10 @@ import androidx.core.view.doOnPreDraw
 import androidx.appcompat.widget.AppCompatTextView
 import com.github.andreyasadchy.xtra.R
 import com.github.andreyasadchy.xtra.XtraApp
+import com.github.andreyasadchy.xtra.BuildConfig
 import com.github.andreyasadchy.xtra.ui.chat.v2.assets.ChatAssetRepository
 import com.github.andreyasadchy.xtra.ui.chat.v2.assets.ChatAssetState
+import com.github.andreyasadchy.xtra.util.ChatRenderDiagnostics
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatAssetKey
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatAssetSpec
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatEmoteInteraction
@@ -122,6 +125,8 @@ open class ChatMessageTextView private constructor(
     }
     private var renderingActive = true
     private var animateGifs = true
+    private var windowAttached = false
+    private var animatedAssetKeys = emptySet<ChatAssetKey>()
     private var boundMessageId: ChatMessageId? = null
     private var longPressConsumed = false
     private var touchDownX = 0f
@@ -171,22 +176,20 @@ open class ChatMessageTextView private constructor(
 
     fun setAnimateGifs(value: Boolean) {
         animateGifs = value
-        if (!value) {
-            drawables.values.forEach { it.stopIfNeeded() }
-        } else if (renderingActive && isAttachedToWindow) {
-            drawables.values.forEach { drawable ->
-                drawable.callback = this
-                drawable.startIfNeeded()
-            }
-        }
+        updateDrawableAnimations()
     }
 
     fun bind(row: ChatRowUiModel) {
         boundRow = row
         bindingRow = true
+        if (BuildConfig.PERF_DIAGNOSTICS) {
+            ChatRenderDiagnostics.recordBind()
+            Trace.beginSection("Xtra.ChatV2.bind")
+        }
         try {
             bindRow(row)
         } finally {
+            if (BuildConfig.PERF_DIAGNOSTICS) Trace.endSection()
             bindingRow = false
         }
     }
@@ -229,6 +232,16 @@ open class ChatMessageTextView private constructor(
         oldKeys.filterNot(newKeys::contains).forEach { assets.removeObserver(it, assetInvalidator) }
         newKeys.filterNot(oldKeys::contains).forEach { assets.observe(it, assetInvalidator) }
         keys = newKeys
+        animatedAssetKeys = row.pieces.flatMap { piece ->
+            val spec = when (piece) {
+                is ChatPiece.Emote -> piece.asset.takeIf { piece.animated }
+                is ChatPiece.Gif -> piece.asset
+                is ChatPiece.Badge -> piece.asset.takeIf { piece.interaction?.animated == true }
+                is ChatPiece.Cheermote -> piece.asset.takeIf { piece.interaction?.animated == true }
+                else -> null
+            }
+            spec?.allKeys().orEmpty()
+        }.toSet()
         initialAssetSpecs = row.pieces.mapNotNull { piece ->
             when (piece) {
                 is ChatPiece.Badge -> piece.asset
@@ -488,15 +501,23 @@ open class ChatMessageTextView private constructor(
     }
 
     override fun onDraw(canvas: Canvas) {
-        super.onDraw(canvas)
-        val previews = resolvedClipPreviews()
-        if (previews.isEmpty()) return
-        val left = totalPaddingLeft.toFloat()
-        val right = (width - totalPaddingRight).toFloat()
-        var top = (paddingTop + layout?.height.orZero() + clipPreviewGap()).toFloat()
-        previews.forEach { (link, preview) ->
-            drawClipPreview(canvas, left, top, right, link, preview)
-            top += clipPreviewBlockHeight() + clipPreviewGap()
+        if (BuildConfig.PERF_DIAGNOSTICS) {
+            ChatRenderDiagnostics.recordDraw()
+            Trace.beginSection("Xtra.ChatV2.onDraw")
+        }
+        try {
+            super.onDraw(canvas)
+            val previews = resolvedClipPreviews()
+            if (previews.isEmpty()) return
+            val left = totalPaddingLeft.toFloat()
+            val right = (width - totalPaddingRight).toFloat()
+            var top = (paddingTop + layout?.height.orZero() + clipPreviewGap()).toFloat()
+            previews.forEach { (link, preview) ->
+                drawClipPreview(canvas, left, top, right, link, preview)
+                top += clipPreviewBlockHeight() + clipPreviewGap()
+            }
+        } finally {
+            if (BuildConfig.PERF_DIAGNOSTICS) Trace.endSection()
         }
     }
 
@@ -809,6 +830,8 @@ open class ChatMessageTextView private constructor(
         interaction: ChatEmoteInteraction? = null,
         gifInteraction: ChatGifInteraction? = null,
     ) {
+        val layerSpecs = spec.flatten()
+        val compositionKey = spec.compositionKey
         val start = output.length
         output.append(" ")
         val end = output.length
@@ -816,8 +839,9 @@ open class ChatMessageTextView private constructor(
             ChatAssetSpan(
                 spec,
                 fallback,
-                { drawableLayersFor(spec) },
-                { assetRenderState(spec) },
+                layerSpecs,
+                { layerSpec -> drawableFor(layerSpec.key, layerSpec) },
+                { assetRenderState(compositionKey, layerSpecs) },
                 fallbackMode,
             ),
             start,
@@ -854,22 +878,8 @@ open class ChatMessageTextView private constructor(
             drawables[key] ?: return null
         }
         drawable.setBounds(0, 0, spec.computedWidth, spec.targetHeight)
-        if (isAttachedToWindow && renderingActive) {
-            drawable.callback = this
-            if (animateGifs) drawable.startIfNeeded()
-        }
+        updateAnimationState(key, drawable)
         return drawable
-    }
-
-    private fun drawableLayersFor(spec: ChatAssetSpec): List<DrawableLayer>? {
-        val specs = spec.flatten()
-        if (specs.any { assets.peek(it.key) !is ChatAssetState.Ready }) return null
-        val layers = ArrayList<DrawableLayer>(specs.size)
-        for (layerSpec in specs) {
-            val drawable = drawableFor(layerSpec.key, layerSpec) ?: return null
-            layers += DrawableLayer(layerSpec, drawable)
-        }
-        return layers
     }
 
     fun recycle() {
@@ -882,6 +892,7 @@ open class ChatMessageTextView private constructor(
         drawables.clear()
         drawableHandles.clear()
         keys = emptySet()
+        animatedAssetKeys = emptySet()
         clipPreviewSlugs = emptySet()
         clipPreviewAssetKeys = emptySet()
         initialAssetSpecs = emptyList()
@@ -899,16 +910,47 @@ open class ChatMessageTextView private constructor(
 
     private fun assetRenderState(spec: ChatAssetSpec): ChatAssetRenderState {
         val flattened = spec.flatten()
-        if (spec.compositionKey in latchedFailedCompositionKeys) return ChatAssetRenderState.FAILED
-        val states = flattened.map { assets.peek(it.key) }
-        return when {
-            states.all { it is ChatAssetState.Ready } -> ChatAssetRenderState.READY
-            states.any {
-                it === ChatAssetState.Missing ||
-                    it === ChatAssetState.Loading ||
-                    it is ChatAssetState.Failed && !it.isPresentationTerminal
-            } -> ChatAssetRenderState.PENDING
-            else -> ChatAssetRenderState.FAILED
+        return assetRenderState(spec.compositionKey, flattened)
+    }
+
+    private fun assetRenderState(
+        compositionKey: String,
+        flattened: List<ChatAssetSpec>,
+    ): ChatAssetRenderState {
+        if (compositionKey in latchedFailedCompositionKeys) return ChatAssetRenderState.FAILED
+        for (layerSpec in flattened) {
+            when (val state = assets.peek(layerSpec.key)) {
+                is ChatAssetState.Ready -> Unit
+                ChatAssetState.Missing,
+                ChatAssetState.Loading,
+                -> return ChatAssetRenderState.PENDING
+                is ChatAssetState.Failed -> {
+                    if (!state.isPresentationTerminal) return ChatAssetRenderState.PENDING
+                    return ChatAssetRenderState.FAILED
+                }
+            }
+        }
+        return ChatAssetRenderState.READY
+    }
+
+    private fun updateDrawableAnimations() {
+        drawables.forEach { (key, drawable) ->
+            updateAnimationState(key, drawable)
+        }
+    }
+
+    private fun updateAnimationState(key: ChatAssetKey, drawable: Drawable) {
+        drawable.callback = if (renderingActive && windowAttached) this else null
+        val animatable = drawable as? Animatable ?: return
+        val shouldRun = animateGifs && renderingActive && windowAttached && key in animatedAssetKeys
+        if (shouldRun) {
+            if (!animatable.isRunning) {
+                animatable.start()
+                ChatRenderDiagnostics.recordAnimationStarted()
+            }
+        } else if (animatable.isRunning) {
+            animatable.stop()
+            ChatRenderDiagnostics.recordAnimationStopped()
         }
     }
 
@@ -926,21 +968,17 @@ open class ChatMessageTextView private constructor(
                 refreshClipPreviewAssets()
                 maybeRevealInitialAssetFrame()
             }
-            if (isAttachedToWindow) {
-                drawables.values.forEach { drawable ->
-                    drawable.callback = this
-                    if (animateGifs) drawable.startIfNeeded()
-                }
-            }
+            if (isAttachedToWindow) updateDrawableAnimations()
         } else {
             keys.forEach { assets.removeObserver(it, assetInvalidator) }
             clipPreviewSlugs.forEach { slug -> clipPreviews?.removeObserver(slug, clipMetadataInvalidator) }
             clipPreviewAssetKeys.forEach { assets.removeObserver(it, clipThumbnailInvalidator) }
-            drawables.values.forEach { drawable -> drawable.stopIfNeeded(); drawable.callback = null }
+            drawables.forEach { (key, drawable) -> updateAnimationState(key, drawable) }
         }
     }
 
     override fun onDetachedFromWindow() {
+        windowAttached = false
         longPressRunnable?.let(mainHandler::removeCallbacks)
         longPressRunnable = null
         keys.forEach { assets.removeObserver(it, assetInvalidator) }
@@ -952,28 +990,37 @@ open class ChatMessageTextView private constructor(
 
     override fun onAttachedToWindow() {
         super.onAttachedToWindow()
+        windowAttached = true
         if (renderingActive) {
             keys.forEach { assets.observe(it, assetInvalidator) }
             clipPreviewSlugs.forEach { slug -> clipPreviews?.observe(slug, clipMetadataInvalidator) }
             clipPreviewAssetKeys.forEach { assets.observe(it, clipThumbnailInvalidator) }
             refreshClipPreviewAssets()
             maybeRevealInitialAssetFrame()
-            drawables.values.forEach { drawable ->
-                drawable.callback = this
-                if (animateGifs) drawable.startIfNeeded()
-            }
+            updateDrawableAnimations()
         }
     }
 
     override fun verifyDrawable(who: Drawable): Boolean =
         super.verifyDrawable(who) || drawables.values.any { it === who }
+
+    override fun invalidateDrawable(drawable: Drawable) {
+        if (BuildConfig.PERF_DIAGNOSTICS && drawable is Animatable) {
+            ChatRenderDiagnostics.recordAnimationInvalidation()
+        }
+        super.invalidateDrawable(drawable)
+    }
 }
 
 private fun Int?.orZero(): Int = this ?: 0
 
-private fun Drawable.stopIfNeeded() { (this as? Animatable)?.stop() }
-private fun Drawable.startIfNeeded() {
-    (this as? Animatable)?.let { if (!it.isRunning) it.start() }
+private fun Drawable.stopIfNeeded() {
+    (this as? Animatable)?.let { animatable ->
+        if (animatable.isRunning) {
+            animatable.stop()
+            ChatRenderDiagnostics.recordAnimationStopped()
+        }
+    }
 }
 
 private fun ChatAssetSpec.allKeys(): List<ChatAssetKey> = buildList {
@@ -985,8 +1032,6 @@ private fun ChatAssetSpec.flatten(): List<ChatAssetSpec> = buildList {
     add(this@flatten)
     overlays.forEach { addAll(it.flatten()) }
 }
-
-private data class DrawableLayer(val spec: ChatAssetSpec, val drawable: Drawable)
 
 private enum class ChatAssetRenderState {
     PENDING,
@@ -1075,12 +1120,17 @@ private class ChatNamePaintSpan(
 private class ChatAssetSpan(
     private val spec: ChatAssetSpec,
     private val fallback: String,
-    private val drawables: () -> List<DrawableLayer>?,
+    private val layerSpecs: List<ChatAssetSpec>,
+    private val drawableFor: (ChatAssetSpec) -> Drawable?,
     private val renderState: () -> ChatAssetRenderState,
     private val fallbackMode: ChatAssetFallbackMode,
 ) : ReplacementSpan() {
+    private val compositionWidth = spec.compositionWidth
+    private val compositionHeight = spec.compositionHeight
+    private val resolvedDrawables = arrayOfNulls<Drawable>(layerSpecs.size)
+
     override fun getSize(paint: Paint, text: CharSequence, start: Int, end: Int, fm: Paint.FontMetricsInt?): Int {
-        val height = spec.compositionHeight
+        val height = compositionHeight
         if (fm != null) {
             val currentHeight = fm.descent - fm.ascent
             if (height > currentHeight) {
@@ -1096,9 +1146,9 @@ private class ChatAssetSpan(
         return if (renderState() == ChatAssetRenderState.FAILED &&
             fallbackMode == ChatAssetFallbackMode.TEXT_ON_FAILURE
         ) {
-            maxOf(spec.compositionWidth, fallbackWidth(paint))
+            maxOf(compositionWidth, fallbackWidth(paint))
         } else {
-            spec.compositionWidth
+            compositionWidth
         }
     }
 
@@ -1112,21 +1162,20 @@ private class ChatAssetSpan(
     }
 
     private fun drawReady(canvas: Canvas, x: Float, top: Int, bottom: Int) {
-        val images = drawables() ?: return
+        for (index in layerSpecs.indices) {
+            resolvedDrawables[index] = drawableFor(layerSpecs[index]) ?: return
+        }
+        val centerX = x + compositionWidth / 2f
         val centerY = (top + bottom) / 2f
-        val rect = RectF(
-            x,
-            centerY - spec.compositionHeight / 2f,
-            x + spec.compositionWidth,
-            centerY + spec.compositionHeight / 2f,
-        )
-        images.forEach { layer ->
-            val width = layer.spec.computedWidth
-            val height = layer.spec.targetHeight
-            val left = rect.centerX() - width / 2f
-            val layerRect = RectF(left, rect.centerY() - height / 2f, left + width, rect.centerY() + height / 2f)
-            layer.drawable.setBounds(layerRect.left.toInt(), layerRect.top.toInt(), layerRect.right.toInt(), layerRect.bottom.toInt())
-            layer.drawable.draw(canvas)
+        for (index in layerSpecs.indices) {
+            val layerSpec = layerSpecs[index]
+            val drawable = resolvedDrawables[index] ?: return
+            val width = layerSpec.computedWidth
+            val height = layerSpec.targetHeight
+            val left = (centerX - width / 2f).roundToInt()
+            val layerTop = (centerY - height / 2f).roundToInt()
+            drawable.setBounds(left, layerTop, left + width, layerTop + height)
+            drawable.draw(canvas)
         }
     }
 
@@ -1138,14 +1187,13 @@ private class ChatAssetSpan(
         val centerY = (top + bottom) / 2f
         val label = fallback.trim().ifEmpty { "?" }
         val fallbackPaint = fallbackPaint(paint)
-        val reservedWidth = maxOf(spec.compositionWidth, fallbackPaint.measureText(label).roundToInt())
-        val rect = RectF(x, centerY - spec.compositionHeight / 2f, x + reservedWidth, centerY + spec.compositionHeight / 2f)
+        val reservedWidth = maxOf(compositionWidth, fallbackPaint.measureText(label).roundToInt())
         paint.color = oldColor
         paint.style = Paint.Style.FILL
         paint.textAlign = Paint.Align.CENTER
         paint.textSize = fallbackPaint.textSize
-        val baseline = rect.centerY() - (paint.ascent() + paint.descent()) / 2f
-        canvas.drawText(label, rect.centerX(), baseline, paint)
+        val baseline = centerY - (paint.ascent() + paint.descent()) / 2f
+        canvas.drawText(label, x + reservedWidth / 2f, baseline, paint)
         paint.color = oldColor
         paint.style = oldStyle
         paint.textSize = oldTextSize
@@ -1159,7 +1207,7 @@ private class ChatAssetSpan(
     private fun fallbackPaint(paint: Paint): Paint = Paint(paint).apply {
         textSize = min(
             paint.textSize.takeIf { it > 0f } ?: Float.MAX_VALUE,
-            (spec.compositionHeight * 0.5f).coerceAtLeast(8f),
+            (compositionHeight * 0.5f).coerceAtLeast(8f),
         )
     }
 }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatV2RendererController.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatV2RendererController.kt
@@ -1,11 +1,13 @@
 package com.github.andreyasadchy.xtra.ui.chat.v2.ui
 
+import android.os.Trace
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import com.github.andreyasadchy.xtra.BuildConfig
 import com.github.andreyasadchy.xtra.ui.chat.v2.assets.ChatAssetRepository
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessageId
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessage
@@ -255,7 +257,7 @@ class ChatV2RendererController(
                 if (!rendererVisible.value || latestPublication !== publication) return@withContext
                 latestRows = rows
                 onPublicationChanged(publication.messages, rows)
-                adapter.submitList(rows.toList())
+                adapter.submitList(rows)
             }
         }
     }
@@ -293,7 +295,7 @@ class ChatV2RendererController(
             previousTailId = publication.messages.lastOrNull()?.id
             latestRows = rows
             onPublicationChanged(publication.messages, rows)
-            adapter.submitList(rows.toList()) {
+            adapter.submitList(rows) {
                 viewport.onSnapshotCommitted(previousAnchor, rows, appendedCount)
                 onStateChanged(viewport.state)
             }
@@ -310,8 +312,13 @@ class ChatV2RendererController(
                 captureBadges = renderStyle.showBadges,
             )
             val rows = withContext(Dispatchers.Default) {
-                publication.messages.zip(catalogs).map { (message, catalog) ->
-                    compiler.resolve(message, catalog)
+                if (BuildConfig.PERF_DIAGNOSTICS) Trace.beginSection("Xtra.ChatV2.compileCurrent")
+                try {
+                    publication.messages.zip(catalogs).map { (message, catalog) ->
+                        compiler.resolve(message, catalog)
+                    }
+                } finally {
+                    if (BuildConfig.PERF_DIAGNOSTICS) Trace.endSection()
                 }
             }
             if (presentation.isCurrent(compiler)) return rows

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/PlaybackService.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/PlaybackService.kt
@@ -26,10 +26,12 @@ import androidx.media3.common.util.UnstableApi
 import androidx.media3.datasource.DefaultDataSource
 import androidx.media3.datasource.HttpDataSource
 import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.exoplayer.analytics.AnalyticsListener
 import androidx.media3.exoplayer.hls.HlsManifest
 import androidx.media3.exoplayer.hls.HlsMediaSource
 import androidx.media3.exoplayer.source.ProgressiveMediaSource
 import androidx.media3.exoplayer.source.MediaSource
+import androidx.media3.exoplayer.source.MediaLoadData
 import androidx.media3.session.MediaSession
 import androidx.media3.session.MediaSessionService
 import androidx.media3.session.SessionCommand
@@ -172,6 +174,40 @@ class PlaybackService : MediaSessionService() {
                 }
             }
         )
+        if (BuildConfig.PERF_DIAGNOSTICS) {
+            player.addAnalyticsListener(object : AnalyticsListener {
+                override fun onVideoDecoderInitialized(
+                    eventTime: AnalyticsListener.EventTime,
+                    decoderName: String,
+                    initializedTimestampMs: Long,
+                    initializationDurationMs: Long,
+                ) {
+                    Log.i(PERF_TAG, "primary videoDecoder=$decoderName initMs=$initializationDurationMs")
+                }
+
+                override fun onDroppedVideoFrames(
+                    eventTime: AnalyticsListener.EventTime,
+                    droppedFrames: Int,
+                    elapsedMs: Long,
+                ) {
+                    Log.i(PERF_TAG, "primary droppedFrames=$droppedFrames elapsedMs=$elapsedMs")
+                }
+
+                override fun onDownstreamFormatChanged(
+                    eventTime: AnalyticsListener.EventTime,
+                    mediaLoadData: MediaLoadData,
+                ) {
+                    if (mediaLoadData.trackType != androidx.media3.common.C.TRACK_TYPE_VIDEO) return
+                    val format = mediaLoadData.trackFormat ?: return
+                    Log.i(
+                        PERF_TAG,
+                        "primary videoFormat=${format.width}x${format.height} " +
+                            "fps=${format.frameRate} bitrate=${format.bitrate} " +
+                            "mime=${format.sampleMimeType} codecs=${format.codecs}",
+                    )
+                }
+            })
+        }
         mediaSession = MediaSession.Builder(
             this,
             object : ForwardingSimpleBasePlayer(player) {
@@ -1141,6 +1177,7 @@ class PlaybackService : MediaSessionService() {
     }
 
     companion object {
+        private const val PERF_TAG = "PlaybackPerf"
         const val START_STREAM = "startStream"
         const val START_LIVE_REWIND = "startLiveRewind"
         const val GET_LIVE_REWIND_STATE = "getLiveRewindState"

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/ChatRenderDiagnostics.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/ChatRenderDiagnostics.kt
@@ -1,0 +1,64 @@
+package com.github.andreyasadchy.xtra.util
+
+import com.github.andreyasadchy.xtra.BuildConfig
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicLong
+
+internal data class ChatRenderDiagnosticsSnapshot(
+    val binds: Long,
+    val draws: Long,
+    val animationInvalidations: Long,
+    val animationStarts: Long,
+    val animationStops: Long,
+    val activeAnimations: Int,
+) {
+    override fun toString(): String =
+        "binds=$binds draws=$draws animationInvalidations=$animationInvalidations " +
+            "animationStarts=$animationStarts animationStops=$animationStops " +
+            "activeAnimations=$activeAnimations"
+}
+
+/** Per-report chat rendering counters for performance builds. */
+internal object ChatRenderDiagnostics {
+    private val binds = AtomicLong()
+    private val draws = AtomicLong()
+    private val animationInvalidations = AtomicLong()
+    private val animationStarts = AtomicLong()
+    private val animationStops = AtomicLong()
+    private val activeAnimations = AtomicInteger()
+
+    fun recordBind() {
+        if (BuildConfig.PERF_DIAGNOSTICS) binds.incrementAndGet()
+    }
+
+    fun recordDraw() {
+        if (BuildConfig.PERF_DIAGNOSTICS) draws.incrementAndGet()
+    }
+
+    fun recordAnimationInvalidation() {
+        if (BuildConfig.PERF_DIAGNOSTICS) animationInvalidations.incrementAndGet()
+    }
+
+    fun recordAnimationStarted() {
+        if (BuildConfig.PERF_DIAGNOSTICS) {
+            animationStarts.incrementAndGet()
+            activeAnimations.incrementAndGet()
+        }
+    }
+
+    fun recordAnimationStopped() {
+        if (BuildConfig.PERF_DIAGNOSTICS) {
+            animationStops.incrementAndGet()
+            if (activeAnimations.get() > 0) activeAnimations.decrementAndGet()
+        }
+    }
+
+    fun snapshotAndReset(): ChatRenderDiagnosticsSnapshot = ChatRenderDiagnosticsSnapshot(
+        binds = binds.getAndSet(0),
+        draws = draws.getAndSet(0),
+        animationInvalidations = animationInvalidations.getAndSet(0),
+        animationStarts = animationStarts.getAndSet(0),
+        animationStops = animationStops.getAndSet(0),
+        activeAnimations = activeAnimations.get(),
+    )
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/MainLooperStallWatchdog.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/MainLooperStallWatchdog.kt
@@ -34,7 +34,7 @@ internal object MainLooperStallWatchdog {
     private var worstStallMs = 0L
 
     fun start() {
-        if (!BuildConfig.DEBUG) return
+        if (!BuildConfig.DEBUG && !BuildConfig.PERF_DIAGNOSTICS) return
         executor.scheduleAtFixedRate(
             {
                 val now = SystemClock.uptimeMillis()

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/PerfFrameMetricsDiagnostics.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/PerfFrameMetricsDiagnostics.kt
@@ -21,15 +21,18 @@ internal object PerfFrameMetricsDiagnostics {
     private var lastReportMs = 0L
     private var attachedWindow: Window? = null
 
-    private val listener = Window.OnFrameMetricsAvailableListener { _, metrics, _ ->
-        val durationMs = metrics.getMetric(FrameMetrics.TOTAL_DURATION) / 1_000_000L
+    private val listener = Window.OnFrameMetricsAvailableListener { window, metrics, _ ->
+        val durationNs = metrics.getMetric(FrameMetrics.TOTAL_DURATION)
+        val refreshRateHz = window.decorView.display?.refreshRate?.takeIf { it > 1f } ?: 60f
+        val frameBudgetNs = (1_000_000_000.0 / refreshRateHz).toLong()
+        val durationMs = durationNs / 1_000_000L
         val bucket = when {
-            durationMs <= 16L -> 0
-            durationMs <= 32L -> 1
-            durationMs <= 50L -> 2
-            durationMs <= 100L -> 3
-            durationMs <= 250L -> 4
-            durationMs <= 500L -> 5
+            durationNs <= frameBudgetNs -> 0
+            durationNs <= frameBudgetNs * 3L / 2L -> 1
+            durationNs <= frameBudgetNs * 2L -> 2
+            durationNs <= frameBudgetNs * 3L -> 3
+            durationNs <= frameBudgetNs * 6L -> 4
+            durationNs <= frameBudgetNs * 12L -> 5
             else -> 6
         }
         buckets[bucket]++
@@ -40,9 +43,14 @@ internal object PerfFrameMetricsDiagnostics {
             lastReportMs = now
             Log.i(
                 TAG,
-                "frames=$frameCount worstMs=$worstFrameMs buckets=${buckets.joinToString(",")}",
+                "frames=$frameCount refreshHz=$refreshRateHz budgetMs=${frameBudgetNs / 1_000_000.0} " +
+                    "worstMs=$worstFrameMs budgetBuckets=${buckets.joinToString(",")}",
             )
+            Log.i(TAG, "chatRender=${ChatRenderDiagnostics.snapshotAndReset()}")
             Log.i(TAG, "keystorePrefs=${KeystorePreferenceDiagnostics.snapshot()}")
+            buckets.fill(0)
+            frameCount = 0L
+            worstFrameMs = 0L
         }
     }
 

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatDomainPresentationTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatDomainPresentationTest.kt
@@ -23,12 +23,15 @@ import com.github.andreyasadchy.xtra.ui.chat.v2.presentation.ChatColorResolver
 import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatAssetProvider
 import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatCatalogEmote
 import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatCatalogBadge
+import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatCatalogCheermote
 import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatCatalogSnapshot
 import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatEmoteScope
 import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatNamePaint
 import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatUserDecoration
 import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ScopedEmoteCatalog
+import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.toCatalog
 import com.github.andreyasadchy.xtra.ui.chat.ChatGifDisplayMode
+import com.github.andreyasadchy.xtra.model.chat.CheerEmote
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
@@ -370,8 +373,61 @@ class ChatDomainPresentationTest {
         val cheer = row.pieces.filterIsInstance<ChatPiece.Cheermote>().single()
         assertEquals(100, cheer.bits)
         assertEquals(ChatAssetProvider.TWITCH, cheer.interaction?.provider)
+        assertTrue(cheer.interaction?.animated == false)
         assertTrue(row.accessibilityText.contains("100 Bits"))
         assertTrue(!row.accessibilityText.contains("Cheer100 100"))
+    }
+
+    @Test
+    fun animatedCheermoteRetainsCatalogAnimationMetadata() {
+        val row = ChatRowCompiler().compile(
+            message(ChatSegment.Cheermote(base, "Cheer100", 100, null)),
+            ChatCatalogSnapshot(
+                revision = 1,
+                cheermotes = mapOf(
+                    base.key.value to ChatCatalogCheermote(base, null, animated = true),
+                ),
+            ),
+        )
+        val cheer = row.pieces.filterIsInstance<ChatPiece.Cheermote>().single()
+        assertTrue(cheer.interaction?.animated == true)
+    }
+
+    @Test
+    fun staticCheermoteRetainsCatalogAnimationMetadata() {
+        val row = ChatRowCompiler().compile(
+            message(ChatSegment.Cheermote(base, "Cheer100", 100, null)),
+            ChatCatalogSnapshot(
+                revision = 1,
+                cheermotes = mapOf(
+                    base.key.value to ChatCatalogCheermote(base, null, animated = false),
+                ),
+            ),
+        )
+        val cheer = row.pieces.filterIsInstance<ChatPiece.Cheermote>().single()
+        assertTrue(cheer.interaction?.animated == false)
+    }
+
+    @Test
+    fun cheerCatalogConversionPreservesAnimatedFlag() {
+        val catalog = CheerEmote(
+            name = "Cheer100",
+            url1x = "https://cdn.example.test/cheer.gif",
+            isAnimated = true,
+            minBits = 100,
+        ).toCatalog()!!.second
+        assertTrue(catalog.animated)
+    }
+
+    @Test
+    fun cheerCatalogConversionPreservesStaticFlag() {
+        val catalog = CheerEmote(
+            name = "Cheer100",
+            url1x = "https://cdn.example.test/cheer.png",
+            isAnimated = false,
+            minBits = 100,
+        ).toCatalog()!!.second
+        assertTrue(!catalog.animated)
     }
 
     @Test
@@ -501,6 +557,7 @@ class ChatDomainPresentationTest {
         val modifier = emote("Crown", ChatAssetProvider.SEVEN_TV).copy(
             id = "modifier-id",
             zeroWidth = true,
+            animated = true,
         )
         val row = ChatRowCompiler().compile(
             message(ChatSegment.Text("Party Crown")),
@@ -515,6 +572,7 @@ class ChatDomainPresentationTest {
         assertEquals("base-id", piece.interaction?.id)
         assertEquals(ChatAssetProvider.SEVEN_TV, piece.interaction?.provider)
         assertEquals(1, piece.asset.overlays.size)
+        assertTrue(piece.animated)
     }
 
     @Test


### PR DESCRIPTION
Stops chat assets from animating unless the message model allows it, removes avoidable redraw work, and adds perf-only rendering and playback diagnostics.