### PR TITLE
Reduce player power use in background audio mode

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/Media3Fragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/Media3Fragment.kt
@@ -24,6 +24,7 @@ import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.repeatOnLifecycle
 import androidx.media3.common.Format
+import androidx.media3.common.C as Media3C
 import androidx.media3.common.PlaybackException
 import androidx.media3.common.PlaybackParameters
 import androidx.media3.common.Player
@@ -39,6 +40,7 @@ import androidx.media3.session.MediaController
 import androidx.media3.session.SessionCommand
 import androidx.media3.session.SessionResult
 import androidx.media3.session.SessionToken
+import com.github.andreyasadchy.xtra.BuildConfig
 import com.github.andreyasadchy.xtra.R
 import com.github.andreyasadchy.xtra.model.VideoQuality
 import com.github.andreyasadchy.xtra.model.ui.Clip
@@ -101,7 +103,6 @@ class Media3Fragment : Media3PlayerFragment() {
         attachTarget = { currentPlayer, target -> currentPlayer.setVideoSurfaceView(target) },
         detachTarget = { currentPlayer, target -> currentPlayer.clearVideoSurfaceView(target) },
     )
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
@@ -460,10 +461,30 @@ class Media3Fragment : Media3PlayerFragment() {
                     logVideoSurfaceBinding("first_frame", controller, binding.playerSurface)
                 }
             }
