### PR TITLE
Fix blank emote-spam rows in chat v2

### DIFF
--- a/app/src/androidTest/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatMessageTextViewTest.kt
+++ b/app/src/androidTest/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatMessageTextViewTest.kt
@@ -263,6 +263,224 @@ class ChatMessageTextViewTest {
     }
 
     @Test
+    fun sameIdRebindStagesPendingEmoteSpamUntilAllAssetsAreReady() = runBlocking {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val releases = (0 until 24).associate { index ->
+            "spam-$index" to CompletableDeferred<ChatImageHandle?>()
+        }
+        val repository = ChatAssetRepository(scope, ChatAssetLoader { key ->
+            releases[key.value]?.await() ?: ChatImageHandle { SolidDrawable(Color.RED) }
+        })
+        val attached = attachView(repository)
+        val view = attached.view
+        val oldSpec = ChatAssetSpec(ChatAssetKey("old-emote"), 16, 16, 24)
+        val candidateSpecs = releases.keys.map { key ->
+            ChatAssetSpec(ChatAssetKey(key), 16, 16, 24)
+        }
+        val oldRow = emoteSpamRow(ChatMessageId("spam-row"), listOf(oldSpec))
+        val candidateRow = emoteSpamRow(ChatMessageId("spam-row"), candidateSpecs)
+        try {
+            runOnMain {
+                view.layoutParams = FrameLayout.LayoutParams(160, ViewGroup.LayoutParams.WRAP_CONTENT)
+                view.bind(oldRow)
+            }
+            awaitSettled(repository, listOf(oldSpec.key))
+            awaitPreDraw(view)
+            val initial = runOnMainValue {
+                val spanned = view.text as Spanned
+                Triple(view.text.toString(), view.layout.lineCount, spanned.getSpans(0, spanned.length, ReplacementSpan::class.java).size)
+            }
+
+            runOnMain { view.bind(candidateRow) }
+            awaitPreDraw(view)
+            runOnMain {
+                val spanned = view.text as Spanned
+                assertEquals(1f, view.alpha)
+                assertEquals(initial.first, view.text.toString())
+                assertEquals(initial.second, view.layout.lineCount)
+                assertEquals(initial.third, spanned.getSpans(0, spanned.length, ReplacementSpan::class.java).size)
+            }
+
+            candidateSpecs.take(12).forEach { spec ->
+                releases.getValue(spec.key.value).complete(ChatImageHandle { SolidDrawable(Color.BLUE) })
+            }
+            awaitSettled(repository, candidateSpecs.take(12).map(ChatAssetSpec::key))
+            awaitPreDraw(view)
+            runOnMain {
+                val spanned = view.text as Spanned
+                assertEquals(initial.first, view.text.toString())
+                assertEquals(initial.third, spanned.getSpans(0, spanned.length, ReplacementSpan::class.java).size)
+            }
+
+            candidateSpecs.drop(12).forEach { spec ->
+                releases.getValue(spec.key.value).complete(ChatImageHandle { SolidDrawable(Color.BLUE) })
+            }
+            awaitSettled(repository, candidateSpecs.map(ChatAssetSpec::key))
+            awaitPreDraw(view)
+            val final = runOnMainValue {
+                val spanned = view.text as Spanned
+                val spans = spanned.getSpans(0, spanned.length, ReplacementSpan::class.java)
+                Triple(
+                    view.layout.lineCount,
+                    spans.size,
+                    spans.all { hasVisiblePixels(draw(it, spanned, Paint.FontMetricsInt())) },
+                )
+            }
+            assertEquals(candidateSpecs.size, final.second)
+            assertTrue(final.first in 2..8)
+            assertTrue(final.third)
+        } finally {
+            attached.close()
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun sameIdRebindStagesComposedOverlayUntilTheOverlayIsReady() = runBlocking {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val overlayRelease = CompletableDeferred<ChatImageHandle?>()
+        val repository = ChatAssetRepository(scope, ChatAssetLoader { key ->
+            when (key.value) {
+                "old-composed" -> ChatImageHandle { SolidDrawable(Color.RED) }
+                "composed-base" -> ChatImageHandle { SolidDrawable(Color.BLUE) }
+                "composed-overlay" -> overlayRelease.await()
+                else -> null
+            }
+        })
+        val attached = attachView(repository)
+        val view = attached.view
+        val oldSpec = ChatAssetSpec(ChatAssetKey("old-composed"), 16, 16, 24)
+        val composite = ChatAssetSpec(
+            key = ChatAssetKey("composed-base"),
+            sourceWidth = 16,
+            sourceHeight = 16,
+            targetHeight = 24,
+            overlays = listOf(
+                ChatAssetSpec(ChatAssetKey("composed-overlay"), sourceWidth = 0, sourceHeight = 1, targetHeight = 24),
+            ),
+        )
+        try {
+            runOnMain {
+                view.layoutParams = FrameLayout.LayoutParams(160, ViewGroup.LayoutParams.WRAP_CONTENT)
+                view.bind(emoteSpamRow(ChatMessageId("composite-row"), listOf(oldSpec)))
+            }
+            awaitSettled(repository, listOf(oldSpec.key))
+            awaitPreDraw(view)
+            val oldText = runOnMainValue { view.text.toString() }
+
+            runOnMain { view.bind(emoteSpamRow(ChatMessageId("composite-row"), listOf(composite))) }
+            awaitSettled(repository, listOf(composite.key))
+            awaitPreDraw(view)
+            runOnMain {
+                assertEquals(oldText, view.text.toString())
+                assertEquals(1, (view.text as Spanned).getSpans(0, view.text.length, ReplacementSpan::class.java).size)
+            }
+
+            overlayRelease.complete(ChatImageHandle { SolidDrawable(Color.GREEN) })
+            awaitSettled(repository, composite.allKeysForTest())
+            awaitPreDraw(view)
+            runOnMain {
+                val spanned = view.text as Spanned
+                val span = spanned.getSpans(0, spanned.length, ReplacementSpan::class.java).single()
+                val bitmap = draw(span, spanned, Paint.FontMetricsInt())
+                assertTrue(containsColor(bitmap, Color.BLUE))
+                assertTrue(containsColor(bitmap, Color.GREEN))
+            }
+        } finally {
+            attached.close()
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun newerSameIdBindDiscardsAnObsoleteStagedRow() = runBlocking {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val releases = (1..2).associate { index ->
+            "obsolete-$index" to CompletableDeferred<ChatImageHandle?>()
+        }
+        val repository = ChatAssetRepository(scope, ChatAssetLoader { key ->
+            when (key.value) {
+                "visible-a" -> ChatImageHandle { SolidDrawable(Color.RED) }
+                else -> releases[key.value]?.await()
+            }
+        })
+        val attached = attachView(repository)
+        val view = attached.view
+        val aSpec = ChatAssetSpec(ChatAssetKey("visible-a"), 16, 16, 24)
+        val bSpecs = releases.keys.map { key -> ChatAssetSpec(ChatAssetKey(key), 16, 16, 24) }
+        val id = ChatMessageId("superseded-row")
+        try {
+            runOnMain {
+                view.bind(emoteSpamRow(id, listOf(aSpec)))
+            }
+            awaitSettled(repository, listOf(aSpec.key))
+            awaitPreDraw(view)
+            val aText = runOnMainValue { view.text.toString() }
+
+            runOnMain { view.bind(emoteSpamRow(id, bSpecs)) }
+            bSpecs.forEach { awaitAssetRequested(repository, it.key) }
+            awaitPreDraw(view)
+            runOnMain { view.bind(emoteSpamRow(id, listOf(aSpec))) }
+            runOnMain {
+                assertEquals(aText, view.text.toString())
+                assertEquals(1, (view.text as Spanned).getSpans(0, view.text.length, ReplacementSpan::class.java).size)
+                bSpecs.forEach { assertEquals(0, repository.observerCount(it.key)) }
+            }
+
+            bSpecs.forEach { releases.getValue(it.key.value).complete(ChatImageHandle { SolidDrawable(Color.BLUE) }) }
+            delay(100)
+            awaitPreDraw(view)
+            runOnMain {
+                assertEquals(aText, view.text.toString())
+                assertEquals(1, (view.text as Spanned).getSpans(0, view.text.length, ReplacementSpan::class.java).size)
+            }
+        } finally {
+            attached.close()
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun stagedRowAppliesTextFallbackAfterTerminalAssetFailure() = runBlocking {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val repository = ChatAssetRepository(scope, ChatAssetLoader { key ->
+            when (key.value) {
+                "visible-before-failure" -> ChatImageHandle { SolidDrawable(Color.RED) }
+                "terminal-emote" -> throw ChatAssetLoadException(404)
+                else -> null
+            }
+        })
+        val attached = attachView(repository)
+        val view = attached.view
+        val id = ChatMessageId("terminal-staged-row")
+        val visibleSpec = ChatAssetSpec(ChatAssetKey("visible-before-failure"), 16, 16, 24)
+        val failedSpec = ChatAssetSpec(ChatAssetKey("terminal-emote"), 20, 20, 28)
+        try {
+            runOnMain { view.bind(emoteSpamRow(id, listOf(visibleSpec))) }
+            awaitSettled(repository, listOf(visibleSpec.key))
+            awaitPreDraw(view)
+
+            runOnMain {
+                view.bind(emoteSpamRow(id, listOf(failedSpec)))
+            }
+            awaitPresentationTerminal(repository, listOf(failedSpec.key))
+            awaitPreDraw(view)
+            runOnMain {
+                val spanned = view.text as Spanned
+                val span = spanned.getSpans(0, spanned.length, ReplacementSpan::class.java).single()
+                assertEquals(1f, view.alpha)
+                assertTrue(span.getSize(Paint(), spanned, 0, 1, Paint.FontMetricsInt()) >= failedSpec.compositionWidth)
+                assertTrue(hasVisiblePixels(draw(span, spanned, Paint.FontMetricsInt())))
+            }
+        } finally {
+            attached.close()
+            scope.cancel()
+        }
+    }
+
+    @Test
     fun failedBadgeNeverDrawsItsName() = runBlocking {
         val context = InstrumentationRegistry.getInstrumentation().targetContext
         val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
@@ -1233,6 +1451,24 @@ class ChatMessageTextViewTest {
         source = null, isAction = false,
     )
 
+    private fun emoteSpamRow(id: ChatMessageId, specs: List<ChatAssetSpec>) = ChatRowUiModel(
+        id = id,
+        channelId = "channel",
+        timestampText = null,
+        pieces = buildList {
+            add(ChatPiece.Username("login", 0xffff8a80.toInt()))
+            specs.forEachIndexed { index, spec ->
+                if (index > 0) add(ChatPiece.Text(" "))
+                add(ChatPiece.Emote(spec, "EMOTE_$index", animated = false))
+            }
+        },
+        background = 0xff101010.toInt(),
+        accessibilityText = "emote spam",
+        reply = null,
+        source = null,
+        isAction = false,
+    )
+
     private fun eventRow(
         style: ChatEventVisualStyle,
         title: String = "Event title",
@@ -1311,6 +1547,12 @@ class ChatMessageTextViewTest {
             while (keys.any { repository.peek(it) is ChatAssetState.Missing || repository.peek(it) is ChatAssetState.Loading }) {
                 delay(1)
             }
+        }
+    }
+
+    private fun awaitAssetRequested(repository: ChatAssetRepository, key: ChatAssetKey) = runBlocking {
+        withTimeout(2_000) {
+            while (repository.peek(key) is ChatAssetState.Missing) delay(1)
         }
     }
 

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatMessageTextView.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatMessageTextView.kt
@@ -113,6 +113,7 @@ open class ChatMessageTextView private constructor(
     private val assetInvalidator: () -> Unit = {
         post {
             latchTerminalAssetFailures()
+            maybeApplyStagedRow()
             requestLayout()
             postInvalidateOnAnimation()
             maybeRevealInitialAssetFrame()
@@ -156,6 +157,11 @@ open class ChatMessageTextView private constructor(
     private var clipPreviewAssetKeys = emptySet<ChatAssetKey>()
     private var awaitingInitialAssetFrame = false
     private var revealOnPreDrawPosted = false
+    private var stagedRow: ChatRowUiModel? = null
+    private var stagedBindGeneration = 0L
+    private var stagedAssetKeys = emptySet<ChatAssetKey>()
+    private var stagedObservedAssetKeys = emptySet<ChatAssetKey>()
+    private var externalBindGeneration = 0L
     private var initialAssetSpecs = emptyList<ChatAssetSpec>()
     private var initialDirectAssetKeys = emptySet<ChatAssetKey>()
     private val latchedFailedCompositionKeys = HashSet<String>()
@@ -191,18 +197,71 @@ open class ChatMessageTextView private constructor(
     }
 
     fun bind(row: ChatRowUiModel) {
-        boundRow = row
+        externalBindGeneration++
+        clearStagedRow()
+        bindInternal(row, stagePendingCandidate = true)
+    }
+
+    private fun bindInternal(row: ChatRowUiModel, stagePendingCandidate: Boolean) {
         bindingRow = true
         if (BuildConfig.PERF_DIAGNOSTICS) {
             ChatRenderDiagnostics.recordBind()
             Trace.beginSection("Xtra.ChatV2.bind")
         }
         try {
-            bindRow(row)
+            if (stagePendingCandidate && shouldStageRow(row)) stageRow(row) else {
+                if (stagePendingCandidate && boundRow != row) clearStagedRow()
+                bindRow(row)
+            }
         } finally {
             if (BuildConfig.PERF_DIAGNOSTICS) Trace.endSection()
             bindingRow = false
         }
+    }
+
+    private fun shouldStageRow(row: ChatRowUiModel): Boolean =
+        boundMessageId == row.id &&
+            !awaitingInitialAssetFrame &&
+            hasPendingAssets(row.assetKeys())
+
+    private fun stageRow(row: ChatRowUiModel) {
+        val nextKeys = row.assetKeys()
+        val previousObservedKeys = stagedObservedAssetKeys
+        previousObservedKeys
+            .filterNot(nextKeys::contains)
+            .filterNot(keys::contains)
+            .forEach { assets.removeObserver(it, assetInvalidator) }
+
+        stagedRow = row
+        stagedBindGeneration = externalBindGeneration
+        stagedAssetKeys = nextKeys
+        stagedObservedAssetKeys = nextKeys - keys
+        stagedObservedAssetKeys
+            .filterNot(previousObservedKeys::contains)
+            .forEach { assets.observe(it, assetInvalidator) }
+        maybeApplyStagedRow()
+    }
+
+    private fun maybeApplyStagedRow() {
+        val row = stagedRow ?: return
+        if (stagedBindGeneration != externalBindGeneration) {
+            clearStagedRow()
+            return
+        }
+        if (hasPendingAssets(stagedAssetKeys)) return
+        clearStagedRow()
+        bindRow(row)
+    }
+
+    private fun clearStagedRow() {
+        val activeKeys = keys
+        stagedObservedAssetKeys
+            .filterNot(activeKeys::contains)
+            .forEach { assets.removeObserver(it, assetInvalidator) }
+        stagedRow = null
+        stagedBindGeneration = 0L
+        stagedAssetKeys = emptySet()
+        stagedObservedAssetKeys = emptySet()
     }
 
     private fun bindRow(row: ChatRowUiModel) {
@@ -214,6 +273,7 @@ open class ChatMessageTextView private constructor(
             latchedFailedDirectKeys.clear()
             latchedFailedClipMetadataSlugs.clear()
         }
+        boundRow = row
         boundMessageId = row.id
         longPressConsumed = false
         longPressRunnable?.let(mainHandler::removeCallbacks)
@@ -224,22 +284,7 @@ open class ChatMessageTextView private constructor(
         drawables.values.forEach { it.stopIfNeeded(); it.callback = null }
         drawables.clear()
         drawableHandles.clear()
-        val newKeys = row.pieces.flatMap { piece ->
-            buildList {
-                val spec = when (piece) {
-                    is ChatPiece.Badge -> piece.asset
-                    is ChatPiece.RewardIcon -> piece.asset
-                    is ChatPiece.Emote -> piece.asset
-                    is ChatPiece.Cheermote -> piece.asset
-                    is ChatPiece.Gif -> piece.asset
-                    else -> null
-                }
-                spec?.let { addAll(it.allKeys()) }
-                if (piece is ChatPiece.Username) {
-                    piece.paint?.imageUrl?.takeIf { it.isNotBlank() }?.let { add(ChatAssetKey(it)) }
-                }
-            }
-        }.toSet()
+        val newKeys = row.assetKeys()
         oldKeys.filterNot(newKeys::contains).forEach { assets.removeObserver(it, assetInvalidator) }
         newKeys.filterNot(oldKeys::contains).forEach { assets.observe(it, assetInvalidator) }
         keys = newKeys
@@ -277,6 +322,7 @@ open class ChatMessageTextView private constructor(
         }
         clipPreviewSlugs = newClipPreviewSlugs
         refreshClipPreviewAssets()
+        latchTerminalAssetFailures()
         val density = resources.displayMetrics.density
         val event = row.eventPresentation
         if (event != null) {
@@ -416,16 +462,7 @@ open class ChatMessageTextView private constructor(
 
         latchFailedClipMetadata()
 
-        val hasPendingAsset = (keys + clipPreviewAssetKeys).any { key ->
-            when (val state = assets.peek(key)) {
-                ChatAssetState.Missing,
-                ChatAssetState.Loading -> true
-
-                is ChatAssetState.Ready -> false
-                is ChatAssetState.Failed -> !state.isPresentationTerminal
-            }
-        }
-        if (hasPendingAsset) return
+        if (hasPendingAssets(keys + clipPreviewAssetKeys)) return
         if (clipPreviewSlugs.any { slug ->
                 when (clipPreviews?.peekState(slug)) {
                     ChatClipPreviewState.Missing,
@@ -447,16 +484,7 @@ open class ChatMessageTextView private constructor(
     private fun revealInitialAssetFrameIfReady() {
         if (!awaitingInitialAssetFrame) return
         latchFailedClipMetadata()
-        val hasPendingAsset = (keys + clipPreviewAssetKeys).any { key ->
-            when (val state = assets.peek(key)) {
-                ChatAssetState.Missing,
-                ChatAssetState.Loading -> true
-
-                is ChatAssetState.Ready -> false
-                is ChatAssetState.Failed -> !state.isPresentationTerminal
-            }
-        }
-        if (hasPendingAsset || clipPreviewSlugs.any { slug ->
+        if (hasPendingAssets(keys + clipPreviewAssetKeys) || clipPreviewSlugs.any { slug ->
                 when (clipPreviews?.peekState(slug)) {
                     ChatClipPreviewState.Missing,
                     ChatClipPreviewState.Loading -> true
@@ -470,6 +498,16 @@ open class ChatMessageTextView private constructor(
 
         awaitingInitialAssetFrame = false
         alpha = 1f
+    }
+
+    private fun hasPendingAssets(assetKeys: Set<ChatAssetKey>): Boolean = assetKeys.any { key ->
+        when (val state = assets.peek(key)) {
+            ChatAssetState.Missing,
+            ChatAssetState.Loading -> true
+
+            is ChatAssetState.Ready -> false
+            is ChatAssetState.Failed -> !state.isPresentationTerminal
+        }
     }
 
     private fun latchTerminalAssetFailures() {
@@ -685,7 +723,7 @@ open class ChatMessageTextView private constructor(
     override fun onSizeChanged(w: Int, h: Int, oldw: Int, oldh: Int) {
         super.onSizeChanged(w, h, oldw, oldh)
         if (w != oldw && !bindingRow && boundRow?.pieces?.any { it is ChatPiece.Reply } == true) {
-            boundRow?.let(::bind)
+            boundRow?.let { bindInternal(it, stagePendingCandidate = false) }
         }
     }
 
@@ -971,6 +1009,7 @@ open class ChatMessageTextView private constructor(
     fun recycle() {
         longPressRunnable?.let(mainHandler::removeCallbacks)
         longPressRunnable = null
+        clearStagedRow()
         keys.forEach { assets.removeObserver(it, assetInvalidator) }
         clipPreviewSlugs.forEach { slug -> clipPreviews?.removeObserver(slug, clipMetadataInvalidator) }
         clipPreviewAssetKeys.forEach { assets.removeObserver(it, clipThumbnailInvalidator) }
@@ -981,6 +1020,11 @@ open class ChatMessageTextView private constructor(
         animatedAssetKeys = emptySet()
         clipPreviewSlugs = emptySet()
         clipPreviewAssetKeys = emptySet()
+        stagedRow = null
+        stagedBindGeneration = 0L
+        stagedAssetKeys = emptySet()
+        stagedObservedAssetKeys = emptySet()
+        externalBindGeneration++
         initialAssetSpecs = emptyList()
         initialDirectAssetKeys = emptySet()
         latchedFailedCompositionKeys.clear()
@@ -1048,15 +1092,18 @@ open class ChatMessageTextView private constructor(
         renderingActive = active
         if (active) {
             if (isAttachedToWindow) keys.forEach { assets.observe(it, assetInvalidator) }
+            if (isAttachedToWindow) stagedObservedAssetKeys.forEach { assets.observe(it, assetInvalidator) }
             if (isAttachedToWindow) clipPreviewSlugs.forEach { slug -> clipPreviews?.observe(slug, clipMetadataInvalidator) }
             if (isAttachedToWindow) clipPreviewAssetKeys.forEach { assets.observe(it, clipThumbnailInvalidator) }
             if (isAttachedToWindow) {
                 refreshClipPreviewAssets()
+                maybeApplyStagedRow()
                 maybeRevealInitialAssetFrame()
             }
             if (isAttachedToWindow) updateDrawableAnimations()
         } else {
             keys.forEach { assets.removeObserver(it, assetInvalidator) }
+            stagedObservedAssetKeys.forEach { assets.removeObserver(it, assetInvalidator) }
             clipPreviewSlugs.forEach { slug -> clipPreviews?.removeObserver(slug, clipMetadataInvalidator) }
             clipPreviewAssetKeys.forEach { assets.removeObserver(it, clipThumbnailInvalidator) }
             drawables.forEach { (key, drawable) -> updateAnimationState(key, drawable) }
@@ -1068,6 +1115,7 @@ open class ChatMessageTextView private constructor(
         longPressRunnable?.let(mainHandler::removeCallbacks)
         longPressRunnable = null
         keys.forEach { assets.removeObserver(it, assetInvalidator) }
+        stagedObservedAssetKeys.forEach { assets.removeObserver(it, assetInvalidator) }
         clipPreviewSlugs.forEach { slug -> clipPreviews?.removeObserver(slug, clipMetadataInvalidator) }
         clipPreviewAssetKeys.forEach { assets.removeObserver(it, clipThumbnailInvalidator) }
         drawables.values.forEach { it.stopIfNeeded(); it.callback = null }
@@ -1079,9 +1127,11 @@ open class ChatMessageTextView private constructor(
         windowAttached = true
         if (renderingActive) {
             keys.forEach { assets.observe(it, assetInvalidator) }
+            stagedObservedAssetKeys.forEach { assets.observe(it, assetInvalidator) }
             clipPreviewSlugs.forEach { slug -> clipPreviews?.observe(slug, clipMetadataInvalidator) }
             clipPreviewAssetKeys.forEach { assets.observe(it, clipThumbnailInvalidator) }
             refreshClipPreviewAssets()
+            maybeApplyStagedRow()
             maybeRevealInitialAssetFrame()
             updateDrawableAnimations()
         }
@@ -1176,6 +1226,22 @@ private fun ChatAssetSpec.allKeys(): List<ChatAssetKey> = buildList {
     add(key)
     overlays.forEach { addAll(it.allKeys()) }
 }
+
+private fun ChatRowUiModel.assetKeys(): Set<ChatAssetKey> = pieces.flatMap { piece ->
+    buildList {
+        when (piece) {
+            is ChatPiece.Badge -> addAll(piece.asset.allKeys())
+            is ChatPiece.RewardIcon -> addAll(piece.asset.allKeys())
+            is ChatPiece.Emote -> addAll(piece.asset.allKeys())
+            is ChatPiece.Cheermote -> addAll(piece.asset.allKeys())
+            is ChatPiece.Gif -> addAll(piece.asset.allKeys())
+            else -> Unit
+        }
+        if (piece is ChatPiece.Username) {
+            piece.paint?.imageUrl?.takeIf { it.isNotBlank() }?.let { add(ChatAssetKey(it)) }
+        }
+    }
+}.toSet()
 
 private fun ChatAssetSpec.flatten(): List<ChatAssetSpec> = buildList {
     add(this@flatten)


### PR DESCRIPTION
Keep revealed same-message rows visible while new emote assets load, then apply the compact replacement once assets are ready. Added regression coverage for emote spam, partial readiness, and composed overlays.