### PR TITLE
Add predictive emote recommendations

### DIFF
--- a/app/schemas/com.github.andreyasadchy.xtra.db.AppDatabase/52.json
+++ b/app/schemas/com.github.andreyasadchy.xtra.db.AppDatabase/52.json
@@ -1,0 +1,1977 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 52,
+    "identityHash": "e85fd19d9972cb60eeb55d0a35edbebb",
+    "entities": [
+      {
+        "tableName": "videos",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`url` TEXT, `source_url` TEXT, `source_start_position` INTEGER, `name` TEXT, `channel_id` TEXT, `channel_login` TEXT, `channel_name` TEXT, `channel_logo` TEXT, `thumbnail` TEXT, `gameId` TEXT, `gameSlug` TEXT, `gameName` TEXT, `duration` INTEGER, `upload_date` INTEGER, `download_date` INTEGER, `last_watch_position` INTEGER, `progress` INTEGER NOT NULL, `max_progress` INTEGER NOT NULL, `bytes` INTEGER NOT NULL, `downloadPath` TEXT, `fromTime` INTEGER, `toTime` INTEGER, `status` INTEGER NOT NULL, `type` TEXT, `videoId` TEXT, `videoCreatedAt` TEXT, `clipId` TEXT, `quality` TEXT, `downloadChat` INTEGER NOT NULL, `downloadChatEmotes` INTEGER NOT NULL, `chatProgress` INTEGER NOT NULL, `maxChatProgress` INTEGER NOT NULL, `chatBytes` INTEGER NOT NULL, `chatOffsetSeconds` INTEGER NOT NULL, `chatUrl` TEXT, `playlistToFile` INTEGER NOT NULL, `live` INTEGER NOT NULL, `lastSegmentUrl` TEXT, `liveCommentsArrayStarted` INTEGER NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceUrl",
+            "columnName": "source_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceStartPosition",
+            "columnName": "source_start_position",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channel_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelLogin",
+            "columnName": "channel_login",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelName",
+            "columnName": "channel_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelLogo",
+            "columnName": "channel_logo",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "thumbnail",
+            "columnName": "thumbnail",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "gameId",
+            "columnName": "gameId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "gameSlug",
+            "columnName": "gameSlug",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "gameName",
+            "columnName": "gameName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "uploadDate",
+            "columnName": "upload_date",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "downloadDate",
+            "columnName": "download_date",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastWatchPosition",
+            "columnName": "last_watch_position",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "progress",
+            "columnName": "progress",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxProgress",
+            "columnName": "max_progress",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bytes",
+            "columnName": "bytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadPath",
+            "columnName": "downloadPath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "fromTime",
+            "columnName": "fromTime",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "toTime",
+            "columnName": "toTime",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "videoId",
+            "columnName": "videoId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "videoCreatedAt",
+            "columnName": "videoCreatedAt",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "clipId",
+            "columnName": "clipId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "quality",
+            "columnName": "quality",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "downloadChat",
+            "columnName": "downloadChat",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadChatEmotes",
+            "columnName": "downloadChatEmotes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chatProgress",
+            "columnName": "chatProgress",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxChatProgress",
+            "columnName": "maxChatProgress",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chatBytes",
+            "columnName": "chatBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chatOffsetSeconds",
+            "columnName": "chatOffsetSeconds",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chatUrl",
+            "columnName": "chatUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "playlistToFile",
+            "columnName": "playlistToFile",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "live",
+            "columnName": "live",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSegmentUrl",
+            "columnName": "lastSegmentUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "liveCommentsArrayStarted",
+            "columnName": "liveCommentsArrayStarted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_videos_url",
+            "unique": false,
+            "columnNames": [
+              "url"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_videos_url` ON `${TABLE_NAME}` (`url`)"
+          },
+          {
+            "name": "index_videos_status",
+            "unique": false,
+            "columnNames": [
+              "status"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_videos_status` ON `${TABLE_NAME}` (`status`)"
+          },
+          {
+            "name": "index_videos_videoId",
+            "unique": false,
+            "columnNames": [
+              "videoId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_videos_videoId` ON `${TABLE_NAME}` (`videoId`)"
+          },
+          {
+            "name": "index_videos_channel_id",
+            "unique": false,
+            "columnNames": [
+              "channel_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_videos_channel_id` ON `${TABLE_NAME}` (`channel_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "recent_emotes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`name` TEXT NOT NULL, `used_at` INTEGER NOT NULL, PRIMARY KEY(`name`))",
+        "fields": [
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "usedAt",
+            "columnName": "used_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "name"
+          ]
+        }
+      },
+      {
+        "tableName": "emote_usage",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`viewer_id` TEXT NOT NULL, `usage_key` TEXT NOT NULL, `provider` TEXT NOT NULL, `emote_id` TEXT NOT NULL, `scope` TEXT NOT NULL, `channel_id` TEXT, `use_count` INTEGER NOT NULL, `last_used_at` INTEGER NOT NULL, PRIMARY KEY(`viewer_id`, `usage_key`))",
+        "fields": [
+          {
+            "fieldPath": "viewerId",
+            "columnName": "viewer_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "usageKey",
+            "columnName": "usage_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "provider",
+            "columnName": "provider",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "emoteId",
+            "columnName": "emote_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scope",
+            "columnName": "scope",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channel_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "useCount",
+            "columnName": "use_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastUsedAt",
+            "columnName": "last_used_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "viewer_id",
+            "usage_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_emote_usage_viewer_id_channel_id",
+            "unique": false,
+            "columnNames": [
+              "viewer_id",
+              "channel_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_emote_usage_viewer_id_channel_id` ON `${TABLE_NAME}` (`viewer_id`, `channel_id`)"
+          },
+          {
+            "name": "index_emote_usage_viewer_id_provider_emote_id",
+            "unique": false,
+            "columnNames": [
+              "viewer_id",
+              "provider",
+              "emote_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_emote_usage_viewer_id_provider_emote_id` ON `${TABLE_NAME}` (`viewer_id`, `provider`, `emote_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "favorite_emotes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`provider` TEXT NOT NULL, `emote_id` TEXT NOT NULL, `favorited_at` INTEGER NOT NULL, `sort_order` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`provider`, `emote_id`))",
+        "fields": [
+          {
+            "fieldPath": "provider",
+            "columnName": "provider",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "emoteId",
+            "columnName": "emote_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "favoritedAt",
+            "columnName": "favorited_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sort_order",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "provider",
+            "emote_id"
+          ]
+        }
+      },
+      {
+        "tableName": "video_positions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `position` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "video_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `position` INTEGER NOT NULL, `durationSeconds` INTEGER, `channelId` TEXT, `channelLogin` TEXT, `channelName` TEXT, `channelImageURL` TEXT, `title` TEXT, `thumbnailURL` TEXT, `gameId` TEXT, `gameSlug` TEXT, `gameName` TEXT, `createdAt` TEXT, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationSeconds",
+            "columnName": "durationSeconds",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channelId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelLogin",
+            "columnName": "channelLogin",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelName",
+            "columnName": "channelName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelImageURL",
+            "columnName": "channelImageURL",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "thumbnailURL",
+            "columnName": "thumbnailURL",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "gameId",
+            "columnName": "gameId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "gameSlug",
+            "columnName": "gameSlug",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "gameName",
+            "columnName": "gameName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_video_history_updatedAt",
+            "unique": false,
+            "columnNames": [
+              "updatedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_video_history_updatedAt` ON `${TABLE_NAME}` (`updatedAt`)"
+          },
+          {
+            "name": "index_video_history_channelId",
+            "unique": false,
+            "columnNames": [
+              "channelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_video_history_channelId` ON `${TABLE_NAME}` (`channelId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "local_follows",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`userId` TEXT, `userLogin` TEXT, `userName` TEXT, `channelLogo` TEXT, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userLogin",
+            "columnName": "userLogin",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userName",
+            "columnName": "userName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelLogo",
+            "columnName": "channelLogo",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "local_follows_games",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`gameId` TEXT, `gameSlug` TEXT, `gameName` TEXT, `boxArt` TEXT, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "gameId",
+            "columnName": "gameId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "gameSlug",
+            "columnName": "gameSlug",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "gameName",
+            "columnName": "gameName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "boxArt",
+            "columnName": "boxArt",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "bookmarks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`videoId` TEXT, `userId` TEXT, `userLogin` TEXT, `userName` TEXT, `userType` TEXT, `userBroadcasterType` TEXT, `userLogo` TEXT, `gameId` TEXT, `gameSlug` TEXT, `gameName` TEXT, `title` TEXT, `createdAt` TEXT, `thumbnail` TEXT, `type` TEXT, `duration` TEXT, `animatedPreviewURL` TEXT, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "videoId",
+            "columnName": "videoId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userLogin",
+            "columnName": "userLogin",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userName",
+            "columnName": "userName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userType",
+            "columnName": "userType",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userBroadcasterType",
+            "columnName": "userBroadcasterType",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userLogo",
+            "columnName": "userLogo",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "gameId",
+            "columnName": "gameId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "gameSlug",
+            "columnName": "gameSlug",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "gameName",
+            "columnName": "gameName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "thumbnail",
+            "columnName": "thumbnail",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "animatedPreviewURL",
+            "columnName": "animatedPreviewURL",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_bookmarks_videoId",
+            "unique": false,
+            "columnNames": [
+              "videoId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_bookmarks_videoId` ON `${TABLE_NAME}` (`videoId`)"
+          },
+          {
+            "name": "index_bookmarks_userId",
+            "unique": false,
+            "columnNames": [
+              "userId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_bookmarks_userId` ON `${TABLE_NAME}` (`userId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "vod_bookmark_ignored_users",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`user_id` TEXT NOT NULL, PRIMARY KEY(`user_id`))",
+        "fields": [
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "user_id"
+          ]
+        }
+      },
+      {
+        "tableName": "sort_channel",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `videoSort` TEXT, `videoType` TEXT, `clipPeriod` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "videoSort",
+            "columnName": "videoSort",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "videoType",
+            "columnName": "videoType",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "clipPeriod",
+            "columnName": "clipPeriod",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "sort_game",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `streamSort` TEXT, `streamTags` TEXT, `streamLanguages` TEXT, `videoSort` TEXT, `videoPeriod` TEXT, `videoType` TEXT, `videoLanguages` TEXT, `clipPeriod` TEXT, `clipLanguages` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "streamSort",
+            "columnName": "streamSort",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "streamTags",
+            "columnName": "streamTags",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "streamLanguages",
+            "columnName": "streamLanguages",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "videoSort",
+            "columnName": "videoSort",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "videoPeriod",
+            "columnName": "videoPeriod",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "videoType",
+            "columnName": "videoType",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "videoLanguages",
+            "columnName": "videoLanguages",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "clipPeriod",
+            "columnName": "clipPeriod",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "clipLanguages",
+            "columnName": "clipLanguages",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "shown_notifications",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `channelId` TEXT NOT NULL, `streamId` TEXT NOT NULL, `startedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channelId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "streamId",
+            "columnName": "streamId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startedAt",
+            "columnName": "startedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_shown_notifications_streamId",
+            "unique": true,
+            "columnNames": [
+              "streamId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_shown_notifications_streamId` ON `${TABLE_NAME}` (`streamId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "notifications",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`channelId` TEXT NOT NULL, PRIMARY KEY(`channelId`))",
+        "fields": [
+          {
+            "fieldPath": "channelId",
+            "columnName": "channelId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "channelId"
+          ]
+        }
+      },
+      {
+        "tableName": "notification_events",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`eventId` TEXT NOT NULL, `channelId` TEXT NOT NULL, `streamId` TEXT, `channelLogin` TEXT, `channelName` TEXT, `channelImageURL` TEXT, `gameName` TEXT, `title` TEXT, `thumbnailURL` TEXT, `createdAt` TEXT, `viewerCount` INTEGER, `startedAt` INTEGER NOT NULL, `queuedAt` INTEGER NOT NULL, PRIMARY KEY(`eventId`))",
+        "fields": [
+          {
+            "fieldPath": "eventId",
+            "columnName": "eventId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channelId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "streamId",
+            "columnName": "streamId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelLogin",
+            "columnName": "channelLogin",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelName",
+            "columnName": "channelName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelImageURL",
+            "columnName": "channelImageURL",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "gameName",
+            "columnName": "gameName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "thumbnailURL",
+            "columnName": "thumbnailURL",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "viewerCount",
+            "columnName": "viewerCount",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "startedAt",
+            "columnName": "startedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "queuedAt",
+            "columnName": "queuedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "eventId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_notification_events_channelId",
+            "unique": false,
+            "columnNames": [
+              "channelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_notification_events_channelId` ON `${TABLE_NAME}` (`channelId`)"
+          },
+          {
+            "name": "index_notification_events_queuedAt",
+            "unique": false,
+            "columnNames": [
+              "queuedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_notification_events_queuedAt` ON `${TABLE_NAME}` (`queuedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "translate_all_messages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`channelId` TEXT NOT NULL, PRIMARY KEY(`channelId`))",
+        "fields": [
+          {
+            "fieldPath": "channelId",
+            "columnName": "channelId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "channelId"
+          ]
+        }
+      },
+      {
+        "tableName": "filters",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`gameId` TEXT, `gameSlug` TEXT, `gameName` TEXT, `tags` TEXT, `languages` TEXT, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "gameId",
+            "columnName": "gameId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "gameSlug",
+            "columnName": "gameSlug",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "gameName",
+            "columnName": "gameName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "tags",
+            "columnName": "tags",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "languages",
+            "columnName": "languages",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "recent_search",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`query` TEXT NOT NULL, `type` TEXT NOT NULL, `lastSearched` INTEGER NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "query",
+            "columnName": "query",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSearched",
+            "columnName": "lastSearched",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_recent_search_type_lastSearched",
+            "unique": false,
+            "columnNames": [
+              "type",
+              "lastSearched"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_recent_search_type_lastSearched` ON `${TABLE_NAME}` (`type`, `lastSearched`)"
+          },
+          {
+            "name": "index_recent_search_query_type",
+            "unique": false,
+            "columnNames": [
+              "query",
+              "type"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_recent_search_query_type` ON `${TABLE_NAME}` (`query`, `type`)"
+          }
+        ]
+      },
+      {
+        "tableName": "playback_states",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`type` TEXT, `streamId` TEXT, `videoId` TEXT, `clipId` TEXT, `offlineVideoId` INTEGER, `channelId` TEXT, `channelLogin` TEXT, `channelName` TEXT, `channelImage` TEXT, `gameId` TEXT, `gameSlug` TEXT, `gameName` TEXT, `title` TEXT, `thumbnail` TEXT, `createdAt` TEXT, `viewerCount` INTEGER, `durationSeconds` INTEGER, `videoType` TEXT, `videoOffsetSeconds` INTEGER, `videoCreatedAt` TEXT, `videoAnimatedPreviewURL` TEXT, `videoUrl` TEXT, `position` INTEGER, `paused` INTEGER NOT NULL, `qualities` TEXT, `quality` TEXT, `previousQuality` TEXT, `restoreQuality` INTEGER NOT NULL, `playlistUrl` TEXT, `restorePlaylist` INTEGER NOT NULL, `useCustomProxy` INTEGER NOT NULL, `skipAccessToken` INTEGER NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "streamId",
+            "columnName": "streamId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "videoId",
+            "columnName": "videoId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "clipId",
+            "columnName": "clipId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "offlineVideoId",
+            "columnName": "offlineVideoId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channelId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelLogin",
+            "columnName": "channelLogin",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelName",
+            "columnName": "channelName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelImage",
+            "columnName": "channelImage",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "gameId",
+            "columnName": "gameId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "gameSlug",
+            "columnName": "gameSlug",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "gameName",
+            "columnName": "gameName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "thumbnail",
+            "columnName": "thumbnail",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "viewerCount",
+            "columnName": "viewerCount",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "durationSeconds",
+            "columnName": "durationSeconds",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "videoType",
+            "columnName": "videoType",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "videoOffsetSeconds",
+            "columnName": "videoOffsetSeconds",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "videoCreatedAt",
+            "columnName": "videoCreatedAt",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "videoAnimatedPreviewURL",
+            "columnName": "videoAnimatedPreviewURL",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "videoUrl",
+            "columnName": "videoUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "paused",
+            "columnName": "paused",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "qualities",
+            "columnName": "qualities",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "quality",
+            "columnName": "quality",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "previousQuality",
+            "columnName": "previousQuality",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "restoreQuality",
+            "columnName": "restoreQuality",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playlistUrl",
+            "columnName": "playlistUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "restorePlaylist",
+            "columnName": "restorePlaylist",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "useCustomProxy",
+            "columnName": "useCustomProxy",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "skipAccessToken",
+            "columnName": "skipAccessToken",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "viewing_sessions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `channel_id` TEXT NOT NULL, `channel_login` TEXT, `channel_name` TEXT, `channel_image` TEXT, `content_type` TEXT NOT NULL, `content_id` TEXT, `started_at` INTEGER NOT NULL, `ended_at` INTEGER NOT NULL, `watched_ms` INTEGER NOT NULL, `last_checkpoint_at` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channel_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "channelLogin",
+            "columnName": "channel_login",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelName",
+            "columnName": "channel_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelImage",
+            "columnName": "channel_image",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "contentType",
+            "columnName": "content_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contentId",
+            "columnName": "content_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "startedAt",
+            "columnName": "started_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endedAt",
+            "columnName": "ended_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "watchedMs",
+            "columnName": "watched_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastCheckpointAt",
+            "columnName": "last_checkpoint_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_viewing_sessions_started_at",
+            "unique": false,
+            "columnNames": [
+              "started_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_viewing_sessions_started_at` ON `${TABLE_NAME}` (`started_at`)"
+          },
+          {
+            "name": "index_viewing_sessions_channel_id_started_at",
+            "unique": false,
+            "columnNames": [
+              "channel_id",
+              "started_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_viewing_sessions_channel_id_started_at` ON `${TABLE_NAME}` (`channel_id`, `started_at`)"
+          }
+        ]
+      },
+      {
+        "tableName": "viewing_intervals",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `session_id` INTEGER NOT NULL, `channel_id` TEXT NOT NULL, `channel_login` TEXT, `channel_name` TEXT, `channel_image` TEXT, `category_id` TEXT, `category_name` TEXT, `category_image` TEXT, `content_type` TEXT NOT NULL, `content_id` TEXT, `stream_title` TEXT, `start_at` INTEGER NOT NULL, `end_at` INTEGER NOT NULL, `watched_ms` INTEGER NOT NULL, `last_checkpoint_at` INTEGER NOT NULL, FOREIGN KEY(`session_id`) REFERENCES `viewing_sessions`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "session_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channel_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "channelLogin",
+            "columnName": "channel_login",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelName",
+            "columnName": "channel_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelImage",
+            "columnName": "channel_image",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "categoryId",
+            "columnName": "category_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "categoryName",
+            "columnName": "category_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "categoryImage",
+            "columnName": "category_image",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "contentType",
+            "columnName": "content_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contentId",
+            "columnName": "content_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "streamTitle",
+            "columnName": "stream_title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "startAt",
+            "columnName": "start_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endAt",
+            "columnName": "end_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "watchedMs",
+            "columnName": "watched_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastCheckpointAt",
+            "columnName": "last_checkpoint_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_viewing_intervals_start_at",
+            "unique": false,
+            "columnNames": [
+              "start_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_viewing_intervals_start_at` ON `${TABLE_NAME}` (`start_at`)"
+          },
+          {
+            "name": "index_viewing_intervals_channel_id_start_at",
+            "unique": false,
+            "columnNames": [
+              "channel_id",
+              "start_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_viewing_intervals_channel_id_start_at` ON `${TABLE_NAME}` (`channel_id`, `start_at`)"
+          },
+          {
+            "name": "index_viewing_intervals_category_id_start_at",
+            "unique": false,
+            "columnNames": [
+              "category_id",
+              "start_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_viewing_intervals_category_id_start_at` ON `${TABLE_NAME}` (`category_id`, `start_at`)"
+          },
+          {
+            "name": "index_viewing_intervals_content_type_start_at",
+            "unique": false,
+            "columnNames": [
+              "content_type",
+              "start_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_viewing_intervals_content_type_start_at` ON `${TABLE_NAME}` (`content_type`, `start_at`)"
+          },
+          {
+            "name": "index_viewing_intervals_session_id",
+            "unique": false,
+            "columnNames": [
+              "session_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_viewing_intervals_session_id` ON `${TABLE_NAME}` (`session_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "viewing_sessions",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "session_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "stream_feed_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`feedKey` TEXT NOT NULL, `itemKey` TEXT NOT NULL, `position` INTEGER NOT NULL, `streamId` TEXT, `channelId` TEXT, `channelLogin` TEXT, `channelName` TEXT, `channelImageURL` TEXT, `gameId` TEXT, `gameSlug` TEXT, `gameName` TEXT, `title` TEXT, `thumbnailURL` TEXT, `createdAt` TEXT, `viewerCount` INTEGER, `tags` TEXT, `generation` INTEGER NOT NULL, PRIMARY KEY(`feedKey`, `itemKey`))",
+        "fields": [
+          {
+            "fieldPath": "feedKey",
+            "columnName": "feedKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemKey",
+            "columnName": "itemKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "streamId",
+            "columnName": "streamId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channelId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelLogin",
+            "columnName": "channelLogin",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelName",
+            "columnName": "channelName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelImageURL",
+            "columnName": "channelImageURL",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "gameId",
+            "columnName": "gameId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "gameSlug",
+            "columnName": "gameSlug",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "gameName",
+            "columnName": "gameName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "thumbnailURL",
+            "columnName": "thumbnailURL",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "viewerCount",
+            "columnName": "viewerCount",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "tags",
+            "columnName": "tags",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "generation",
+            "columnName": "generation",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "feedKey",
+            "itemKey"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_stream_feed_items_feedKey_position",
+            "unique": false,
+            "columnNames": [
+              "feedKey",
+              "position"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_stream_feed_items_feedKey_position` ON `${TABLE_NAME}` (`feedKey`, `position`)"
+          },
+          {
+            "name": "index_stream_feed_items_feedKey_channelId",
+            "unique": false,
+            "columnNames": [
+              "feedKey",
+              "channelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_stream_feed_items_feedKey_channelId` ON `${TABLE_NAME}` (`feedKey`, `channelId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "stream_feed_states",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`feedKey` TEXT NOT NULL, `nextCursor` TEXT, `lastSuccessAt` INTEGER, `lastAttemptAt` INTEGER, `lastAccessAt` INTEGER NOT NULL, `failureBackoffUntil` INTEGER, `rateLimitUntil` INTEGER, `nextCursorApi` TEXT, `activeGeneration` INTEGER NOT NULL, `staleTailRetainedAt` INTEGER, PRIMARY KEY(`feedKey`))",
+        "fields": [
+          {
+            "fieldPath": "feedKey",
+            "columnName": "feedKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nextCursor",
+            "columnName": "nextCursor",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastSuccessAt",
+            "columnName": "lastSuccessAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastAttemptAt",
+            "columnName": "lastAttemptAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastAccessAt",
+            "columnName": "lastAccessAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "failureBackoffUntil",
+            "columnName": "failureBackoffUntil",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "rateLimitUntil",
+            "columnName": "rateLimitUntil",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "nextCursorApi",
+            "columnName": "nextCursorApi",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "activeGeneration",
+            "columnName": "activeGeneration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "staleTailRetainedAt",
+            "columnName": "staleTailRetainedAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "feedKey"
+          ]
+        }
+      },
+      {
+        "tableName": "game_feed_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`feedKey` TEXT NOT NULL, `itemKey` TEXT NOT NULL, `position` INTEGER NOT NULL, `gameId` TEXT, `gameSlug` TEXT, `gameName` TEXT, `boxArtURL` TEXT, `viewerCount` INTEGER, `broadcasterCount` INTEGER, `tags` TEXT, `generation` INTEGER NOT NULL, PRIMARY KEY(`feedKey`, `itemKey`))",
+        "fields": [
+          {
+            "fieldPath": "feedKey",
+            "columnName": "feedKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemKey",
+            "columnName": "itemKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gameId",
+            "columnName": "gameId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "gameSlug",
+            "columnName": "gameSlug",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "gameName",
+            "columnName": "gameName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "boxArtURL",
+            "columnName": "boxArtURL",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "viewerCount",
+            "columnName": "viewerCount",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "broadcasterCount",
+            "columnName": "broadcasterCount",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "tags",
+            "columnName": "tags",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "generation",
+            "columnName": "generation",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "feedKey",
+            "itemKey"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_game_feed_items_feedKey_position",
+            "unique": false,
+            "columnNames": [
+              "feedKey",
+              "position"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_game_feed_items_feedKey_position` ON `${TABLE_NAME}` (`feedKey`, `position`)"
+          }
+        ]
+      },
+      {
+        "tableName": "game_feed_states",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`feedKey` TEXT NOT NULL, `nextCursor` TEXT, `lastSuccessAt` INTEGER, `lastAttemptAt` INTEGER, `lastAccessAt` INTEGER NOT NULL, `failureBackoffUntil` INTEGER, `rateLimitUntil` INTEGER, `nextCursorApi` TEXT, `activeGeneration` INTEGER NOT NULL, `staleTailRetainedAt` INTEGER, PRIMARY KEY(`feedKey`))",
+        "fields": [
+          {
+            "fieldPath": "feedKey",
+            "columnName": "feedKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nextCursor",
+            "columnName": "nextCursor",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastSuccessAt",
+            "columnName": "lastSuccessAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastAttemptAt",
+            "columnName": "lastAttemptAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastAccessAt",
+            "columnName": "lastAccessAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "failureBackoffUntil",
+            "columnName": "failureBackoffUntil",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "rateLimitUntil",
+            "columnName": "rateLimitUntil",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "nextCursorApi",
+            "columnName": "nextCursorApi",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "activeGeneration",
+            "columnName": "activeGeneration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "staleTailRetainedAt",
+            "columnName": "staleTailRetainedAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "feedKey"
+          ]
+        }
+      },
+      {
+        "tableName": "metadata_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`kind` TEXT NOT NULL, `cacheKey` TEXT NOT NULL, `payload` TEXT NOT NULL, `updatedAt` INTEGER NOT NULL, `lastAccessAt` INTEGER NOT NULL, PRIMARY KEY(`kind`, `cacheKey`))",
+        "fields": [
+          {
+            "fieldPath": "kind",
+            "columnName": "kind",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cacheKey",
+            "columnName": "cacheKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "payload",
+            "columnName": "payload",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAccessAt",
+            "columnName": "lastAccessAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "kind",
+            "cacheKey"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_metadata_cache_lastAccessAt",
+            "unique": false,
+            "columnNames": [
+              "lastAccessAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_metadata_cache_lastAccessAt` ON `${TABLE_NAME}` (`lastAccessAt`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'e85fd19d9972cb60eeb55d0a35edbebb')"
+    ]
+  }
+}

--- a/app/src/androidTest/java/com/github/andreyasadchy/xtra/db/AppDatabaseMigrationTest.kt
+++ b/app/src/androidTest/java/com/github/andreyasadchy/xtra/db/AppDatabaseMigrationTest.kt
@@ -201,6 +201,7 @@ class AppDatabaseMigrationTest {
                 },
                 GameFeedMigrations.FROM_49,
                 NotificationMigrations.FROM_50,
+                EmoteUsageMigrations.FROM_51,
             )
             .build()
             .also { it.openHelper.writableDatabase }

--- a/app/src/androidTest/java/com/github/andreyasadchy/xtra/db/EmoteUsageMigrationTest.kt
+++ b/app/src/androidTest/java/com/github/andreyasadchy/xtra/db/EmoteUsageMigrationTest.kt
@@ -1,0 +1,168 @@
+package com.github.andreyasadchy.xtra.db
+
+import androidx.room.Room
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatAssetProvider
+import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatCatalogEmote
+import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatEmoteScope
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatAssetKey
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatAssetSpec
+import com.github.andreyasadchy.xtra.ui.chat.v2.recommendations.EmoteUsageKeys
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class EmoteUsageMigrationTest {
+    private val context = InstrumentationRegistry.getInstrumentation().targetContext
+    private val databaseName = "emote-usage-migration.db"
+    private var database: AppDatabase? = null
+
+    @After
+    fun closeDatabase() {
+        database?.close()
+        context.deleteDatabase(databaseName)
+    }
+
+    @Test
+    fun migrationAndConcurrentIncrementWorkOnDeviceSqlite() = runBlocking {
+        val seed = Room.databaseBuilder(context, AppDatabase::class.java, databaseName).build()
+        val seedSqlite = seed.openHelper.writableDatabase
+        seedSqlite.execSQL("DROP INDEX IF EXISTS index_emote_usage_viewer_id_channel_id")
+        seedSqlite.execSQL("DROP INDEX IF EXISTS index_emote_usage_viewer_id_provider_emote_id")
+        seedSqlite.execSQL("DROP TABLE IF EXISTS emote_usage")
+        seedSqlite.execSQL("PRAGMA user_version = 51")
+        seed.close()
+
+        database = Room.databaseBuilder(context, AppDatabase::class.java, databaseName)
+            .addMigrations(EmoteUsageMigrations.FROM_51)
+            .build()
+        val db = checkNotNull(database)
+        val dao = db.emoteUsage()
+        coroutineScope {
+            (0 until 8).map {
+                async(Dispatchers.IO) {
+                    repeat(25) {
+                        dao.increment(
+                            viewerId = "viewer-a",
+                            usageKey = usageKey("viewer-a", "kappa", ChatEmoteScope.GLOBAL, "channel"),
+                            provider = "TWITCH",
+                            emoteId = "kappa",
+                            scope = "GLOBAL",
+                            channelId = null,
+                            count = 1,
+                            lastUsedAt = it.toLong(),
+                        )
+                    }
+                }
+            }.awaitAll()
+        }
+
+        assertEquals(
+            200L,
+            dao.getForChannel("viewer-a", "channel").single().useCount,
+        )
+
+        dao.increment(
+            viewerId = "viewer-a",
+            usageKey = usageKey("viewer-a", "monotonic", ChatEmoteScope.GLOBAL, "channel"),
+            provider = "TWITCH",
+            emoteId = "monotonic",
+            scope = "GLOBAL",
+            channelId = null,
+            count = 1,
+            lastUsedAt = 200,
+        )
+        dao.increment(
+            viewerId = "viewer-a",
+            usageKey = usageKey("viewer-a", "monotonic", ChatEmoteScope.GLOBAL, "channel"),
+            provider = "TWITCH",
+            emoteId = "monotonic",
+            scope = "GLOBAL",
+            channelId = null,
+            count = 1,
+            lastUsedAt = 100,
+        )
+
+        val monotonic = dao.getForChannel("viewer-a", "channel").single { it.emoteId == "monotonic" }
+        assertEquals(2L, monotonic.useCount)
+        assertEquals(200L, monotonic.lastUsedAt)
+        dao.increment(
+            viewerId = "viewer-b",
+            usageKey = usageKey("viewer-b", "kappa", ChatEmoteScope.GLOBAL, "channel"),
+            provider = "TWITCH",
+            emoteId = "kappa",
+            scope = "GLOBAL",
+            channelId = null,
+            count = 3,
+            lastUsedAt = 300,
+        )
+        assertTrue(dao.getForChannel("viewer-b", "channel").single().useCount == 3L)
+        assertEquals(200L, dao.getForChannel("viewer-a", "channel").single { it.emoteId == "monotonic" }.lastUsedAt)
+
+        dao.increment(
+            viewerId = "viewer-a",
+            usageKey = usageKey("viewer-a", "follower", ChatEmoteScope.CHANNEL, "channel-a"),
+            provider = "TWITCH",
+            emoteId = "follower",
+            scope = "CHANNEL",
+            channelId = "channel-a",
+            count = 4,
+            lastUsedAt = 400,
+        )
+        assertEquals(4L, dao.getForChannel("viewer-a", "channel-a").single { it.emoteId == "follower" }.useCount)
+        assertTrue(dao.getForChannel("viewer-a", "channel-b").none { it.emoteId == "follower" })
+        assertTrue(dao.getForChannel("viewer-b", "channel-a").none { it.emoteId == "follower" })
+
+        // A delayed write from viewer A must stay in A's namespace after viewer B has become active.
+        dao.increment(
+            viewerId = "viewer-a",
+            usageKey = usageKey("viewer-a", "kappa", ChatEmoteScope.GLOBAL, "channel"),
+            provider = "TWITCH",
+            emoteId = "kappa",
+            scope = "GLOBAL",
+            channelId = null,
+            count = 1,
+            lastUsedAt = 500,
+        )
+        assertEquals(3L, dao.getForChannel("viewer-b", "channel").single().useCount)
+        assertEquals(201L, dao.getForChannel("viewer-a", "channel").single { it.emoteId == "kappa" }.useCount)
+        assertTrue(tableExists(db.openHelper.readableDatabase, "emote_usage"))
+        assertTrue(indexExists(db.openHelper.readableDatabase, "index_emote_usage_viewer_id_channel_id"))
+        assertTrue(indexExists(db.openHelper.readableDatabase, "index_emote_usage_viewer_id_provider_emote_id"))
+    }
+
+    private fun usageKey(viewerId: String, emoteId: String, scope: ChatEmoteScope, channelId: String): String =
+        EmoteUsageKeys.forEmote(
+            ChatCatalogEmote(
+                name = emoteId,
+                id = emoteId,
+                asset = ChatAssetSpec(ChatAssetKey("https://example.com/$emoteId"), 56, 56, 28),
+                provider = ChatAssetProvider.TWITCH,
+                animated = false,
+                scope = scope,
+            ),
+            channelId = channelId,
+            viewerId = viewerId,
+        )
+
+    private fun tableExists(database: androidx.sqlite.db.SupportSQLiteDatabase, name: String): Boolean =
+        database.query(
+            "SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?",
+            arrayOf(name),
+        ).use { it.moveToFirst() }
+
+    private fun indexExists(database: androidx.sqlite.db.SupportSQLiteDatabase, name: String): Boolean =
+        database.query(
+            "SELECT name FROM sqlite_master WHERE type = 'index' AND name = ?",
+            arrayOf(name),
+        ).use { it.moveToFirst() }
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/XtraModule.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/XtraModule.kt
@@ -15,6 +15,7 @@ import com.github.andreyasadchy.xtra.db.MetadataCacheMigrations
 import com.github.andreyasadchy.xtra.db.StreamFeedMigrations
 import com.github.andreyasadchy.xtra.db.GameFeedMigrations
 import com.github.andreyasadchy.xtra.db.NotificationMigrations
+import com.github.andreyasadchy.xtra.db.EmoteUsageMigrations
 import com.github.andreyasadchy.xtra.db.ViewingStatsMigrations
 import com.github.andreyasadchy.xtra.repository.AuthRepository
 import com.github.andreyasadchy.xtra.repository.BookmarksRepository
@@ -22,6 +23,7 @@ import com.github.andreyasadchy.xtra.repository.ChannelSortRepository
 import com.github.andreyasadchy.xtra.repository.GameSortRepository
 import com.github.andreyasadchy.xtra.repository.GraphQLRepository
 import com.github.andreyasadchy.xtra.repository.DropsRepository
+import com.github.andreyasadchy.xtra.repository.EmoteUsageRepository
 import com.github.andreyasadchy.xtra.repository.HelixRepository
 import com.github.andreyasadchy.xtra.repository.LocalChannelFollowsRepository
 import com.github.andreyasadchy.xtra.repository.LocalGameFollowsRepository
@@ -570,6 +572,7 @@ class XtraModule(application: Application) {
                 },
                 GameFeedMigrations.FROM_49,
                 NotificationMigrations.FROM_50,
+                EmoteUsageMigrations.FROM_51,
             )
         }.build()
 
@@ -662,6 +665,10 @@ class XtraModule(application: Application) {
 
     val playerRepository by lazy {
         PlayerRepository(httpEngine, cronetEngine, cronetExecutor, okHttpClient, json, database.recentEmotes(), database.favoriteEmotes(), database.translatedChannels(), database.videoPositions(), database.videoHistory(), database.playbackStates(), graphQLRepository, helixRepository)
+    }
+
+    val emoteUsageRepository by lazy {
+        EmoteUsageRepository(database.emoteUsage())
     }
 
     val recentSearchesRepository by lazy {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/db/AppDatabase.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/db/AppDatabase.kt
@@ -9,6 +9,7 @@ import com.github.andreyasadchy.xtra.model.ShownNotification
 import com.github.andreyasadchy.xtra.model.VideoPosition
 import com.github.andreyasadchy.xtra.model.VideoHistory
 import com.github.andreyasadchy.xtra.model.chat.FavoriteEmote
+import com.github.andreyasadchy.xtra.model.chat.EmoteUsage
 import com.github.andreyasadchy.xtra.model.chat.RecentEmote
 import com.github.andreyasadchy.xtra.model.stats.ViewingInterval
 import com.github.andreyasadchy.xtra.model.stats.ViewingSession
@@ -27,6 +28,7 @@ import com.github.andreyasadchy.xtra.model.ui.TranslatedChannel
     entities = [
         OfflineVideo::class,
         RecentEmote::class,
+        EmoteUsage::class,
         FavoriteEmote::class,
         VideoPosition::class,
         VideoHistory::class,
@@ -51,18 +53,19 @@ import com.github.andreyasadchy.xtra.model.ui.TranslatedChannel
         GameFeedState::class,
         MetadataCacheEntry::class,
     ],
-    version = 51,
+    version = 52,
     exportSchema = true
 )
 abstract class AppDatabase : RoomDatabase() {
 
     companion object {
-        const val VERSION = 51
-        const val IDENTITY_HASH = "3ddfbd1373044465dbcacbc3383eced6"
+        const val VERSION = 52
+        const val IDENTITY_HASH = "e85fd19d9972cb60eeb55d0a35edbebb"
     }
 
     abstract fun offlineVideos(): OfflineVideosDao
     abstract fun recentEmotes(): RecentEmotesDao
+    abstract fun emoteUsage(): EmoteUsageDao
     abstract fun favoriteEmotes(): FavoriteEmotesDao
     abstract fun videoPositions(): VideoPositionsDao
     abstract fun videoHistory(): VideoHistoryDao

--- a/app/src/main/java/com/github/andreyasadchy/xtra/db/EmoteUsageDao.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/db/EmoteUsageDao.kt
@@ -1,0 +1,60 @@
+package com.github.andreyasadchy.xtra.db
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Transaction
+import com.github.andreyasadchy.xtra.model.chat.EmoteUsage
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface EmoteUsageDao {
+
+    @Query("SELECT * FROM emote_usage WHERE viewer_id = :viewerId AND (channel_id IS NULL OR channel_id = :channelId)")
+    fun observeForChannel(viewerId: String, channelId: String): Flow<List<EmoteUsage>>
+
+    @Query("SELECT * FROM emote_usage WHERE viewer_id = :viewerId AND (channel_id IS NULL OR channel_id = :channelId)")
+    suspend fun getForChannel(viewerId: String, channelId: String): List<EmoteUsage>
+
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    suspend fun insertIfAbsent(usage: EmoteUsage): Long
+
+    @Query(
+        "UPDATE emote_usage SET use_count = use_count + :count, last_used_at = MAX(last_used_at, :lastUsedAt) " +
+                "WHERE viewer_id = :viewerId AND usage_key = :usageKey"
+    )
+    suspend fun incrementExisting(viewerId: String, usageKey: String, count: Long, lastUsedAt: Long)
+
+    /**
+     * INSERT OR IGNORE followed by UPDATE is supported by the SQLite version on API 26.
+     * Room wraps this method in one transaction, so concurrent increments cannot be lost.
+     */
+    @Transaction
+    suspend fun increment(
+        viewerId: String,
+        usageKey: String,
+        provider: String,
+        emoteId: String,
+        scope: String,
+        channelId: String?,
+        count: Long,
+        lastUsedAt: Long,
+    ) {
+        val inserted = insertIfAbsent(
+            EmoteUsage(
+                viewerId = viewerId,
+                usageKey = usageKey,
+                provider = provider,
+                emoteId = emoteId,
+                scope = scope,
+                channelId = channelId,
+                useCount = count,
+                lastUsedAt = lastUsedAt,
+            ),
+        )
+        if (inserted == -1L) {
+            incrementExisting(viewerId, usageKey, count, lastUsedAt)
+        }
+    }
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/db/EmoteUsageMigrations.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/db/EmoteUsageMigrations.kt
@@ -1,0 +1,25 @@
+package com.github.andreyasadchy.xtra.db
+
+import androidx.room.migration.Migration
+
+object EmoteUsageMigrations {
+    val FROM_51 = Migration(51, 52) { db ->
+        db.execSQL(
+            """
+            CREATE TABLE IF NOT EXISTS emote_usage (
+                viewer_id TEXT NOT NULL,
+                usage_key TEXT NOT NULL,
+                provider TEXT NOT NULL,
+                emote_id TEXT NOT NULL,
+                scope TEXT NOT NULL,
+                channel_id TEXT,
+                use_count INTEGER NOT NULL,
+                last_used_at INTEGER NOT NULL,
+                PRIMARY KEY(viewer_id, usage_key)
+            )
+            """.trimIndent(),
+        )
+        db.execSQL("CREATE INDEX IF NOT EXISTS index_emote_usage_viewer_id_channel_id ON emote_usage(viewer_id, channel_id)")
+        db.execSQL("CREATE INDEX IF NOT EXISTS index_emote_usage_viewer_id_provider_emote_id ON emote_usage(viewer_id, provider, emote_id)")
+    }
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/model/chat/EmoteUsage.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/model/chat/EmoteUsage.kt
@@ -1,0 +1,30 @@
+package com.github.andreyasadchy.xtra.model.chat
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.Index
+
+@Entity(
+    tableName = "emote_usage",
+    primaryKeys = ["viewer_id", "usage_key"],
+    indices = [
+        Index(value = ["viewer_id", "channel_id"]),
+        Index(value = ["viewer_id", "provider", "emote_id"]),
+    ],
+)
+data class EmoteUsage(
+    @ColumnInfo(name = "viewer_id")
+    val viewerId: String,
+    @ColumnInfo(name = "usage_key")
+    val usageKey: String,
+    val provider: String,
+    @ColumnInfo(name = "emote_id")
+    val emoteId: String,
+    val scope: String,
+    @ColumnInfo(name = "channel_id")
+    val channelId: String?,
+    @ColumnInfo(name = "use_count")
+    val useCount: Long,
+    @ColumnInfo(name = "last_used_at")
+    val lastUsedAt: Long,
+)

--- a/app/src/main/java/com/github/andreyasadchy/xtra/model/chat/TwitchEmote.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/model/chat/TwitchEmote.kt
@@ -14,4 +14,6 @@ class TwitchEmote(
     var end: Int = 0,
     val setId: String? = null,
     val ownerId: String? = null,
+    /** Twitch's availability restriction from the Helix user-emotes response. */
+    val restrictionType: String? = null,
 )

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/EmoteUsageRepository.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/EmoteUsageRepository.kt
@@ -1,0 +1,44 @@
+package com.github.andreyasadchy.xtra.repository
+
+import com.github.andreyasadchy.xtra.db.EmoteUsageDao
+import com.github.andreyasadchy.xtra.model.chat.EmoteUsage
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.withContext
+
+data class EmoteUsageIncrement(
+    val viewerId: String,
+    val usageKey: String,
+    val provider: String,
+    val emoteId: String,
+    val scope: String,
+    val channelId: String?,
+    val count: Long,
+    val lastUsedAt: Long,
+)
+
+class EmoteUsageRepository(
+    private val dao: EmoteUsageDao,
+) {
+    fun observeForChannel(viewerId: String, channelId: String): Flow<List<EmoteUsage>> =
+        dao.observeForChannel(viewerId, channelId)
+
+    suspend fun loadForChannel(viewerId: String, channelId: String): List<EmoteUsage> = withContext(Dispatchers.IO) {
+        dao.getForChannel(viewerId, channelId)
+    }
+
+    suspend fun record(increments: Collection<EmoteUsageIncrement>) = withContext(Dispatchers.IO) {
+        increments.forEach { increment ->
+            dao.increment(
+                viewerId = increment.viewerId,
+                usageKey = increment.usageKey,
+                provider = increment.provider,
+                emoteId = increment.emoteId,
+                scope = increment.scope,
+                channelId = increment.channelId,
+                count = increment.count,
+                lastUsedAt = increment.lastUsedAt,
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/PlayerRepository.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/PlayerRepository.kt
@@ -2056,6 +2056,15 @@ class PlayerRepository(
     }
 
     suspend fun loadUserEmotes(networkLibrary: String?, helixHeaders: Map<String, String>, gqlHeaders: Map<String, String>, channelId: String?, userId: String?, animateGifs: Boolean): List<TwitchEmote> = withContext(Dispatchers.IO) {
+        if (!helixHeaders[C.HEADER_TOKEN].isNullOrBlank()) {
+            try {
+                return@withContext loadUserEmotesFromHelix(networkLibrary, helixHeaders, userId, channelId, animateGifs)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (_: Exception) {
+                // Keep the existing GraphQL fallbacks for accounts where Helix is unavailable.
+            }
+        }
         try {
             if (gqlHeaders[C.HEADER_TOKEN].isNullOrBlank()) throw Exception()
             val emotes = mutableListOf<TwitchEmote>()
@@ -2077,7 +2086,8 @@ class PlayerRepository(
                                             .replace(Regex("\\[(.).*?]")) { it.groups[1]?.value ?: "" }
                                     } else token,
                                     setId = emote.setID,
-                                    ownerId = set.owner?.id
+                                    ownerId = set.owner?.id,
+                                    restrictionType = emote.type,
                                 )
                             }
                         }
@@ -2102,7 +2112,8 @@ class PlayerRepository(
                                         .replace(Regex("\\[(.).*?]")) { it.groups[1]?.value ?: "" }
                                 } else emote.token,
                                 setId = emote.setID,
-                                ownerId = emote.owner?.id
+                                ownerId = emote.owner?.id,
+                                restrictionType = emote.type?.rawValue,
                             )
                         } else null
                     }
@@ -2143,7 +2154,8 @@ class PlayerRepository(
                                     url4x = url.replaceFirst("{{scale}}", scale3x),
                                     format = if (format == "animated") "gif" else null,
                                     setId = emote.setId,
-                                    ownerId = emote.ownerId
+                                    ownerId = emote.ownerId,
+                                    restrictionType = emote.type,
                                 )
                             }
                         }
@@ -2153,6 +2165,57 @@ class PlayerRepository(
                 emotes
             }
         }
+    }
+
+    private suspend fun loadUserEmotesFromHelix(
+        networkLibrary: String?,
+        helixHeaders: Map<String, String>,
+        userId: String?,
+        channelId: String?,
+        animateGifs: Boolean,
+    ): List<TwitchEmote> {
+        val emotes = mutableListOf<TwitchEmote>()
+        var offset: String? = null
+        do {
+            val response = helixRepository.getUserEmotes(networkLibrary, helixHeaders, userId, channelId, offset)
+            response.data.mapNotNull { emote ->
+                emote.name?.let { name ->
+                    emote.id?.let { id ->
+                        val format = if (animateGifs) {
+                            emote.format?.find { it == "animated" } ?: emote.format?.find { it == "static" }
+                        } else {
+                            emote.format?.find { it == "static" }
+                        } ?: emote.format?.firstOrNull() ?: ""
+                        val theme = emote.theme?.find { it == "dark" } ?: emote.theme?.lastOrNull() ?: ""
+                        val scale1x = emote.scale?.find { it.startsWith("1") } ?: emote.scale?.lastOrNull() ?: ""
+                        val scale2x = emote.scale?.find { it.startsWith("2") } ?: scale1x
+                        val scale3x = emote.scale?.find { it.startsWith("3") } ?: scale2x
+                        val url = response.template
+                            .replaceFirst("{{id}}", id)
+                            .replaceFirst("{{format}}", format)
+                            .replaceFirst("{{theme_mode}}", theme)
+                        TwitchEmote(
+                            id = id,
+                            name = if (emote.type == "smilies") {
+                                name.replace("\\", "").replace("?", "")
+                                    .replace(Regex("\\((.)\\|.\\)")) { it.groups[1]?.value ?: "" }
+                                    .replace(Regex("\\[(.).*?]")) { it.groups[1]?.value ?: "" }
+                            } else name,
+                            url1x = url.replaceFirst("{{scale}}", scale1x),
+                            url2x = url.replaceFirst("{{scale}}", scale2x),
+                            url3x = url.replaceFirst("{{scale}}", scale3x),
+                            url4x = url.replaceFirst("{{scale}}", scale3x),
+                            format = if (format == "animated") "gif" else null,
+                            setId = emote.setId,
+                            ownerId = emote.ownerId,
+                            restrictionType = emote.type,
+                        )
+                    }
+                }
+            }.let { emotes.addAll(it) }
+            offset = response.pagination?.cursor
+        } while (!response.pagination?.cursor.isNullOrBlank())
+        return emotes
     }
 
     suspend fun loadEmotesFromSet(networkLibrary: String?, helixHeaders: Map<String, String>, setIds: List<String>, animateGifs: Boolean): List<TwitchEmote> = withContext(Dispatchers.IO) {
@@ -2187,7 +2250,8 @@ class PlayerRepository(
                         url4x = url.replaceFirst("{{scale}}", scale3x),
                         format = if (format == "animated") "gif" else null,
                         setId = emote.setId,
-                        ownerId = emote.ownerId
+                        ownerId = emote.ownerId,
+                        restrictionType = emote.type,
                     )
                 }
             }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatFragment.kt
@@ -94,6 +94,9 @@ import com.github.andreyasadchy.xtra.ui.chat.v2.session.LiveChatSessionSpec
 import com.github.andreyasadchy.xtra.ui.chat.v2.ui.ChatV2RendererController
 import com.github.andreyasadchy.xtra.ui.chat.v2.ui.ChatViewportState
 import com.github.andreyasadchy.xtra.ui.chat.v2.presentation.ChatPresentationLabels
+import com.github.andreyasadchy.xtra.ui.chat.v2.recommendations.ChatInputToken
+import com.github.andreyasadchy.xtra.ui.chat.v2.recommendations.EmoteRecommendation
+import com.github.andreyasadchy.xtra.ui.chat.v2.recommendations.EmoteRecommendationEngine
 import com.github.andreyasadchy.xtra.ui.main.MainActivity
 import com.github.andreyasadchy.xtra.ui.multiview.MultiviewFragment
 import com.github.andreyasadchy.xtra.ui.player.Media3PlayerFragment
@@ -123,6 +126,7 @@ import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.merge
@@ -131,6 +135,8 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import java.util.Locale
 import kotlin.math.max
 
@@ -410,6 +416,21 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
     }
 
     private var autoCompleteAdapter: AutoCompleteAdapter<Any>? = null
+    private var recommendationAdapter: EmoteRecommendationAdapter? = null
+    private val recommendationEngine = EmoteRecommendationEngine()
+    private val recommendationInput = MutableStateFlow(RecommendationInput())
+    private var currentRecommendations = emptyList<EmoteRecommendation>()
+    private var currentRecommendationQuery: String? = null
+
+    private data class RecommendationInput(
+        val text: String = "",
+        val cursor: Int = 0,
+    )
+
+    private data class RecommendationResult(
+        val query: String,
+        val recommendations: List<EmoteRecommendation>,
+    )
 
     private val backPressedCallback = object : OnBackPressedCallback(true) {
         override fun handleOnBackPressed() {
@@ -1177,6 +1198,17 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
                                 setNotifyOnChange(hasFocus)
                             }
                         }
+                        val app = requireContext().applicationContext as XtraApp
+                        recommendationAdapter = EmoteRecommendationAdapter(
+                            assets = app.xtraModule.chatAssetRepository,
+                            clickListener = ::insertRecommendedEmote,
+                        )
+                        recommendationStrip.layoutManager = LinearLayoutManager(
+                            requireContext(),
+                            LinearLayoutManager.HORIZONTAL,
+                            false,
+                        )
+                        recommendationStrip.adapter = recommendationAdapter
                         if (useChatV2) {
                             viewLifecycleOwner.lifecycleScope.launch {
                                 repeatOnLifecycle(Lifecycle.State.STARTED) {
@@ -1186,13 +1218,54 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
                                                 viewModel.refreshV2AutoCompleteList(catalog)
                                                 autoCompleteAdapter?.notifyDataSetChanged()
                                             }
+                                    }
+                                }
+                            }
+                            viewLifecycleOwner.lifecycleScope.launch {
+                                repeatOnLifecycle(Lifecycle.State.STARTED) {
+                                    combine(
+                                        recommendationInput,
+                                        viewModel.emoteRecommendationCatalogFor(channelId, channelLogin, useV2 = true),
+                                    ) { input, catalog ->
+                                        withContext(Dispatchers.Default) {
+                                            val token = ChatInputToken.aroundCursor(input.text, input.cursor)
+                                            if (token == null) {
+                                                RecommendationResult("", emptyList())
+                                            } else if (catalog == null) {
+                                                RecommendationResult(token.text, emptyList())
+                                            } else {
+                                                RecommendationResult(
+                                                    query = token.text,
+                                                    recommendations = recommendationEngine.recommend(
+                                                        query = token.text,
+                                                        channelId = channelId.orEmpty(),
+                                                        catalog = catalog.catalog,
+                                                        usage = catalog.usage,
+                                                        viewerId = catalog.viewerId,
+                                                    ),
+                                                )
+                                            }
                                         }
+                                    }.collectLatest { result ->
+                                        val queryChanged = currentRecommendationQuery != result.query
+                                        currentRecommendationQuery = result.query
+                                        currentRecommendations = result.recommendations
+                                        if (queryChanged) {
+                                            recommendationStrip.stopScroll()
+                                            recommendationStrip.scrollToPosition(0)
+                                        }
+                                        recommendationAdapter?.submitList(result.recommendations)
+                                        updateRecommendationVisibility()
+                                    }
                                 }
                             }
                         }
                         editText.addTextChangedListener(onTextChanged = { text, _, _, _ ->
+                            updateRecommendationInput()
                             updateComposerButtons()
                         })
+                        editText.onSelectionChangedListener = { _, _ -> updateRecommendationInput() }
+                        updateRecommendationInput()
                         editText.setTokenizer(SpaceTokenizer())
                         editText.setOnKeyListener { _, keyCode, event ->
                             if (event.action == KeyEvent.ACTION_DOWN && keyCode == KeyEvent.KEYCODE_ENTER) {
@@ -1228,6 +1301,7 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
                             isSlidingPlayerLayout = isInSlidingPlayerLayout(binding.root),
                             chatBarVisible = requireContext().prefs().getBoolean(C.KEY_CHAT_BAR_VISIBLE, true),
                         )
+                        updateRecommendationVisibility()
                         editText.isEnabled = enableMessaging && !composerSubmissionInProgress
                         updateSlowModeIndicator(viewModel.slowModeState.value)
                         messageView.addOnLayoutChangeListener { _, _, _, _, _, _, _, _, _ ->
@@ -2236,6 +2310,32 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
         binding.editText.text.append(emote.name).append(' ')
     }
 
+    private fun insertRecommendedEmote(recommendation: EmoteRecommendation) {
+        val current = binding.editText
+        val replacement = ChatInputToken.replace(
+            text = current.text,
+            cursor = current.selectionStart,
+            replacement = recommendation.emote.name,
+        ) ?: return
+        current.setText(replacement.text)
+        current.setSelection(replacement.cursor.coerceIn(0, current.length()))
+        updateRecommendationInput()
+    }
+
+    private fun updateRecommendationInput() {
+        val current = _binding?.editText ?: return
+        recommendationInput.value = RecommendationInput(
+            text = current.text.toString(),
+            cursor = current.selectionStart.coerceAtLeast(0),
+        )
+    }
+
+    private fun updateRecommendationVisibility() {
+        val currentBinding = _binding ?: return
+        currentBinding.recommendationStrip.isVisible = currentRecommendations.isNotEmpty() &&
+                messagingEnabled && currentBinding.messageView.isVisible
+    }
+
     private fun resetMessageComposerAction() {
         replyComposerState = null
         with(binding) {
@@ -2270,6 +2370,7 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
         binding.send.isVisible = !composerSubmissionInProgress && (hasText || canShareWithoutMessage)
         binding.send.isEnabled = !blockedBySlowMode
         binding.clear.isVisible = !composerSubmissionInProgress && hasText
+        updateRecommendationVisibility()
     }
 
     private fun refreshMessagingEnabled() {
@@ -2289,6 +2390,7 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
         )
         binding.editText.isEnabled = messagingEnabled && !composerSubmissionInProgress
         updateComposerButtons()
+        updateRecommendationVisibility()
         updateSlowModeIndicator(viewModel.slowModeState.value)
     }
 
@@ -3370,6 +3472,11 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
         backPressedCallback.remove()
         backPressedCallbackAdded = false
         _binding?.recyclerView?.removeCallbacks(chatAdapterUpdateRunnable)
+        _binding?.recommendationStrip?.adapter = null
+        recommendationAdapter?.submitList(emptyList())
+        recommendationAdapter = null
+        currentRecommendations = emptyList()
+        currentRecommendationQuery = null
         chatAdapterUpdatePosted = false
         chatAdapterReady = false
         chatSnapshotSyncPending = false

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatViewModel.kt
@@ -59,6 +59,7 @@ import com.github.andreyasadchy.xtra.model.ui.ChannelPointRedemptionResult
 import com.github.andreyasadchy.xtra.model.ui.TranslatedChannel
 import com.github.andreyasadchy.xtra.model.ui.TwitchDrop
 import com.github.andreyasadchy.xtra.repository.DropsRepository
+import com.github.andreyasadchy.xtra.repository.EmoteUsageRepository
 import com.github.andreyasadchy.xtra.model.ui.WatchStreak
 import com.github.andreyasadchy.xtra.model.ui.WatchStreakReward
 import com.github.andreyasadchy.xtra.model.ui.WatchStreakShareResult
@@ -106,7 +107,13 @@ import com.github.andreyasadchy.xtra.util.watch.WatchCreditTelemetry
 import kotlinx.coroutines.cancel
 import com.github.andreyasadchy.xtra.util.tokenPrefs
 import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatEmoteScope
+import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatCatalogSnapshot
+import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatAssetProvider
+import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.viewerSendableValues
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatCommunityGift
+import com.github.andreyasadchy.xtra.ui.chat.v2.recommendations.EmoteRecommendationEngine
+import com.github.andreyasadchy.xtra.ui.chat.v2.recommendations.EmoteRecommendationState
+import com.github.andreyasadchy.xtra.ui.chat.v2.recommendations.EmoteUsageKeys
 import com.github.andreyasadchy.xtra.ui.chat.v2.session.ChatSessionManager
 import com.github.andreyasadchy.xtra.ui.chat.v2.transport.TwitchChatEventParser
 import kotlinx.coroutines.CancellationException
@@ -302,12 +309,26 @@ class ChatViewModel(
     private val dropsRepository: DropsRepository,
     private val helixRepository: HelixRepository,
     private val playerRepository: PlayerRepository,
+    private val emoteUsageRepository: EmoteUsageRepository,
     private val trustManager: Lazy<X509TrustManager>,
     private val json: Json,
     private val chatSessionManager: ChatSessionManager,
 ) : ViewModel() {
 
+    private val emoteRecommendationEngine = EmoteRecommendationEngine()
+    private val emoteUsageViewerId = MutableStateFlow(currentEmoteUsageViewerId())
+    private val emoteUsageViewerPreferenceListener =
+        SharedPreferences.OnSharedPreferenceChangeListener { _, key ->
+            if (key == C.USER_ID) {
+                emoteUsageViewerId.value = currentEmoteUsageViewerId()
+            }
+        }
+
+    private fun currentEmoteUsageViewerId(): String =
+        EmoteUsageKeys.normalizeViewerId(applicationContext.tokenPrefs().getString(C.USER_ID, null))
+
     init {
+        applicationContext.tokenPrefs().registerOnSharedPreferenceChangeListener(emoteUsageViewerPreferenceListener)
         viewModelScope.launch {
             chatSessionManager.active
                 .flatMapLatest { active ->
@@ -368,6 +389,36 @@ class ChatViewModel(
         }
     }
 
+    fun emoteRecommendationCatalogFor(
+        expectedChannelId: String?,
+        expectedChannelLogin: String?,
+        useV2: Boolean = true,
+    ): Flow<EmoteRecommendationState?> =
+        if (!useV2) {
+            flowOf(null)
+        } else {
+            chatSessionManager.active.flatMapLatest { active ->
+                val session = active ?: return@flatMapLatest flowOf(null)
+                if (!matchesV2PickerSession(session.spec, expectedChannelId, expectedChannelLogin)) {
+                    flowOf(null)
+                } else {
+                    emoteUsageViewerId.flatMapLatest { viewerId ->
+                        combine(
+                            session.catalog.state,
+                            emoteUsageRepository.observeForChannel(viewerId, session.spec.channelId),
+                        ) { state, usage ->
+                            if (!state.hydrated) null
+                            else EmoteRecommendationState(
+                                viewerId = viewerId,
+                                catalog = emoteRecommendationEngine.catalog(state.snapshot),
+                                usage = usage,
+                            )
+                        }
+                    }
+                }
+            }
+        }
+
     fun thirdPartyPickerStateFor(
         expectedChannelId: String?,
         expectedChannelLogin: String?,
@@ -394,12 +445,10 @@ class ChatViewModel(
         refreshFailed: Boolean,
         retry: () -> Unit,
     ): ThirdPartyPickerState {
-        val emotes = mergePickerThirdPartyEmotes(
-            personalPickerEmotes(),
-            snapshot.sevenTv.effectiveValues().map(::toPickerEmote) +
-                    snapshot.bttv.effectiveValues().map(::toPickerEmote) +
-                    snapshot.ffz.effectiveValues().map(::toPickerEmote),
-        ).filter { it.name?.isNotBlank() == true && isPickerProviderEnabled(it) }
+        val emotes = snapshot.viewerSendableValues()
+            .filter { it.provider != ChatAssetProvider.TWITCH }
+            .map(::toPickerEmote)
+            .filter { it.name?.isNotBlank() == true && isPickerProviderEnabled(it) }
         return if (emotes.isEmpty() && refreshFailed) ThirdPartyPickerState.Error(retry)
         else if (emotes.isEmpty()) ThirdPartyPickerState.Empty
         else ThirdPartyPickerState.Ready(emotes.sortedBy { it.name.orEmpty().lowercase() })
@@ -1039,9 +1088,9 @@ class ChatViewModel(
             val isLoggedIn = !applicationContext.tokenPrefs().getString(C.USERNAME, null).isNullOrBlank() &&
                     (!TwitchApiHelper.getGQLHeaders(applicationContext, true)[C.HEADER_TOKEN].isNullOrBlank() ||
                             !TwitchApiHelper.getHelixHeaders(applicationContext)[C.HEADER_TOKEN].isNullOrBlank())
-            if (isLoggedIn) {
-                // v2 owns third-party loading, but Twitch subscriber/user emotes are still
-                // needed by the Twitch picker and autocomplete.
+            if (isLoggedIn && !useChatV2) {
+                // The v2 catalog owns Twitch user emotes as well as third-party emotes. The
+                // legacy path still loads them through its existing picker pipeline.
                 loadUserEmotes(channelId)
             }
             if (useChatV2) {
@@ -1099,6 +1148,7 @@ class ChatViewModel(
     }
 
     override fun onCleared() {
+        applicationContext.tokenPrefs().unregisterOnSharedPreferenceChangeListener(emoteUsageViewerPreferenceListener)
         releaseSession()
     }
 
@@ -2903,15 +2953,14 @@ class ChatViewModel(
     private fun pickerCatalogFor(
         snapshot: com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatCatalogSnapshot,
     ): PickerCatalog {
-        val thirdParty = mergePickerThirdPartyEmotes(
-            personalPickerEmotes(),
-            snapshot.sevenTv.effectiveValues().map(::toPickerEmote) +
-                    snapshot.bttv.effectiveValues().map(::toPickerEmote) +
-                    snapshot.ffz.effectiveValues().map(::toPickerEmote),
-        ).filter { it.name?.isNotBlank() == true && isPickerProviderEnabled(it) }
+        val sendable = snapshot.viewerSendableValues()
+        val thirdParty = sendable
+            .filter { it.provider != ChatAssetProvider.TWITCH }
+            .map(::toPickerEmote)
+            .filter { it.name?.isNotBlank() == true && isPickerProviderEnabled(it) }
             .sortedBy { it.name.orEmpty().lowercase() }
         return PickerCatalog(
-            twitch = twitchPickerEmotes(),
+            twitch = sendable.filter { it.provider == ChatAssetProvider.TWITCH }.map(::toPickerEmote),
             thirdParty = thirdParty,
         )
     }
@@ -3038,6 +3087,7 @@ class ChatViewModel(
         started = true
         _connectionState.value = ConnectionState.CONNECTING
         val currentIdentityViewerId = applicationContext.tokenPrefs().getString(C.USER_ID, null)
+        emoteUsageViewerId.value = currentEmoteUsageViewerId()
         if (_chatIdentityState.value.loadedChannelId != channelId ||
             _chatIdentityState.value.loadedViewerId != currentIdentityViewerId
         ) {
@@ -5435,6 +5485,15 @@ class ChatViewModel(
         replyId: String? = null,
         onResult: (ChatSendResult) -> Unit = {},
     ) {
+        val usageViewerId = accountId?.trim()?.takeIf(String::isNotEmpty)
+            ?: applicationContext.tokenPrefs().getString(C.USER_ID, null)?.trim()?.takeIf(String::isNotEmpty)
+        val usageSnapshot = chatSessionManager.active.value
+            ?.takeIf { it.spec.channelId == channelId }
+            ?.catalog
+            ?.state
+            ?.value
+            ?.takeIf { it.hydrated }
+            ?.snapshot
         viewModelScope.launch {
             val result = try {
                 if (useApiChatMessages) {
@@ -5495,8 +5554,35 @@ class ChatViewModel(
             } catch (e: Exception) {
                 ChatSendResult.Failure(e.message ?: "Unable to send chat message")
             }
-            if (result is ChatSendResult.Success) recordRecentEmotes(message)
+            if (result is ChatSendResult.Success) {
+                recordRecentEmotes(message)
+                recordEmoteUsage(message, usageViewerId, channelId, usageSnapshot)
+            }
             onResult(result)
+        }
+    }
+
+    private fun recordEmoteUsage(
+        message: CharSequence,
+        viewerId: String?,
+        channelId: String?,
+        snapshot: ChatCatalogSnapshot?,
+    ) {
+        val normalizedViewerId = viewerId?.trim()?.takeIf(String::isNotEmpty) ?: return
+        val active = chatSessionManager.active.value ?: return
+        val targetChannelId = channelId?.takeIf { it == active.spec.channelId } ?: return
+        val usageSnapshot = snapshot ?: return
+        val increments = emoteRecommendationEngine.usageInMessage(
+            snapshot = usageSnapshot,
+            message = message,
+            channelId = targetChannelId,
+            usedAt = System.currentTimeMillis(),
+            viewerId = normalizedViewerId,
+        )
+        if (increments.isNotEmpty()) {
+            viewModelScope.launch {
+                emoteUsageRepository.record(increments)
+            }
         }
     }
 
@@ -6951,7 +7037,7 @@ class ChatViewModel(
             initializer {
                 val application = (this[APPLICATION_KEY] as XtraApp)
                 val xtraModule = application.xtraModule
-                ChatViewModel(application.applicationContext, xtraModule.graphQLRepository, xtraModule.dropsRepository, xtraModule.helixRepository, xtraModule.playerRepository, xtraModule.trustManager, xtraModule.json, xtraModule.chatSessionManager)
+                ChatViewModel(application.applicationContext, xtraModule.graphQLRepository, xtraModule.dropsRepository, xtraModule.helixRepository, xtraModule.playerRepository, xtraModule.emoteUsageRepository, xtraModule.trustManager, xtraModule.json, xtraModule.chatSessionManager)
             }
         }
     }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/EmoteRecommendationAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/EmoteRecommendationAdapter.kt
@@ -1,0 +1,89 @@
+package com.github.andreyasadchy.xtra.ui.chat
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.core.view.isVisible
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.RecyclerView
+import com.github.andreyasadchy.xtra.R
+import com.github.andreyasadchy.xtra.databinding.ItemEmoteRecommendationBinding
+import com.github.andreyasadchy.xtra.ui.chat.v2.assets.ChatAssetRepository
+import com.github.andreyasadchy.xtra.ui.chat.v2.assets.ChatAssetState
+import com.github.andreyasadchy.xtra.ui.chat.v2.recommendations.EmoteRecommendation
+
+class EmoteRecommendationAdapter(
+    private val assets: ChatAssetRepository,
+    private val clickListener: (EmoteRecommendation) -> Unit,
+) : ListAdapter<EmoteRecommendation, EmoteRecommendationAdapter.ViewHolder>(DIFF_CALLBACK) {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder = ViewHolder(
+        ItemEmoteRecommendationBinding.inflate(LayoutInflater.from(parent.context), parent, false),
+    )
+
+    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        holder.bind(getItem(position))
+    }
+
+    override fun onViewRecycled(holder: ViewHolder) {
+        holder.unbind()
+        super.onViewRecycled(holder)
+    }
+
+    inner class ViewHolder(
+        private val binding: ItemEmoteRecommendationBinding,
+    ) : RecyclerView.ViewHolder(binding.root) {
+        private var observedKey: com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatAssetKey? = null
+        private var observer: (() -> Unit)? = null
+
+        fun bind(item: EmoteRecommendation) {
+            unbind()
+            val key = item.emote.asset.key
+            observedKey = key
+            binding.name.text = item.emote.name
+            binding.root.contentDescription = binding.root.context.getString(R.string.use_emote, item.emote.name)
+            binding.root.setOnClickListener { clickListener(item) }
+            binding.image.setImageDrawable(null)
+            binding.image.tag = key
+            val updateImage: () -> Unit = {
+                binding.image.post {
+                    if (binding.image.tag != key) return@post
+                    when (val state = assets.peek(key)) {
+                        is ChatAssetState.Ready -> {
+                            binding.image.setImageDrawable(state.image.newDrawable())
+                            binding.image.isVisible = true
+                        }
+                        else -> {
+                            binding.image.setImageDrawable(null)
+                            binding.image.isVisible = false
+                        }
+                    }
+                }
+            }
+            observer = updateImage
+            assets.observe(key, updateImage)
+            updateImage()
+        }
+
+        fun unbind() {
+            observer?.let { callback -> observedKey?.let { assets.removeObserver(it, callback) } }
+            observer = null
+            observedKey = null
+            binding.image.tag = null
+            binding.image.setImageDrawable(null)
+            binding.root.setOnClickListener(null)
+        }
+    }
+
+    private companion object {
+        val DIFF_CALLBACK = object : DiffUtil.ItemCallback<EmoteRecommendation>() {
+            override fun areItemsTheSame(oldItem: EmoteRecommendation, newItem: EmoteRecommendation): Boolean =
+                oldItem.emote.provider == newItem.emote.provider &&
+                        oldItem.emote.id == newItem.emote.id &&
+                        oldItem.emote.scope == newItem.emote.scope
+
+            override fun areContentsTheSame(oldItem: EmoteRecommendation, newItem: EmoteRecommendation): Boolean =
+                oldItem == newItem
+        }
+    }
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/catalog/ChatCatalogRepository.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/catalog/ChatCatalogRepository.kt
@@ -25,6 +25,8 @@ data class ChatCatalogProviderUpdate<T>(
     val channel: ScopeUpdate<T>? = null,
     /** Only emote providers use this; each entry is keyed by a sender-owned 7TV set ID. */
     val personal: ScopeUpdate<Map<String, Map<String, ChatCatalogEmote>>>? = null,
+    /** Personal 7TV sets belonging to the logged-in viewer, not arbitrary chatters. */
+    val viewerPersonalSetIds: Set<String> = emptySet(),
     /** The channel's actual 7TV emote-set ID, when this is the 7TV provider update. */
     val channelSetId: String? = null,
 ) {
@@ -683,6 +685,7 @@ class ChatCatalogRepository(
         var personal = current.personal
         var pending = current.pending
         var legacyCombined = current.legacyCombined
+        var viewerPersonalSetIds = current.viewerPersonalSetIds
         fun apply(scope: ChatEmoteScope, result: ScopeUpdate<Map<String, ChatCatalogEmote>>?) {
             when (result) {
                 is ScopeUpdate.Success -> {
@@ -701,13 +704,23 @@ class ChatCatalogRepository(
         when (val result = update.personal) {
             // Keep sender sets discovered through the live decoration stream; a later account
             // entitlement refresh only knows about the logged-in viewer's sets.
-            is ScopeUpdate.Success -> personal = personal + result.value
+            is ScopeUpdate.Success -> {
+                personal = personal + result.value
+                viewerPersonalSetIds = update.viewerPersonalSetIds
+            }
             ScopeUpdate.Failed, null -> Unit
         }
         if (update.global is ScopeUpdate.Success && update.channel is ScopeUpdate.Success) {
             legacyCombined = emptyMap()
         }
-        return ScopedEmoteCatalog(global, channel, personal, pending, legacyCombined)
+        return ScopedEmoteCatalog(
+            global = global,
+            channel = channel,
+            personal = personal,
+            pending = pending,
+            legacyCombined = legacyCombined,
+            viewerPersonalSetIds = viewerPersonalSetIds,
+        )
     }
 
     private fun resolveSevenTvPendingChannelSet(snapshot: ChatCatalogSnapshot): ChatCatalogSnapshot {
@@ -749,6 +762,11 @@ class ChatCatalogRepository(
             global = if (ChatEmoteScope.GLOBAL in observed) current.global else cached.global,
             channel = if (ChatEmoteScope.CHANNEL in observed) current.channel else cached.channel,
             personal = if (ChatEmoteScope.PERSONAL in observed) current.personal else cached.personal,
+            viewerPersonalSetIds = if (ChatEmoteScope.PERSONAL in observed) {
+                current.viewerPersonalSetIds
+            } else {
+                cached.viewerPersonalSetIds
+            },
             legacyCombined = when {
                 realScopesAuthoritative -> emptyMap()
                 current.legacyCombined.isNotEmpty() -> current.legacyCombined

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/catalog/ChatCatalogSnapshot.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/catalog/ChatCatalogSnapshot.kt
@@ -20,6 +20,8 @@ data class ScopedEmoteCatalog(
     val pending: Map<String, Map<String, ChatCatalogEmote>> = emptyMap(),
     /** Entries from the pre-v2 combined cache, whose original scope is unknown. */
     val legacyCombined: Map<String, ChatCatalogEmote> = emptyMap(),
+    /** 7TV personal sets actually entitled to the logged-in viewer. */
+    val viewerPersonalSetIds: Set<String> = emptySet(),
 ) {
     private val personalProjection: Map<String, ChatCatalogEmote> by lazy(LazyThreadSafetyMode.PUBLICATION) {
         buildMap {
@@ -48,6 +50,20 @@ data class ScopedEmoteCatalog(
     /** Builds the merged projection once for consumers such as the picker. */
     fun effectiveValues(): Collection<ChatCatalogEmote> =
         (legacyCombined + global + personalProjection + channel).values
+
+    fun viewerPersonalValues(): Collection<ChatCatalogEmote> =
+        viewerPersonalSetIds.asSequence().flatMap { personal[it].orEmpty().values.asSequence() }.toList()
+
+    /**
+     * The viewer-sendable name projection. The first entry wins because chat sends a textual
+     * token, so exposing more than one entry for a name would not preserve the selected ID.
+     */
+    fun sendableValues(): Collection<ChatCatalogEmote> = buildList {
+        addAll(channel.values)
+        addAll(viewerPersonalSetIds.asSequence().sorted().flatMap { personal[it].orEmpty().values.asSequence() })
+        addAll(global.values)
+        addAll(legacyCombined.values)
+    }.distinctBy(ChatCatalogEmote::name)
 
     fun isEmpty(): Boolean =
         global.isEmpty() && channel.isEmpty() && personal.isEmpty() && pending.isEmpty() && legacyCombined.isEmpty()
@@ -158,6 +174,19 @@ data class ChatCatalogSnapshot(
     /** Changes when runtime reward metadata changes without a provider catalog refresh. */
     val channelPointRewardsRevision: Int = 0,
 )
+
+/**
+ * Resolves viewer-sendable textual names in the same order as successful chat sends:
+ * Twitch, then 7TV, BTTV, and FFZ. Each provider projection already applies its
+ * channel > viewer-personal > global > legacy precedence.
+ */
+fun ChatCatalogSnapshot.viewerSendableValues(): List<ChatCatalogEmote> = buildList {
+    addAll(twitch.values)
+    addAll(sevenTv.sendableValues())
+    addAll(bttv.sendableValues())
+    addAll(ffz.sendableValues())
+}.filter { it.name.isNotBlank() && it.id.isNotBlank() }
+    .distinctBy(ChatCatalogEmote::name)
 
 /**
  * The catalog and its local-cache hydration status are one observable state transition.

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/catalog/TwitchChatCatalogSource.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/catalog/TwitchChatCatalogSource.kt
@@ -5,6 +5,7 @@ import android.graphics.Color
 import com.github.andreyasadchy.xtra.model.chat.CheerEmote
 import com.github.andreyasadchy.xtra.model.chat.Emote
 import com.github.andreyasadchy.xtra.model.chat.TwitchBadge
+import com.github.andreyasadchy.xtra.model.chat.TwitchEmote
 import com.github.andreyasadchy.xtra.repository.PlayerRepository
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatAssetKey
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatAssetSpec
@@ -24,6 +25,21 @@ import kotlinx.coroutines.supervisorScope
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+
+/**
+ * Unknown Twitch restriction metadata is kept global: without a reliable restriction we cannot
+ * safely split usage by channel. Helix uses `channelpoints`; GraphQL may expose `CHANNEL_POINTS`.
+ */
+internal fun twitchEmoteScope(restrictionType: String?): ChatEmoteScope {
+    val normalized = restrictionType.orEmpty().replace("_", "").replace("-", "")
+    return if (normalized.equals("follower", ignoreCase = true) ||
+        normalized.equals("channelpoints", ignoreCase = true)
+    ) {
+        ChatEmoteScope.CHANNEL
+    } else {
+        ChatEmoteScope.GLOBAL
+    }
+}
 
 /**
  * Bridges the already-used catalog endpoints into the immutable v2 catalog.
@@ -76,6 +92,23 @@ class TwitchChatCatalogSource(
             val sevenTv = async { if (context.prefs().getBoolean(C.CHAT_ENABLE_STV, true)) loadSevenTv(network, useWebp, force) else emptyProviderUpdate() }
             val bttv = async { if (context.prefs().getBoolean(C.CHAT_ENABLE_BTTV, true)) loadBttv(network, useWebp, force) else emptyProviderUpdate() }
             val ffz = async { if (context.prefs().getBoolean(C.CHAT_ENABLE_FFZ, true)) loadFfz(network, useWebp, force) else emptyProviderUpdate() }
+            val twitch = async<ChatCatalogProviderUpdate<Map<String, ChatCatalogEmote>>?> {
+                try {
+                    val emotes = playerRepository.loadUserEmotes(
+                        network,
+                        helix,
+                        gql,
+                        channelId,
+                        context.tokenPrefs().getString(C.USER_ID, null),
+                        animateGifs = context.prefs().getBoolean(C.ANIMATED_EMOTES, true),
+                    )
+                    ChatCatalogProviderUpdate(twitchEmoteMap(emotes))
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (_: Throwable) {
+                    null
+                }
+            }
             val cheermotes = async { provider {
                 playerRepository.loadCheerEmotes(
                     network,
@@ -87,7 +120,7 @@ class TwitchChatCatalogSource(
                 ).mapNotNull { it.toCatalog() }.toMap()
             } }
             ChatCatalogLoadResult(
-                twitch = ChatCatalogProviderUpdate(emptyMap()),
+                twitch = twitch.await(),
                 sevenTv = sevenTv.await(),
                 bttv = bttv.await(),
                 ffz = ffz.await(),
@@ -143,11 +176,14 @@ class TwitchChatCatalogSource(
                 ).second
             } else emptyList()
         }.map { emoteMap(it, ChatAssetProvider.SEVEN_TV, ChatEmoteScope.CHANNEL) }
+        var viewerPersonalSetIds = emptySet<String>()
         val personal = context.tokenPrefs().getString(C.USER_ID, null)?.let { accountId ->
             // Personal emotes are optional. A missing entitlement query must not make the
             // channel catalog retry forever or hide the global/channel scopes.
             scopeUpdate(channel = true, emptyValue = emptyMap()) {
-                playerRepository.loadSTVEntitledEmoteSetIds(network, accountId).associateWith { setId ->
+                val entitledSetIds = playerRepository.loadSTVEntitledEmoteSetIds(network, accountId)
+                viewerPersonalSetIds = entitledSetIds.toSet()
+                entitledSetIds.associateWith { setId ->
                     try {
                         emoteMap(
                             playerRepository.loadSTVPersonalEmotes(
@@ -169,7 +205,13 @@ class TwitchChatCatalogSource(
                 }
             }
         } ?: ScopeUpdate.Success(emptyMap())
-        return scopedProviderUpdate(global, channel, personal, channelSetId)
+        return scopedProviderUpdate(
+            global = global,
+            channel = channel,
+            personal = personal,
+            channelSetId = channelSetId,
+            viewerPersonalSetIds = viewerPersonalSetIds,
+        )
     }
 
     private suspend fun loadBttv(
@@ -249,6 +291,31 @@ class TwitchChatCatalogSource(
         }
     }
 
+    private fun twitchEmoteMap(emotes: List<TwitchEmote>): Map<String, ChatCatalogEmote> = buildMap {
+        emotes.forEach { emote ->
+            val name = emote.name?.takeIf { it.isNotBlank() } ?: return@forEach
+            val id = emote.id?.takeIf { it.isNotBlank() } ?: return@forEach
+            if (name in this) return@forEach
+            val url = emote.url4x ?: emote.url3x ?: emote.url2x ?: emote.url1x ?: return@forEach
+            put(
+                name,
+                ChatCatalogEmote(
+                    name = name,
+                    id = id,
+                    asset = ChatAssetSpec(
+                        key = ChatAssetKey(url),
+                        sourceWidth = 56,
+                        sourceHeight = 56,
+                        targetHeight = 28,
+                    ),
+                    provider = ChatAssetProvider.TWITCH,
+                    animated = emote.isAnimated,
+                    scope = twitchEmoteScope(emote.restrictionType),
+                ),
+            )
+        }
+    }
+
     private fun TwitchBadge.toCatalog(): ChatCatalogBadge {
         val url = url4x ?: url3x ?: url2x ?: url1x
         return ChatCatalogBadge(
@@ -295,6 +362,7 @@ class TwitchChatCatalogSource(
         channel: ScopeUpdate<Map<String, ChatCatalogEmote>>,
         personal: ScopeUpdate<Map<String, Map<String, ChatCatalogEmote>>>? = null,
         channelSetId: String? = null,
+        viewerPersonalSetIds: Set<String> = emptySet(),
     ): ChatCatalogProviderUpdate<Map<String, ChatCatalogEmote>> {
         val value = buildMap {
             if (global is ScopeUpdate.Success) putAll(global.value)
@@ -306,6 +374,7 @@ class TwitchChatCatalogSource(
             global = global,
             channel = channel,
             personal = personal,
+            viewerPersonalSetIds = viewerPersonalSetIds,
             channelSetId = channelSetId,
         )
     }
@@ -544,7 +613,7 @@ class TwitchChatCatalogCache(
         catalogConfigFingerprint: String?,
         badgeConfigFingerprint: String?,
     ): JSONObject = JSONObject().apply {
-        put("schemaVersion", 6)
+        put("schemaVersion", 7)
         put("revision", snapshot.revision)
         put("provider", "combined")
         put("fetchedAt", fetchedAtMs)
@@ -583,6 +652,9 @@ class TwitchChatCatalogCache(
         put("pending", JSONObject().apply {
             scoped.pending.forEach { (setId, emotes) -> put(setId, encodeEmotes(emotes)) }
         })
+        put("viewerPersonalSetIds", JSONArray().apply {
+            scoped.viewerPersonalSetIds.forEach(::put)
+        })
     }
 
     private fun encodeBadges(map: Map<String, ChatCatalogBadge>) = JSONArray().apply {
@@ -610,7 +682,7 @@ class TwitchChatCatalogCache(
 
     private fun decode(root: JSONObject): ChatCatalogSnapshot {
         val schemaVersion = root.optInt("schemaVersion")
-        check(schemaVersion in 1..6)
+        check(schemaVersion in 1..7)
         fun emoteArray(
             array: JSONArray?,
             legacyCombined: Boolean = false,
@@ -657,6 +729,13 @@ class TwitchChatCatalogCache(
                         buildMap {
                             pending.keys().forEach { setId ->
                                 put(setId, emoteArray(pending.optJSONArray(setId)))
+                            }
+                        }
+                    }.orEmpty(),
+                    viewerPersonalSetIds = value.optJSONArray("viewerPersonalSetIds")?.let { ids ->
+                        buildSet {
+                            for (index in 0 until ids.length()) {
+                                ids.optString(index).takeIf { it.isNotBlank() }?.let(::add)
                             }
                         }
                     }.orEmpty(),

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/recommendations/ChatInputToken.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/recommendations/ChatInputToken.kt
@@ -1,0 +1,47 @@
+package com.github.andreyasadchy.xtra.ui.chat.v2.recommendations
+
+data class CurrentChatToken(
+    val text: String,
+    val start: Int,
+    val end: Int,
+)
+
+data class ChatTokenReplacement(
+    val text: String,
+    val cursor: Int,
+)
+
+object ChatInputToken {
+    fun aroundCursor(text: CharSequence, cursor: Int): CurrentChatToken? {
+        val value = text.toString()
+        if (value.isEmpty()) return null
+        val position = cursor.coerceIn(0, value.length)
+        val tokenPosition = when {
+            position < value.length && !value[position].isWhitespace() -> position
+            position > 0 && !value[position - 1].isWhitespace() -> position - 1
+            else -> return null
+        }
+        var start = tokenPosition
+        var end = tokenPosition + 1
+        while (start > 0 && !value[start - 1].isWhitespace()) start--
+        while (end < value.length && !value[end].isWhitespace()) end++
+        return CurrentChatToken(value.substring(start, end), start, end)
+    }
+
+    fun replace(
+        text: CharSequence,
+        cursor: Int,
+        replacement: String,
+    ): ChatTokenReplacement? {
+        val value = text.toString()
+        val token = aroundCursor(value, cursor) ?: return null
+        val appendSpace = token.end == value.length
+        val suffix = if (appendSpace) " " else ""
+        val next = value.substring(0, token.start) + replacement + suffix + value.substring(token.end)
+        return ChatTokenReplacement(
+            text = next,
+            cursor = token.start + replacement.length + suffix.length,
+        )
+    }
+
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/recommendations/EmoteRecommendationEngine.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/recommendations/EmoteRecommendationEngine.kt
@@ -1,0 +1,130 @@
+package com.github.andreyasadchy.xtra.ui.chat.v2.recommendations
+
+import com.github.andreyasadchy.xtra.model.chat.EmoteUsage
+import com.github.andreyasadchy.xtra.repository.EmoteUsageIncrement
+import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatAssetProvider
+import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatCatalogEmote
+import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatCatalogSnapshot
+import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatEmoteScope
+import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.viewerSendableValues
+import java.util.Locale
+
+data class EmoteRecommendationCatalog(
+    val emotes: List<ChatCatalogEmote>,
+)
+
+data class EmoteRecommendationState(
+    val viewerId: String,
+    val catalog: EmoteRecommendationCatalog,
+    val usage: List<EmoteUsage>,
+)
+
+data class EmoteRecommendation(
+    val emote: ChatCatalogEmote,
+    val match: FuzzyMatch,
+    val useCount: Long,
+    val lastUsedAt: Long,
+)
+
+object EmoteUsageKeys {
+    const val ANONYMOUS_VIEWER_ID = "anonymous"
+
+    fun normalizeViewerId(viewerId: String?): String =
+        viewerId?.trim()?.takeIf(String::isNotEmpty) ?: ANONYMOUS_VIEWER_ID
+
+    fun forEmote(
+        emote: ChatCatalogEmote,
+        channelId: String,
+        viewerId: String,
+    ): String {
+        val usageChannel = channelIdFor(emote.scope, channelId)
+        return listOf(normalizeViewerId(viewerId), emote.provider.name, emote.scope.name, usageChannel.orEmpty(), emote.id)
+            .joinToString("|")
+    }
+
+    fun channelIdFor(scope: ChatEmoteScope, channelId: String): String? = when (scope) {
+        ChatEmoteScope.CHANNEL, ChatEmoteScope.LEGACY_COMBINED -> channelId
+        ChatEmoteScope.GLOBAL, ChatEmoteScope.PERSONAL -> null
+    }
+}
+
+class EmoteRecommendationEngine(
+    private val matcher: FuzzySubsequenceMatcher = FuzzySubsequenceMatcher(),
+    private val maxResults: Int = 10,
+) {
+    fun catalog(snapshot: ChatCatalogSnapshot): EmoteRecommendationCatalog =
+        EmoteRecommendationCatalog(
+            emotes = sendableEmotes(snapshot),
+        )
+
+    fun recommend(
+        query: String,
+        channelId: String,
+        catalog: EmoteRecommendationCatalog,
+        usage: List<EmoteUsage>,
+        viewerId: String,
+    ): List<EmoteRecommendation> {
+        if (query.isBlank()) return emptyList()
+        val usageByKey = usage.associateBy(EmoteUsage::usageKey)
+        return catalog.emotes.mapNotNull { emote ->
+            val match = matcher.match(emote.name, query) ?: return@mapNotNull null
+            val record = usageByKey[EmoteUsageKeys.forEmote(emote, channelId, viewerId)]
+            EmoteRecommendation(
+                emote = emote,
+                match = match,
+                useCount = record?.useCount ?: 0L,
+                lastUsedAt = record?.lastUsedAt ?: 0L,
+            )
+        }.sortedWith(
+            compareByDescending<EmoteRecommendation> { it.useCount }
+                .thenByDescending { it.match.score }
+                .thenByDescending { it.lastUsedAt }
+                .thenBy { it.emote.name.lowercase(Locale.ROOT) }
+                .thenBy { it.emote.provider.name }
+                .thenBy { it.emote.id },
+        ).take(maxResults)
+    }
+
+    /** Resolves exactly what a whitespace-delimited sent token can refer to in this catalog. */
+    fun resolveSentToken(snapshot: ChatCatalogSnapshot, token: String): ChatCatalogEmote? {
+        if (token.isEmpty()) return null
+        return sendableEmotes(snapshot).firstOrNull { it.name == token }
+    }
+
+    fun usageInMessage(
+        snapshot: ChatCatalogSnapshot,
+        message: CharSequence,
+        channelId: String,
+        usedAt: Long,
+        viewerId: String,
+    ): List<EmoteUsageIncrement> {
+        val increments = LinkedHashMap<String, EmoteUsageIncrement>()
+        message.toString().trim().split(WHITESPACE).filter(String::isNotEmpty).forEach { token ->
+            val emote = resolveSentToken(snapshot, token) ?: return@forEach
+            val key = EmoteUsageKeys.forEmote(emote, channelId, viewerId)
+            val previous = increments[key]
+            increments[key] = if (previous == null) {
+                EmoteUsageIncrement(
+                    viewerId = EmoteUsageKeys.normalizeViewerId(viewerId),
+                    usageKey = key,
+                    provider = emote.provider.name,
+                    emoteId = emote.id,
+                    scope = emote.scope.name,
+                    channelId = EmoteUsageKeys.channelIdFor(emote.scope, channelId),
+                    count = 1,
+                    lastUsedAt = usedAt,
+                )
+            } else {
+                previous.copy(count = previous.count + 1, lastUsedAt = usedAt)
+            }
+        }
+        return increments.values.toList()
+    }
+
+    private fun sendableEmotes(snapshot: ChatCatalogSnapshot): List<ChatCatalogEmote> =
+        snapshot.viewerSendableValues()
+
+    private companion object {
+        val WHITESPACE = Regex("\\s+")
+    }
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/recommendations/FuzzySubsequenceMatcher.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/recommendations/FuzzySubsequenceMatcher.kt
@@ -1,0 +1,51 @@
+package com.github.andreyasadchy.xtra.ui.chat.v2.recommendations
+
+import java.util.Locale
+
+data class FuzzyMatch(
+    val score: Int,
+    val matchedIndexes: List<Int>,
+    val startIndex: Int,
+    val span: Int,
+    val gapCount: Int,
+    val consecutivePairs: Int,
+)
+
+/** Matches every query character in order, while allowing gaps in the candidate. */
+class FuzzySubsequenceMatcher {
+    fun match(candidate: String, query: String): FuzzyMatch? {
+        val normalizedCandidate = candidate.lowercase(Locale.ROOT)
+        val normalizedQuery = query.lowercase(Locale.ROOT)
+        if (normalizedCandidate.isEmpty() || normalizedQuery.isEmpty()) return null
+
+        val indexes = ArrayList<Int>(normalizedQuery.length)
+        var candidateIndex = 0
+        normalizedQuery.forEach { queryChar ->
+            val matchIndex = normalizedCandidate.indexOf(queryChar, candidateIndex)
+            if (matchIndex < 0) return null
+            indexes += matchIndex
+            candidateIndex = matchIndex + 1
+        }
+
+        val start = indexes.first()
+        val end = indexes.last()
+        val span = end - start + 1
+        val gapCount = span - indexes.size
+        val consecutivePairs = indexes.zipWithNext().count { (left, right) -> right == left + 1 }
+        val score = when {
+            normalizedCandidate == normalizedQuery -> 1_000_000
+            normalizedCandidate.startsWith(normalizedQuery) -> 800_000
+            normalizedCandidate.contains(normalizedQuery) -> 700_000
+            else -> 400_000
+        } + consecutivePairs * 5_000 - gapCount * 750 - start * 1_000 - span
+
+        return FuzzyMatch(
+            score = score,
+            matchedIndexes = indexes,
+            startIndex = start,
+            span = span,
+            gapCount = gapCount,
+            consecutivePairs = consecutivePairs,
+        )
+    }
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/view/CursorAwareMultiAutoCompleteTextView.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/view/CursorAwareMultiAutoCompleteTextView.kt
@@ -1,0 +1,18 @@
+package com.github.andreyasadchy.xtra.ui.view
+
+import android.content.Context
+import android.util.AttributeSet
+import android.widget.MultiAutoCompleteTextView
+
+class CursorAwareMultiAutoCompleteTextView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = android.R.attr.autoCompleteTextViewStyle,
+) : MultiAutoCompleteTextView(context, attrs, defStyleAttr) {
+    var onSelectionChangedListener: ((selectionStart: Int, selectionEnd: Int) -> Unit)? = null
+
+    override fun onSelectionChanged(selStart: Int, selEnd: Int) {
+        super.onSelectionChanged(selStart, selEnd)
+        onSelectionChangedListener?.invoke(selStart, selEnd)
+    }
+}

--- a/app/src/main/res/layout/fragment_chat.xml
+++ b/app/src/main/res/layout/fragment_chat.xml
@@ -9,6 +9,7 @@
         android:id="@+id/chatContentColumn"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:animateLayoutChanges="true"
         android:orientation="vertical"
         tools:visibility="visible">
 
@@ -201,6 +202,17 @@
                 android:background="?attr/colorOutlineVariant" />
         </LinearLayout>
 
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/recommendationStrip"
+            android:layout_width="match_parent"
+            android:layout_height="56dp"
+            android:background="?attr/colorSurfaceContainer"
+            android:clipToPadding="false"
+            android:paddingStart="4dp"
+            android:paddingEnd="4dp"
+            android:visibility="gone"
+            tools:listitem="@layout/item_emote_recommendation" />
+
         <LinearLayout
             android:id="@+id/messageView"
             android:layout_width="match_parent"
@@ -226,7 +238,7 @@
                 android:visibility="gone"
                 app:tint="?attr/colorControlNormal" />
 
-            <MultiAutoCompleteTextView
+            <com.github.andreyasadchy.xtra.ui.view.CursorAwareMultiAutoCompleteTextView
                 android:id="@+id/editText"
                 android:layout_width="0dp"
                 android:layout_height="match_parent"

--- a/app/src/main/res/layout/item_emote_recommendation.xml
+++ b/app/src/main/res/layout/item_emote_recommendation.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="68dp"
+    android:layout_height="56dp"
+    android:background="?android:selectableItemBackgroundBorderless"
+    android:clickable="true"
+    android:focusable="true"
+    android:gravity="center"
+    android:orientation="vertical"
+    android:paddingStart="4dp"
+    android:paddingEnd="4dp">
+
+    <ImageView
+        android:id="@+id/image"
+        android:layout_width="30dp"
+        android:layout_height="30dp"
+        android:importantForAccessibility="no"
+        android:scaleType="centerInside" />
+
+    <TextView
+        android:id="@+id/name"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:ellipsize="end"
+        android:gravity="center"
+        android:maxLines="1"
+        android:textAppearance="?attr/textAppearanceLabelSmall" />
+</LinearLayout>

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/ChatPickerCatalogTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/ChatPickerCatalogTest.kt
@@ -3,6 +3,14 @@ package com.github.andreyasadchy.xtra.ui.chat
 import com.github.andreyasadchy.xtra.model.chat.Emote
 import com.github.andreyasadchy.xtra.model.chat.FavoriteEmote
 import com.github.andreyasadchy.xtra.model.chat.FavoriteEmoteCatalog
+import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatAssetProvider
+import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatCatalogEmote
+import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatCatalogSnapshot
+import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatEmoteScope
+import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ScopedEmoteCatalog
+import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.viewerSendableValues
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatAssetKey
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatAssetSpec
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -54,6 +62,21 @@ class ChatPickerCatalogTest {
     }
 
     @Test
+    fun v2SendablePickerProjectionKeepsOnlyTheWinningSameNameScope() {
+        val global = catalogEmote("same", "global", ChatEmoteScope.GLOBAL)
+        val channel = catalogEmote("same", "channel", ChatEmoteScope.CHANNEL)
+        val snapshot = ChatCatalogSnapshot(
+            revision = 1,
+            sevenTv = ScopedEmoteCatalog(
+                global = mapOf(global.name to global),
+                channel = mapOf(channel.name to channel),
+            ),
+        )
+
+        assertEquals(listOf(channel), snapshot.viewerSendableValues())
+    }
+
+    @Test
     fun initialPersonalSevenTvHydrationMakesTheRestEmotesPickerEligible() {
         var userSetId: String? = null
         var personalEmoteSets = emptyMap<String, List<Emote>>()
@@ -68,4 +91,13 @@ class ChatPickerCatalogTest {
         assertEquals(Emote.PERSONAL_STV, hydrated.single().source)
         assertEquals("personal-7tv-id", hydrated.single().id)
     }
+
+    private fun catalogEmote(name: String, id: String, scope: ChatEmoteScope) = ChatCatalogEmote(
+        name = name,
+        id = id,
+        asset = ChatAssetSpec(ChatAssetKey(id), 56, 56, 28),
+        provider = ChatAssetProvider.SEVEN_TV,
+        animated = false,
+        scope = scope,
+    )
 }

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatCatalogRepositoryTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatCatalogRepositoryTest.kt
@@ -178,6 +178,46 @@ class ChatCatalogRepositoryTest {
     }
 
     @Test
+    fun failedTwitchRefreshKeepsTheLastGoodCatalog() = runBlocking {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val attempts = AtomicInteger()
+        val kappa = emote("Kappa", ChatAssetProvider.TWITCH)
+        val repository = ChatCatalogRepository(
+            scope = scope,
+            source = ChatCatalogSource {
+                if (attempts.incrementAndGet() == 1) {
+                    ChatCatalogLoadResult(
+                        twitch = ChatCatalogProviderUpdate(mapOf(kappa.name to kappa)),
+                        sevenTv = ChatCatalogProviderUpdate(emptyMap()),
+                        bttv = ChatCatalogProviderUpdate(emptyMap()),
+                        ffz = ChatCatalogProviderUpdate(emptyMap()),
+                        badges = ChatCatalogProviderUpdate(emptyMap()),
+                        cheermotes = ChatCatalogProviderUpdate(emptyMap()),
+                    )
+                } else {
+                    ChatCatalogLoadResult(
+                        twitch = null,
+                        sevenTv = ChatCatalogProviderUpdate(emptyMap()),
+                        bttv = ChatCatalogProviderUpdate(emptyMap()),
+                        ffz = ChatCatalogProviderUpdate(emptyMap()),
+                        badges = ChatCatalogProviderUpdate(emptyMap()),
+                        cheermotes = ChatCatalogProviderUpdate(emptyMap()),
+                    )
+                }
+            },
+        )
+
+        repository.refresh()
+        withTimeout(1_000) { while (repository.state.value.snapshot.twitch.isEmpty()) delay(1) }
+        repository.refresh()
+        withTimeout(1_000) { while (!repository.state.value.refreshFailed) delay(1) }
+
+        assertEquals(mapOf(kappa.name to kappa), repository.state.value.snapshot.twitch)
+        repository.close()
+        scope.cancel()
+    }
+
+    @Test
     fun successfulBadgesAreNotRestartedByAggregateRetries() = runBlocking {
         val releaseFirstAggregate = CompletableDeferred<Unit>()
         val secondAggregateStarted = CompletableDeferred<Unit>()

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/catalog/TwitchChatCatalogSourceTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/catalog/TwitchChatCatalogSourceTest.kt
@@ -1,0 +1,39 @@
+package com.github.andreyasadchy.xtra.ui.chat.v2.catalog
+
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatAssetKey
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatAssetSpec
+import com.github.andreyasadchy.xtra.ui.chat.v2.recommendations.EmoteUsageKeys
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+
+class TwitchChatCatalogSourceTest {
+    @Test
+    fun `subscriber emotes use global usage while follower emotes use channel usage`() {
+        assertEquals(ChatEmoteScope.GLOBAL, twitchEmoteScope("subscriptions"))
+        assertEquals(ChatEmoteScope.CHANNEL, twitchEmoteScope("follower"))
+        assertEquals(ChatEmoteScope.CHANNEL, twitchEmoteScope("channelpoints"))
+        assertEquals(ChatEmoteScope.CHANNEL, twitchEmoteScope("CHANNEL_POINTS"))
+        assertEquals(ChatEmoteScope.GLOBAL, twitchEmoteScope("unknown"))
+
+        val subscriber = emote("Subscriber", "subscriber", twitchEmoteScope("subscriptions"))
+        val follower = emote("Follower", "follower", twitchEmoteScope("follower"))
+        assertEquals(
+            EmoteUsageKeys.forEmote(subscriber, "channel-a", "viewer-a"),
+            EmoteUsageKeys.forEmote(subscriber, "channel-b", "viewer-a"),
+        )
+        assertNotEquals(
+            EmoteUsageKeys.forEmote(follower, "channel-a", "viewer-a"),
+            EmoteUsageKeys.forEmote(follower, "channel-b", "viewer-a"),
+        )
+    }
+
+    private fun emote(name: String, id: String, scope: ChatEmoteScope) = ChatCatalogEmote(
+        name = name,
+        id = id,
+        asset = ChatAssetSpec(ChatAssetKey(id), 56, 56, 28),
+        provider = ChatAssetProvider.TWITCH,
+        animated = false,
+        scope = scope,
+    )
+}

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/recommendations/ChatInputTokenTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/recommendations/ChatInputTokenTest.kt
@@ -1,0 +1,69 @@
+package com.github.andreyasadchy.xtra.ui.chat.v2.recommendations
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ChatInputTokenTest {
+    @Test
+    fun `replaces token at the end and appends one space`() {
+        assertEquals(
+            ChatTokenReplacement("hello Kappa ", 12),
+            ChatInputToken.replace("hello kap", 9, "Kappa"),
+        )
+    }
+
+    @Test
+    fun `replaces token at the beginning and keeps following text`() {
+        assertEquals(
+            ChatTokenReplacement("Kappa wow", 5),
+            ChatInputToken.replace("kap wow", 2, "Kappa"),
+        )
+    }
+
+    @Test
+    fun `replaces token in the middle without duplicate spaces`() {
+        val result = ChatInputToken.replace("that was so kapp wow", 15, "Kappa")
+        assertEquals("that was so Kappa wow", result?.text)
+        assertEquals(17, result?.cursor)
+    }
+
+    @Test
+    fun `punctuation adjacent to prose stays part of the message token`() {
+        val result = ChatInputToken.replace("kap!", 3, "Kappa")
+        assertEquals("Kappa ", result?.text)
+        assertEquals(6, result?.cursor)
+    }
+
+    @Test
+    fun `punctuation emote is a complete whitespace token`() {
+        assertEquals(CurrentChatToken("<3", 6, 8), ChatInputToken.aroundCursor("hello <3", 8))
+        assertEquals(
+            ChatTokenReplacement("hello <3 ", 9),
+            ChatInputToken.replace("hello <", 7, "<3"),
+        )
+        assertEquals(
+            ChatTokenReplacement("say :) now", 6),
+            ChatInputToken.replace("say : now", 5, ":)"),
+        )
+    }
+
+    @Test
+    fun `punctuation and alphanumeric tokens in the middle preserve surrounding prose`() {
+        assertEquals(CurrentChatToken(":)", 6, 8), ChatInputToken.aroundCursor("hello :) wow", 7))
+        assertEquals(
+            ChatTokenReplacement("hello Kappa wow", 11),
+            ChatInputToken.replace("hello kap wow", 9, "Kappa"),
+        )
+        assertEquals(
+            ChatTokenReplacement("hello <3 wow", 8),
+            ChatInputToken.replace("hello < wow", 7, "<3"),
+        )
+    }
+
+    @Test
+    fun `empty and whitespace positions have no token`() {
+        assertNull(ChatInputToken.aroundCursor("", 0))
+        assertNull(ChatInputToken.aroundCursor("   ", 1))
+    }
+}

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/recommendations/EmoteRecommendationEngineTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/recommendations/EmoteRecommendationEngineTest.kt
@@ -1,0 +1,247 @@
+package com.github.andreyasadchy.xtra.ui.chat.v2.recommendations
+
+import com.github.andreyasadchy.xtra.model.chat.EmoteUsage
+import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatAssetProvider
+import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatCatalogEmote
+import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatCatalogSnapshot
+import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatEmoteScope
+import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ScopedEmoteCatalog
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatAssetSpec
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatAssetKey
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class EmoteRecommendationEngineTest {
+    private val engine = EmoteRecommendationEngine(maxResults = 20)
+
+    @Test
+    fun `usage is dominant then quality recency and stable fallback`() {
+        val exact = emote("Kappa", "1")
+        val prefix = emote("KappaPride", "2")
+        val later = emote("Kappaa", "3")
+        val catalog = engine.catalog(ChatCatalogSnapshot(1, twitch = mapOf(exact.name to exact, prefix.name to prefix, later.name to later)))
+        val usage = listOf(
+            usage(exact, "channel", count = 190, lastUsedAt = 1),
+            usage(prefix, "channel", count = 4, lastUsedAt = 100),
+            usage(later, "channel", count = 4, lastUsedAt = 50),
+        )
+
+        val result = engine.recommend("kapp", "channel", catalog, usage, EmoteUsageKeys.ANONYMOUS_VIEWER_ID)
+
+        assertEquals(listOf("Kappa", "KappaPride", "Kappaa"), result.map { it.emote.name })
+    }
+
+    @Test
+    fun `global usage follows channels while channel usage does not`() {
+        val global = emote("Kappa", "global", ChatEmoteScope.GLOBAL)
+        val channel = emote("KappaLocal", "channel", ChatEmoteScope.CHANNEL)
+        assertEquals(
+            EmoteUsageKeys.forEmote(global, "a", "viewer-a"),
+            EmoteUsageKeys.forEmote(global, "b", "viewer-a"),
+        )
+        assertTrue(EmoteUsageKeys.forEmote(channel, "a", "viewer-a") != EmoteUsageKeys.forEmote(channel, "b", "viewer-a"))
+    }
+
+    @Test
+    fun `provider and stable id are part of usage identity`() {
+        val twitch = emote("Same", "same", provider = ChatAssetProvider.TWITCH)
+        val bttv = emote("Same", "same", provider = ChatAssetProvider.BTTV)
+        assertTrue(EmoteUsageKeys.forEmote(twitch, "channel", "viewer-a") != EmoteUsageKeys.forEmote(bttv, "channel", "viewer-a"))
+    }
+
+    @Test
+    fun `equal usage uses recency then deterministic provider ordering`() {
+        val twitch = emote("SameTwitch", "same-twitch", provider = ChatAssetProvider.TWITCH)
+        val bttv = emote("SameBttv", "same-bttv", provider = ChatAssetProvider.BTTV)
+        val catalog = engine.catalog(
+            ChatCatalogSnapshot(1, twitch = mapOf(twitch.name to twitch)).copy(
+                bttv = com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ScopedEmoteCatalog(
+                    global = mapOf(bttv.name to bttv),
+                ),
+            ),
+        )
+        val recentFirst = engine.recommend(
+            "same",
+            "channel",
+            catalog,
+            listOf(usage(twitch, "channel", 1, 10), usage(bttv, "channel", 1, 20)),
+            EmoteUsageKeys.ANONYMOUS_VIEWER_ID,
+        )
+        assertEquals("SameBttv", recentFirst.first().emote.name)
+        assertEquals(ChatAssetProvider.BTTV, recentFirst.first().emote.provider)
+
+        val stable = engine.recommend(
+            "same",
+            "channel",
+            catalog,
+            listOf(usage(twitch, "channel", 1, 20), usage(bttv, "channel", 1, 20)),
+            EmoteUsageKeys.ANONYMOUS_VIEWER_ID,
+        )
+        assertEquals(ChatAssetProvider.BTTV, stable.first().emote.provider)
+    }
+
+    @Test
+    fun `usage recorder counts only exact sendable emotes and occurrences`() {
+        val kappa = emote("Kappa", "1")
+        val snapshot = ChatCatalogSnapshot(1, twitch = mapOf(kappa.name to kappa))
+        val increments = engine.usageInMessage(snapshot, "Kappa Kappa plain", "channel", 10, EmoteUsageKeys.ANONYMOUS_VIEWER_ID)
+
+        assertEquals(1, increments.size)
+        assertEquals(2L, increments.single().count)
+        assertNull(engine.resolveSentToken(snapshot, "plain"))
+    }
+
+    @Test
+    fun `other chatters personal sets are not recommendation or send candidates`() {
+        val viewer = emote("ViewerOnly", "viewer", ChatEmoteScope.PERSONAL, ChatAssetProvider.SEVEN_TV)
+        val chatter = emote("ChatterOnly", "chatter", ChatEmoteScope.PERSONAL, ChatAssetProvider.SEVEN_TV)
+        val snapshot = ChatCatalogSnapshot(
+            revision = 1,
+            sevenTv = ScopedEmoteCatalog(
+                personal = mapOf(
+                    "viewer-set" to mapOf(viewer.name to viewer),
+                    "chatter-set" to mapOf(chatter.name to chatter),
+                ),
+                viewerPersonalSetIds = setOf("viewer-set"),
+            ),
+        )
+
+        val catalog = engine.catalog(snapshot)
+        assertEquals(listOf("ViewerOnly"), catalog.emotes.map { it.name })
+        assertEquals(viewer, engine.resolveSentToken(snapshot, "ViewerOnly"))
+        assertNull(engine.resolveSentToken(snapshot, "ChatterOnly"))
+        assertEquals(listOf(viewer.id), engine.usageInMessage(snapshot, "ViewerOnly ChatterOnly", "channel", 10, EmoteUsageKeys.ANONYMOUS_VIEWER_ID).map { it.emoteId })
+    }
+
+    @Test
+    fun `same name has one recommendation and usage follows send resolution`() {
+        val twitch = emote("Same", "twitch-same", provider = ChatAssetProvider.TWITCH)
+        val bttv = emote("Same", "bttv-same", provider = ChatAssetProvider.BTTV)
+        val snapshot = ChatCatalogSnapshot(
+            revision = 1,
+            twitch = mapOf(twitch.name to twitch),
+            bttv = ScopedEmoteCatalog(global = mapOf(bttv.name to bttv)),
+        )
+
+        val catalog = engine.catalog(snapshot)
+        assertEquals(listOf(twitch), catalog.emotes)
+        assertEquals(twitch, engine.resolveSentToken(snapshot, "Same"))
+        assertEquals(listOf(twitch.id), engine.usageInMessage(snapshot, "Same", "channel", 10, EmoteUsageKeys.ANONYMOUS_VIEWER_ID).map { it.emoteId })
+    }
+
+    @Test
+    fun `channel name collision wins within one provider projection`() {
+        val global = emote("Same", "global", ChatEmoteScope.GLOBAL, ChatAssetProvider.SEVEN_TV)
+        val channel = emote("Same", "channel", ChatEmoteScope.CHANNEL, ChatAssetProvider.SEVEN_TV)
+        val snapshot = ChatCatalogSnapshot(
+            revision = 1,
+            sevenTv = ScopedEmoteCatalog(
+                global = mapOf(global.name to global),
+                channel = mapOf(channel.name to channel),
+            ),
+        )
+
+        assertEquals(listOf(channel), snapshot.sevenTv.sendableValues().toList())
+        assertEquals(listOf(channel), engine.catalog(snapshot).emotes)
+        assertEquals(channel, engine.resolveSentToken(snapshot, "Same"))
+        assertEquals(listOf(channel.id), engine.usageInMessage(snapshot, "Same", "channel", 10, EmoteUsageKeys.ANONYMOUS_VIEWER_ID).map { it.emoteId })
+    }
+
+    @Test
+    fun `usage identity is viewer scoped and switching back restores the original history`() {
+        val emote = emote("Kappa", "kappa")
+        val aKey = EmoteUsageKeys.forEmote(emote, "channel", viewerId = "viewer-a")
+        val bKey = EmoteUsageKeys.forEmote(emote, "channel", viewerId = "viewer-b")
+        assertTrue(aKey != bKey)
+
+        val catalog = engine.catalog(ChatCatalogSnapshot(1, twitch = mapOf(emote.name to emote)))
+        val aUsage = listOf(usage(emote, "channel", 7, 10, viewerId = "viewer-a"))
+        val bUsage = listOf(usage(emote, "channel", 2, 20, viewerId = "viewer-b"))
+
+        assertEquals(7L, engine.recommend("kap", "channel", catalog, aUsage, "viewer-a").single().useCount)
+        assertEquals(2L, engine.recommend("kap", "channel", catalog, bUsage, "viewer-b").single().useCount)
+        assertEquals(7L, engine.recommend("kap", "channel", catalog, aUsage, "viewer-a").single().useCount)
+        assertEquals("viewer-a", engine.usageInMessage(
+            ChatCatalogSnapshot(1, twitch = mapOf(emote.name to emote)),
+            "Kappa",
+            "channel",
+            30,
+            viewerId = "viewer-a",
+        ).single().viewerId)
+    }
+
+    @Test
+    fun `recommendation state carries its viewer namespace through ranking`() {
+        val kappa = emote("Kappa", "kappa")
+        val catalog = engine.catalog(ChatCatalogSnapshot(1, twitch = mapOf(kappa.name to kappa)))
+        val stateA = EmoteRecommendationState(
+            viewerId = "viewer-a",
+            catalog = catalog,
+            usage = listOf(usage(kappa, "channel", 9, 100, viewerId = "viewer-a")),
+        )
+        val stateB = EmoteRecommendationState(
+            viewerId = "viewer-b",
+            catalog = catalog,
+            usage = emptyList(),
+        )
+
+        fun rank(state: EmoteRecommendationState) = engine.recommend(
+            query = "kap",
+            channelId = "channel",
+            catalog = state.catalog,
+            usage = state.usage,
+            viewerId = state.viewerId,
+        )
+
+        assertEquals(9L, rank(stateA).single().useCount)
+        assertEquals(0L, rank(stateB).single().useCount)
+        assertEquals(9L, rank(stateA).single().useCount)
+    }
+
+    @Test
+    fun `global and channel usage remain scoped correctly within one viewer`() {
+        val global = emote("Global", "global", ChatEmoteScope.GLOBAL)
+        val channel = emote("Channel", "channel", ChatEmoteScope.CHANNEL)
+        assertEquals(
+            EmoteUsageKeys.forEmote(global, "a", "viewer-a"),
+            EmoteUsageKeys.forEmote(global, "b", "viewer-a"),
+        )
+        assertTrue(
+            EmoteUsageKeys.forEmote(channel, "a", "viewer-a") !=
+                    EmoteUsageKeys.forEmote(channel, "b", "viewer-a"),
+        )
+    }
+
+    private fun emote(
+        name: String,
+        id: String,
+        scope: ChatEmoteScope = ChatEmoteScope.GLOBAL,
+        provider: ChatAssetProvider = ChatAssetProvider.TWITCH,
+    ) = ChatCatalogEmote(
+        name = name,
+        id = id,
+        asset = ChatAssetSpec(ChatAssetKey("https://example.com/$id"), 56, 56, 28),
+        provider = provider,
+        animated = false,
+        scope = scope,
+    )
+
+    private fun usage(
+        emote: ChatCatalogEmote,
+        channelId: String,
+        count: Long,
+        lastUsedAt: Long,
+        viewerId: String = EmoteUsageKeys.ANONYMOUS_VIEWER_ID,
+    ) = EmoteUsage(
+        viewerId = viewerId,
+        usageKey = EmoteUsageKeys.forEmote(emote, channelId, viewerId),
+        provider = emote.provider.name,
+        emoteId = emote.id,
+        scope = emote.scope.name,
+        channelId = EmoteUsageKeys.channelIdFor(emote.scope, channelId),
+        useCount = count,
+        lastUsedAt = lastUsedAt,
+    )
+}

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/recommendations/FuzzySubsequenceMatcherTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/recommendations/FuzzySubsequenceMatcherTest.kt
@@ -1,0 +1,34 @@
+package com.github.andreyasadchy.xtra.ui.chat.v2.recommendations
+
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class FuzzySubsequenceMatcherTest {
+    private val matcher = FuzzySubsequenceMatcher()
+
+    @Test
+    fun `matches ordered subsequences case insensitively`() {
+        listOf("g", "ga", "gar", "gare", "gr", "ge", "gren", "aen", "gn").forEach { query ->
+            assertNotNull(query, matcher.match("Garen", query))
+        }
+        assertNull(matcher.match("Garen", "rg"))
+        assertNull(matcher.match("Garen", "xz"))
+        assertNotNull(matcher.match("Garen", "GA"))
+    }
+
+    @Test
+    fun `quality prefers exact prefix contiguous compact and loose matches`() {
+        val exact = matcher.match("Garen", "Garen")!!.score
+        val prefix = matcher.match("Garen", "Gar")!!.score
+        val contiguous = matcher.match("Garen", "are")!!.score
+        val compact = matcher.match("Garen", "gren")!!.score
+        val loose = matcher.match("Garen", "gn")!!.score
+
+        assertTrue(exact > prefix)
+        assertTrue(prefix > contiguous)
+        assertTrue(contiguous > compact)
+        assertTrue(compact > loose)
+    }
+}


### PR DESCRIPTION
## Summary

- Adds fuzzy subsequence emote suggestions directly above the chat input.
- Learns successful sends with global and channel-specific Room-backed usage counts.
- Ranks by usage first, then match quality, recency, and deterministic provider/name order.
- Replaces only the token under the cursor and keeps existing autocomplete and picker behavior.

## Verification

- Focused matcher, ranking, usage-scope, repeated-send, and token-replacement tests passed.
- Existing chat/emote/catalog tests passed.
- :app:assembleDebug passed.
- git diff --check passed.
- Debug APK installed and launched on xtra-api35; live chat interaction smoke steps were not run because the emulator had no logged-in chat session.
