### PR TITLE
Cache Chat Identity trigger badges

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatFragment.kt
@@ -3,11 +3,13 @@ package com.github.andreyasadchy.xtra.ui.chat
 import android.content.Context
 import android.content.res.ColorStateList
 import android.graphics.Color
+import android.graphics.drawable.Drawable
 import android.os.Build
 import android.os.Bundle
 import android.os.SystemClock
 import android.text.format.DateUtils
 import android.util.Log
+import android.util.LruCache
 import android.util.TypedValue
 import android.view.KeyEvent
 import android.view.LayoutInflater
@@ -39,6 +41,7 @@ import androidx.navigation.NavOptions
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import androidx.viewpager2.adapter.FragmentStateAdapter
+import coil3.Image
 import coil3.imageLoader
 import coil3.request.CachePolicy
 import coil3.request.Disposable
@@ -47,6 +50,7 @@ import coil3.request.crossfade
 import coil3.request.error
 import coil3.request.target
 import coil3.request.transformations
+import coil3.target.ImageViewTarget
 import coil3.transform.CircleCropTransformation
 import com.github.andreyasadchy.xtra.R
 import com.github.andreyasadchy.xtra.XtraApp
@@ -74,6 +78,7 @@ import com.github.andreyasadchy.xtra.model.ui.WatchStreakShareResult
 import com.github.andreyasadchy.xtra.ui.channel.ChannelPagerFragmentDirections
 import com.github.andreyasadchy.xtra.ui.chat.ChatViewModel.Companion.ChatViewModelFactory
 import com.github.andreyasadchy.xtra.ui.common.BaseNetworkFragment
+import com.github.andreyasadchy.xtra.ui.common.restoreDecodedMemoryImage
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessageId
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessage as V2ChatMessage
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatUserClearReason
@@ -136,6 +141,41 @@ import kotlin.math.max
 
 private const val TWITCH_LISTENING_ONLY_BADGE_URL =
     "https://static-cdn.jtvnw.net/badges/v1/199a0dba-58f3-494e-a7fc-1fa0a1001fb8/3"