-            val restored = viewModel.videoOutputState.restoreIfNeeded {
+            val restoreBackgroundVideo = shouldRestoreVideoAfterBackground(
+                backgroundOwnedVideoDisable = viewModel.videoTrackDisabledForBackground,
+                audioOnly = viewModel.quality?.name == AUDIO_ONLY_QUALITY,
+                chatOnly = viewModel.quality?.name == CHAT_ONLY_QUALITY,
+                videoAlreadySuppressed = viewModel.hidden,
+            )
+            if (restoreBackgroundVideo) {
+                controller.trackSelectionParameters = controller.trackSelectionParameters
+                    .buildUpon()
+                    .setTrackTypeDisabled(Media3C.TRACK_TYPE_VIDEO, false)
+                    .build()
+                if (BuildConfig.PERF_DIAGNOSTICS) {
+                    Log.i("XtraPerf", "backgroundVideoTrack restored")
+                }
+            } else if (viewModel.videoTrackDisabledForBackground) {
+                viewModel.videoOutputState.clear()
+            }
+            viewModel.videoTrackDisabledForBackground = false
+            val restored = if (restoreBackgroundVideo) viewModel.videoOutputState.restoreIfNeeded {
                 binding.playerSurface.visibility = View.VISIBLE
                 attachVideoOutput(controller)
                 true
+            } else {
+                false
             }
             if (!restored) {
                 attachVideoOutput(controller)
@@ -1559,10 +1580,26 @@ class Media3Fragment : Media3PlayerFragment() {
                     viewModel.usingProxy = false
                 }
                 if (requireContext().prefs().getBoolean(C.SETTINGS_BACKGROUND_PLAYBACK, true)) {
-                    if (!isInPIPMode && player.playWhenReady && viewModel.quality?.name != AUDIO_ONLY_QUALITY) {
-                        if (player.currentMediaItem != null) {
-                            viewModel.videoOutputState.markDetachedForBackground()
-                            binding.playerSurface.visibility = View.GONE
+                    val shouldDisableVideo = shouldDisableVideoForBackground(
+                        backgroundPlaybackEnabled = true,
+                        isInPictureInPicture = isInPIPMode,
+                        playWhenReady = player.playWhenReady,
+                        playbackState = player.playbackState,
+                        hasMediaItem = player.currentMediaItem != null,
+                        audioOnly = viewModel.quality?.name == AUDIO_ONLY_QUALITY,
+                        chatOnly = viewModel.quality?.name == CHAT_ONLY_QUALITY,
+                        videoAlreadySuppressed = viewModel.hidden,
+                    )
+                    if (shouldDisableVideo) {
+                        player.trackSelectionParameters = player.trackSelectionParameters
+                            .buildUpon()
+                            .setTrackTypeDisabled(Media3C.TRACK_TYPE_VIDEO, true)
+                            .build()
+                        viewModel.videoTrackDisabledForBackground = true
+                        viewModel.videoOutputState.markDetachedForBackground()
+                        binding.playerSurface.visibility = View.GONE
+                        if (BuildConfig.PERF_DIAGNOSTICS) {
+                            Log.i("XtraPerf", "backgroundVideoTrack disabled")
                         }
                     }
                 } else {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/Media3PlayerViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/Media3PlayerViewModel.kt
@@ -114,6 +114,8 @@ class Media3PlayerViewModel(
     var updateQualities = false
     var started = false
     var restoreQuality = false
+    /** True only when backgrounding temporarily disabled the video track. */
+    var videoTrackDisabledForBackground = false
     internal val videoOutputState = VideoOutputState()
     var resume = false
     var hidden = false

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/VideoPlaybackPolicy.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/VideoPlaybackPolicy.kt
@@ -1,0 +1,36 @@
+package com.github.andreyasadchy.xtra.ui.player
+
+import androidx.media3.common.Player
+
+internal fun shouldDisableVideoForBackground(
+    backgroundPlaybackEnabled: Boolean,
+    isInPictureInPicture: Boolean,
+    playWhenReady: Boolean,
+    playbackState: Int,
+    hasMediaItem: Boolean,
+    audioOnly: Boolean,
+    chatOnly: Boolean,
+    videoAlreadySuppressed: Boolean,
+): Boolean {
+    return backgroundPlaybackEnabled &&
+        !isInPictureInPicture &&
+        playWhenReady &&
+        playbackState != Player.STATE_IDLE &&
+        playbackState != Player.STATE_ENDED &&
+        hasMediaItem &&
+        !audioOnly &&
+        !chatOnly &&
+        !videoAlreadySuppressed
+}
+
+internal fun shouldRestoreVideoAfterBackground(
+    backgroundOwnedVideoDisable: Boolean,
+    audioOnly: Boolean,
+    chatOnly: Boolean,
+    videoAlreadySuppressed: Boolean,
+): Boolean {
+    return backgroundOwnedVideoDisable &&
+        !audioOnly &&
+        !chatOnly &&
+        !videoAlreadySuppressed
+}

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/player/VideoPlaybackPolicyTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/player/VideoPlaybackPolicyTest.kt
@@ -1,0 +1,76 @@
+package com.github.andreyasadchy.xtra.ui.player
+
+import androidx.media3.common.Player
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class VideoPlaybackPolicyTest {
+
+    @Test
+    fun activeNormalPlaybackDisablesVideoWhenBackgrounded() {
+        assertTrue(policy())
+    }
+
+    @Test
+    fun pipKeepsVideoEnabled() {
+        assertFalse(policy(isInPictureInPicture = true))
+    }
+
+    @Test
+    fun pausedEndedOrIdlePlaybackDoesNotDisableVideo() {
+        assertFalse(policy(playWhenReady = false))
+        assertFalse(policy(playbackState = Player.STATE_ENDED))
+        assertFalse(policy(playbackState = Player.STATE_IDLE))
+        assertFalse(policy(hasMediaItem = false))
+    }
+
+    @Test
+    fun intentionalVideoSuppressionKeepsOwnershipWithItsExistingState() {
+        assertFalse(policy(audioOnly = true))
+        assertFalse(policy(chatOnly = true))
+        assertFalse(policy(videoAlreadySuppressed = true))
+        assertFalse(policy(backgroundPlaybackEnabled = false))
+    }
+
+    @Test
+    fun backgroundOwnedVideoDisableIsRestoredOnlyForNormalForegroundPlayback() {
+        assertTrue(restorePolicy(backgroundOwnedVideoDisable = true))
+        assertFalse(restorePolicy(backgroundOwnedVideoDisable = false))
+        assertFalse(restorePolicy(backgroundOwnedVideoDisable = true, audioOnly = true))
+        assertFalse(restorePolicy(backgroundOwnedVideoDisable = true, chatOnly = true))
+        assertFalse(restorePolicy(backgroundOwnedVideoDisable = true, videoAlreadySuppressed = true))
+    }
+
+    private fun policy(
+        backgroundPlaybackEnabled: Boolean = true,
+        isInPictureInPicture: Boolean = false,
+        playWhenReady: Boolean = true,
+        playbackState: Int = Player.STATE_READY,
+        hasMediaItem: Boolean = true,
+        audioOnly: Boolean = false,
+        chatOnly: Boolean = false,
+        videoAlreadySuppressed: Boolean = false,
+    ) = shouldDisableVideoForBackground(
+        backgroundPlaybackEnabled = backgroundPlaybackEnabled,
+        isInPictureInPicture = isInPictureInPicture,
+        playWhenReady = playWhenReady,
+        playbackState = playbackState,
+        hasMediaItem = hasMediaItem,
+        audioOnly = audioOnly,
+        chatOnly = chatOnly,
+        videoAlreadySuppressed = videoAlreadySuppressed,
+    )
+
+    private fun restorePolicy(
+        backgroundOwnedVideoDisable: Boolean,
+        audioOnly: Boolean = false,
+        chatOnly: Boolean = false,
+        videoAlreadySuppressed: Boolean = false,
+    ) = shouldRestoreVideoAfterBackground(
+        backgroundOwnedVideoDisable = backgroundOwnedVideoDisable,
+        audioOnly = audioOnly,
+        chatOnly = chatOnly,
+        videoAlreadySuppressed = videoAlreadySuppressed,
+    )
+}


### PR DESCRIPTION
Keep SurfaceView playback. When background audio playback is enabled outside PiP, stop selecting video until the player returns to the foreground. Preserve Audio Only, Chat Only, ad suppression, and existing PiP behavior.