### PR TITLE
Make chat emote loading cache-first

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatFragment.kt
@@ -1911,7 +1911,7 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
         adapter?.refreshChatHighlightSettings()
         if (useChatV2) {
             chatV2Renderer?.refreshStyle(resolveChatRenderStyle(requireContext()))
-            (requireContext().applicationContext as XtraApp).xtraModule.chatSessionManager.active.value?.catalog?.refresh()
+            (requireContext().applicationContext as XtraApp).xtraModule.chatSessionManager.active.value?.catalog?.refresh(force = false)
         }
         if (useChatV2 && chatV2RendererVisible) chatV2Renderer?.setVisible(true)
         val args = requireArguments()
@@ -2048,7 +2048,7 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
     fun reloadEmotes() {
         if (useChatV2) {
             val app = requireContext().applicationContext as XtraApp
-            app.xtraModule.chatSessionManager.active.value?.catalog?.refresh()
+            app.xtraModule.chatSessionManager.active.value?.catalog?.refresh(force = true)
         } else {
             viewModel.reloadEmotes(
                 requireArguments().getString(KEY_CHANNEL_ID),

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatViewModel.kt
@@ -389,17 +389,6 @@ class ChatViewModel(
         }
     }
 
-    fun forceRefreshThirdPartyCatalog(
-        expectedChannelId: String?,
-        expectedChannelLogin: String?,
-        useV2: Boolean = true,
-    ) {
-        if (!useV2) return
-        val active = chatSessionManager.active.value ?: return
-        if (!matchesV2PickerSession(active.spec, expectedChannelId, expectedChannelLogin)) return
-        active.catalog.refresh(force = true)
-    }
-
     private fun thirdPartyPickerStateFor(
         snapshot: com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatCatalogSnapshot,
         refreshFailed: Boolean,

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatViewModel.kt
@@ -382,9 +382,22 @@ class ChatViewModel(
                 thirdPartyEmotesUpdated.onStart { emit(Unit) },
             ) { state, _ ->
                 if (!state.hydrated) ThirdPartyPickerState.Loading
-                else thirdPartyPickerStateFor(state.snapshot, state.thirdPartyRefreshFailed) { session.catalog.refresh() }
+                else thirdPartyPickerStateFor(state.snapshot, state.thirdPartyRefreshFailed) {
+                    session.catalog.refresh(force = true)
+                }
             }
         }
+    }
+
+    fun forceRefreshThirdPartyCatalog(
+        expectedChannelId: String?,
+        expectedChannelLogin: String?,
+        useV2: Boolean = true,
+    ) {
+        if (!useV2) return
+        val active = chatSessionManager.active.value ?: return
+        if (!matchesV2PickerSession(active.spec, expectedChannelId, expectedChannelLogin)) return
+        active.catalog.refresh(force = true)
     }
 
     private fun thirdPartyPickerStateFor(

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/EmotesFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/EmotesFragment.kt
@@ -74,6 +74,10 @@ class EmotesFragment : Fragment() {
         val expectedChannelId = chatFragment?.arguments?.getString(ChatFragment.KEY_CHANNEL_ID)
         val expectedChannelLogin = chatFragment?.arguments?.getString(ChatFragment.KEY_CHANNEL_LOGIN)
         val usesV2 = chatFragment?.isUsingChatV2 == true
+        binding.refreshEmotes.isVisible = usesV2
+        binding.refreshEmotes.setOnClickListener {
+            viewModel.forceRefreshThirdPartyCatalog(expectedChannelId, expectedChannelLogin, usesV2)
+        }
         binding.emptyState.setOnClickListener {
             (thirdPartyPickerState as? ChatViewModel.ThirdPartyPickerState.Error)?.retry?.invoke()
         }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/EmotesFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/EmotesFragment.kt
@@ -76,7 +76,7 @@ class EmotesFragment : Fragment() {
         val usesV2 = chatFragment?.isUsingChatV2 == true
         binding.refreshEmotes.isVisible = usesV2
         binding.refreshEmotes.setOnClickListener {
-            viewModel.forceRefreshThirdPartyCatalog(expectedChannelId, expectedChannelLogin, usesV2)
+            chatFragment?.reloadEmotes()
         }
         binding.emptyState.setOnClickListener {
             (thirdPartyPickerState as? ChatViewModel.ThirdPartyPickerState.Error)?.retry?.invoke()

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/catalog/ChatCatalogRepository.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/catalog/ChatCatalogRepository.kt
@@ -65,6 +65,10 @@ fun interface ChatCatalogSource {
 
     suspend fun load(force: Boolean): ChatCatalogLoadResult = load()
 
+    /** Changes when provider-related settings or the signed-in emote scope changes. */
+    val catalogConfigFingerprint: String
+        get() = ""
+
     /** True when Twitch badges are published independently of the aggregate catalog request. */
     val hasIndependentBadgeProvider: Boolean
         get() = false
@@ -78,6 +82,9 @@ fun interface ChatCatalogSource {
 data class ChatCatalogCacheEntry(
     val snapshot: ChatCatalogSnapshot,
     val fetchedAtMs: Long,
+    val badgesFetchedAtMs: Long = 0L,
+    val catalogConfigFingerprint: String? = null,
+    val badgeConfigFingerprint: String? = null,
 )
 
 /** A last-good cache. A provider is absent from a result when its refresh failed. */
@@ -89,6 +96,13 @@ interface ChatCatalogCache {
     }
     suspend fun write(snapshot: ChatCatalogSnapshot)
     suspend fun write(snapshot: ChatCatalogSnapshot, fetchedAtMs: Long) = write(snapshot)
+    suspend fun write(
+        snapshot: ChatCatalogSnapshot,
+        fetchedAtMs: Long,
+        badgesFetchedAtMs: Long,
+        catalogConfigFingerprint: String?,
+        badgeConfigFingerprint: String?,
+    ) = write(snapshot, fetchedAtMs)
 }
 
 /** Replaces scattered mutable provider lists with one atomically published catalog revision. */
@@ -119,6 +133,9 @@ class ChatCatalogRepository(
     private var cacheJob: Job? = null
     private var persistenceJob: Job? = null
     private var cacheFetchedAtMs: Long? = null
+    private var badgesFetchedAtMs: Long? = null
+    private var cacheCatalogConfigFingerprint: String? = null
+    private var cacheBadgeConfigFingerprint: String? = null
     private val personalEmoteSetJobs = mutableMapOf<String, Job>()
     private val loadedPersonalEmoteSets = mutableSetOf<String>()
     private var networkProvidersObserved = emptySet<Provider>()
@@ -277,19 +294,30 @@ class ChatCatalogRepository(
                     if (!closed) {
                         val currentState = _state.value
                         val current = currentState.snapshot
-                        if (cached != null) {
+                        val cacheConfigMatches = cached == null ||
+                                cached.catalogConfigFingerprint == null ||
+                                cached.catalogConfigFingerprint == source.catalogConfigFingerprint
+                        if (cached != null && cacheConfigMatches) {
                             cacheFetchedAtMs = cached.fetchedAtMs.takeIf { it > 0L }
+                            badgesFetchedAtMs = cached.badgesFetchedAtMs.takeIf { it > 0L }
+                            cacheCatalogConfigFingerprint = cached.catalogConfigFingerprint
+                            cacheBadgeConfigFingerprint = cached.badgeConfigFingerprint
                             val cachedSnapshot = cached.snapshot
+                            val cachedBadgesSettled = !source.hasIndependentBadgeProvider ||
+                                    (cached.badgesFetchedAtMs > 0L &&
+                                            isFresh(cached.badgesFetchedAtMs, cacheFreshnessMs) &&
+                                            cached.badgeConfigFingerprint == source.catalogConfigFingerprint)
                             if (networkProvidersObserved.isEmpty() && networkEmoteScopesObserved.isEmpty()) {
                                 // A refresh may already be in flight while disk hydration is pending.
                                 // Publish the last-good cache before that refresh completes.
                                 _state.value = ChatCatalogState(
                                     cachedSnapshot.withRuntimeDecorations(runtimeDecorations),
                                     hydrated = true,
-                                    badgesSettled = currentState.badgesSettled || cachedSnapshot.badges.isNotEmpty(),
+                                    badgesSettled = currentState.badgesSettled || cachedBadgesSettled,
                                     structuralCatalogSettled = currentState.structuralCatalogSettled,
                                     refreshFailed = currentState.refreshFailed,
                                     thirdPartyRefreshFailed = currentState.thirdPartyRefreshFailed,
+                                    forceRefreshRevision = currentState.forceRefreshRevision,
                                 )
                             } else {
                                 // Hydrate only providers that have not produced a network result yet.
@@ -310,15 +338,16 @@ class ChatCatalogRepository(
                                     _state.value = ChatCatalogState(
                                         merged.copy(revision = current.revision + 1),
                                         hydrated = true,
-                                        badgesSettled = currentState.badgesSettled || cachedSnapshot.badges.isNotEmpty(),
+                                        badgesSettled = currentState.badgesSettled || cachedBadgesSettled,
                                         structuralCatalogSettled = currentState.structuralCatalogSettled,
                                         refreshFailed = currentState.refreshFailed,
                                         thirdPartyRefreshFailed = currentState.thirdPartyRefreshFailed,
+                                        forceRefreshRevision = currentState.forceRefreshRevision,
                                     )
                                 } else {
                                     _state.value = currentState.copy(
                                         hydrated = true,
-                                        badgesSettled = currentState.badgesSettled || cachedSnapshot.badges.isNotEmpty(),
+                                        badgesSettled = currentState.badgesSettled || cachedBadgesSettled,
                                     )
                                 }
                             }
@@ -335,6 +364,15 @@ class ChatCatalogRepository(
     @Synchronized fun refresh(force: Boolean = true) {
         if (closed) return
         val requestGeneration = ++generation
+        val currentState = _state.value
+        val forceRefreshRevision = if (force) {
+            currentState.forceRefreshRevision + 1L
+        } else {
+            null
+        }
+        _state.value = currentState.copy(
+            forceRefreshRevision = forceRefreshRevision ?: currentState.forceRefreshRevision,
+        )
         refreshJob?.cancel()
         badgeRefreshJob?.cancel()
         badgeRefreshGeneration = null
@@ -342,11 +380,33 @@ class ChatCatalogRepository(
             if (!force) cacheJob?.join()
             synchronized(this@ChatCatalogRepository) {
                 if (closed || requestGeneration != generation) return@synchronized
-                if (!force && isCacheFresh()) {
+                val structuralCacheFresh = isCacheFresh()
+                val badgeCacheFresh = isBadgeCacheFresh()
+                if (!force && structuralCacheFresh) {
+                    _state.value = _state.value.copy(
+                        structuralCatalogSettled = true,
+                        badgesSettled = if (source.hasIndependentBadgeProvider) badgeCacheFresh else true,
+                    )
+                    if (source.hasIndependentBadgeProvider && !badgeCacheFresh && badgeRefreshJob?.isActive != true) {
+                        badgeRefreshGeneration = requestGeneration
+                        badgeRefreshJob = launchBadgeRefresh(
+                            requestGeneration,
+                            attempt = 1,
+                            delayMs = 0L,
+                            force = false,
+                            forceRefreshRevision = null,
+                        )
+                    }
                     refreshJob = null
                     return@synchronized
                 }
-                refreshJob = launchRefresh(requestGeneration, attempt = 1, delayMs = 0L, force = force)
+                refreshJob = launchRefresh(
+                    requestGeneration,
+                    attempt = 1,
+                    delayMs = 0L,
+                    force = force,
+                    forceRefreshRevision = forceRefreshRevision,
+                )
             }
         }
     }
@@ -380,14 +440,22 @@ class ChatCatalogRepository(
         attempt: Int,
         delayMs: Long,
         force: Boolean,
+        forceRefreshRevision: Long?,
     ): Job = scope.launch {
         if (delayMs > 0) wait(delayMs)
         if (source.hasIndependentBadgeProvider &&
+            (force || !isBadgeCacheFresh()) &&
             badgeRefreshGeneration != requestGeneration &&
             badgeRefreshJob?.isActive != true
         ) {
             badgeRefreshGeneration = requestGeneration
-            badgeRefreshJob = launchBadgeRefresh(requestGeneration, attempt, delayMs = 0L, force = force)
+            badgeRefreshJob = launchBadgeRefresh(
+                requestGeneration,
+                attempt,
+                delayMs = 0L,
+                force = force,
+                forceRefreshRevision = forceRefreshRevision,
+            )
         }
         val result = try {
             source.load(force)
@@ -411,7 +479,13 @@ class ChatCatalogRepository(
                         thirdPartyRefreshFailed = true,
                     )
                 }
-                refreshJob = launchRefresh(requestGeneration, attempt + 1, retryDelay(attempt), force = false)
+                refreshJob = launchRefresh(
+                    requestGeneration,
+                    attempt + 1,
+                    retryDelay(attempt),
+                    force = false,
+                    forceRefreshRevision = forceRefreshRevision,
+                )
                 return@synchronized
             }
             networkProvidersObserved = buildSet {
@@ -454,27 +528,41 @@ class ChatCatalogRepository(
                     result.hasFailedProvider
                 },
                 thirdPartyRefreshFailed = result.hasFailedThirdPartyProvider,
+                forceRefreshRevision = currentState.forceRefreshRevision,
             )
+            val nextForceRefreshRevision = currentState.forceRefreshRevision +
+                    if (forceRefreshRevision != null) 1L else 0L
+            val nextStateWithRefresh = nextState.copy(forceRefreshRevision = nextForceRefreshRevision)
             val aggregateFailed = if (source.hasIndependentBadgeProvider) {
                 result.hasFailedProviderIgnoringBadges()
             } else {
                 result.hasFailedProvider
             }
-            if (!aggregateFailed) cacheFetchedAtMs = System.currentTimeMillis()
+            if (!aggregateFailed) {
+                cacheFetchedAtMs = System.currentTimeMillis()
+                cacheCatalogConfigFingerprint = source.catalogConfigFingerprint
+            }
             if (changed) {
-                _state.value = nextState
+                _state.value = nextStateWithRefresh
                 enqueuePersistence(next)
             } else if (
                 currentState.refreshFailed != nextState.refreshFailed ||
                 currentState.thirdPartyRefreshFailed != nextState.thirdPartyRefreshFailed ||
                 currentState.badgesSettled != nextState.badgesSettled ||
-                currentState.structuralCatalogSettled != nextState.structuralCatalogSettled
+                currentState.structuralCatalogSettled != nextState.structuralCatalogSettled ||
+                currentState.forceRefreshRevision != nextStateWithRefresh.forceRefreshRevision
             ) {
-                _state.value = nextState
+                _state.value = nextStateWithRefresh
             }
             if (!aggregateFailed && !changed) enqueuePersistence(next)
             refreshJob = if (aggregateFailed) {
-                launchRefresh(requestGeneration, attempt + 1, retryDelay(attempt), force = false)
+                launchRefresh(
+                    requestGeneration,
+                    attempt + 1,
+                    retryDelay(attempt),
+                    force = false,
+                    forceRefreshRevision = forceRefreshRevision,
+                )
             } else {
                 null
             }
@@ -486,6 +574,7 @@ class ChatCatalogRepository(
         attempt: Int,
         delayMs: Long,
         force: Boolean,
+        forceRefreshRevision: Long?,
     ): Job = scope.launch {
         if (delayMs > 0) wait(delayMs)
         val result = try {
@@ -499,6 +588,8 @@ class ChatCatalogRepository(
             if (closed || requestGeneration != generation) return@synchronized
             if (result != null) {
                 networkProvidersObserved = networkProvidersObserved + Provider.BADGES
+                badgesFetchedAtMs = System.currentTimeMillis()
+                cacheBadgeConfigFingerprint = source.catalogConfigFingerprint
                 val currentState = _state.value
                 val current = currentState.snapshot
                 val next = current.copy(
@@ -508,6 +599,8 @@ class ChatCatalogRepository(
                 _state.value = currentState.copy(
                     snapshot = next,
                     badgesSettled = true,
+                    forceRefreshRevision = currentState.forceRefreshRevision +
+                            if (forceRefreshRevision != null) 1L else 0L,
                 )
                 enqueuePersistence(next)
                 badgeRefreshJob = null
@@ -516,7 +609,13 @@ class ChatCatalogRepository(
                     badgesSettled = true,
                     refreshFailed = true,
                 )
-                badgeRefreshJob = launchBadgeRefresh(requestGeneration, attempt + 1, retryDelay(attempt), force = false)
+                badgeRefreshJob = launchBadgeRefresh(
+                    requestGeneration,
+                    attempt + 1,
+                    retryDelay(attempt),
+                    force = false,
+                    forceRefreshRevision = forceRefreshRevision,
+                )
             }
         }
     }
@@ -528,11 +627,20 @@ class ChatCatalogRepository(
     private fun enqueuePersistence(next: ChatCatalogSnapshot) {
         val persistence = cache ?: return
         val fetchedAtMs = cacheFetchedAtMs ?: 0L
+        val badgeFetchedAtMs = badgesFetchedAtMs ?: 0L
+        val catalogConfigFingerprint = cacheCatalogConfigFingerprint
+        val badgeConfigFingerprint = cacheBadgeConfigFingerprint
         val previous = persistenceJob
         persistenceJob = scope.launch {
             previous?.join()
             try {
-                persistence.write(next, fetchedAtMs)
+                persistence.write(
+                    next,
+                    fetchedAtMs,
+                    badgeFetchedAtMs,
+                    catalogConfigFingerprint,
+                    badgeConfigFingerprint,
+                )
             } catch (e: CancellationException) {
                 throw e
             } catch (_: Throwable) {
@@ -550,7 +658,21 @@ class ChatCatalogRepository(
     }
 
     private fun isCacheFresh(nowMs: Long = System.currentTimeMillis()): Boolean =
-        cacheFetchedAtMs?.let { fetchedAt -> nowMs - fetchedAt in 0 until cacheFreshnessMs } == true
+        cacheFetchedAtMs?.let { fetchedAt ->
+            cacheConfigIsCurrent() && isFresh(fetchedAt, cacheFreshnessMs, nowMs)
+        } == true
+
+    private fun isBadgeCacheFresh(nowMs: Long = System.currentTimeMillis()): Boolean {
+        val fetchedAt = badgesFetchedAtMs ?: return false
+        if (cacheBadgeConfigFingerprint != source.catalogConfigFingerprint) return false
+        return isFresh(fetchedAt, cacheFreshnessMs, nowMs)
+    }
+
+    private fun cacheConfigIsCurrent(): Boolean =
+        cacheCatalogConfigFingerprint == source.catalogConfigFingerprint
+
+    private fun isFresh(fetchedAtMs: Long, ttlMs: Long, nowMs: Long = System.currentTimeMillis()): Boolean =
+        nowMs - fetchedAtMs in 0 until ttlMs
 
     private fun mergeEmoteScopes(
         current: ScopedEmoteCatalog,

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/catalog/ChatCatalogRepository.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/catalog/ChatCatalogRepository.kt
@@ -370,9 +370,6 @@ class ChatCatalogRepository(
         } else {
             null
         }
-        _state.value = currentState.copy(
-            forceRefreshRevision = forceRefreshRevision ?: currentState.forceRefreshRevision,
-        )
         refreshJob?.cancel()
         badgeRefreshJob?.cancel()
         badgeRefreshGeneration = null

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/catalog/ChatCatalogRepository.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/catalog/ChatCatalogRepository.kt
@@ -63,18 +63,32 @@ data class ChatCatalogLoadResult(
 fun interface ChatCatalogSource {
     suspend fun load(): ChatCatalogLoadResult
 
+    suspend fun load(force: Boolean): ChatCatalogLoadResult = load()
+
     /** True when Twitch badges are published independently of the aggregate catalog request. */
     val hasIndependentBadgeProvider: Boolean
         get() = false
 
     /** Returns the Twitch badge result as soon as that provider finishes. */
     suspend fun loadBadges(): ChatCatalogProviderUpdate<Map<String, ChatCatalogBadge>>? = null
+
+    suspend fun loadBadges(force: Boolean): ChatCatalogProviderUpdate<Map<String, ChatCatalogBadge>>? = loadBadges()
 }
+
+data class ChatCatalogCacheEntry(
+    val snapshot: ChatCatalogSnapshot,
+    val fetchedAtMs: Long,
+)
 
 /** A last-good cache. A provider is absent from a result when its refresh failed. */
 interface ChatCatalogCache {
     suspend fun read(): ChatCatalogSnapshot?
+    suspend fun readFetchedAtMs(): Long = 0L
+    suspend fun readEntry(): ChatCatalogCacheEntry? = read()?.let { snapshot ->
+        ChatCatalogCacheEntry(snapshot, readFetchedAtMs())
+    }
     suspend fun write(snapshot: ChatCatalogSnapshot)
+    suspend fun write(snapshot: ChatCatalogSnapshot, fetchedAtMs: Long) = write(snapshot)
 }
 
 /** Replaces scattered mutable provider lists with one atomically published catalog revision. */
@@ -84,6 +98,7 @@ class ChatCatalogRepository(
     private val cache: ChatCatalogCache? = null,
     private val wait: suspend (Long) -> Unit = { delay(it) },
     private val personalEmoteSetLoader: (suspend (String) -> Map<String, ChatCatalogEmote>)? = null,
+    private val cacheFreshnessMs: Long = 60 * 60 * 1000L,
 ) {
     private enum class Provider { TWITCH, SEVEN_TV, BTTV, FFZ, BADGES, CHEERMOTES }
 
@@ -103,6 +118,7 @@ class ChatCatalogRepository(
     private var closed = false
     private var cacheJob: Job? = null
     private var persistenceJob: Job? = null
+    private var cacheFetchedAtMs: Long? = null
     private val personalEmoteSetJobs = mutableMapOf<String, Job>()
     private val loadedPersonalEmoteSets = mutableSetOf<String>()
     private var networkProvidersObserved = emptySet<Provider>()
@@ -251,7 +267,7 @@ class ChatCatalogRepository(
         cache?.let { persistence ->
             cacheJob = scope.launch {
                 val cached = try {
-                    persistence.read()
+                    persistence.readEntry()
                 } catch (e: CancellationException) {
                     throw e
                 } catch (_: Throwable) {
@@ -262,13 +278,15 @@ class ChatCatalogRepository(
                         val currentState = _state.value
                         val current = currentState.snapshot
                         if (cached != null) {
+                            cacheFetchedAtMs = cached.fetchedAtMs.takeIf { it > 0L }
+                            val cachedSnapshot = cached.snapshot
                             if (networkProvidersObserved.isEmpty() && networkEmoteScopesObserved.isEmpty()) {
                                 // A refresh may already be in flight while disk hydration is pending.
                                 // Publish the last-good cache before that refresh completes.
                                 _state.value = ChatCatalogState(
-                                    cached.withRuntimeDecorations(runtimeDecorations),
+                                    cachedSnapshot.withRuntimeDecorations(runtimeDecorations),
                                     hydrated = true,
-                                    badgesSettled = currentState.badgesSettled || cached.badges.isNotEmpty(),
+                                    badgesSettled = currentState.badgesSettled || cachedSnapshot.badges.isNotEmpty(),
                                     structuralCatalogSettled = currentState.structuralCatalogSettled,
                                     refreshFailed = currentState.refreshFailed,
                                     thirdPartyRefreshFailed = currentState.thirdPartyRefreshFailed,
@@ -278,21 +296,21 @@ class ChatCatalogRepository(
                                 // A partial refresh must not erase cached data for providers that are
                                 // still retrying, while a successful provider must remain authoritative.
                                 val merged = current.copy(
-                                    twitch = if (Provider.TWITCH in networkProvidersObserved) current.twitch else cached.twitch,
-                                    sevenTv = hydrateUnobservedScopes(current.sevenTv, cached.sevenTv, Provider.SEVEN_TV),
+                                    twitch = if (Provider.TWITCH in networkProvidersObserved) current.twitch else cachedSnapshot.twitch,
+                                    sevenTv = hydrateUnobservedScopes(current.sevenTv, cachedSnapshot.sevenTv, Provider.SEVEN_TV),
                                     sevenTvChannelSetId = if (
                                         ChatEmoteScope.CHANNEL in networkEmoteScopesObserved[Provider.SEVEN_TV].orEmpty()
-                                    ) current.sevenTvChannelSetId else cached.sevenTvChannelSetId,
-                                    bttv = hydrateUnobservedScopes(current.bttv, cached.bttv, Provider.BTTV),
-                                    ffz = hydrateUnobservedScopes(current.ffz, cached.ffz, Provider.FFZ),
-                                    badges = if (Provider.BADGES in networkProvidersObserved) current.badges else cached.badges,
-                                    cheermotes = if (Provider.CHEERMOTES in networkProvidersObserved) current.cheermotes else cached.cheermotes,
+                                    ) current.sevenTvChannelSetId else cachedSnapshot.sevenTvChannelSetId,
+                                    bttv = hydrateUnobservedScopes(current.bttv, cachedSnapshot.bttv, Provider.BTTV),
+                                    ffz = hydrateUnobservedScopes(current.ffz, cachedSnapshot.ffz, Provider.FFZ),
+                                    badges = if (Provider.BADGES in networkProvidersObserved) current.badges else cachedSnapshot.badges,
+                                    cheermotes = if (Provider.CHEERMOTES in networkProvidersObserved) current.cheermotes else cachedSnapshot.cheermotes,
                                 )
                                 if (merged != current) {
                                     _state.value = ChatCatalogState(
                                         merged.copy(revision = current.revision + 1),
                                         hydrated = true,
-                                        badgesSettled = currentState.badgesSettled || cached.badges.isNotEmpty(),
+                                        badgesSettled = currentState.badgesSettled || cachedSnapshot.badges.isNotEmpty(),
                                         structuralCatalogSettled = currentState.structuralCatalogSettled,
                                         refreshFailed = currentState.refreshFailed,
                                         thirdPartyRefreshFailed = currentState.thirdPartyRefreshFailed,
@@ -300,7 +318,7 @@ class ChatCatalogRepository(
                                 } else {
                                     _state.value = currentState.copy(
                                         hydrated = true,
-                                        badgesSettled = currentState.badgesSettled || cached.badges.isNotEmpty(),
+                                        badgesSettled = currentState.badgesSettled || cachedSnapshot.badges.isNotEmpty(),
                                     )
                                 }
                             }
@@ -313,13 +331,24 @@ class ChatCatalogRepository(
         }
     }
 
-    @Synchronized fun refresh() {
+    /** Refreshes immediately by default. Pass false for the normal stale-while-revalidate path. */
+    @Synchronized fun refresh(force: Boolean = true) {
         if (closed) return
         val requestGeneration = ++generation
         refreshJob?.cancel()
         badgeRefreshJob?.cancel()
         badgeRefreshGeneration = null
-        refreshJob = launchRefresh(requestGeneration, attempt = 1, delayMs = 0L)
+        refreshJob = scope.launch {
+            if (!force) cacheJob?.join()
+            synchronized(this@ChatCatalogRepository) {
+                if (closed || requestGeneration != generation) return@synchronized
+                if (!force && isCacheFresh()) {
+                    refreshJob = null
+                    return@synchronized
+                }
+                refreshJob = launchRefresh(requestGeneration, attempt = 1, delayMs = 0L, force = force)
+            }
+        }
     }
 
     /** Stops provider refresh/retry work while an owning session is paused. */
@@ -346,17 +375,22 @@ class ChatCatalogRepository(
         personalEmoteSetJobs.clear()
     }
 
-    private fun launchRefresh(requestGeneration: Long, attempt: Int, delayMs: Long): Job = scope.launch {
+    private fun launchRefresh(
+        requestGeneration: Long,
+        attempt: Int,
+        delayMs: Long,
+        force: Boolean,
+    ): Job = scope.launch {
         if (delayMs > 0) wait(delayMs)
         if (source.hasIndependentBadgeProvider &&
             badgeRefreshGeneration != requestGeneration &&
             badgeRefreshJob?.isActive != true
         ) {
             badgeRefreshGeneration = requestGeneration
-            badgeRefreshJob = launchBadgeRefresh(requestGeneration, attempt, delayMs = 0L)
+            badgeRefreshJob = launchBadgeRefresh(requestGeneration, attempt, delayMs = 0L, force = force)
         }
         val result = try {
-            source.load()
+            source.load(force)
         } catch (e: CancellationException) {
             throw e
         } catch (_: Throwable) {
@@ -377,7 +411,7 @@ class ChatCatalogRepository(
                         thirdPartyRefreshFailed = true,
                     )
                 }
-                refreshJob = launchRefresh(requestGeneration, attempt + 1, retryDelay(attempt))
+                refreshJob = launchRefresh(requestGeneration, attempt + 1, retryDelay(attempt), force = false)
                 return@synchronized
             }
             networkProvidersObserved = buildSet {
@@ -421,6 +455,12 @@ class ChatCatalogRepository(
                 },
                 thirdPartyRefreshFailed = result.hasFailedThirdPartyProvider,
             )
+            val aggregateFailed = if (source.hasIndependentBadgeProvider) {
+                result.hasFailedProviderIgnoringBadges()
+            } else {
+                result.hasFailedProvider
+            }
+            if (!aggregateFailed) cacheFetchedAtMs = System.currentTimeMillis()
             if (changed) {
                 _state.value = nextState
                 enqueuePersistence(next)
@@ -432,23 +472,24 @@ class ChatCatalogRepository(
             ) {
                 _state.value = nextState
             }
-            val aggregateFailed = if (source.hasIndependentBadgeProvider) {
-                result.hasFailedProviderIgnoringBadges()
-            } else {
-                result.hasFailedProvider
-            }
+            if (!aggregateFailed && !changed) enqueuePersistence(next)
             refreshJob = if (aggregateFailed) {
-                launchRefresh(requestGeneration, attempt + 1, retryDelay(attempt))
+                launchRefresh(requestGeneration, attempt + 1, retryDelay(attempt), force = false)
             } else {
                 null
             }
         }
     }
 
-    private fun launchBadgeRefresh(requestGeneration: Long, attempt: Int, delayMs: Long): Job = scope.launch {
+    private fun launchBadgeRefresh(
+        requestGeneration: Long,
+        attempt: Int,
+        delayMs: Long,
+        force: Boolean,
+    ): Job = scope.launch {
         if (delayMs > 0) wait(delayMs)
         val result = try {
-            source.loadBadges()
+            source.loadBadges(force)
         } catch (e: CancellationException) {
             throw e
         } catch (_: Throwable) {
@@ -475,7 +516,7 @@ class ChatCatalogRepository(
                     badgesSettled = true,
                     refreshFailed = true,
                 )
-                badgeRefreshJob = launchBadgeRefresh(requestGeneration, attempt + 1, retryDelay(attempt))
+                badgeRefreshJob = launchBadgeRefresh(requestGeneration, attempt + 1, retryDelay(attempt), force = false)
             }
         }
     }
@@ -486,11 +527,12 @@ class ChatCatalogRepository(
      */
     private fun enqueuePersistence(next: ChatCatalogSnapshot) {
         val persistence = cache ?: return
+        val fetchedAtMs = cacheFetchedAtMs ?: 0L
         val previous = persistenceJob
         persistenceJob = scope.launch {
             previous?.join()
             try {
-                persistence.write(next)
+                persistence.write(next, fetchedAtMs)
             } catch (e: CancellationException) {
                 throw e
             } catch (_: Throwable) {
@@ -506,6 +548,9 @@ class ChatCatalogRepository(
         4 -> 30_000L
         else -> 60_000L
     }
+
+    private fun isCacheFresh(nowMs: Long = System.currentTimeMillis()): Boolean =
+        cacheFetchedAtMs?.let { fetchedAt -> nowMs - fetchedAt in 0 until cacheFreshnessMs } == true
 
     private fun mergeEmoteScopes(
         current: ScopedEmoteCatalog,

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/catalog/ChatCatalogSnapshot.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/catalog/ChatCatalogSnapshot.kt
@@ -172,7 +172,7 @@ data class ChatCatalogState(
     val structuralCatalogSettled: Boolean = false,
     val refreshFailed: Boolean = false,
     val thirdPartyRefreshFailed: Boolean = false,
-    /** Monotonic marker for explicit refresh requests and their provider results. */
+    /** Monotonic marker for explicit refresh results published to the renderer. */
     val forceRefreshRevision: Long = 0L,
 )
 

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/catalog/ChatCatalogSnapshot.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/catalog/ChatCatalogSnapshot.kt
@@ -172,6 +172,8 @@ data class ChatCatalogState(
     val structuralCatalogSettled: Boolean = false,
     val refreshFailed: Boolean = false,
     val thirdPartyRefreshFailed: Boolean = false,
+    /** Monotonic marker for explicit refresh requests and their provider results. */
+    val forceRefreshRevision: Long = 0L,
 )
 
 internal fun ChatCatalogState.isReadyForChatPublication(showBadges: Boolean): Boolean =

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/catalog/TwitchChatCatalogSource.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/catalog/TwitchChatCatalogSource.kt
@@ -37,6 +37,7 @@ class TwitchChatCatalogSource(
     private val channelLogin: String,
 ) : ChatCatalogSource {
     private val context = context.applicationContext
+    private val globalCatalogCache = GlobalCatalogCacheRegistry.get(context)
 
     override val hasIndependentBadgeProvider: Boolean = true
 
@@ -54,15 +55,17 @@ class TwitchChatCatalogSource(
         }
     }
 
-    override suspend fun load(): ChatCatalogLoadResult = withContext(Dispatchers.IO) {
+    override suspend fun load(): ChatCatalogLoadResult = load(force = false)
+
+    override suspend fun load(force: Boolean): ChatCatalogLoadResult = withContext(Dispatchers.IO) {
         val network = context.prefs().getString(C.NETWORK_LIBRARY, C.OKHTTP)
         val helix = TwitchApiHelper.getHelixHeaders(context)
         val gql = TwitchApiHelper.getGQLHeaders(context, true)
         val useWebp = true
         supervisorScope {
-            val sevenTv = async { if (context.prefs().getBoolean(C.CHAT_ENABLE_STV, true)) loadSevenTv(network, useWebp) else emptyProviderUpdate() }
-            val bttv = async { if (context.prefs().getBoolean(C.CHAT_ENABLE_BTTV, true)) loadBttv(network, useWebp) else emptyProviderUpdate() }
-            val ffz = async { if (context.prefs().getBoolean(C.CHAT_ENABLE_FFZ, true)) loadFfz(network, useWebp) else emptyProviderUpdate() }
+            val sevenTv = async { if (context.prefs().getBoolean(C.CHAT_ENABLE_STV, true)) loadSevenTv(network, useWebp, force) else emptyProviderUpdate() }
+            val bttv = async { if (context.prefs().getBoolean(C.CHAT_ENABLE_BTTV, true)) loadBttv(network, useWebp, force) else emptyProviderUpdate() }
+            val ffz = async { if (context.prefs().getBoolean(C.CHAT_ENABLE_FFZ, true)) loadFfz(network, useWebp, force) else emptyProviderUpdate() }
             val cheermotes = async { provider {
                 playerRepository.loadCheerEmotes(
                     network,
@@ -83,12 +86,14 @@ class TwitchChatCatalogSource(
         }
     }
 
-    override suspend fun loadBadges(): ChatCatalogProviderUpdate<Map<String, ChatCatalogBadge>>? = withContext(Dispatchers.IO) {
+    override suspend fun loadBadges(): ChatCatalogProviderUpdate<Map<String, ChatCatalogBadge>>? = loadBadges(force = false)
+
+    override suspend fun loadBadges(force: Boolean): ChatCatalogProviderUpdate<Map<String, ChatCatalogBadge>>? = withContext(Dispatchers.IO) {
         val network = context.prefs().getString(C.NETWORK_LIBRARY, C.OKHTTP)
         val helix = TwitchApiHelper.getHelixHeaders(context)
         val gql = TwitchApiHelper.getGQLHeaders(context, true)
         provider {
-            val global = GlobalChatCatalogCache.get(GlobalCatalogKey.TWITCH_BADGES) {
+            val global = GlobalBadgeCache.get(GlobalCatalogKey.TWITCH_BADGES, force = force) {
                 playerRepository.loadGlobalBadges(network, helix, gql, "4")
             }
             val channel = playerRepository.loadChannelBadges(network, helix, gql, channelId, channelLogin, "4")
@@ -96,14 +101,19 @@ class TwitchChatCatalogSource(
         }
     }
 
-    private suspend fun loadSevenTv(network: String?, useWebp: Boolean): ChatCatalogProviderUpdate<Map<String, ChatCatalogEmote>> {
+    private suspend fun loadSevenTv(
+        network: String?,
+        useWebp: Boolean,
+        force: Boolean,
+    ): ChatCatalogProviderUpdate<Map<String, ChatCatalogEmote>> {
         var channelSetId: String? = null
         val global = scopeUpdate(channel = false) {
-            GlobalChatCatalogCache.get(GlobalCatalogKey.SEVEN_TV) {
-                playerRepository.loadSTVEmoteSet(
-                    playerRepository.loadGlobalSTVEmoteSetResponse(network), useWebp, true,
-                ).second
+            val response = globalCatalogCache.get(GlobalCatalogKey.SEVEN_TV, force) {
+                playerRepository.loadGlobalSTVEmoteSetResponse(network).also {
+                    playerRepository.loadSTVEmoteSet(it, useWebp, true)
+                }
             }
+            playerRepository.loadSTVEmoteSet(response, useWebp, true).second
         }.map { emoteMap(it, ChatAssetProvider.SEVEN_TV, ChatEmoteScope.GLOBAL) }
         val channel = scopeUpdate(channel = true, emptyValue = emptyList()) {
             val user = playerRepository.loadSTVUser(
@@ -152,13 +162,18 @@ class TwitchChatCatalogSource(
         return scopedProviderUpdate(global, channel, personal, channelSetId)
     }
 
-    private suspend fun loadBttv(network: String?, useWebp: Boolean): ChatCatalogProviderUpdate<Map<String, ChatCatalogEmote>> {
+    private suspend fun loadBttv(
+        network: String?,
+        useWebp: Boolean,
+        force: Boolean,
+    ): ChatCatalogProviderUpdate<Map<String, ChatCatalogEmote>> {
         val global = scopeUpdate(channel = false) {
-            GlobalChatCatalogCache.get(GlobalCatalogKey.BTTV) {
-                playerRepository.loadGlobalBTTVEmotes(
-                    playerRepository.loadGlobalBTTVEmotesResponse(network), useWebp,
-                )
+            val response = globalCatalogCache.get(GlobalCatalogKey.BTTV, force) {
+                playerRepository.loadGlobalBTTVEmotesResponse(network).also {
+                    playerRepository.loadGlobalBTTVEmotes(it, useWebp)
+                }
             }
+            playerRepository.loadGlobalBTTVEmotes(response, useWebp)
         }.map { emoteMap(it, ChatAssetProvider.BTTV, ChatEmoteScope.GLOBAL) }
         val channel = scopeUpdate(channel = true, emptyValue = emptyList()) {
             playerRepository.loadBTTVEmotes(
@@ -173,13 +188,18 @@ class TwitchChatCatalogSource(
         return scopedProviderUpdate(global, channel)
     }
 
-    private suspend fun loadFfz(network: String?, useWebp: Boolean): ChatCatalogProviderUpdate<Map<String, ChatCatalogEmote>> {
+    private suspend fun loadFfz(
+        network: String?,
+        useWebp: Boolean,
+        force: Boolean,
+    ): ChatCatalogProviderUpdate<Map<String, ChatCatalogEmote>> {
         val global = scopeUpdate(channel = false) {
-            GlobalChatCatalogCache.get(GlobalCatalogKey.FFZ) {
-                playerRepository.loadGlobalFFZEmotes(
-                    playerRepository.loadGlobalFFZEmotesResponse(network), useWebp,
-                )
+            val response = globalCatalogCache.get(GlobalCatalogKey.FFZ, force) {
+                playerRepository.loadGlobalFFZEmotesResponse(network).also {
+                    playerRepository.loadGlobalFFZEmotes(it, useWebp)
+                }
             }
+            playerRepository.loadGlobalFFZEmotes(response, useWebp)
         }.map { emoteMap(it, ChatAssetProvider.FFZ, ChatEmoteScope.GLOBAL) }
         val channel = scopeUpdate(channel = true, emptyValue = emptyList()) {
             playerRepository.loadFFZEmotes(
@@ -332,11 +352,11 @@ internal class ExpiringSingleFlightCache<K>(private val ttlMs: Long = 5 * 60 * 1
     private val inFlight = mutableMapOf<K, CompletableDeferred<Any>>()
 
     @Suppress("UNCHECKED_CAST")
-    suspend fun <T : Any> get(key: K, loader: suspend () -> T): T {
+    suspend fun <T : Any> get(key: K, force: Boolean = false, loader: suspend () -> T): T {
         data class Lookup(val deferred: CompletableDeferred<Any>, val owner: Boolean)
         val lookup = mutex.withLock {
             val now = System.currentTimeMillis()
-            entries[key]?.takeIf { now - it.createdAtMs < ttlMs }?.let {
+            entries[key]?.takeIf { !force && now - it.createdAtMs < ttlMs }?.let {
                 return@withLock Lookup(CompletableDeferred(it.value), owner = false)
             }
             inFlight[key]?.let { return@withLock Lookup(it, owner = false) }
@@ -361,8 +381,95 @@ internal class ExpiringSingleFlightCache<K>(private val ttlMs: Long = 5 * 60 * 1
     private data class Entry(val createdAtMs: Long, val value: Any)
 }
 
-private val GlobalChatCatalogCache = ExpiringSingleFlightCache<GlobalCatalogKey>()
+private val GlobalBadgeCache = ExpiringSingleFlightCache<GlobalCatalogKey>()
 private val PersonalEmoteSetCache = ExpiringSingleFlightCache<String>()
+
+private object GlobalCatalogCacheRegistry {
+    @Volatile
+    private var cache: PersistentStringSingleFlightCache<GlobalCatalogKey>? = null
+
+    @Synchronized
+    fun get(context: Context): PersistentStringSingleFlightCache<GlobalCatalogKey> =
+        cache ?: PersistentStringSingleFlightCache<GlobalCatalogKey>(
+            directory = File(context.applicationContext.filesDir, "chat-v2/global"),
+            ttlMs = 12 * 60 * 60 * 1000L,
+            fileName = { key: GlobalCatalogKey -> "${key.name.lowercase()}.json" },
+        ).also { cache = it }
+}
+
+/** Persistent L1/L2 cache for provider responses shared by all channel sessions. */
+internal class PersistentStringSingleFlightCache<K>(
+    private val directory: File,
+    private val ttlMs: Long,
+    private val fileName: (K) -> String,
+) {
+    private data class Entry(val fetchedAtMs: Long, val value: String)
+    private data class DiskEntry(val fetchedAtMs: Long, val value: String)
+
+    private val mutex = Mutex()
+    private val entries = mutableMapOf<K, Entry>()
+    private val inFlight = mutableMapOf<K, CompletableDeferred<String>>()
+
+    suspend fun get(key: K, force: Boolean = false, loader: suspend () -> String): String {
+        data class Lookup(val deferred: CompletableDeferred<String>, val owner: Boolean)
+        val lookup = mutex.withLock {
+            inFlight[key]?.let { return@withLock Lookup(it, owner = false) }
+            if (!force) {
+                entries[key]?.takeIf { isFresh(it.fetchedAtMs) }?.let {
+                    return@withLock Lookup(CompletableDeferred(it.value), owner = false)
+                }
+            }
+            val deferred = CompletableDeferred<String>()
+            inFlight[key] = deferred
+            Lookup(deferred, owner = true)
+        }
+        if (!lookup.owner) return lookup.deferred.await()
+
+        return try {
+            val disk = if (!force) readDisk(key) else null
+            val diskFresh = disk?.takeIf { isFresh(it.fetchedAtMs) }
+            val value = diskFresh?.value ?: loader()
+            val fetchedAtMs = diskFresh?.fetchedAtMs ?: System.currentTimeMillis()
+            mutex.withLock {
+                entries[key] = Entry(fetchedAtMs, value)
+                inFlight.remove(key)?.complete(value)
+            }
+            if (diskFresh == null) writeDisk(key, fetchedAtMs, value)
+            value
+        } catch (error: Throwable) {
+            mutex.withLock { inFlight.remove(key)?.completeExceptionally(error) }
+            throw error
+        }
+    }
+
+    private fun isFresh(fetchedAtMs: Long): Boolean =
+        fetchedAtMs > 0L && System.currentTimeMillis() - fetchedAtMs in 0 until ttlMs
+
+    private suspend fun readDisk(key: K): DiskEntry? = withContext(Dispatchers.IO) {
+        val file = File(directory, fileName(key))
+        if (!file.isFile) return@withContext null
+        runCatching {
+            val root = JSONObject(file.readText())
+            DiskEntry(root.optLong("fetchedAt", 0L), root.getString("payload"))
+        }.getOrNull()
+    }
+
+    private suspend fun writeDisk(key: K, fetchedAtMs: Long, value: String) = withContext(Dispatchers.IO) {
+        runCatching {
+            directory.mkdirs()
+            val file = File(directory, fileName(key))
+            val temp = File(directory, "${file.name}.tmp")
+            temp.writeText(JSONObject().apply {
+                put("fetchedAt", fetchedAtMs)
+                put("payload", value)
+            }.toString())
+            if (!temp.renameTo(file)) {
+                file.delete()
+                if (!temp.renameTo(file)) temp.delete()
+            }
+        }
+    }
+}
 
 /** Structured, versioned last-good catalog storage for one playback channel. */
 class TwitchChatCatalogCache(
@@ -374,26 +481,36 @@ class TwitchChatCatalogCache(
         channelId.replace(Regex("[^A-Za-z0-9._-]"), "_") + ".json",
     )
 
-    override suspend fun read(): ChatCatalogSnapshot? = withContext(Dispatchers.IO) {
+    override suspend fun read(): ChatCatalogSnapshot? = readEntry()?.snapshot
+
+    override suspend fun readEntry(): ChatCatalogCacheEntry? = withContext(Dispatchers.IO) {
         if (!file.isFile) return@withContext null
-        runCatching { decode(JSONObject(file.readText())) }.getOrNull()
+        runCatching {
+            val root = JSONObject(file.readText())
+            ChatCatalogCacheEntry(
+                snapshot = decode(root),
+                fetchedAtMs = root.optLong("fetchedAt", 0L),
+            )
+        }.getOrNull()
     }
 
-    override suspend fun write(snapshot: ChatCatalogSnapshot) = withContext(Dispatchers.IO) {
+    override suspend fun write(snapshot: ChatCatalogSnapshot) = write(snapshot, System.currentTimeMillis())
+
+    override suspend fun write(snapshot: ChatCatalogSnapshot, fetchedAtMs: Long) = withContext(Dispatchers.IO) {
         file.parentFile?.mkdirs()
         val temp = File(file.parentFile, "${file.name}.tmp")
-        temp.writeText(encode(snapshot).toString())
+        temp.writeText(encode(snapshot, fetchedAtMs).toString())
         if (!temp.renameTo(file)) {
             file.delete()
             check(temp.renameTo(file)) { "Unable to publish chat catalog cache" }
         }
     }
 
-    private fun encode(snapshot: ChatCatalogSnapshot): JSONObject = JSONObject().apply {
+    private fun encode(snapshot: ChatCatalogSnapshot, fetchedAtMs: Long): JSONObject = JSONObject().apply {
         put("schemaVersion", 5)
         put("revision", snapshot.revision)
         put("provider", "combined")
-        put("fetchedAt", System.currentTimeMillis())
+        put("fetchedAt", fetchedAtMs)
         put("twitch", encodeEmotes(snapshot.twitch))
         put("sevenTv", encodeScopedEmotes(snapshot.sevenTv))
         putOpt("sevenTvChannelSetId", snapshot.sevenTvChannelSetId)

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/catalog/TwitchChatCatalogSource.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/catalog/TwitchChatCatalogSource.kt
@@ -41,6 +41,16 @@ class TwitchChatCatalogSource(
 
     override val hasIndependentBadgeProvider: Boolean = true
 
+    override val catalogConfigFingerprint: String
+        get() = listOf(
+            context.prefs().getString(C.NETWORK_LIBRARY, C.OKHTTP),
+            context.prefs().getBoolean(C.CHAT_ENABLE_STV, true),
+            context.prefs().getBoolean(C.CHAT_ENABLE_BTTV, true),
+            context.prefs().getBoolean(C.CHAT_ENABLE_FFZ, true),
+            context.prefs().getBoolean(C.ANIMATED_EMOTES, true),
+            context.tokenPrefs().getString(C.USER_ID, null),
+        ).joinToString("|")
+
     suspend fun loadPersonalEmoteSet(setId: String): Map<String, ChatCatalogEmote> {
         return PersonalEmoteSetCache.get(setId) {
             val network = context.prefs().getString(C.NETWORK_LIBRARY, C.OKHTTP)
@@ -490,6 +500,9 @@ class TwitchChatCatalogCache(
             ChatCatalogCacheEntry(
                 snapshot = decode(root),
                 fetchedAtMs = root.optLong("fetchedAt", 0L),
+                badgesFetchedAtMs = root.optLong("badgesFetchedAt", 0L),
+                catalogConfigFingerprint = root.optString("catalogConfigFingerprint").takeIf { it.isNotBlank() },
+                badgeConfigFingerprint = root.optString("badgeConfigFingerprint").takeIf { it.isNotBlank() },
             )
         }.getOrNull()
     }
@@ -497,20 +510,47 @@ class TwitchChatCatalogCache(
     override suspend fun write(snapshot: ChatCatalogSnapshot) = write(snapshot, System.currentTimeMillis())
 
     override suspend fun write(snapshot: ChatCatalogSnapshot, fetchedAtMs: Long) = withContext(Dispatchers.IO) {
+        write(snapshot, fetchedAtMs, 0L, null, null)
+    }
+
+    override suspend fun write(
+        snapshot: ChatCatalogSnapshot,
+        fetchedAtMs: Long,
+        badgesFetchedAtMs: Long,
+        catalogConfigFingerprint: String?,
+        badgeConfigFingerprint: String?,
+    ) = withContext(Dispatchers.IO) {
         file.parentFile?.mkdirs()
         val temp = File(file.parentFile, "${file.name}.tmp")
-        temp.writeText(encode(snapshot, fetchedAtMs).toString())
+        temp.writeText(
+            encode(
+                snapshot,
+                fetchedAtMs,
+                badgesFetchedAtMs,
+                catalogConfigFingerprint,
+                badgeConfigFingerprint,
+            ).toString(),
+        )
         if (!temp.renameTo(file)) {
             file.delete()
             check(temp.renameTo(file)) { "Unable to publish chat catalog cache" }
         }
     }
 
-    private fun encode(snapshot: ChatCatalogSnapshot, fetchedAtMs: Long): JSONObject = JSONObject().apply {
-        put("schemaVersion", 5)
+    private fun encode(
+        snapshot: ChatCatalogSnapshot,
+        fetchedAtMs: Long,
+        badgesFetchedAtMs: Long,
+        catalogConfigFingerprint: String?,
+        badgeConfigFingerprint: String?,
+    ): JSONObject = JSONObject().apply {
+        put("schemaVersion", 6)
         put("revision", snapshot.revision)
         put("provider", "combined")
         put("fetchedAt", fetchedAtMs)
+        put("badgesFetchedAt", badgesFetchedAtMs)
+        putOpt("catalogConfigFingerprint", catalogConfigFingerprint)
+        putOpt("badgeConfigFingerprint", badgeConfigFingerprint)
         put("twitch", encodeEmotes(snapshot.twitch))
         put("sevenTv", encodeScopedEmotes(snapshot.sevenTv))
         putOpt("sevenTvChannelSetId", snapshot.sevenTvChannelSetId)
@@ -570,7 +610,7 @@ class TwitchChatCatalogCache(
 
     private fun decode(root: JSONObject): ChatCatalogSnapshot {
         val schemaVersion = root.optInt("schemaVersion")
-        check(schemaVersion in 1..5)
+        check(schemaVersion in 1..6)
         fun emoteArray(
             array: JSONArray?,
             legacyCombined: Boolean = false,

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/presentation/ChatPresentationSnapshot.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/presentation/ChatPresentationSnapshot.kt
@@ -29,6 +29,8 @@ internal class ChatPresentationSnapshot {
         messages: List<ChatMessage>,
         catalog: ChatCatalogSnapshot,
         captureBadges: Boolean = true,
+        metadataSettled: Boolean = true,
+        forceUpgrade: Boolean = false,
     ): List<ChatCatalogSnapshot> {
         if (sessionKey != key) {
             sessionKey = key
@@ -39,9 +41,13 @@ internal class ChatPresentationSnapshot {
         return messages.map { message ->
             val frozen = catalogsByMessage[message.id]
             if (frozen == null) {
-                val created = FrozenCatalog.from(catalog, captureBadges)
+                val created = FrozenCatalog.from(catalog, captureBadges, provisional = !metadataSettled)
                 catalogsByMessage[message.id] = created
                 created.toCatalog(catalog)
+            } else if (forceUpgrade || metadataSettled && frozen.provisional) {
+                val upgraded = FrozenCatalog.from(catalog, captureBadges, provisional = false)
+                catalogsByMessage[message.id] = upgraded
+                upgraded.toCatalog(catalog)
             } else {
                 if (captureBadges) frozen.captureBadges(catalog)
                 frozen.toCatalog(catalog)
@@ -69,6 +75,7 @@ internal class ChatPresentationSnapshot {
         private val channelPointRewards: Map<String, ChatReward>,
         private val automaticChannelPointRewards: Map<String, ChatReward>,
         private val channelPointRewardsRevision: Int,
+        var provisional: Boolean,
     ) {
         fun captureBadges(catalog: ChatCatalogSnapshot) {
             if (badges == null) badges = catalog.badges
@@ -91,7 +98,7 @@ internal class ChatPresentationSnapshot {
         )
 
         companion object {
-            fun from(catalog: ChatCatalogSnapshot, captureBadges: Boolean): FrozenCatalog = FrozenCatalog(
+            fun from(catalog: ChatCatalogSnapshot, captureBadges: Boolean, provisional: Boolean): FrozenCatalog = FrozenCatalog(
                 twitch = catalog.twitch,
                 sevenTv = catalog.sevenTv,
                 sevenTvChannelSetId = catalog.sevenTvChannelSetId,
@@ -105,6 +112,7 @@ internal class ChatPresentationSnapshot {
                 channelPointRewards = catalog.channelPointRewards,
                 automaticChannelPointRewards = catalog.automaticChannelPointRewards,
                 channelPointRewardsRevision = catalog.channelPointRewardsRevision,
+                provisional = provisional,
             )
         }
     }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/presentation/ChatPresentationSnapshot.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/presentation/ChatPresentationSnapshot.kt
@@ -12,12 +12,18 @@ import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessageId
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatReward
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatSessionKey
 
+internal data class ChatMetadataSettlement(
+    val structuralSettled: Boolean,
+    val badgesSettled: Boolean,
+    val rewardsSettled: Boolean,
+)
+
 /**
- * Keeps structural catalog inputs stable for every message already published in a session.
+ * Keeps settled catalog inputs stable for every message already published in a session.
  *
- * Catalog retries and live decoration updates are allowed to improve the presentation of new
- * messages. They must not insert a new span into an existing row, because the row may already
- * have been revealed by the atomic asset gate.
+ * A message published before all metadata is available remains component-wise provisional. Each
+ * settled component may upgrade the existing row once; later retries and live decoration updates
+ * do not insert a new span into an already settled row.
  */
 internal class ChatPresentationSnapshot {
     private var sessionKey: ChatSessionKey? = null
@@ -29,7 +35,9 @@ internal class ChatPresentationSnapshot {
         messages: List<ChatMessage>,
         catalog: ChatCatalogSnapshot,
         captureBadges: Boolean = true,
-        metadataSettled: Boolean = true,
+        structuralSettled: Boolean = true,
+        badgesSettled: Boolean = true,
+        rewardsSettled: Boolean = true,
         forceUpgrade: Boolean = false,
     ): List<ChatCatalogSnapshot> {
         if (sessionKey != key) {
@@ -38,18 +46,24 @@ internal class ChatPresentationSnapshot {
         }
         val messageIds = messages.asSequence().map(ChatMessage::id).toSet()
         catalogsByMessage.keys.retainAll(messageIds)
+        val settlement = ChatMetadataSettlement(structuralSettled, badgesSettled, rewardsSettled)
         return messages.map { message ->
             val frozen = catalogsByMessage[message.id]
             if (frozen == null) {
-                val created = FrozenCatalog.from(catalog, captureBadges, provisional = !metadataSettled)
+                val created = FrozenCatalog.from(
+                    catalog = catalog,
+                    captureBadges = captureBadges,
+                    settlement = settlement,
+                )
                 catalogsByMessage[message.id] = created
                 created.toCatalog(catalog)
-            } else if (forceUpgrade || metadataSettled && frozen.provisional) {
-                val upgraded = FrozenCatalog.from(catalog, captureBadges, provisional = false)
-                catalogsByMessage[message.id] = upgraded
-                upgraded.toCatalog(catalog)
             } else {
-                if (captureBadges) frozen.captureBadges(catalog)
+                frozen.update(
+                    catalog = catalog,
+                    captureBadges = captureBadges,
+                    settlement = settlement,
+                    forceUpgrade = forceUpgrade,
+                )
                 frozen.toCatalog(catalog)
             }
         }
@@ -62,23 +76,62 @@ internal class ChatPresentationSnapshot {
     }
 
     private class FrozenCatalog(
-        private val twitch: Map<String, ChatCatalogEmote>,
-        private val sevenTv: ScopedEmoteCatalog,
-        private val sevenTvChannelSetId: String?,
-        private val bttv: ScopedEmoteCatalog,
-        private val ffz: ScopedEmoteCatalog,
+        private var twitch: Map<String, ChatCatalogEmote>,
+        private var sevenTv: ScopedEmoteCatalog,
+        private var sevenTvChannelSetId: String?,
+        private var bttv: ScopedEmoteCatalog,
+        private var ffz: ScopedEmoteCatalog,
         private var badges: Map<String, ChatCatalogBadge>?,
-        private val cheermotes: Map<String, ChatCatalogCheermote>,
-        private val userDecorations: Map<String, ChatUserDecoration>,
-        private val namePaints: Map<String, ChatNamePaint>,
-        private val sevenTvBadges: Map<String, ChatCatalogBadge>,
-        private val channelPointRewards: Map<String, ChatReward>,
-        private val automaticChannelPointRewards: Map<String, ChatReward>,
-        private val channelPointRewardsRevision: Int,
-        var provisional: Boolean,
+        private var cheermotes: Map<String, ChatCatalogCheermote>,
+        private var userDecorations: Map<String, ChatUserDecoration>,
+        private var namePaints: Map<String, ChatNamePaint>,
+        private var sevenTvBadges: Map<String, ChatCatalogBadge>,
+        private var channelPointRewards: Map<String, ChatReward>,
+        private var automaticChannelPointRewards: Map<String, ChatReward>,
+        private var channelPointRewardsRevision: Int,
+        private var structuralSettled: Boolean,
+        private var badgesSettled: Boolean,
+        private var rewardsSettled: Boolean,
     ) {
-        fun captureBadges(catalog: ChatCatalogSnapshot) {
-            if (badges == null) badges = catalog.badges
+        fun update(
+            catalog: ChatCatalogSnapshot,
+            captureBadges: Boolean,
+            settlement: ChatMetadataSettlement,
+            forceUpgrade: Boolean,
+        ) {
+            if (captureBadges && badges == null) badges = catalog.badges
+
+            if (forceUpgrade || !structuralSettled && settlement.structuralSettled) {
+                captureStructural(catalog)
+            }
+            if (captureBadges && (forceUpgrade || !badgesSettled && settlement.badgesSettled)) {
+                badges = catalog.badges
+            }
+            if (forceUpgrade || !rewardsSettled && settlement.rewardsSettled) {
+                captureRewards(catalog)
+            }
+
+            structuralSettled = structuralSettled || settlement.structuralSettled
+            badgesSettled = badgesSettled || settlement.badgesSettled
+            rewardsSettled = rewardsSettled || settlement.rewardsSettled
+        }
+
+        private fun captureStructural(catalog: ChatCatalogSnapshot) {
+            twitch = catalog.twitch
+            sevenTv = catalog.sevenTv
+            sevenTvChannelSetId = catalog.sevenTvChannelSetId
+            bttv = catalog.bttv
+            ffz = catalog.ffz
+            cheermotes = catalog.cheermotes
+            userDecorations = catalog.userDecorations
+            namePaints = catalog.namePaints
+            sevenTvBadges = catalog.sevenTvBadges
+        }
+
+        private fun captureRewards(catalog: ChatCatalogSnapshot) {
+            channelPointRewards = catalog.channelPointRewards
+            automaticChannelPointRewards = catalog.automaticChannelPointRewards
+            channelPointRewardsRevision = catalog.channelPointRewardsRevision
         }
 
         fun toCatalog(current: ChatCatalogSnapshot): ChatCatalogSnapshot = current.copy(
@@ -98,7 +151,11 @@ internal class ChatPresentationSnapshot {
         )
 
         companion object {
-            fun from(catalog: ChatCatalogSnapshot, captureBadges: Boolean, provisional: Boolean): FrozenCatalog = FrozenCatalog(
+            fun from(
+                catalog: ChatCatalogSnapshot,
+                captureBadges: Boolean,
+                settlement: ChatMetadataSettlement,
+            ): FrozenCatalog = FrozenCatalog(
                 twitch = catalog.twitch,
                 sevenTv = catalog.sevenTv,
                 sevenTvChannelSetId = catalog.sevenTvChannelSetId,
@@ -112,7 +169,9 @@ internal class ChatPresentationSnapshot {
                 channelPointRewards = catalog.channelPointRewards,
                 automaticChannelPointRewards = catalog.automaticChannelPointRewards,
                 channelPointRewardsRevision = catalog.channelPointRewardsRevision,
-                provisional = provisional,
+                structuralSettled = settlement.structuralSettled,
+                badgesSettled = settlement.badgesSettled,
+                rewardsSettled = settlement.rewardsSettled,
             )
         }
     }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/session/ChatSessionManager.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/session/ChatSessionManager.kt
@@ -107,7 +107,7 @@ class ChatSessionHandle internal constructor(
             if (closed || started) return@withLock
             active.session.start(active.key)
             started = true
-            active.catalog.refresh()
+            active.catalog.refresh(force = false)
             startupWork = scope.launch {
                 // Transport, catalog, history, settings, and reward metadata are independent.
                 launch { reconcileRecent() }
@@ -225,7 +225,7 @@ class ChatSessionManager(
         session.start(key)
         val active = ActiveChatSession(spec, key, session, catalog, rewardCatalogFactory(spec, scope))
         _active.value = active
-        catalog.refresh()
+        catalog.refresh(force = false)
         // Reconcile startup/reconstruction history independently of transport startup. Live
         // events can arrive while this request is in flight; ChatEventProcessor serializes the
         // atomic merge with those events and rejects the work if this generation is no longer

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatV2RendererController.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatV2RendererController.kt
@@ -12,12 +12,10 @@ import com.github.andreyasadchy.xtra.ui.chat.v2.assets.ChatAssetRepository
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessageId
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessage
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatRewardCatalog
-import com.github.andreyasadchy.xtra.ui.chat.v2.domain.requiresInitialRewardMetadata
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatEmoteInteraction
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatGifInteraction
 import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatDecorationSnapshot
 import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatCatalogState
-import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.isReadyForChatPublication
 import com.github.andreyasadchy.xtra.ui.chat.v2.presentation.ChatColorResolver
 import com.github.andreyasadchy.xtra.ui.chat.v2.presentation.ChatPresentationSnapshot
 import com.github.andreyasadchy.xtra.ui.chat.v2.presentation.ChatPresentationResolver
@@ -269,11 +267,13 @@ class ChatV2RendererController(
 
     private suspend fun publish(publication: PresentationPublication) {
         if (!rendererVisible.value) return
+        val previousPublication = latestPublication
+        val previousRows = latestRows
         withContext(Dispatchers.Main.immediate) {
             if (!rendererVisible.value) return@withContext
             latestPublication = publication
         }
-        val rows = compileCurrent(publication)
+        val rows = compileCurrent(publication, previousPublication, previousRows)
         if (!rendererVisible.value) return
         withContext(Dispatchers.Main.immediate) {
             if (!rendererVisible.value) return@withContext
@@ -302,7 +302,11 @@ class ChatV2RendererController(
         }
     }
 
-    private suspend fun compileCurrent(publication: PresentationPublication): List<ChatRowUiModel> {
+    private suspend fun compileCurrent(
+        publication: PresentationPublication,
+        previousPublication: PresentationPublication? = null,
+        previousRows: List<ChatRowUiModel> = emptyList(),
+    ): List<ChatRowUiModel> {
         while (true) {
             val compiler = presentation.snapshot()
             val catalogs = presentationSnapshot.catalogsFor(
@@ -314,8 +318,22 @@ class ChatV2RendererController(
             val rows = withContext(Dispatchers.Default) {
                 if (BuildConfig.PERF_DIAGNOSTICS) Trace.beginSection("Xtra.ChatV2.compileCurrent")
                 try {
-                    publication.messages.zip(catalogs).map { (message, catalog) ->
-                        compiler.resolve(message, catalog)
+                    val previousMessages = if (previousPublication?.key == publication.key) {
+                        previousPublication.messages.associateBy { it.id }
+                    } else {
+                        emptyMap()
+                    }
+                    val reusableRows = if (previousPublication?.key == publication.key) {
+                        previousRows.associateBy { it.id }
+                    } else {
+                        emptyMap()
+                    }
+                    publication.messages.mapIndexed { index, message ->
+                        if (previousMessages[message.id] == message) {
+                            reusableRows[message.id]
+                        } else {
+                            null
+                        } ?: compiler.resolve(message, catalogs[index])
                     }
                 } finally {
                     if (BuildConfig.PERF_DIAGNOSTICS) Trace.endSection()
@@ -414,5 +432,4 @@ internal fun isReadyForChatPublication(
     showBadges: Boolean,
     messages: List<ChatMessage>,
     rewardCatalogSettled: Boolean,
-): Boolean = catalogState.isReadyForChatPublication(showBadges) &&
-    (rewardCatalogSettled || messages.none { it.requiresInitialRewardMetadata() })
+): Boolean = catalogState.hydrated

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatV2RendererController.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatV2RendererController.kt
@@ -309,21 +309,33 @@ class ChatV2RendererController(
     ): List<ChatRowUiModel> {
         while (true) {
             val compiler = presentation.snapshot()
+            val forceCatalogUpgrade = previousPublication?.let { previous ->
+                publication.forceRefreshRevision != previous.forceRefreshRevision
+            } == true
             val catalogs = presentationSnapshot.catalogsFor(
                 publication.key,
                 publication.messages,
                 publication.catalog,
                 captureBadges = renderStyle.showBadges,
+                metadataSettled = publication.initialMetadataSettled,
+                forceUpgrade = forceCatalogUpgrade,
             )
+            val metadataSettlementChanged = previousPublication?.initialMetadataSettled !=
+                    publication.initialMetadataSettled
+            val reusablePublication = previousPublication?.takeIf {
+                !forceCatalogUpgrade &&
+                        !metadataSettlementChanged &&
+                        it.key == publication.key
+            }
             val rows = withContext(Dispatchers.Default) {
                 if (BuildConfig.PERF_DIAGNOSTICS) Trace.beginSection("Xtra.ChatV2.compileCurrent")
                 try {
-                    val previousMessages = if (previousPublication?.key == publication.key) {
-                        previousPublication.messages.associateBy { it.id }
+                    val previousMessages = if (reusablePublication != null) {
+                        reusablePublication.messages.associateBy { it.id }
                     } else {
                         emptyMap()
                     }
-                    val reusableRows = if (previousPublication?.key == publication.key) {
+                    val reusableRows = if (reusablePublication != null) {
                         previousRows.associateBy { it.id }
                     } else {
                         emptyMap()
@@ -339,7 +351,9 @@ class ChatV2RendererController(
                     if (BuildConfig.PERF_DIAGNOSTICS) Trace.endSection()
                 }
             }
-            if (presentation.isCurrent(compiler)) return rows
+            if (presentation.isCurrent(compiler)) {
+                return rows
+            }
         }
     }
 
@@ -406,6 +420,10 @@ class ChatV2RendererController(
                 PresentationPublication(
                     key,
                     snapshot.messages,
+                    initialMetadataSettled = catalogState.structuralCatalogSettled &&
+                            (!renderStyle.showBadges || catalogState.badgesSettled) &&
+                            rewardsSettled,
+                    forceRefreshRevision = catalogState.forceRefreshRevision,
                     catalogState.snapshot.copy(
                         channelPointRewards = rewards.byId,
                         automaticChannelPointRewards = rewards.automaticByType,
@@ -423,6 +441,8 @@ class ChatV2RendererController(
     private data class PresentationPublication(
         val key: com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatSessionKey,
         val messages: List<com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessage>,
+        val initialMetadataSettled: Boolean,
+        val forceRefreshRevision: Long,
         val catalog: com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatCatalogSnapshot,
     )
 }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatV2RendererController.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatV2RendererController.kt
@@ -17,6 +17,7 @@ import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatGifInteraction
 import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatDecorationSnapshot
 import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatCatalogState
 import com.github.andreyasadchy.xtra.ui.chat.v2.presentation.ChatColorResolver
+import com.github.andreyasadchy.xtra.ui.chat.v2.presentation.ChatMetadataSettlement
 import com.github.andreyasadchy.xtra.ui.chat.v2.presentation.ChatPresentationSnapshot
 import com.github.andreyasadchy.xtra.ui.chat.v2.presentation.ChatPresentationResolver
 import com.github.andreyasadchy.xtra.ui.chat.v2.presentation.ChatRowCompiler
@@ -317,11 +318,13 @@ class ChatV2RendererController(
                 publication.messages,
                 publication.catalog,
                 captureBadges = renderStyle.showBadges,
-                metadataSettled = publication.initialMetadataSettled,
+                structuralSettled = publication.metadataSettlement.structuralSettled,
+                badgesSettled = publication.metadataSettlement.badgesSettled,
+                rewardsSettled = publication.metadataSettlement.rewardsSettled,
                 forceUpgrade = forceCatalogUpgrade,
             )
-            val metadataSettlementChanged = previousPublication?.initialMetadataSettled !=
-                    publication.initialMetadataSettled
+            val metadataSettlementChanged = previousPublication?.metadataSettlement !=
+                    publication.metadataSettlement
             val reusablePublication = previousPublication?.takeIf {
                 !forceCatalogUpgrade &&
                         !metadataSettlementChanged &&
@@ -420,9 +423,11 @@ class ChatV2RendererController(
                 PresentationPublication(
                     key,
                     snapshot.messages,
-                    initialMetadataSettled = catalogState.structuralCatalogSettled &&
-                            (!renderStyle.showBadges || catalogState.badgesSettled) &&
-                            rewardsSettled,
+                    metadataSettlement = ChatMetadataSettlement(
+                        structuralSettled = catalogState.structuralCatalogSettled,
+                        badgesSettled = !renderStyle.showBadges || catalogState.badgesSettled,
+                        rewardsSettled = rewardsSettled,
+                    ),
                     forceRefreshRevision = catalogState.forceRefreshRevision,
                     catalogState.snapshot.copy(
                         channelPointRewards = rewards.byId,
@@ -441,7 +446,7 @@ class ChatV2RendererController(
     private data class PresentationPublication(
         val key: com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatSessionKey,
         val messages: List<com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessage>,
-        val initialMetadataSettled: Boolean,
+        val metadataSettlement: ChatMetadataSettlement,
         val forceRefreshRevision: Long,
         val catalog: com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatCatalogSnapshot,
     )

--- a/app/src/main/res/drawable/baseline_refresh_black_24.xml
+++ b/app/src/main/res/drawable/baseline_refresh_black_24.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M17.65,6.35C16.2,4.9 14.21,4 12,4c-4.42,0 -7.99,3.58 -7.99,8s3.57,8 7.99,8c3.73,0 6.84,-2.55 7.73,-6h-2.08c-0.82,2.33 -3.04,4 -5.65,4 -3.31,0 -6,-2.69 -6,-6s2.69,-6 6,-6c1.66,0 3.14,0.69 4.22,1.78L13,11h7V4l-2.35,2.35z" />
+</vector>

--- a/app/src/main/res/layout/fragment_emotes.xml
+++ b/app/src/main/res/layout/fragment_emotes.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
@@ -26,6 +27,18 @@
         android:paddingEnd="12dp"
         android:text="@string/reorder_favorite_emotes"
         android:visibility="gone" />
+
+    <ImageButton
+        android:id="@+id/refreshEmotes"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
+        android:layout_gravity="top|end"
+        android:background="?android:selectableItemBackgroundBorderless"
+        android:contentDescription="@string/refresh"
+        android:padding="12dp"
+        android:src="@drawable/baseline_refresh_black_24"
+        android:visibility="visible"
+        app:tint="@android:color/white" />
 
     <TextView
         android:id="@+id/emptyState"

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatCatalogRepositoryTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatCatalogRepositoryTest.kt
@@ -461,6 +461,34 @@ class ChatCatalogRepositoryTest {
     }
 
     @Test
+    fun forcedRefreshPublishesUpgradeMarkerOnlyAfterProviderResult() = runBlocking {
+        val loadStarted = CompletableDeferred<Unit>()
+        val releaseLoad = CompletableDeferred<Unit>()
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val repository = ChatCatalogRepository(
+            scope = scope,
+            source = ChatCatalogSource {
+                loadStarted.complete(Unit)
+                releaseLoad.await()
+                ChatCatalogLoadResult(twitch = ChatCatalogProviderUpdate(emptyMap()))
+            },
+        )
+
+        repository.refresh(force = true)
+        loadStarted.await()
+        assertEquals(0L, repository.state.value.forceRefreshRevision)
+
+        releaseLoad.complete(Unit)
+        withTimeout(1_000) {
+            while (repository.state.value.forceRefreshRevision == 0L) delay(1)
+        }
+        assertEquals(1L, repository.state.value.forceRefreshRevision)
+
+        repository.close()
+        scope.cancel()
+    }
+
+    @Test
     fun failedInitialCatalogAttemptSettlesBadgesAndRetryKeepsItSettled() = runBlocking {
         val retryStarted = CompletableDeferred<Unit>()
         val releaseRetry = CompletableDeferred<Unit>()

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatCatalogRepositoryTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatCatalogRepositoryTest.kt
@@ -1,6 +1,7 @@
 package com.github.andreyasadchy.xtra.ui.chat.v2
 
 import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatCatalogCache
+import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatCatalogCacheEntry
 import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatCatalogBadge
 import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatCatalogEmote
 import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatCatalogLoadResult
@@ -368,6 +369,93 @@ class ChatCatalogRepositoryTest {
         withTimeout(1_000) { while (!repository.state.value.badgesSettled) delay(1) }
         assertTrue(repository.state.value.badgesSettled)
         assertTrue(repository.state.value.structuralCatalogSettled)
+        repository.close()
+        scope.cancel()
+    }
+
+    @Test
+    fun freshStructuralCacheStillRefreshesStaleIndependentBadges() = runBlocking {
+        val aggregateCalls = AtomicInteger()
+        val badgeCalls = AtomicInteger()
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val repository = ChatCatalogRepository(
+            scope = scope,
+            source = object : ChatCatalogSource {
+                override val hasIndependentBadgeProvider = true
+                override val catalogConfigFingerprint = "config"
+
+                override suspend fun load(): ChatCatalogLoadResult {
+                    aggregateCalls.incrementAndGet()
+                    return ChatCatalogLoadResult()
+                }
+
+                override suspend fun loadBadges(): ChatCatalogProviderUpdate<Map<String, ChatCatalogBadge>> {
+                    badgeCalls.incrementAndGet()
+                    return ChatCatalogProviderUpdate(emptyMap())
+                }
+            },
+            cache = object : ChatCatalogCache {
+                override suspend fun read() = null
+
+                override suspend fun readEntry() = ChatCatalogCacheEntry(
+                    snapshot = ChatCatalogSnapshot(revision = 3),
+                    fetchedAtMs = System.currentTimeMillis(),
+                    catalogConfigFingerprint = "config",
+                    badgeConfigFingerprint = "config",
+                )
+
+                override suspend fun write(snapshot: ChatCatalogSnapshot) = Unit
+            },
+        )
+
+        repository.refresh(force = false)
+        withTimeout(1_000) { while (badgeCalls.get() == 0) delay(1) }
+        assertEquals(0, aggregateCalls.get())
+        assertEquals(1, badgeCalls.get())
+
+        repository.close()
+        scope.cancel()
+    }
+
+    @Test
+    fun providerConfigChangeInvalidatesFreshStructuralCache() = runBlocking {
+        val aggregateCalls = AtomicInteger()
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val repository = ChatCatalogRepository(
+            scope = scope,
+            source = object : ChatCatalogSource {
+                override val catalogConfigFingerprint = "new-config"
+
+                override suspend fun load(): ChatCatalogLoadResult {
+                    aggregateCalls.incrementAndGet()
+                    return ChatCatalogLoadResult(
+                        twitch = ChatCatalogProviderUpdate(emptyMap()),
+                        sevenTv = ChatCatalogProviderUpdate(emptyMap()),
+                        bttv = ChatCatalogProviderUpdate(emptyMap()),
+                        ffz = ChatCatalogProviderUpdate(emptyMap()),
+                        badges = ChatCatalogProviderUpdate(emptyMap()),
+                        cheermotes = ChatCatalogProviderUpdate(emptyMap()),
+                    )
+                }
+            },
+            cache = object : ChatCatalogCache {
+                override suspend fun read() = null
+
+                override suspend fun readEntry() = ChatCatalogCacheEntry(
+                    snapshot = ChatCatalogSnapshot(revision = 3),
+                    fetchedAtMs = System.currentTimeMillis(),
+                    catalogConfigFingerprint = "old-config",
+                    badgeConfigFingerprint = "old-config",
+                )
+
+                override suspend fun write(snapshot: ChatCatalogSnapshot) = Unit
+            },
+        )
+
+        repository.refresh(force = false)
+        withTimeout(1_000) { while (!repository.state.value.structuralCatalogSettled) delay(1) }
+        assertEquals(1, aggregateCalls.get())
+
         repository.close()
         scope.cancel()
     }

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatV2PublicationSemanticsTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatV2PublicationSemanticsTest.kt
@@ -219,6 +219,45 @@ class ChatV2PublicationSemanticsTest {
     }
 
     @Test
+    fun provisionalThirdPartyCatalogRecoveryUpgradesExistingMessage() {
+        val session = ChatSessionKey("channel", 20L)
+        val message = message("first", 1L).copy(segments = listOf(ChatSegment.Text("OMEGALUL")))
+        val emote = ChatCatalogEmote(
+            name = "OMEGALUL",
+            asset = ChatAssetSpec(ChatAssetKey("https://cdn.example/omegalul.png"), 28, 28, 28),
+            provider = ChatAssetProvider.SEVEN_TV,
+            animated = false,
+        )
+        val compiler = ChatRowCompiler()
+        val presentation = ChatPresentationSnapshot()
+
+        val provisionalRow = compiler.compile(
+            message,
+            presentation.catalogsFor(
+                session,
+                listOf(message),
+                ChatCatalogSnapshot(revision = 1),
+                metadataSettled = false,
+            ).single(),
+        )
+        val enrichedRow = compiler.compile(
+            message,
+            presentation.catalogsFor(
+                session,
+                listOf(message),
+                ChatCatalogSnapshot(
+                    revision = 2,
+                    sevenTv = ScopedEmoteCatalog(global = mapOf(emote.name to emote)),
+                ),
+                metadataSettled = true,
+            ).single(),
+        )
+
+        assertTrue(provisionalRow.pieces.none { it is ChatPiece.Emote })
+        assertTrue(enrichedRow.pieces.any { it is ChatPiece.Emote })
+    }
+
+    @Test
     fun lateSevenTvBadgeDoesNotRetrofitExistingMessage() {
         val session = ChatSessionKey("channel", 3L)
         val user = ChatUser("user", "user", "User", null)
@@ -256,6 +295,111 @@ class ChatV2PublicationSemanticsTest {
         assertTrue(firstRow.pieces.none { it is ChatPiece.Badge })
         assertEquals(firstRow, existingRowAfterRecovery)
         assertTrue(newRowAfterRecovery.pieces.any { it is ChatPiece.Badge })
+    }
+
+    @Test
+    fun provisionalBadgeRecoveryUpgradesExistingMessage() {
+        val session = ChatSessionKey("channel", 21L)
+        val badgeRef = ChatBadgeRef("subscriber", "1")
+        val message = message("first", 1L, badgeRef)
+        val badge = ChatCatalogBadge(
+            name = "subscriber:1",
+            asset = ChatAssetSpec(ChatAssetKey("https://cdn.example/subscriber.png"), 18, 18, 18),
+            provider = ChatAssetProvider.TWITCH,
+            setId = badgeRef.setId,
+            versionId = badgeRef.versionId,
+        )
+        val compiler = ChatRowCompiler()
+        val presentation = ChatPresentationSnapshot()
+
+        val provisionalRow = compiler.compile(
+            message,
+            presentation.catalogsFor(
+                session,
+                listOf(message),
+                ChatCatalogSnapshot(revision = 1),
+                metadataSettled = false,
+            ).single(),
+        )
+        val enrichedRow = compiler.compile(
+            message,
+            presentation.catalogsFor(
+                session,
+                listOf(message),
+                ChatCatalogSnapshot(revision = 2, badges = mapOf(badgeRef.catalogKey to badge)),
+                metadataSettled = true,
+            ).single(),
+        )
+
+        assertTrue(provisionalRow.pieces.none { it is ChatPiece.Badge })
+        assertTrue(enrichedRow.pieces.any { it is ChatPiece.Badge })
+    }
+
+    @Test
+    fun provisionalRewardRecoveryUpgradesExistingMessage() {
+        val session = ChatSessionKey("channel", 22L)
+        val message = message("first", 1L).copy(rewardId = "reward-id")
+        val reward = ChatReward("Super Reward", cost = 1_000, imageUrl = "https://cdn.example/reward.png")
+        val compiler = ChatRowCompiler()
+        val presentation = ChatPresentationSnapshot()
+
+        val provisionalRow = compiler.compile(
+            message,
+            presentation.catalogsFor(
+                session,
+                listOf(message),
+                ChatCatalogSnapshot(revision = 1),
+                metadataSettled = false,
+            ).single(),
+        )
+        val enrichedRow = compiler.compile(
+            message,
+            presentation.catalogsFor(
+                session,
+                listOf(message),
+                ChatCatalogSnapshot(
+                    revision = 2,
+                    channelPointRewards = mapOf("reward-id" to reward),
+                ),
+                metadataSettled = true,
+            ).single(),
+        )
+
+        assertTrue(provisionalRow.pieces.none { it is ChatPiece.RewardIcon })
+        assertTrue(enrichedRow.pieces.any { it is ChatPiece.RewardIcon })
+    }
+
+    @Test
+    fun explicitCatalogRefreshUpgradesFrozenMessage() {
+        val session = ChatSessionKey("channel", 23L)
+        val message = message("first", 1L).copy(segments = listOf(ChatSegment.Text("OMEGALUL")))
+        val emote = emote("OMEGALUL", ChatAssetProvider.SEVEN_TV)
+        val compiler = ChatRowCompiler()
+        val presentation = ChatPresentationSnapshot()
+
+        val frozenRow = compiler.compile(
+            message,
+            presentation.catalogsFor(
+                session,
+                listOf(message),
+                ChatCatalogSnapshot(revision = 1),
+            ).single(),
+        )
+        val refreshedRow = compiler.compile(
+            message,
+            presentation.catalogsFor(
+                session,
+                listOf(message),
+                ChatCatalogSnapshot(
+                    revision = 2,
+                    sevenTv = ScopedEmoteCatalog(global = mapOf(emote.name to emote)),
+                ),
+                forceUpgrade = true,
+            ).single(),
+        )
+
+        assertTrue(frozenRow.pieces.none { it is ChatPiece.Emote })
+        assertTrue(refreshedRow.pieces.any { it is ChatPiece.Emote })
     }
 
     @Test
@@ -333,6 +477,13 @@ class ChatV2PublicationSemanticsTest {
         badges = emptyList(),
         segments = emptyList(),
         kind = ChatMessageKind.CHAT,
+    )
+
+    private fun emote(name: String, provider: ChatAssetProvider) = ChatCatalogEmote(
+        name = name,
+        asset = ChatAssetSpec(ChatAssetKey("https://cdn.example/$name.png"), 28, 28, 28),
+        provider = provider,
+        animated = false,
     )
 
     private fun message(id: String, timestampMs: Long) = ChatMessage(

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatV2PublicationSemanticsTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatV2PublicationSemanticsTest.kt
@@ -48,7 +48,7 @@ class ChatV2PublicationSemanticsTest {
     }
 
     @Test
-    fun rewardMessageWaitsForInitialRewardMetadata() {
+    fun rewardMessagePublishesBeforeInitialRewardMetadata() {
         val state = ChatCatalogState(
             snapshot = ChatCatalogSnapshot(0),
             hydrated = true,
@@ -59,7 +59,7 @@ class ChatV2PublicationSemanticsTest {
         val ordinaryMessage = message("ordinary", 2L)
 
         assertEquals(
-            false,
+            true,
             isPresentationReady(state, showBadges = true, messages = listOf(rewardMessage), rewardCatalogSettled = false),
         )
         assertEquals(

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatV2PublicationSemanticsTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatV2PublicationSemanticsTest.kt
@@ -237,7 +237,9 @@ class ChatV2PublicationSemanticsTest {
                 session,
                 listOf(message),
                 ChatCatalogSnapshot(revision = 1),
-                metadataSettled = false,
+                structuralSettled = false,
+                badgesSettled = false,
+                rewardsSettled = false,
             ).single(),
         )
         val enrichedRow = compiler.compile(
@@ -249,12 +251,51 @@ class ChatV2PublicationSemanticsTest {
                     revision = 2,
                     sevenTv = ScopedEmoteCatalog(global = mapOf(emote.name to emote)),
                 ),
-                metadataSettled = true,
+                structuralSettled = true,
+                badgesSettled = true,
+                rewardsSettled = true,
             ).single(),
         )
 
         assertTrue(provisionalRow.pieces.none { it is ChatPiece.Emote })
         assertTrue(enrichedRow.pieces.any { it is ChatPiece.Emote })
+    }
+
+    @Test
+    fun structuralSettlementUpgradesEmotesBeforeRewardsSettle() {
+        val session = ChatSessionKey("channel", 24L)
+        val message = message("first", 1L).copy(segments = listOf(ChatSegment.Text("OMEGALUL")))
+        val emote = emote("OMEGALUL", ChatAssetProvider.SEVEN_TV)
+        val compiler = ChatRowCompiler()
+        val presentation = ChatPresentationSnapshot()
+
+        compiler.compile(
+            message,
+            presentation.catalogsFor(
+                session,
+                listOf(message),
+                ChatCatalogSnapshot(revision = 1),
+                structuralSettled = false,
+                badgesSettled = false,
+                rewardsSettled = false,
+            ).single(),
+        )
+        val rowAfterStructuralSettlement = compiler.compile(
+            message,
+            presentation.catalogsFor(
+                session,
+                listOf(message),
+                ChatCatalogSnapshot(
+                    revision = 2,
+                    sevenTv = ScopedEmoteCatalog(global = mapOf(emote.name to emote)),
+                ),
+                structuralSettled = true,
+                badgesSettled = false,
+                rewardsSettled = false,
+            ).single(),
+        )
+
+        assertTrue(rowAfterStructuralSettlement.pieces.any { it is ChatPiece.Emote })
     }
 
     @Test
@@ -318,7 +359,9 @@ class ChatV2PublicationSemanticsTest {
                 session,
                 listOf(message),
                 ChatCatalogSnapshot(revision = 1),
-                metadataSettled = false,
+                structuralSettled = false,
+                badgesSettled = false,
+                rewardsSettled = false,
             ).single(),
         )
         val enrichedRow = compiler.compile(
@@ -327,12 +370,51 @@ class ChatV2PublicationSemanticsTest {
                 session,
                 listOf(message),
                 ChatCatalogSnapshot(revision = 2, badges = mapOf(badgeRef.catalogKey to badge)),
-                metadataSettled = true,
+                structuralSettled = true,
+                badgesSettled = true,
+                rewardsSettled = true,
             ).single(),
         )
 
         assertTrue(provisionalRow.pieces.none { it is ChatPiece.Badge })
         assertTrue(enrichedRow.pieces.any { it is ChatPiece.Badge })
+    }
+
+    @Test
+    fun structuralSettlementUpgradesEmotesBeforeBadgesSettle() {
+        val session = ChatSessionKey("channel", 25L)
+        val message = message("first", 1L).copy(segments = listOf(ChatSegment.Text("OMEGALUL")))
+        val emote = emote("OMEGALUL", ChatAssetProvider.SEVEN_TV)
+        val compiler = ChatRowCompiler()
+        val presentation = ChatPresentationSnapshot()
+
+        compiler.compile(
+            message,
+            presentation.catalogsFor(
+                session,
+                listOf(message),
+                ChatCatalogSnapshot(revision = 1),
+                structuralSettled = false,
+                badgesSettled = false,
+                rewardsSettled = true,
+            ).single(),
+        )
+        val rowAfterStructuralSettlement = compiler.compile(
+            message,
+            presentation.catalogsFor(
+                session,
+                listOf(message),
+                ChatCatalogSnapshot(
+                    revision = 2,
+                    sevenTv = ScopedEmoteCatalog(global = mapOf(emote.name to emote)),
+                ),
+                structuralSettled = true,
+                badgesSettled = false,
+                rewardsSettled = true,
+            ).single(),
+        )
+
+        assertTrue(rowAfterStructuralSettlement.pieces.any { it is ChatPiece.Emote })
     }
 
     @Test
@@ -349,7 +431,9 @@ class ChatV2PublicationSemanticsTest {
                 session,
                 listOf(message),
                 ChatCatalogSnapshot(revision = 1),
-                metadataSettled = false,
+                structuralSettled = false,
+                badgesSettled = false,
+                rewardsSettled = false,
             ).single(),
         )
         val enrichedRow = compiler.compile(
@@ -361,7 +445,9 @@ class ChatV2PublicationSemanticsTest {
                     revision = 2,
                     channelPointRewards = mapOf("reward-id" to reward),
                 ),
-                metadataSettled = true,
+                structuralSettled = true,
+                badgesSettled = true,
+                rewardsSettled = true,
             ).single(),
         )
 
@@ -400,6 +486,55 @@ class ChatV2PublicationSemanticsTest {
 
         assertTrue(frozenRow.pieces.none { it is ChatPiece.Emote })
         assertTrue(refreshedRow.pieces.any { it is ChatPiece.Emote })
+    }
+
+    @Test
+    fun cancelledForceRefreshKeepsProvisionalMessageUpgradeable() {
+        val session = ChatSessionKey("channel", 26L)
+        val message = message("first", 1L).copy(segments = listOf(ChatSegment.Text("OMEGALUL")))
+        val emote = emote("OMEGALUL", ChatAssetProvider.SEVEN_TV)
+        val compiler = ChatRowCompiler()
+        val presentation = ChatPresentationSnapshot()
+
+        compiler.compile(
+            message,
+            presentation.catalogsFor(
+                session,
+                listOf(message),
+                ChatCatalogSnapshot(revision = 1),
+                structuralSettled = false,
+                badgesSettled = false,
+                rewardsSettled = false,
+            ).single(),
+        )
+        compiler.compile(
+            message,
+            presentation.catalogsFor(
+                session,
+                listOf(message),
+                ChatCatalogSnapshot(revision = 1),
+                structuralSettled = false,
+                badgesSettled = false,
+                rewardsSettled = false,
+                forceUpgrade = true,
+            ).single(),
+        )
+        val rowAfterNormalSettlement = compiler.compile(
+            message,
+            presentation.catalogsFor(
+                session,
+                listOf(message),
+                ChatCatalogSnapshot(
+                    revision = 2,
+                    sevenTv = ScopedEmoteCatalog(global = mapOf(emote.name to emote)),
+                ),
+                structuralSettled = true,
+                badgesSettled = false,
+                rewardsSettled = false,
+            ).single(),
+        )
+
+        assertTrue(rowAfterNormalSettlement.pieces.any { it is ChatPiece.Emote })
     }
 
     @Test


### PR DESCRIPTION
Chat now opens immediately with the last good emote catalog, refreshes stale data in the background, and keeps current rows stable while new emotes load. Added a manual refresh control for newly added emotes during a stream.