### PR TITLE
Open the gifter profile from gift cards

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatFragment.kt
@@ -76,6 +76,8 @@ import com.github.andreyasadchy.xtra.ui.chat.ChatViewModel.Companion.ChatViewMod
 import com.github.andreyasadchy.xtra.ui.common.BaseNetworkFragment
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessageId
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessage as V2ChatMessage
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessageKind
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatUser
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatUserClearReason
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatEmoteInteraction
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatGifInteraction
@@ -786,6 +788,7 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
                             onOpenHistoricalPrediction = { prediction ->
                                 showChannelPointsDialog(prediction)
                             },
+                            onOpenGiftProfile = ::showHappeningNowGiftProfile,
                             onDismiss = viewModel::dismissHappeningNowCard,
                         )
                     }
@@ -1778,6 +1781,48 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
             badges = if (pinner) message.pinnedByBadges else message.senderBadges,
             timestamp = message.sentAt,
         )
+        hideChatInputForDialog()
+        MessageClickedDialog.newInstance(
+            messagingEnabled = messagingEnabled,
+            channelId = requireArguments().getString(KEY_CHANNEL_ID),
+            channelLogin = requireArguments().getString(KEY_CHANNEL_LOGIN),
+        ).show(childFragmentManager, "messageDialog")
+    }
+
+    private fun showHappeningNowGiftProfile(gift: HappeningNowGift) {
+        if (gift.isAnonymous) return
+
+        val userId = gift.gifterUserId
+        val userLogin = gift.gifterLogin
+        if (userId.isNullOrBlank() && userLogin.isNullOrBlank()) return
+
+        if (useChatV2) {
+            selectedPinnedMessage = null
+            selectedV2Message = V2ChatMessage(
+                id = ChatMessageId("happening-now-gift:${gift.stableId}"),
+                channelId = requireArguments().getString(KEY_CHANNEL_ID).orEmpty(),
+                timestampMs = gift.occurredAt,
+                user = ChatUser(
+                    id = userId,
+                    login = userLogin,
+                    displayName = gift.gifterDisplayName ?: userLogin,
+                    color = null,
+                ),
+                badges = emptyList(),
+                segments = emptyList(),
+                kind = ChatMessageKind.SYSTEM,
+            )
+        } else {
+            selectedV2Message = null
+            selectedPinnedMessage = ChatMessage(
+                type = ChatMessage.USER_MESSAGE,
+                userId = userId,
+                userLogin = userLogin,
+                userName = gift.gifterDisplayName ?: userLogin,
+                message = null,
+                timestamp = gift.occurredAt,
+            )
+        }
         hideChatInputForDialog()
         MessageClickedDialog.newInstance(
             messagingEnabled = messagingEnabled,

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatViewModel.kt
@@ -319,6 +319,8 @@ class ChatViewModel(
                             stableId = gift.stableId,
                             occurredAt = gift.occurredAt,
                             gifterDisplayName = gift.gifterDisplayName,
+                            gifterUserId = gift.gifterUserId,
+                            gifterLogin = gift.gifterLogin,
                             isAnonymous = gift.isAnonymous,
                             count = gift.count,
                             source = gift.source,

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/HappeningNowGiftParser.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/HappeningNowGiftParser.kt
@@ -25,8 +25,12 @@ internal object HappeningNowGiftParser {
         val id = gift.optString("id").takeIf { it.isNotBlank() } ?: return null
         val count = gift.optInt("total", 0).takeIf { it > 0 } ?: return null
 
+        val userId = event.optString("chatter_user_id")
+            .takeIf { it.isNotBlank() }
+        val login = event.optString("chatter_user_login")
+            .takeIf { it.isNotBlank() }
         val displayName = event.optString("chatter_user_name")
-            .ifBlank { event.optString("chatter_user_login") }
+            .ifBlank { login.orEmpty() }
             .takeIf { it.isNotBlank() }
         val anonymous = event.optBoolean("chatter_is_anonymous", false) || displayName == null
         val gifter = displayName.takeUnless { anonymous }
@@ -38,6 +42,8 @@ internal object HappeningNowGiftParser {
                 ?.toEpochMilliseconds()
                 ?: now,
             gifterDisplayName = gifter,
+            gifterUserId = userId.takeUnless { anonymous },
+            gifterLogin = login.takeUnless { anonymous },
             isAnonymous = anonymous,
             count = count,
             source = ChatGiftSource.EVENTSUB,
@@ -65,6 +71,7 @@ internal object HappeningNowGiftParser {
             ?: return null
 
         val login = message.tags["login"].orEmpty()
+        val userId = message.tags["user-id"]?.takeIf { it.isNotBlank() }
         val displayName = message.tags["display-name"].orEmpty()
 
         val anonymous =
@@ -88,6 +95,8 @@ internal object HappeningNowGiftParser {
             stableId = id,
             occurredAt = timestamp,
             gifterDisplayName = gifter,
+            gifterUserId = userId.takeUnless { isAnonymous },
+            gifterLogin = login.takeIf { it.isNotBlank() }.takeUnless { isAnonymous },
             isAnonymous = isAnonymous,
             count = count,
             source = ChatGiftSource.IRC,

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/HappeningNowModels.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/HappeningNowModels.kt
@@ -6,6 +6,8 @@ internal data class HappeningNowGift(
     val stableId: String,
     val occurredAt: Long,
     val gifterDisplayName: String?,
+    val gifterUserId: String?,
+    val gifterLogin: String?,
     val isAnonymous: Boolean,
     val count: Int,
     val source: ChatGiftSource,

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/HappeningNowView.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/HappeningNowView.kt
@@ -77,6 +77,7 @@ internal class HappeningNowView @JvmOverloads constructor(
         state: RenderState,
         onOpenChannelPoints: () -> Unit,
         onOpenHistoricalPrediction: (Prediction) -> Unit,
+        onOpenGiftProfile: (HappeningNowGift) -> Unit,
         onDismiss: (String) -> Unit,
     ) {
         cards.removeAllViews()
@@ -90,7 +91,7 @@ internal class HappeningNowView @JvmOverloads constructor(
         state.gift?.let { gift ->
             val key = HappeningNowKeys.gift(gift.stableId)
             if (key !in state.dismissedIds) {
-                addGiftCard(gift)
+                addGiftCard(gift, onOpenGiftProfile)
                 visibleKeys += key
             }
         }
@@ -213,12 +214,21 @@ internal class HappeningNowView @JvmOverloads constructor(
         )
     }
 
-    private fun addGiftCard(gift: HappeningNowGift) {
+    private fun addGiftCard(
+        gift: HappeningNowGift,
+        onOpenGiftProfile: (HappeningNowGift) -> Unit,
+    ) {
         val view = inflater.inflate(
             R.layout.view_happening_now_gift_card,
             cards,
             false,
         )
+
+        // Keep the overlay in the touch hierarchy even when the gift is anonymous.
+        // Otherwise a tap can fall through to the chat row underneath it.
+        view.setOnClickListener {
+            onOpenGiftProfile(gift)
+        }
 
         val giftText = view.findViewById<TextView>(R.id.happeningGiftText)
         val giftCount = view.findViewById<TextView>(R.id.happeningGiftCount)

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/domain/ChatEvent.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/domain/ChatEvent.kt
@@ -18,6 +18,8 @@ data class ChatCommunityGift(
     val stableId: String,
     val occurredAt: Long,
     val gifterDisplayName: String?,
+    val gifterUserId: String?,
+    val gifterLogin: String?,
     val isAnonymous: Boolean,
     val count: Int,
     val source: ChatGiftSource,

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/transport/TwitchChatTransport.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/transport/TwitchChatTransport.kt
@@ -333,6 +333,8 @@ class TwitchChatTransport(
             stableId = stableId,
             occurredAt = occurredAt,
             gifterDisplayName = gifterDisplayName,
+            gifterUserId = gifterUserId,
+            gifterLogin = gifterLogin,
             isAnonymous = isAnonymous,
             count = count,
             source = source,

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/HappeningNowGiftParserTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/HappeningNowGiftParserTest.kt
@@ -20,6 +20,8 @@ class HappeningNowGiftParserTest {
                 {
                   "notice_type":"community_sub_gift",
                   "community_sub_gift":{"id":"abc","total":5},
+                  "chatter_user_id":"123",
+                  "chatter_user_login":"merc_unleashed",
                   "chatter_user_name":"MeRc_UnLeAsHeD"
                 }
                 """.trimIndent(),
@@ -32,6 +34,8 @@ class HappeningNowGiftParserTest {
         assertEquals("abc", gift?.stableId)
         assertEquals(5, gift?.count)
         assertEquals("MeRc_UnLeAsHeD", gift?.gifterDisplayName)
+        assertEquals("123", gift?.gifterUserId)
+        assertEquals("merc_unleashed", gift?.gifterLogin)
         assertEquals(123L, gift?.occurredAt)
     }
 
@@ -44,6 +48,8 @@ class HappeningNowGiftParserTest {
                   "notice_type":"community_sub_gift",
                   "community_sub_gift":{"id":"abc","total":5},
                   "chatter_is_anonymous":true,
+                  "chatter_user_id":"123",
+                  "chatter_user_login":"ignored_login",
                   "chatter_user_name":"ignored"
                 }
                 """.trimIndent(),
@@ -53,6 +59,8 @@ class HappeningNowGiftParserTest {
 
         assertTrue(gift?.isAnonymous == true)
         assertNull(gift?.gifterDisplayName)
+        assertNull(gift?.gifterUserId)
+        assertNull(gift?.gifterLogin)
     }
 
     @Test
@@ -63,6 +71,8 @@ class HappeningNowGiftParserTest {
                 {
                   "notice_type":"shared_chat_community_sub_gift",
                   "shared_chat_community_sub_gift":{"id":"shared-abc","total":5},
+                  "chatter_user_id":"123",
+                  "chatter_user_login":"merc_unleashed",
                   "chatter_user_name":"MeRc_UnLeAsHeD"
                 }
                 """.trimIndent(),
@@ -75,6 +85,8 @@ class HappeningNowGiftParserTest {
         assertEquals("shared-abc", gift?.stableId)
         assertEquals(5, gift?.count)
         assertEquals("MeRc_UnLeAsHeD", gift?.gifterDisplayName)
+        assertEquals("123", gift?.gifterUserId)
+        assertEquals("merc_unleashed", gift?.gifterLogin)
         assertEquals(123L, gift?.occurredAt)
     }
 
@@ -98,7 +110,7 @@ class HappeningNowGiftParserTest {
     @Test
     fun `irc community gift uses mass gift count`() {
         val message = ChatUtils.parseIRCMessage(
-            "@display-name=MeRc_UnLeAsHeD;id=gift-id;login=merc_unleashed;msg-id=submysterygift;msg-param-mass-gift-count=5;tmi-sent-ts=1700000000000 :user!user@tmi.twitch.tv USERNOTICE #channel :gift",
+            "@display-name=MeRc_UnLeAsHeD;id=gift-id;login=merc_unleashed;user-id=123;msg-id=submysterygift;msg-param-mass-gift-count=5;tmi-sent-ts=1700000000000 :user!user@tmi.twitch.tv USERNOTICE #channel :gift",
         )
 
         val gift = HappeningNowGiftParser.fromIrc(message)
@@ -106,6 +118,8 @@ class HappeningNowGiftParserTest {
         assertNotNull(gift)
         assertEquals(5, gift?.count)
         assertEquals("gift-id", gift?.stableId)
+        assertEquals("123", gift?.gifterUserId)
+        assertEquals("merc_unleashed", gift?.gifterLogin)
     }
 
     @Test


### PR DESCRIPTION
Gift cards now consume taps so they cannot activate chat rows underneath them. Tapping a named gift card opens that gifter's message profile; anonymous cards remain non-interactive.