### PR TITLE
Show lead moderator badge on pinned messages

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/PinnedChatBadgeRoles.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/PinnedChatBadgeRoles.kt
@@ -2,6 +2,15 @@ package com.github.andreyasadchy.xtra.ui.chat
 
 import com.github.andreyasadchy.xtra.model.chat.Badge
 
+private val pinnedChatRoleBadgePriority = listOf(
+    "broadcaster",
+    "lead_moderator",
+    "moderator",
+)
+
 internal fun highestPinnedChatRoleBadge(badges: List<Badge>): Badge? =
-    badges.firstOrNull { it.setId.equals("broadcaster", ignoreCase = true) }
-        ?: badges.firstOrNull { it.setId.equals("moderator", ignoreCase = true) }
+    pinnedChatRoleBadgePriority.asSequence()
+        .mapNotNull { roleSetId ->
+            badges.firstOrNull { it.setId.equals(roleSetId, ignoreCase = true) }
+        }
+        .firstOrNull()

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/PinnedChatBadgeRolesTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/PinnedChatBadgeRolesTest.kt
@@ -1,6 +1,7 @@
 package com.github.andreyasadchy.xtra.ui.chat
 
 import com.github.andreyasadchy.xtra.model.chat.Badge
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertSame
 import org.junit.Test
 
@@ -15,6 +16,31 @@ class PinnedChatBadgeRolesTest {
         assertSame(
             broadcaster,
             highestPinnedChatRoleBadge(listOf(subscriber, moderator, broadcaster)),
+        )
+    }
+
+    @Test
+    fun `lead moderator role wins over moderator and non-role badges`() {
+        val leadModerator = Badge("lead_moderator", "1", imageUrl = "https://twitch.tv/lead-moderator")
+        val moderator = Badge("moderator", "1", imageUrl = "https://twitch.tv/moderator")
+        val vip = Badge("vip", "1", imageUrl = "https://twitch.tv/vip")
+
+        assertSame(
+            leadModerator,
+            highestPinnedChatRoleBadge(listOf(vip, moderator, leadModerator)),
+        )
+    }
+
+    @Test
+    fun `non-pinner badges are not treated as role badges`() {
+        assertNull(
+            highestPinnedChatRoleBadge(
+                listOf(
+                    Badge("vip", "1"),
+                    Badge("subscriber", "12"),
+                    Badge("partner", "1"),
+                ),
+            ),
         )
     }
 }


### PR DESCRIPTION
Pinned messages now show the broadcaster, moderator, or lead moderator badge for the account that pinned them. Older head moderator badge IDs are supported too, while unrelated badges such as VIP and subscriber remain excluded because they do not grant pin permission.