### PR TITLE
Keep deleted chat messages visible by default

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatFragment.kt
@@ -975,6 +975,7 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
                                         )
                                         ChatUserClearReason.BAN -> getString(R.string.chat_moderation_ban)
                                         ChatUserClearReason.MESSAGES_CLEARED -> getString(R.string.chat_moderation_messages_cleared)
+                                        ChatUserClearReason.MESSAGE_DELETED -> "(${getString(R.string.chat_message_deleted)})"
                                     }
                                 },
                             ),

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/domain/ChatEvent.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/domain/ChatEvent.kt
@@ -6,6 +6,7 @@ enum class ChatUserClearReason {
     TIMEOUT,
     BAN,
     MESSAGES_CLEARED,
+    MESSAGE_DELETED,
 }
 
 enum class ChatGiftSource {
@@ -31,7 +32,12 @@ sealed interface ChatEvent {
         override val eventId: String? = message.id.value,
         override val receivedAtMs: Long = System.currentTimeMillis(),
     ) : ChatEvent
-    data class Delete(val messageId: ChatMessageId, override val eventId: String?, override val receivedAtMs: Long) : ChatEvent
+    data class Delete(
+        val messageId: ChatMessageId,
+        override val eventId: String?,
+        override val receivedAtMs: Long,
+        val displayMode: ChatModerationDisplayMode = ChatModerationDisplayMode.NOTICE,
+    ) : ChatEvent
     data class ClearUser(
         val userId: String?,
         override val eventId: String?,

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/presentation/ChatRowCompiler.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/presentation/ChatRowCompiler.kt
@@ -38,6 +38,7 @@ data class ChatPresentationLabels(
                 "(${moderation.timeoutSeconds ?: 0}s Timeout)"
             ChatUserClearReason.BAN -> "(Ban)"
             ChatUserClearReason.MESSAGES_CLEARED -> "(Messages cleared)"
+            ChatUserClearReason.MESSAGE_DELETED -> "(Message deleted)"
         }
     },
     val announcement: String = "Announcement",

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/session/ChatTimelineStore.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/session/ChatTimelineStore.kt
@@ -5,6 +5,7 @@ import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessage
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessageId
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatModeration
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatModerationDisplayMode
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatUserClearReason
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.flow.Flow
@@ -17,7 +18,11 @@ import kotlin.math.abs
 sealed interface TimelineOperation {
     data class Append(val items: List<ChatMessage>) : TimelineOperation
     data class Prepend(val items: List<ChatMessage>) : TimelineOperation
-    data class Delete(val id: ChatMessageId, val atMs: Long) : TimelineOperation
+    data class Delete(
+        val id: ChatMessageId,
+        val atMs: Long,
+        val displayMode: ChatModerationDisplayMode = ChatModerationDisplayMode.NOTICE,
+    ) : TimelineOperation
     data class ClearUser(
         val userId: String?,
         val userLogin: String?,
@@ -49,7 +54,7 @@ class ChatTimelineStore(
             val ids = HashSet<com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessageId>(maxSize * 2)
             // These tombstones belong to the active generation. Replace(emptyList()) is the
             // processor's generation boundary and resets them before a new channel is accepted.
-            val deletedMessageIds = LinkedHashSet<ChatMessageId>(MODERATION_TOMBSTONE_LIMIT)
+            val deletedMessages = LinkedHashMap<ChatMessageId, ChatModerationDisplayMode>(MODERATION_TOMBSTONE_LIMIT)
             val clearedUsers = ArrayDeque<UserModeration>(MODERATION_TOMBSTONE_LIMIT)
             var globallyClearedAt: Long? = null
             for (operation in operations) {
@@ -63,19 +68,40 @@ class ChatTimelineStore(
                         continue
                     }
                     is TimelineOperation.Append -> operation.items.forEach { item ->
-                        if (isSuppressed(item, deletedMessageIds, clearedUsers, globallyClearedAt)) continue
+                        if (isSuppressed(item, deletedMessages, clearedUsers, globallyClearedAt)) continue
                         if (isDuplicateReward(item, items)) continue
-                        if (ids.add(item.id)) items.addLast(decorate(item, clearedUsers))
+                        if (ids.add(item.id)) items.addLast(decorate(item, deletedMessages, clearedUsers))
                     }
                     is TimelineOperation.Prepend -> operation.items.asReversed().forEach { item ->
-                        if (isSuppressed(item, deletedMessageIds, clearedUsers, globallyClearedAt)) continue
+                        if (isSuppressed(item, deletedMessages, clearedUsers, globallyClearedAt)) continue
                         if (isDuplicateReward(item, items)) continue
-                        if (ids.add(item.id)) items.addFirst(decorate(item, clearedUsers))
+                        if (ids.add(item.id)) items.addFirst(decorate(item, deletedMessages, clearedUsers))
                     }
                     is TimelineOperation.Delete -> {
-                        deletedMessageIds.add(operation.id)
-                        trimModerationTombstones(deletedMessageIds, clearedUsers)
-                        if (ids.remove(operation.id)) items.removeIf { it.id == operation.id }
+                        when (operation.displayMode) {
+                            // NOTICE leaves no tombstone: a message which was deleted before
+                            // recent-history reconciliation must still be rendered with its
+                            // notice when it eventually arrives.
+                            ChatModerationDisplayMode.NOTICE -> Unit
+                            ChatModerationDisplayMode.HIDE -> {
+                                deletedMessages[operation.id] = ChatModerationDisplayMode.HIDE
+                                if (ids.remove(operation.id)) items.removeIf { it.id == operation.id }
+                            }
+                            ChatModerationDisplayMode.STRIKETHROUGH -> {
+                                deletedMessages[operation.id] = ChatModerationDisplayMode.STRIKETHROUGH
+                                val deleted = ChatModeration(ChatUserClearReason.MESSAGE_DELETED)
+                                val decorated = items.map { item ->
+                                    if (item.id == operation.id && item.moderation == null) {
+                                        item.copy(moderation = deleted)
+                                    } else {
+                                        item
+                                    }
+                                }
+                                items.clear()
+                                items.addAll(decorated)
+                            }
+                        }
+                        trimModerationTombstones(deletedMessages, clearedUsers)
                     }
                     is TimelineOperation.ClearUser -> {
                         if (operation.userId == null && operation.userLogin == null) continue
@@ -89,7 +115,7 @@ class ChatTimelineStore(
                                 displayMode = operation.displayMode,
                             ),
                         )
-                        trimModerationTombstones(deletedMessageIds, clearedUsers)
+                        trimModerationTombstones(deletedMessages, clearedUsers)
                         when (operation.displayMode) {
                             ChatModerationDisplayMode.NOTICE -> Unit
                             ChatModerationDisplayMode.HIDE -> items.removeIf { item ->
@@ -119,15 +145,15 @@ class ChatTimelineStore(
                     }
                     is TimelineOperation.Replace -> {
                         items.clear(); ids.clear()
-                        deletedMessageIds.clear()
+                        deletedMessages.clear()
                         clearedUsers.clear()
                         globallyClearedAt = null
                         operation.items.takeLast(maxSize).forEach { if (ids.add(it.id)) items.addLast(it) }
                     }
                     is TimelineOperation.Reconcile -> {
                         val merged = (items.toList() + operation.recent.mapNotNull {
-                            if (isSuppressed(it, deletedMessageIds, clearedUsers, globallyClearedAt)) null
-                            else decorate(it, clearedUsers)
+                            if (isSuppressed(it, deletedMessages, clearedUsers, globallyClearedAt)) null
+                            else decorate(it, deletedMessages, clearedUsers)
                         })
                             .distinctBy { it.id }
                             .sortedBy { it.timestampMs }
@@ -146,19 +172,26 @@ class ChatTimelineStore(
 
     private fun isSuppressed(
         message: ChatMessage,
-        deletedMessageIds: Set<ChatMessageId>,
+        deletedMessages: Map<ChatMessageId, ChatModerationDisplayMode>,
         clearedUsers: Collection<UserModeration>,
         globallyClearedAt: Long?,
     ): Boolean {
-        if (message.id in deletedMessageIds) return true
+        if (deletedMessages[message.id] == ChatModerationDisplayMode.HIDE) return true
         if (globallyClearedAt?.let { message.timestampMs <= it } == true) return true
         return clearedUsers.any {
             it.displayMode == ChatModerationDisplayMode.HIDE && it.matches(message)
         }
     }
 
-    private fun decorate(message: ChatMessage, clearedUsers: Collection<UserModeration>): ChatMessage {
+    private fun decorate(
+        message: ChatMessage,
+        deletedMessages: Map<ChatMessageId, ChatModerationDisplayMode>,
+        clearedUsers: Collection<UserModeration>,
+    ): ChatMessage {
         if (message.moderation != null) return message
+        if (deletedMessages[message.id] == ChatModerationDisplayMode.STRIKETHROUGH) {
+            return message.copy(moderation = ChatModeration(ChatUserClearReason.MESSAGE_DELETED))
+        }
         val moderation = clearedUsers.asSequence()
             .filter { it.displayMode == ChatModerationDisplayMode.STRIKETHROUGH }
             .lastOrNull { it.matches(message) }
@@ -188,11 +221,11 @@ class ChatTimelineStore(
     }
 
     private fun trimModerationTombstones(
-        deletedMessageIds: LinkedHashSet<ChatMessageId>,
+        deletedMessages: LinkedHashMap<ChatMessageId, ChatModerationDisplayMode>,
         clearedUsers: ArrayDeque<UserModeration>,
     ) {
-        while (deletedMessageIds.size > MODERATION_TOMBSTONE_LIMIT) {
-            deletedMessageIds.remove(deletedMessageIds.first())
+        while (deletedMessages.size > MODERATION_TOMBSTONE_LIMIT) {
+            deletedMessages.remove(deletedMessages.entries.first().key)
         }
         while (clearedUsers.size > MODERATION_TOMBSTONE_LIMIT) clearedUsers.removeFirst()
     }
@@ -238,7 +271,13 @@ class ChatTimelineStore(
         when (event) {
             is ChatEvent.Message -> apply(TimelineOperation.Append(listOf(event.message)))
             is ChatEvent.Notice -> apply(TimelineOperation.Append(listOf(event.message)))
-            is ChatEvent.Delete -> apply(TimelineOperation.Delete(event.messageId, event.receivedAtMs))
+            is ChatEvent.Delete -> apply(
+                TimelineOperation.Delete(
+                    id = event.messageId,
+                    atMs = event.receivedAtMs,
+                    displayMode = event.displayMode,
+                ),
+            )
             // Notice-only moderation keeps the timeline unchanged. Other display modes are
             // applied here so append/reconcile and live events share the same user boundary.
             is ChatEvent.ClearUser -> apply(

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/transport/TwitchChatTransport.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/transport/TwitchChatTransport.kt
@@ -64,8 +64,10 @@ data class TwitchChatTransportConfig(
     val helixHeaders: Map<String, String> = emptyMap(),
     val networkLibrary: String? = null,
     val showUserNotices: Boolean = true,
+    /** Master toggle for single-message deletion notices and retained deleted rows. */
     val showClearMessages: Boolean = true,
     val showClearChat: Boolean = true,
+    /** Shared display policy for single deletions and user-level moderation clears. */
     val moderationDisplayMode: () -> ChatModerationDisplayMode = { ChatModerationDisplayMode.NOTICE },
     val joinedMessage: String? = null,
     val messageDeletedMessage: String? = null,
@@ -121,9 +123,10 @@ class TwitchChatTransport(
                 }
 
                 override suspend fun onClearMessage(message: ChatUtils.IRCMessage) {
-                    TwitchChatEventParser.fromIrc(message, config.channelId)?.let { event ->
+                    TwitchChatEventParser.fromIrc(message, config.channelId)?.let { parsedEvent ->
+                        val event = applyDeletionDisplay(parsedEvent)
                         send(event)
-                        if (config.showClearMessages) {
+                        if (shouldShowDeletionNotice(event)) {
                             val eventKey = message.tags["target-msg-id"]
                                 ?: message.tags["tmi-sent-ts"]
                                 ?: System.nanoTime().toString()
@@ -225,9 +228,11 @@ class TwitchChatTransport(
                 }
 
                 override suspend fun onMessageDelete(event: org.json.JSONObject, timestamp: String?) {
-                    val deleteEvent = TwitchChatEventParser.fromEventSubClear(event, timestamp)
+                    val deleteEvent = applyDeletionDisplay(
+                        TwitchChatEventParser.fromEventSubClear(event, timestamp),
+                    )
                     flowScope.send(deleteEvent)
-                    if (config.showClearMessages) {
+                    if (shouldShowDeletionNotice(deleteEvent)) {
                         systemMessage(session, "delete-${deleteEvent.eventId ?: timestamp ?: System.nanoTime()}", config.messageDeletedMessage)?.let { flowScope.send(it) }
                     }
                 }
@@ -442,6 +447,7 @@ class TwitchChatTransport(
                     ChatUserClearReason.BAN -> config.chatBanMessage?.invoke(target)
                         ?: config.chatUserMessagesClearedMessage?.invoke(target)
                     ChatUserClearReason.MESSAGES_CLEARED -> config.chatUserMessagesClearedMessage?.invoke(target)
+                    ChatUserClearReason.MESSAGE_DELETED -> config.messageDeletedMessage
                 }
             }
             else -> null
@@ -461,6 +467,24 @@ class TwitchChatTransport(
         } else {
             event
         }
+
+    private fun applyDeletionDisplay(event: ChatEvent): ChatEvent =
+        if (event is ChatEvent.Delete) {
+            event.copy(
+                displayMode = if (config.showClearMessages) {
+                    config.moderationDisplayMode()
+                } else {
+                    ChatModerationDisplayMode.HIDE
+                },
+            )
+        } else {
+            event
+        }
+
+    private fun shouldShowDeletionNotice(event: ChatEvent): Boolean =
+        event is ChatEvent.Delete &&
+            config.showClearMessages &&
+            event.displayMode != ChatModerationDisplayMode.STRIKETHROUGH
 
     private fun systemMessage(
         session: ChatSessionKey,

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/multiview/CombinedChatFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/multiview/CombinedChatFragment.kt
@@ -624,6 +624,7 @@ private class CombinedChatAdapter(
                         )
                         ChatUserClearReason.BAN -> fragment.getString(R.string.chat_moderation_ban)
                         ChatUserClearReason.MESSAGES_CLEARED -> fragment.getString(R.string.chat_moderation_messages_cleared)
+                        ChatUserClearReason.MESSAGE_DELETED -> "(${fragment.getString(R.string.chat_message_deleted)})"
                     }
                 },
             ),

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/settings/ChatModerationDisplayPreview.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/settings/ChatModerationDisplayPreview.kt
@@ -67,11 +67,11 @@ class ChatModerationDisplayPreviewView @JvmOverloads constructor(
         when (mode) {
             ChatModerationDisplayMode.NOTICE -> {
                 addMessage(previewMessage())
-                addNotice(moderationNotice())
+                addNotice(deletedMessageNotice())
             }
             ChatModerationDisplayMode.STRIKETHROUGH -> {
                 val body = previewMessage()
-                val suffix = " ${context.getString(R.string.chat_moderation_messages_cleared)}"
+                val suffix = " (${deletedMessageNotice()})"
                 val text = SpannableString(body + suffix).apply {
                     setSpan(StrikethroughSpan(), 0, body.length, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
                     setSpan(ForegroundColorSpan(secondaryColor), 0, body.length, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
@@ -80,8 +80,8 @@ class ChatModerationDisplayPreviewView @JvmOverloads constructor(
                 addLine(text, secondary = false)
             }
             ChatModerationDisplayMode.HIDE -> {
+                addNotice(deletedMessageNotice())
                 addMessage(context.getString(R.string.chat_moderation_preview_new_message).let { "${previewUsername()}: $it" })
-                addNotice(moderationNotice())
             }
         }
         contentDescription = context.getString(R.string.chat_moderation_preview_summary)
@@ -97,10 +97,7 @@ class ChatModerationDisplayPreviewView @JvmOverloads constructor(
         R.string.chat_moderation_preview_message,
     ).let { "${previewUsername()}: $it" }
 
-    private fun moderationNotice(): String = context.getString(
-        R.string.chat_clear_user,
-        previewUsername(),
-    )
+    private fun deletedMessageNotice(): String = context.getString(R.string.chat_message_deleted)
 
     private fun addLine(value: CharSequence, secondary: Boolean) {
         addView(TextView(context).apply {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -485,12 +485,12 @@
     <string name="settings_chat_history_page">History</string>
     <string name="settings_chat_translation_page">Translation</string>
     <string name="settings_chat_visibility">Message visibility</string>
-    <string name="chat_moderation_display">Moderated message display</string>
-    <string name="chat_moderation_display_notice">Notice only</string>
+    <string name="chat_moderation_display">Deleted &amp; moderated messages</string>
+    <string name="chat_moderation_display_notice">Keep message + notice</string>
     <string name="chat_moderation_display_strikethrough">Strike-through message</string>
     <string name="chat_moderation_display_hide">Hide message</string>
     <string name="chat_moderation_display_preview_title">Preview</string>
-    <string name="chat_moderation_preview_summary">Preview after moderation clears a user\'s messages. IRC may include timeout or ban details.</string>
+    <string name="chat_moderation_preview_summary">Preview of the selected deleted and moderated message style.</string>
     <string name="settings_username_appearance">Username appearance</string>
     <string name="settings_7tv_appearance">7TV appearance</string>
     <string name="settings_chat_size">Chat size</string>

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatDomainPresentationTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatDomainPresentationTest.kt
@@ -424,6 +424,19 @@ class ChatDomainPresentationTest {
     }
 
     @Test
+    fun deletedMessageStrikethroughUsesTheDeletionSuffix() {
+        val row = ChatRowCompiler().compile(
+            message(ChatSegment.Text("hello")).copy(
+                user = ChatUser("user", "viewer", "Viewer", null),
+                moderation = ChatModeration(ChatUserClearReason.MESSAGE_DELETED),
+            ),
+        )
+
+        assertTrue(row.pieces.any { it is ChatPiece.Text && it.value.contains("Message deleted") })
+        assertTrue(row.accessibilityText.contains("Message deleted"))
+    }
+
+    @Test
     fun subscriptionNoticeUsesTheSpaciousRailTreatment() {
         val row = ChatRowCompiler().compile(
             message(ChatSegment.Text("They've been subscribed for 6 months!")).copy(

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatTimelineArchitectureTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatTimelineArchitectureTest.kt
@@ -141,7 +141,13 @@ class ChatTimelineArchitectureTest {
         val scope = CoroutineScope(Dispatchers.Default)
         val store = ChatTimelineStore(scope, maxSize = 600)
         store.apply(com.github.andreyasadchy.xtra.ui.chat.v2.session.TimelineOperation.Append(listOf(message(1, "u1"), message(2, "u2"), message(3, "u1"))))
-        store.apply(com.github.andreyasadchy.xtra.ui.chat.v2.session.TimelineOperation.Delete(ChatMessageId("2"), atMs = 4))
+        store.apply(
+            com.github.andreyasadchy.xtra.ui.chat.v2.session.TimelineOperation.Delete(
+                ChatMessageId("2"),
+                atMs = 4,
+                displayMode = ChatModerationDisplayMode.HIDE,
+            ),
+        )
         assertEquals(listOf("1", "3"), store.snapshot().map { it.id.value })
         store.apply(com.github.andreyasadchy.xtra.ui.chat.v2.session.TimelineOperation.Clear(atMs = 5))
         assertEquals(emptyList<String>(), store.snapshot().map { it.id.value })
@@ -178,9 +184,90 @@ class ChatTimelineArchitectureTest {
         processor.submit(key, ChatEvent.Message(message(1), eventId = "1", receivedAtMs = 1))
         awaitSnapshot(store) { it.lastOrNull()?.id?.value == "1" }
 
-        processor.submit(key, ChatEvent.Delete(ChatMessageId("1"), eventId = "1", receivedAtMs = 2))
+        processor.submit(
+            key,
+            ChatEvent.Delete(
+                ChatMessageId("1"),
+                eventId = "1",
+                receivedAtMs = 2,
+                displayMode = ChatModerationDisplayMode.HIDE,
+            ),
+        )
         assertEquals(emptyList<String>(), awaitSnapshot(store) { it.isEmpty() }.map { it.id.value })
         scope.cancel()
+    }
+
+    @Test
+    fun singleDeletionHonorsTheConfiguredDisplayMode() = runBlocking {
+        suspend fun snapshotAfterDeletion(mode: ChatModerationDisplayMode): List<ChatMessage> {
+            val scope = CoroutineScope(Dispatchers.Default)
+            val store = ChatTimelineStore(scope, maxSize = 10)
+            val processor = ChatEventProcessor(scope, store)
+            val key = com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatSessionKey("channel", mode.ordinal.toLong() + 1)
+            val original = message(1, "viewer")
+            processor.activate(key)
+            processor.submit(key, ChatEvent.Message(original, receivedAtMs = 1))
+            awaitSnapshot(store) { it.size == 1 }
+            val versionBeforeDeletion = store.versionedSnapshot().version
+            processor.submit(
+                key,
+                ChatEvent.Delete(
+                    original.id,
+                    eventId = "delete-${mode.name}",
+                    receivedAtMs = 2,
+                    displayMode = mode,
+                ),
+            )
+            withTimeout(5_000) {
+                while (store.versionedSnapshot().version <= versionBeforeDeletion) delay(1)
+            }
+            val result = store.snapshot()
+            scope.cancel()
+            return result
+        }
+
+        val notice = snapshotAfterDeletion(ChatModerationDisplayMode.NOTICE).single()
+        assertEquals(null, notice.moderation)
+
+        val strikethrough = snapshotAfterDeletion(ChatModerationDisplayMode.STRIKETHROUGH).single()
+        assertEquals(ChatUserClearReason.MESSAGE_DELETED, strikethrough.moderation?.reason)
+
+        assertEquals(emptyList<String>(), snapshotAfterDeletion(ChatModerationDisplayMode.HIDE).map { it.id.value })
+    }
+
+    @Test
+    fun deletionBeforeReconciliationHonorsTheConfiguredDisplayMode() = runBlocking {
+        suspend fun reconcileAfterDeletion(mode: ChatModerationDisplayMode): List<ChatMessage> {
+            val scope = CoroutineScope(Dispatchers.Default)
+            val store = ChatTimelineStore(scope, maxSize = 10)
+            val processor = ChatEventProcessor(scope, store)
+            val key = com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatSessionKey("channel", mode.ordinal.toLong() + 10)
+            val deleted = message(1, "viewer")
+            processor.activate(key)
+            processor.submit(
+                key,
+                ChatEvent.Delete(
+                    deleted.id,
+                    eventId = "delete-before-reconcile-${mode.name}",
+                    receivedAtMs = 2,
+                    displayMode = mode,
+                ),
+            )
+            processor.reconcile(key, listOf(deleted))
+            val result = store.snapshot()
+            scope.cancel()
+            return result
+        }
+
+        val notice = reconcileAfterDeletion(ChatModerationDisplayMode.NOTICE).single()
+        assertEquals("1", notice.id.value)
+        assertEquals(null, notice.moderation)
+
+        val strikethrough = reconcileAfterDeletion(ChatModerationDisplayMode.STRIKETHROUGH).single()
+        assertEquals("1", strikethrough.id.value)
+        assertEquals(ChatUserClearReason.MESSAGE_DELETED, strikethrough.moderation?.reason)
+
+        assertEquals(emptyList<String>(), reconcileAfterDeletion(ChatModerationDisplayMode.HIDE).map { it.id.value })
     }
 
     @Test
@@ -213,7 +300,15 @@ class ChatTimelineArchitectureTest {
         val deleted = message(1)
         processor.submit(key, ChatEvent.Message(deleted, receivedAtMs = 1))
         awaitSnapshot(store) { it.lastOrNull()?.id?.value == "1" }
-        processor.submit(key, ChatEvent.Delete(deleted.id, eventId = "1", receivedAtMs = 2))
+        processor.submit(
+            key,
+            ChatEvent.Delete(
+                deleted.id,
+                eventId = "1",
+                receivedAtMs = 2,
+                displayMode = ChatModerationDisplayMode.HIDE,
+            ),
+        )
         awaitSnapshot(store) { it.isEmpty() }
 
         processor.reconcile(key, listOf(deleted))


### PR DESCRIPTION
Most users now keep seeing a deleted message when the visibility setting is left at its default. The existing visibility choices also apply consistently to single deletions: keep the message with a notice, strike it through, or hide it. The deletion toggle remains the master opt-out.\n\nChecks: focused chat unit tests, localization hygiene, debug APK build and emulator launch.