+
+private val chatIdentityBadgeDrawableCache = object : LruCache<String, Drawable.ConstantState>(32) {}
+
+private fun restoreChatIdentityBadgeDrawable(cacheKey: String, imageView: ImageView): Boolean {
+    val state = synchronized(chatIdentityBadgeDrawableCache) {
+        chatIdentityBadgeDrawableCache.get(cacheKey)
+    } ?: return false
+    imageView.setImageDrawable(state.newDrawable(imageView.resources))
+    return true
+}
+
+private class ChatIdentityBadgeImageTarget(
+    imageView: ImageView,
+    private val cacheKey: String,
+    private val isCurrent: () -> Boolean,
+) : ImageViewTarget(imageView) {
+    override fun onStart(placeholder: Image?) {
+        if (isCurrent() && view.drawable != null) return
+        super.onStart(placeholder)
+    }
+
+    override fun onSuccess(result: Image) {
+        if (!isCurrent()) return
+        super.onSuccess(result)
+        view.drawable?.constantState?.let { state ->
+            synchronized(chatIdentityBadgeDrawableCache) {
+                chatIdentityBadgeDrawableCache.put(cacheKey, state)
+            }
+        }
+    }
+
+    override fun onError(error: Image?) {
+        // Preserve the cached badge or the neutral trigger icon on image failure.
+    }
+}
 
 internal fun shouldShowChatComposer(
     chatAvailable: Boolean,
@@ -2172,8 +2212,10 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
 
     private fun updateChatIdentityTrigger(state: ChatIdentityState) {
         val icon = _binding?.chatIdentity ?: return
-        val badge = state.displayBadges.firstOrNull()
-            ?: state.takeIf { !it.loading && it.displayName.isNotBlank() }?.selectedVanityBadge()
+        val badge = resolveChatIdentityTriggerBadge(
+            state = state,
+            cachedBadge = viewModel.cachedChatIdentityBadge(state.loadedChannelId, state.loadedViewerId),
+        )
         if (badge?.imageUrl.isNullOrBlank()) {
             chatIdentityBadgeRequest?.dispose()
             chatIdentityBadgeRequest = null
@@ -2190,14 +2232,26 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
         val url = badge.imageUrl
         if (chatIdentityBadgeUrl == url) return
         chatIdentityBadgeRequest?.dispose()
+        chatIdentityBadgeRequest = null
         chatIdentityBadgeUrl = url
         icon.imageTintList = null
+        val memoryCacheKey = "xtra:chat-identity-badge:$url"
+        if (restoreDecodedMemoryImage(memoryCacheKey, icon) ||
+            restoreChatIdentityBadgeDrawable(memoryCacheKey, icon)
+        ) return
         chatIdentityBadgeRequest = requireContext().imageLoader.enqueue(
             ImageRequest.Builder(requireContext())
                 .data(url)
+                .memoryCacheKey(memoryCacheKey)
                 .diskCachePolicy(CachePolicy.ENABLED)
                 .crossfade(false)
-                .target(icon)
+                .target(
+                    ChatIdentityBadgeImageTarget(
+                        imageView = icon,
+                        cacheKey = memoryCacheKey,
+                        isCurrent = { chatIdentityBadgeUrl == url },
+                    ),
+                )
                 .build(),
         )
     }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatIdentityBadgeCache.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatIdentityBadgeCache.kt
@@ -1,0 +1,52 @@
+package com.github.andreyasadchy.xtra.ui.chat
+
+import com.github.andreyasadchy.xtra.model.chat.ChatIdentityBadge
+import com.github.andreyasadchy.xtra.model.chat.ChatIdentityState
+import com.github.andreyasadchy.xtra.model.chat.selectedVanityBadge
+import java.util.LinkedHashMap
+
+internal data class ChatIdentityBadgeCacheKey(
+    val viewerId: String,
+    val channelId: String,
+)
+
+/** Keeps only the last server-selected trigger badge; it is never Chat Identity presentation state. */
+internal object ChatIdentityBadgeCache {
+    private const val maxEntries = 64
+    private val entries = object : LinkedHashMap<ChatIdentityBadgeCacheKey, ChatIdentityBadge>(
+        maxEntries,
+        0.75f,
+        true,
+    ) {
+        override fun removeEldestEntry(
+            eldest: MutableMap.MutableEntry<ChatIdentityBadgeCacheKey, ChatIdentityBadge>?,
+        ): Boolean = size > maxEntries
+    }
+
+    @Synchronized
+    fun get(channelId: String, viewerId: String): ChatIdentityBadge? =
+        entries[ChatIdentityBadgeCacheKey(viewerId, channelId)]
+
+    @Synchronized
+    fun updateFromServer(
+        viewerId: String,
+        channelId: String,
+        triggerBadge: ChatIdentityBadge?,
+    ) {
+        val key = ChatIdentityBadgeCacheKey(viewerId, channelId)
+        val badge = triggerBadge?.takeIf { it.imageUrl.isNotBlank() }
+        if (badge == null) entries.remove(key) else entries[key] = badge
+    }
+
+    @Synchronized
+    fun clear() = entries.clear()
+}
+
+internal fun ChatIdentityState.resolvedServerChatIdentityTriggerBadge(): ChatIdentityBadge? =
+    displayBadges.firstOrNull()
+        ?: takeIf { displayName.isNotBlank() }?.selectedVanityBadge()
+
+internal fun resolveChatIdentityTriggerBadge(
+    state: ChatIdentityState,
+    cachedBadge: ChatIdentityBadge?,
+): ChatIdentityBadge? = state.resolvedServerChatIdentityTriggerBadge() ?: cachedBadge

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatViewModel.kt
@@ -733,11 +733,25 @@ class ChatViewModel(
         thirdPartyEmotesUpdated.emit(Unit)
     }
 
+    internal fun cachedChatIdentityBadge(channelId: String?, viewerId: String?): ChatIdentityBadge? {
+        if (channelId.isNullOrBlank() || viewerId.isNullOrBlank()) return null
+        return ChatIdentityBadgeCache.get(channelId, viewerId)
+    }
+
+    private fun updateChatIdentityBadgeCache(
+        viewerId: String,
+        channelId: String,
+        triggerBadge: ChatIdentityBadge?,
+    ) {
+        ChatIdentityBadgeCache.updateFromServer(viewerId, channelId, triggerBadge)
+    }
+
     fun ensureChatIdentityLoaded(channelId: String?, channelLogin: String?) {
         if (channelId.isNullOrBlank() || channelLogin.isNullOrBlank()) return
         val viewerId = applicationContext.tokenPrefs().getString(C.USER_ID, null)
         if (viewerId.isNullOrBlank()) {
             chatIdentityCache.clear()
+            ChatIdentityBadgeCache.clear()
             chatIdentityCampaignRepository.clear()
             cancelChatIdentityCampaignLoad()
             _chatIdentityState.value = ChatIdentityState(loadedChannelId = channelId)
@@ -993,6 +1007,13 @@ class ChatViewModel(
             .orEmpty()
         val state = baseData.toState(channelId = channelId, viewerId = viewerId)
             .copy(campaigns = existingCampaigns)
+        if (applicationContext.tokenPrefs().getString(C.USER_ID, null) == viewerId) {
+            updateChatIdentityBadgeCache(
+                viewerId = viewerId,
+                channelId = channelId,
+                triggerBadge = state.resolvedServerChatIdentityTriggerBadge(),
+            )
+        }
         chatIdentityCache[channelId] = CachedChatIdentity(
             viewerId = viewerId,
             loadedAtElapsedRealtime = SystemClock.elapsedRealtime(),
@@ -3045,6 +3066,7 @@ class ChatViewModel(
             cancelChatIdentityCampaignLoad()
             if (_chatIdentityState.value.loadedViewerId != currentIdentityViewerId) {
                 chatIdentityCache.clear()
+                ChatIdentityBadgeCache.clear()
                 chatIdentityCampaignRepository.clear()
             }
             _chatIdentityState.value = ChatIdentityState(
@@ -3443,6 +3465,7 @@ class ChatViewModel(
             chatIdentityLoadJob = null
             cancelChatIdentityCampaignLoad()
             chatIdentityCache.clear()
+            ChatIdentityBadgeCache.clear()
             chatIdentityCampaignRepository.clear()
             _chatIdentityState.value = ChatIdentityState()
         }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/ThumbnailImageRequest.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/ThumbnailImageRequest.kt
@@ -472,7 +472,7 @@ private fun restoreWarmStreamThumbnail(cacheKey: String, imageView: ImageView): 
 /**
  * Coil's decoded memory cache is the source of truth for images that were
  * loaded by another holder. Restoring it synchronously avoids showing the
- * layout's grey placeholder while a cache-only request posts its callback.
+ * layout placeholder while a cache-only request posts its callback.
  * The small ConstantState cache above remains a fallback for images Coil has
  * already evicted from its decoded cache.
  */
@@ -491,7 +491,7 @@ internal fun restoreDecodedMemoryImage(
 
     if (BuildConfig.DEBUG) {
         Log.d(
-            "StreamThumbnail",
+            "ImageCache",
             "memory_restore keyHash=${cacheKey.hashCode().toString(16)}",
         )
     }

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/ChatIdentityBadgeCacheTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/ChatIdentityBadgeCacheTest.kt
@@ -1,0 +1,70 @@
+package com.github.andreyasadchy.xtra.ui.chat
+
+import com.github.andreyasadchy.xtra.model.chat.ChatIdentityBadge
+import com.github.andreyasadchy.xtra.model.chat.ChatIdentityBadgeKey
+import com.github.andreyasadchy.xtra.model.chat.ChatIdentityState
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ChatIdentityBadgeCacheTest {
+    private val subscriber = badge("subscriber")
+    private val vanity = badge("vanity")
+
+    @After
+    fun clearCache() {
+        ChatIdentityBadgeCache.clear()
+    }
+
+    @Test
+    fun `server badge is cached per viewer and channel and empty response clears it`() {
+        val cache = ChatIdentityBadgeCache
+
+        cache.updateFromServer("viewer", "channel", subscriber)
+        assertEquals(subscriber, cache.get("channel", "viewer"))
+        assertNull(cache.get("other-channel", "viewer"))
+        assertNull(cache.get("channel", "other-viewer"))
+
+        cache.updateFromServer("viewer", "channel", null)
+        assertNull(cache.get("channel", "viewer"))
+    }
+
+    @Test
+    fun `server trigger badge wins over cached badge and cached badge wins while loading`() {
+        val cached = badge("cached")
+        val fresh = badge("fresh")
+        val loading = ChatIdentityState(loading = true)
+        val loaded = ChatIdentityState(displayName = "viewer")
+
+        assertEquals(cached, resolveChatIdentityTriggerBadge(loading, cached))
+        assertEquals(
+            fresh,
+            resolveChatIdentityTriggerBadge(loaded.copy(displayBadges = listOf(fresh)), cached),
+        )
+    }
+
+    @Test
+    fun `selected vanity is cached when the server display list is empty`() {
+        val state = ChatIdentityState(
+            displayName = "viewer",
+            globalBadges = listOf(vanity),
+            selectedGlobalBadge = vanity.key,
+        )
+
+        ChatIdentityBadgeCache.updateFromServer(
+            viewerId = "viewer",
+            channelId = "channel",
+            triggerBadge = state.resolvedServerChatIdentityTriggerBadge(),
+        )
+
+        assertEquals(vanity, ChatIdentityBadgeCache.get("channel", "viewer"))
+    }
+
+    private fun badge(setId: String) = ChatIdentityBadge(
+        key = ChatIdentityBadgeKey(setId, "1"),
+        title = setId,
+        description = null,
+        imageUrl = "https://example.com/$setId.png",
+    )
+}


### PR DESCRIPTION
Keep the last server-provided Chat Identity trigger badge per viewer and channel so the composer shows it immediately when revisiting a stream. Restore decoded artwork synchronously when available, then replace it with fresh server data. Add account-safe invalidation and regression coverage.