### PR TITLE
Reduce auth and notification wakeups

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/XtraApp.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/XtraApp.kt
@@ -34,6 +34,8 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.filter
 import okio.Buffer
 import okio.buffer
 import okio.source
@@ -80,6 +82,16 @@ class XtraApp : Application(), SingletonImageLoader.Factory {
         xtraModule = XtraModule(this)
         reconcilePendingAccountScopedState()
         xtraModule.authSessionMaintainer.start(applicationScope)
+        applicationScope.launch {
+            xtraModule.authSessionMaintainer.authenticationChangeGeneration
+                .filter { it > 0L }
+                .collect {
+                    LiveNotificationScheduler.requestImmediateReconciliation(
+                        this@XtraApp,
+                        reason = "authentication_changed",
+                    )
+                }
+        }
         registerActivityLifecycleCallbacks(object : ActivityLifecycleCallbacks {
             override fun onActivityStarted(activity: android.app.Activity) {
                 val wasInBackground = startedActivityCount == 0

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/auth/AuthSessionMaintainer.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/auth/AuthSessionMaintainer.kt
@@ -2,7 +2,9 @@ package com.github.andreyasadchy.xtra.repository.auth
 
 import android.content.Context
 import android.net.ConnectivityManager
+import android.net.Network
 import android.net.NetworkCapabilities
+import android.net.NetworkRequest
 import com.github.andreyasadchy.xtra.model.id.ValidationResponse
 import com.github.andreyasadchy.xtra.repository.AuthRepository
 import com.github.andreyasadchy.xtra.util.C
@@ -13,15 +15,55 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.delay
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withTimeoutOrNull
 import java.io.IOException
+
+internal const val AUTH_SESSION_VALIDATION_INTERVAL_MILLIS = 60 * 60 * 1_000L
+internal const val AUTH_SESSION_TRANSIENT_RETRY_DELAY_MILLIS = 5 * 60 * 1_000L
+internal const val AUTH_SESSION_NETWORK_RETRY_DELAY_MILLIS = 5 * 60 * 1_000L
+
+/** Returns null when only an explicit wake can make the next validation meaningful. */
+internal fun authSessionValidationWaitMs(
+    sessionPresent: Boolean,
+    webTokenPresent: Boolean,
+    maintenanceState: AuthSessionMaintenanceState,
+    validatedNetwork: Boolean,
+    validationChecked: Boolean,
+    lastValidatedAtMs: Long,
+    nowMs: Long,
+    transientRetryDeadlineMs: Long? = null,
+    networkWakeAvailable: Boolean = true,
+): Long? {
+    if (!sessionPresent || !webTokenPresent ||
+        maintenanceState == AuthSessionMaintenanceState.REAUTHORIZATION_REQUIRED
+    ) return null
+    if (!validatedNetwork) {
+        return if (networkWakeAvailable) null else AUTH_SESSION_NETWORK_RETRY_DELAY_MILLIS
+    }
+    transientRetryDeadlineMs?.let { return (it - nowMs).coerceAtLeast(0L) }
+    if (!validationChecked || lastValidatedAtMs <= 0L) return 0L
+    return (lastValidatedAtMs + AUTH_SESSION_VALIDATION_INTERVAL_MILLIS - nowMs)
+        .coerceAtLeast(0L)
+}
+
+internal class AuthSessionChangeSignal {
+    private val _generation = MutableStateFlow(0L)
+    val generation: StateFlow<Long> = _generation.asStateFlow()
+
+    fun signal() {
+        _generation.update { it + 1L }
+    }
+}
 
 /** Public lifecycle states retained for the existing foreground/background consumers. */
 enum class AuthSessionMaintenanceState {
@@ -49,30 +91,115 @@ class AuthSessionMaintainer(
     private val validationMutex = Mutex()
     private val _state = MutableStateFlow(AuthSessionMaintenanceState.IDLE)
     private val _authHealth = MutableStateFlow(AuthHealth.SIGNED_OUT)
+    private val authenticationChangeSignal = AuthSessionChangeSignal()
+    private val wakeSignal = Channel<Unit>(Channel.CONFLATED)
     private var promptedReauthorization = false
     private var schedulerJob: Job? = null
+    private var networkCallback: ConnectivityManager.NetworkCallback? = null
+    @Volatile
+    private var networkCallbackRegistered = false
 
     val state: StateFlow<AuthSessionMaintenanceState> = _state.asStateFlow()
     val authHealth: StateFlow<AuthHealth> = _authHealth.asStateFlow()
+    val authenticationChangeGeneration: StateFlow<Long> = authenticationChangeSignal.generation
 
     init {
-        onAuthenticationStateChanged()
+        refreshAuthenticationState()
     }
 
     @Synchronized
     fun start(scope: CoroutineScope) {
         if (schedulerJob?.isActive == true) return
+        registerNetworkCallback()
         schedulerJob = scope.launch(Dispatchers.IO) {
-            while (isActive) {
-                try {
-                    validateIfDue()
-                } catch (error: CancellationException) {
-                    throw error
-                } catch (_: Exception) {
-                    publish(AuthSessionMaintenanceState.TRANSIENT_FAILURE, AuthHealth.UNKNOWN)
-                }
-                delay(VALIDATION_CHECK_INTERVAL_MILLIS)
+            schedulerLoop()
+        }.also { job ->
+            job.invokeOnCompletion { unregisterNetworkCallback() }
+        }
+    }
+
+    private suspend fun schedulerLoop() {
+        var transientRetryDeadlineMs: Long? = null
+        while (currentCoroutineContext().isActive) {
+            val tokenPrefs = applicationContext.tokenPrefs()
+            val sessionPresent = AuthSessionStore(applicationContext.prefs(), tokenPrefs).read() != null
+            val waitMs = authSessionValidationWaitMs(
+                sessionPresent = sessionPresent,
+                webTokenPresent = !tokenPrefs.getString(C.GQL_TOKEN_WEB, null).isNullOrBlank(),
+                maintenanceState = _state.value,
+                validatedNetwork = hasValidatedNetwork(),
+                validationChecked = TwitchApiHelper.checkedValidation,
+                lastValidatedAtMs = tokenPrefs.getLong(C.TOKEN_VALIDATED_AT, 0L),
+                nowMs = nowMillis(),
+                transientRetryDeadlineMs = transientRetryDeadlineMs,
+                networkWakeAvailable = networkCallbackRegistered,
+            )
+            if (waitMs == null) {
+                wakeSignal.receive()
+                transientRetryDeadlineMs = null
+                continue
             }
+            if (waitMs > 0L) {
+                val woke = withTimeoutOrNull(waitMs) { wakeSignal.receive() }
+                if (woke != null) transientRetryDeadlineMs = null
+                continue
+            }
+            val result = try {
+                validateIfDue()
+            } catch (error: CancellationException) {
+                throw error
+            } catch (_: Exception) {
+                publish(AuthSessionMaintenanceState.TRANSIENT_FAILURE, AuthHealth.UNKNOWN)
+                AuthSessionMaintenanceState.TRANSIENT_FAILURE
+            }
+            transientRetryDeadlineMs = if (result == AuthSessionMaintenanceState.TRANSIENT_FAILURE) {
+                nowMillis() + AUTH_SESSION_TRANSIENT_RETRY_DELAY_MILLIS
+            } else null
+        }
+    }
+
+    private fun registerNetworkCallback() {
+        val connectivityManager = applicationContext
+            .getSystemService(Context.CONNECTIVITY_SERVICE) as? ConnectivityManager ?: return
+        val callback = object : ConnectivityManager.NetworkCallback() {
+            override fun onAvailable(network: Network) {
+                wakeSignal.trySend(Unit)
+            }
+
+            override fun onCapabilitiesChanged(network: Network, capabilities: NetworkCapabilities) {
+                if (capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)) {
+                    wakeSignal.trySend(Unit)
+                }
+            }
+
+            override fun onLost(network: Network) {
+                wakeSignal.trySend(Unit)
+            }
+        }
+        networkCallback = callback
+        runCatching {
+            connectivityManager.registerNetworkCallback(
+                NetworkRequest.Builder()
+                    .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+                    .addCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
+                    .build(),
+                callback,
+            )
+        }.onSuccess {
+            networkCallbackRegistered = true
+        }.onFailure {
+            networkCallback = null
+            networkCallbackRegistered = false
+        }
+    }
+
+    private fun unregisterNetworkCallback() {
+        val callback = networkCallback ?: return
+        networkCallback = null
+        networkCallbackRegistered = false
+        runCatching {
+            (applicationContext.getSystemService(Context.CONNECTIVITY_SERVICE) as? ConnectivityManager)
+                ?.unregisterNetworkCallback(callback)
         }
     }
 
@@ -117,6 +244,12 @@ class AuthSessionMaintainer(
 
     /** Refreshes the in-memory state after the Gecko manager commits a web session. */
     fun onAuthenticationStateChanged() {
+        refreshAuthenticationState()
+        authenticationChangeSignal.signal()
+        wakeSignal.trySend(Unit)
+    }
+
+    private fun refreshAuthenticationState() {
         val sessionStore = AuthSessionStore(applicationContext.prefs(), applicationContext.tokenPrefs())
         promptedReauthorization = false
         if (sessionStore.read() == null) {
@@ -184,7 +317,4 @@ class AuthSessionMaintainer(
         TRANSIENT,
     }
 
-    private companion object {
-        const val VALIDATION_CHECK_INTERVAL_MILLIS = 60_000L
-    }
 }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/channel/ChannelPagerViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/channel/ChannelPagerViewModel.kt
@@ -27,6 +27,7 @@ import com.github.andreyasadchy.xtra.repository.OfflineVideosRepository
 import com.github.andreyasadchy.xtra.repository.resolveChannelFallback
 import com.github.andreyasadchy.xtra.repository.streamfeed.StreamFeedRefreshCoordinator
 import com.github.andreyasadchy.xtra.ui.common.LoadRequestCoalescer
+import com.github.andreyasadchy.xtra.ui.main.LiveNotificationScheduler
 import com.github.andreyasadchy.xtra.util.C
 import com.github.andreyasadchy.xtra.util.NetworkUtils
 import com.github.andreyasadchy.xtra.util.NetworkUtils.executeAsync
@@ -254,7 +255,7 @@ class ChannelPagerViewModel(
                         if (!errorMessage.isNullOrBlank()) {
                             notifications.value = Pair(true, errorMessage)
                         } else {
-                            notificationsRepository.saveUser(NotificationUser(channelId))
+                            saveNotificationUser(channelId)
                             _notificationsEnabled.value = true
                             notifications.value = Pair(true, errorMessage)
                             if (notificationsEnabled) {
@@ -266,7 +267,7 @@ class ChannelPagerViewModel(
                             }
                         }
                     } else {
-                        notificationsRepository.saveUser(NotificationUser(channelId))
+                        saveNotificationUser(channelId)
                         _notificationsEnabled.value = true
                         notifications.value = Pair(true, null)
                         if (notificationsEnabled) {
@@ -297,12 +298,12 @@ class ChannelPagerViewModel(
                         if (!errorMessage.isNullOrBlank()) {
                             notifications.value = Pair(false, errorMessage)
                         } else {
-                            notificationsRepository.deleteUser(NotificationUser(channelId))
+                            deleteNotificationUser(channelId)
                             _notificationsEnabled.value = false
                             notifications.value = Pair(false, errorMessage)
                         }
                     } else {
-                        notificationsRepository.deleteUser(NotificationUser(channelId))
+                        deleteNotificationUser(channelId)
                         _notificationsEnabled.value = false
                         notifications.value = Pair(false, null)
                     }
@@ -369,10 +370,10 @@ class ChannelPagerViewModel(
                             _isFollowing.value = true
                             follow.value = Pair(true, null)
                             if (!disableNotifications) {
-                                notificationsRepository.saveUser(NotificationUser(channelId))
+                                saveNotificationUser(channelId)
                                 _notificationsEnabled.value = true
                             } else {
-                                notificationsRepository.deleteUser(NotificationUser(channelId))
+                                deleteNotificationUser(channelId)
                             }
                             if (liveNotificationsEnabled) {
                                 _stream.value?.createdAt.takeUnless { it.isNullOrBlank() }?.let {
@@ -388,7 +389,7 @@ class ChannelPagerViewModel(
                         _isFollowing.value = true
                         follow.value = Pair(true, null)
                         if (!disableNotifications) {
-                            notificationsRepository.saveUser(NotificationUser(channelId))
+                            saveNotificationUser(channelId)
                             _notificationsEnabled.value = true
                         }
                         if (liveNotificationsEnabled) {
@@ -422,14 +423,14 @@ class ChannelPagerViewModel(
                             _isFollowing.value = false
                             follow.value = Pair(false, null)
                             _notificationsEnabled.value = false
-                            notificationsRepository.deleteUser(NotificationUser(channelId))
+                            deleteNotificationUser(channelId)
                             streamFeedRefreshCoordinator.invalidateFollowedFeeds()
                         }
                     } else {
                         localChannelFollowsRepository.getById(channelId)?.let { localChannelFollowsRepository.delete(it) }
                         _isFollowing.value = false
                         follow.value = Pair(false, null)
-                        notificationsRepository.deleteUser(NotificationUser(channelId))
+                        deleteNotificationUser(channelId)
                         _notificationsEnabled.value = false
                     }
                 }
@@ -440,6 +441,22 @@ class ChannelPagerViewModel(
             } catch (e: Exception) {
             }
         }
+    }
+
+    private suspend fun saveNotificationUser(channelId: String) {
+        notificationsRepository.saveUser(NotificationUser(channelId))
+        LiveNotificationScheduler.requestImmediateReconciliation(
+            XtraApp.INSTANCE,
+            reason = "notification_users_changed",
+        )
+    }
+
+    private suspend fun deleteNotificationUser(channelId: String) {
+        notificationsRepository.deleteUser(NotificationUser(channelId))
+        LiveNotificationScheduler.requestImmediateReconciliation(
+            XtraApp.INSTANCE,
+            reason = "notification_users_changed",
+        )
     }
 
     fun updateLocalUser(networkLibrary: String?, filesDir: String, user: User) {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/main/LiveNotificationMonitor.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/main/LiveNotificationMonitor.kt
@@ -15,6 +15,9 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import androidx.core.content.edit
 
+internal const val LIVE_NOTIFICATION_FOLLOW_SYNC_INTERVAL_MS = 6 * 60 * 60 * 1000L
+internal const val LIVE_NOTIFICATION_FOLLOW_SYNC_RETRY_INTERVAL_MS = 30 * 60 * 1000L
+
 /**
  * Runs one notification reconciliation against the durable Room-backed queue.
  *
@@ -92,13 +95,24 @@ class LiveNotificationMonitor(context: Context) {
         PollResult(delivered, channelCount, apiUsed)
     }
 
-    private fun shouldSyncNotificationUsers(): Boolean {
+    internal fun nextNotificationUserSyncDelayMs(now: Long = System.currentTimeMillis()): Long {
         val prefs = context.prefs()
-        val now = System.currentTimeMillis()
+        val useLocalFollows = (prefs.getString(C.UI_FOLLOW_BUTTON, "0")?.toIntOrNull() ?: 0) != 0
+        if (useLocalFollows) return NO_CHANNELS_RECONCILE_INTERVAL_MS
+        return nextNotificationUserSyncDelayMs(
+            lastSuccessMs = prefs.getLong(C.LIVE_NOTIFICATION_LAST_SYNC_SUCCESS, 0L),
+            lastAttemptMs = prefs.getLong(C.LIVE_NOTIFICATION_LAST_SYNC_ATTEMPT, 0L),
+            nowMs = now,
+        )
+    }
+
+    private fun shouldSyncNotificationUsers(): Boolean = shouldSyncNotificationUsers(System.currentTimeMillis())
+
+    private fun shouldSyncNotificationUsers(now: Long): Boolean {
+        val prefs = context.prefs()
         val lastSuccess = prefs.getLong(C.LIVE_NOTIFICATION_LAST_SYNC_SUCCESS, 0L)
         val lastAttempt = prefs.getLong(C.LIVE_NOTIFICATION_LAST_SYNC_ATTEMPT, 0L)
-        return (lastSuccess == 0L || now - lastSuccess >= FOLLOW_SYNC_INTERVAL_MS) &&
-            (lastAttempt == 0L || now - lastAttempt >= FOLLOW_SYNC_RETRY_INTERVAL_MS)
+        return nextNotificationUserSyncDelayMs(lastSuccess, lastAttempt, now) == 0L
     }
 
     data class PollResult(
@@ -109,8 +123,24 @@ class LiveNotificationMonitor(context: Context) {
 
     companion object {
         private const val TAG = "LiveNotificationMonitor"
-        private const val FOLLOW_SYNC_INTERVAL_MS = 6 * 60 * 60 * 1000L
-        private const val FOLLOW_SYNC_RETRY_INTERVAL_MS = 30 * 60 * 1000L
         private val mutex = Mutex()
     }
+}
+
+internal fun nextNotificationUserSyncDelayMs(
+    lastSuccessMs: Long,
+    lastAttemptMs: Long,
+    nowMs: Long,
+): Long {
+    val successDeadline = if (lastSuccessMs > 0L) {
+        lastSuccessMs + LIVE_NOTIFICATION_FOLLOW_SYNC_INTERVAL_MS
+    } else {
+        nowMs
+    }
+    val attemptDeadline = if (lastAttemptMs > 0L) {
+        lastAttemptMs + LIVE_NOTIFICATION_FOLLOW_SYNC_RETRY_INTERVAL_MS
+    } else {
+        nowMs
+    }
+    return (maxOf(nowMs, successDeadline, attemptDeadline) - nowMs).coerceAtLeast(0L)
 }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/main/LiveNotificationPolicy.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/main/LiveNotificationPolicy.kt
@@ -2,10 +2,35 @@ package com.github.andreyasadchy.xtra.ui.main
 
 internal const val FULL_EVENTSUB_RECONCILE_INTERVAL_MS = 15 * 60 * 1000L
 internal const val PARTIAL_EVENTSUB_RECONCILE_INTERVAL_MS = 60 * 1000L
+internal const val NO_CHANNELS_RECONCILE_INTERVAL_MS = 6 * 60 * 60 * 1000L
 internal const val NETWORK_RETRY_INTERVAL_MS = 60 * 1000L
 internal const val RATE_LIMIT_RETRY_INTERVAL_MS = 30 * 1000L
 internal const val MIN_RATE_LIMIT_RETRY_DELAY_MS = 1_000L
 internal const val RATE_LIMIT_SAFETY_MARGIN_MS = 1_000L
+
+internal enum class LiveNotificationCoverageState {
+    NO_CHANNELS,
+    COMPLETE,
+    PARTIAL,
+    DISCONNECTED,
+}
+
+internal fun liveNotificationCoverageState(
+    desiredChannelCount: Int,
+    activeEventSubChannelCount: Int,
+    eventSubConnected: Boolean,
+    eventSubSuspended: Boolean,
+): LiveNotificationCoverageState {
+    if (desiredChannelCount <= 0) return LiveNotificationCoverageState.NO_CHANNELS
+    if (eventSubConnected && !eventSubSuspended && activeEventSubChannelCount >= desiredChannelCount) {
+        return LiveNotificationCoverageState.COMPLETE
+    }
+    return if (eventSubConnected && !eventSubSuspended) {
+        LiveNotificationCoverageState.PARTIAL
+    } else {
+        LiveNotificationCoverageState.DISCONNECTED
+    }
+}
 
 internal fun reconcileIntervalMs(
     desiredChannelCount: Int,
@@ -13,15 +38,17 @@ internal fun reconcileIntervalMs(
     eventSubConnected: Boolean,
     eventSubSuspended: Boolean,
 ): Long {
-    val completeCoverage =
-        eventSubConnected &&
-            !eventSubSuspended &&
-            desiredChannelCount > 0 &&
-            activeEventSubChannelCount >= desiredChannelCount
-    return if (completeCoverage) {
-        FULL_EVENTSUB_RECONCILE_INTERVAL_MS
-    } else {
-        PARTIAL_EVENTSUB_RECONCILE_INTERVAL_MS
+    return when (liveNotificationCoverageState(
+        desiredChannelCount,
+        activeEventSubChannelCount,
+        eventSubConnected,
+        eventSubSuspended,
+    )) {
+        LiveNotificationCoverageState.NO_CHANNELS -> NO_CHANNELS_RECONCILE_INTERVAL_MS
+        LiveNotificationCoverageState.COMPLETE -> FULL_EVENTSUB_RECONCILE_INTERVAL_MS
+        LiveNotificationCoverageState.PARTIAL,
+        LiveNotificationCoverageState.DISCONNECTED,
+        -> PARTIAL_EVENTSUB_RECONCILE_INTERVAL_MS
     }
 }
 
@@ -45,3 +72,17 @@ internal fun applyHelixMinimumDelay(
 
 internal fun shouldSkipLiveNotificationWorker(hasHealthyRealtimeOwner: Boolean): Boolean =
     hasHealthyRealtimeOwner
+
+internal fun liveNotificationOwnerIsHealthy(
+    runnerRunning: Boolean,
+    networkWakeAvailable: Boolean,
+): Boolean = runnerRunning && networkWakeAvailable
+
+internal fun offlineLiveNotificationRetryDelayMs(
+    cachedChannelCount: Int,
+    networkWakeAvailable: Boolean,
+): Long = if (cachedChannelCount == 0 && networkWakeAvailable) {
+    NO_CHANNELS_RECONCILE_INTERVAL_MS
+} else {
+    NETWORK_RETRY_INTERVAL_MS
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/main/LiveNotificationRealtimeEngine.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/main/LiveNotificationRealtimeEngine.kt
@@ -63,7 +63,11 @@ object LiveNotificationRealtimeEngine {
     }
 
     internal fun hasHealthyOwner(): Boolean = synchronized(lock) {
-        current?.runner?.isRunning() == true
+        current?.runner?.isHealthy() == true
+    }
+
+    internal fun requestImmediateReconciliation(reason: String): Boolean = synchronized(lock) {
+        current?.runner?.requestImmediateReconciliation(reason) == true
     }
 
     private data class OwnedRunner(

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/main/LiveNotificationRunner.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/main/LiveNotificationRunner.kt
@@ -55,6 +55,20 @@ internal suspend fun awaitLiveNotificationRetry(
 internal fun isLiveNotificationRetryInterruptible(error: TwitchApiException): Boolean =
     error.statusCode != 429 && error.rateLimitResetEpochSeconds == null
 
+internal class LiveNotificationWakeController {
+    val signal = Channel<Unit>(Channel.CONFLATED)
+    private val pendingReason = AtomicReference<String?>(null)
+
+    fun request(isRunnerActive: Boolean, reason: String): Boolean {
+        if (!isRunnerActive) return false
+        pendingReason.set(reason)
+        signal.trySend(Unit)
+        return true
+    }
+
+    fun consumeReason(): String? = pendingReason.getAndSet(null)
+}
+
 /**
  * Shared Twitch monitoring runner used by Fast mode and Persistent real-time.
  * The owner controls Android process lifetime; this class owns EventSub,
@@ -70,11 +84,11 @@ class LiveNotificationRunner(
     private val xtraApp = applicationContext as XtraApp
     private val module = xtraApp.xtraModule
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
-    private val wakeSignal = Channel<Unit>(Channel.CONFLATED)
-    private val pendingWakeReason = AtomicReference<String?>(null)
+    private val wakeController = LiveNotificationWakeController()
     private val networkAvailable = AtomicBoolean(false)
     private val nextDelayMs = AtomicLong(PARTIAL_EVENTSUB_RECONCILE_INTERVAL_MS)
     private val eventSubStarted = AtomicBoolean(false)
+    private val networkCallbackRegistered = AtomicBoolean(false)
     private val monitor = LiveNotificationMonitor(applicationContext)
     private val eventSub = LiveNotificationEventSub(
         okHttpClient = module.okHttpClient,
@@ -106,7 +120,7 @@ class LiveNotificationRunner(
                 State.STOPPED -> return
                 State.RUNNING -> {
                     if (monitorJob?.isActive == true) {
-                        wakeSignal.trySend(Unit)
+                        wakeController.signal.trySend(Unit)
                         return
                     }
                     unregisterNetworkCallback()
@@ -131,7 +145,7 @@ class LiveNotificationRunner(
             monitorJob?.cancel()
             monitorJob = null
             eventSub.shutdown()
-            wakeSignal.close()
+            wakeController.signal.close()
             scope.cancel()
         }
     }
@@ -140,13 +154,30 @@ class LiveNotificationRunner(
         state == State.RUNNING && monitorJob?.isActive == true
     }
 
+    internal fun isHealthy(): Boolean = synchronized(lifecycleLock) {
+        liveNotificationOwnerIsHealthy(
+            runnerRunning = state == State.RUNNING && monitorJob?.isActive == true,
+            networkWakeAvailable = networkCallbackRegistered.get(),
+        )
+    }
+
     private suspend fun monitorLoop() {
         var notifyOwner = false
         var reconciliationReason = "startup"
         try {
             while (currentCoroutineContext().isActive && isMonitoringEnabled()) {
                 if (!networkAvailable.get()) {
-                    nextDelayMs.set(NETWORK_RETRY_INTERVAL_MS)
+                    if (!networkCallbackRegistered.get() && hasValidatedNetwork()) {
+                        networkAvailable.set(true)
+                        reconciliationReason = "network_recovered"
+                        continue
+                    }
+                    nextDelayMs.set(offlineLiveNotificationRetryDelayMs(
+                        cachedChannelCount = applicationContext.prefs()
+                            .getInt(C.LIVE_NOTIFICATION_CACHED_CHANNEL_COUNT, -1),
+                        networkWakeAvailable = networkCallbackRegistered.get(),
+                    )
+                    )
                     reconciliationReason = waitForNextPoll() ?: "network_retry"
                     continue
                 }
@@ -228,21 +259,17 @@ class LiveNotificationRunner(
                     } else {
                         coverage.copy(connected = false, suspended = true)
                     }
-                    nextDelayMs.set(
-                        applyHelixMinimumDelay(
-                            coverageDelayMs = reconcileIntervalMs(
-                                desiredChannelCount = coverage.desiredChannelCount,
-                                activeEventSubChannelCount = coverage.activeSubscriptionCount,
-                                eventSubConnected = coverage.connected,
-                                eventSubSuspended = coverage.suspended,
-                            ),
-                            helixMinimumDelayMs = helixMinimumDelayMs,
-                        )
-                    )
+                    nextDelayMs.set(nextReconciliationDelay(coverage, helixMinimumDelayMs))
                     if (BuildConfig.PERF_DIAGNOSTICS) {
+                        val coverageState = liveNotificationCoverageState(
+                            desiredChannelCount = coverage.desiredChannelCount,
+                            activeEventSubChannelCount = coverage.activeSubscriptionCount,
+                            eventSubConnected = coverage.connected,
+                            eventSubSuspended = coverage.suspended,
+                        )
                         Log.i(
                             TAG,
-                            "eventSub coverage desired=${coverage.desiredChannelCount} " +
+                            "eventSub state=$coverageState desired=${coverage.desiredChannelCount} " +
                                 "active=${coverage.activeSubscriptionCount} " +
                                 "connected=${coverage.connected} suspended=${coverage.suspended}",
                         )
@@ -251,8 +278,8 @@ class LiveNotificationRunner(
                     }
                 }
                 if (retryDelayMs != null) {
-                    awaitLiveNotificationRetry(retryDelayMs, retryDelayInterruptible, wakeSignal)
-                    reconciliationReason = pendingWakeReason.getAndSet(null) ?: "rate_limit_retry"
+                    awaitLiveNotificationRetry(retryDelayMs, retryDelayInterruptible, wakeController.signal)
+                    reconciliationReason = wakeController.consumeReason() ?: "rate_limit_retry"
                 } else {
                     reconciliationReason = waitForNextPoll()
                         ?: if (coverage.complete) "periodic_safety" else "periodic_partial_coverage"
@@ -281,15 +308,41 @@ class LiveNotificationRunner(
 
     private suspend fun waitForNextPoll(timeoutMs: Long = nextDelayMs.get()): String? {
         val woke = withTimeoutOrNull(timeoutMs) {
-            wakeSignal.receiveCatching()
+            wakeController.signal.receiveCatching()
             true
         } ?: false
-        return if (woke) pendingWakeReason.getAndSet(null) else null
+        return if (woke) wakeController.consumeReason() else null
     }
 
-    private fun requestImmediateReconciliation(reason: String) {
-        pendingWakeReason.set(reason)
-        wakeSignal.trySend(Unit)
+    internal fun requestImmediateReconciliation(reason: String): Boolean = synchronized(lifecycleLock) {
+        if (state != State.RUNNING || monitorJob?.isActive != true) {
+            false
+        } else {
+            wakeController.request(isRunnerActive = true, reason = reason)
+        }
+    }
+
+    private fun nextReconciliationDelay(
+        coverage: LiveEventSubCoverage,
+        helixMinimumDelayMs: Long?,
+    ): Long {
+        val coverageState = liveNotificationCoverageState(
+            desiredChannelCount = coverage.desiredChannelCount,
+            activeEventSubChannelCount = coverage.activeSubscriptionCount,
+            eventSubConnected = coverage.connected,
+            eventSubSuspended = coverage.suspended,
+        )
+        val coverageDelayMs = if (coverageState == LiveNotificationCoverageState.NO_CHANNELS) {
+            monitor.nextNotificationUserSyncDelayMs()
+        } else {
+            reconcileIntervalMs(
+                desiredChannelCount = coverage.desiredChannelCount,
+                activeEventSubChannelCount = coverage.activeSubscriptionCount,
+                eventSubConnected = coverage.connected,
+                eventSubSuspended = coverage.suspended,
+            )
+        }
+        return applyHelixMinimumDelay(coverageDelayMs, helixMinimumDelayMs)
     }
 
     private suspend fun ensureEventSubStarted() {
@@ -377,6 +430,7 @@ class LiveNotificationRunner(
             }
         }
         networkCallback = null
+        networkCallbackRegistered.set(false)
     }
 
     private fun registerNetworkCallback() {
@@ -414,7 +468,10 @@ class LiveNotificationRunner(
                     .build(),
                 networkCallback!!,
             )
+            networkCallbackRegistered.set(true)
         }.onFailure {
+            networkCallbackRegistered.set(false)
+            networkCallback = null
             Log.w(TAG, "Unable to register validated network callback", it)
         }
     }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/main/LiveNotificationScheduler.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/main/LiveNotificationScheduler.kt
@@ -144,6 +144,46 @@ object LiveNotificationScheduler {
         }
     }
 
+    /** Wakes the current realtime owner, or uses the existing WorkManager fallback when needed. */
+    fun requestImmediateReconciliation(context: Context, reason: String): Boolean =
+        synchronized(transitionLock) {
+            if (!context.prefs().getBoolean(C.LIVE_NOTIFICATIONS_ENABLED, false) ||
+                !canPostNotifications(context)
+            ) {
+                return false
+            }
+            val mode = mode(context)
+            routeImmediateReconciliation(
+                mode = mode,
+                wakePersistentOwner = {
+                    LiveNotificationService.requestImmediateReconciliation(reason)
+                },
+                wakeProcessOwner = {
+                    LiveNotificationRealtimeEngine.requestImmediateReconciliation(reason)
+                },
+                enqueueFallback = {
+                    enqueueImmediateWork(context, baselineOnly = false)
+                },
+            )
+        }
+
+    /** Keeps owner selection testable without constructing Android services or WorkManager. */
+    internal fun routeImmediateReconciliation(
+        mode: String,
+        wakePersistentOwner: () -> Boolean,
+        wakeProcessOwner: () -> Boolean,
+        enqueueFallback: () -> Unit,
+    ): Boolean {
+        val wokeOwner = when (mode) {
+            C.LIVE_NOTIFICATIONS_MODE_PERSISTENT ->
+                wakePersistentOwner() || wakeProcessOwner()
+            C.LIVE_NOTIFICATIONS_MODE_FAST -> wakeProcessOwner()
+            else -> false
+        }
+        if (!wokeOwner) enqueueFallback()
+        return true
+    }
+
     fun migrateMode(context: Context): String {
         val preferences = context.prefs()
         val stored = preferences.getString(C.LIVE_NOTIFICATIONS_MODE, null)

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/main/LiveNotificationService.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/main/LiveNotificationService.kt
@@ -59,12 +59,14 @@ class LiveNotificationService : Service() {
             // pending or retried. Make the ownership handoff explicit.
             LiveNotificationRealtimeEngine.stop()
             running = true
-            runner = LiveNotificationRunner(
+            val newRunner = LiveNotificationRunner(
                 context = applicationContext,
                 shouldContinue = ::shouldRunPersistentMode,
                 onMonitoringStopped = { stopSelf() },
-            ).also { it.start() }
-            activeRunner = runner
+            )
+            runner = newRunner
+            activeRunner = newRunner
+            newRunner.start()
         }
         return START_STICKY
     }
@@ -148,7 +150,12 @@ class LiveNotificationService : Service() {
 
         fun isRunning(): Boolean = running
 
-        internal fun hasHealthyRunner(): Boolean = running && activeRunner?.isRunning() == true
+        internal fun hasHealthyRunner(): Boolean = running && activeRunner?.isHealthy() == true
+
+        internal fun requestImmediateReconciliation(reason: String): Boolean {
+            val currentRunner = activeRunner ?: return false
+            return currentRunner.requestImmediateReconciliation(reason)
+        }
 
         fun ensureNotificationChannel(context: Context) {
             if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/main/LiveNotificationWorker.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/main/LiveNotificationWorker.kt
@@ -22,23 +22,21 @@ class LiveNotificationWorker(
     override suspend fun doWork(): Result {
         val startedAt = System.currentTimeMillis()
         val startElapsed = SystemClock.elapsedRealtime()
-        val prefs = context.prefs()
-        prefs.edit {
-            putLong(C.LIVE_NOTIFICATION_LAST_RUN, startedAt)
-        }
-
         val baselineOnly = inputData.getBoolean(INPUT_BASELINE_ONLY, false)
 
         try {
-            val authMaintainer = (context.applicationContext as? XtraApp)?.xtraModule?.authSessionMaintainer
-            if (authMaintainer?.validateIfDue() == AuthSessionMaintenanceState.REAUTHORIZATION_REQUIRED) {
-                return Result.success()
-            }
             if (shouldSkipLiveNotificationWorker(
                     LiveNotificationScheduler.hasHealthyRealtimeOwner(context),
                 )
             ) {
                 Log.d(TAG, "Skipping fallback reconciliation because a realtime owner is healthy")
+                return Result.success()
+            }
+            context.prefs().edit {
+                putLong(C.LIVE_NOTIFICATION_LAST_RUN, startedAt)
+            }
+            val authMaintainer = (context.applicationContext as? XtraApp)?.xtraModule?.authSessionMaintainer
+            if (authMaintainer?.validateIfDue() == AuthSessionMaintenanceState.REAUTHORIZATION_REQUIRED) {
                 return Result.success()
             }
             val result = monitor.poll(baselineOnly = baselineOnly)

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/Media3PlayerViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/Media3PlayerViewModel.kt
@@ -32,6 +32,7 @@ import com.github.andreyasadchy.xtra.repository.OfflineVideosRepository
 import com.github.andreyasadchy.xtra.repository.PlayerRepository
 import com.github.andreyasadchy.xtra.repository.preload.StreamPreloadCoordinator
 import com.github.andreyasadchy.xtra.repository.streamfeed.StreamFeedRefreshCoordinator
+import com.github.andreyasadchy.xtra.ui.main.LiveNotificationScheduler
 import com.github.andreyasadchy.xtra.util.C
 import com.github.andreyasadchy.xtra.util.NetworkUtils
 import com.github.andreyasadchy.xtra.util.NetworkUtils.executeAsync
@@ -721,9 +722,9 @@ class Media3PlayerViewModel(
                             _isFollowing.value = true
                             follow.value = Pair(true, null)
                             if (!disableNotifications) {
-                                notificationsRepository.saveUser(NotificationUser(channelId))
+                                saveNotificationUser(channelId)
                             } else {
-                                notificationsRepository.deleteUser(NotificationUser(channelId))
+                                deleteNotificationUser(channelId)
                             }
                             if (liveNotificationsEnabled) {
                                 startedAt.takeUnless { it.isNullOrBlank() }?.let {
@@ -739,7 +740,7 @@ class Media3PlayerViewModel(
                         _isFollowing.value = true
                         follow.value = Pair(true, null)
                         if (!disableNotifications) {
-                            notificationsRepository.saveUser(NotificationUser(channelId))
+                            saveNotificationUser(channelId)
                         }
                         if (liveNotificationsEnabled) {
                             startedAt.takeUnless { it.isNullOrBlank() }?.let {
@@ -771,14 +772,14 @@ class Media3PlayerViewModel(
                         } else {
                             _isFollowing.value = false
                             follow.value = Pair(false, null)
-                            notificationsRepository.deleteUser(NotificationUser(channelId))
+                            deleteNotificationUser(channelId)
                             streamFeedRefreshCoordinator.invalidateFollowedFeeds()
                         }
                     } else {
                         localChannelFollowsRepository.getById(channelId)?.let { localChannelFollowsRepository.delete(it) }
                         _isFollowing.value = false
                         follow.value = Pair(false, null)
-                        notificationsRepository.deleteUser(NotificationUser(channelId))
+                        deleteNotificationUser(channelId)
                     }
                 }
             } catch (e: CancellationException) {
@@ -788,6 +789,22 @@ class Media3PlayerViewModel(
             } catch (e: Exception) {
             }
         }
+    }
+
+    private suspend fun saveNotificationUser(channelId: String) {
+        notificationsRepository.saveUser(NotificationUser(channelId))
+        LiveNotificationScheduler.requestImmediateReconciliation(
+            applicationContext,
+            reason = "notification_users_changed",
+        )
+    }
+
+    private suspend fun deleteNotificationUser(channelId: String) {
+        notificationsRepository.deleteUser(NotificationUser(channelId))
+        LiveNotificationScheduler.requestImmediateReconciliation(
+            applicationContext,
+            reason = "notification_users_changed",
+        )
     }
 
     companion object {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/PlayerViewModel.kt
@@ -23,6 +23,7 @@ import com.github.andreyasadchy.xtra.repository.MissingAuthenticationException
 import com.github.andreyasadchy.xtra.repository.NotificationsRepository
 import com.github.andreyasadchy.xtra.repository.PlayerRepository
 import com.github.andreyasadchy.xtra.repository.streamfeed.StreamFeedRefreshCoordinator
+import com.github.andreyasadchy.xtra.ui.main.LiveNotificationScheduler
 import com.github.andreyasadchy.xtra.util.C
 import com.github.andreyasadchy.xtra.util.NetworkUtils
 import com.github.andreyasadchy.xtra.util.NetworkUtils.executeAsync
@@ -479,9 +480,9 @@ class PlayerViewModel(
                             _isFollowing.value = true
                             follow.value = Pair(true, null)
                             if (!disableNotifications) {
-                                notificationsRepository.saveUser(NotificationUser(channelId))
+                                saveNotificationUser(channelId)
                             } else {
-                                notificationsRepository.deleteUser(NotificationUser(channelId))
+                                deleteNotificationUser(channelId)
                             }
                             if (liveNotificationsEnabled) {
                                 startedAt.takeUnless { it.isNullOrBlank() }?.let {
@@ -497,7 +498,7 @@ class PlayerViewModel(
                         _isFollowing.value = true
                         follow.value = Pair(true, null)
                         if (!disableNotifications) {
-                            notificationsRepository.saveUser(NotificationUser(channelId))
+                            saveNotificationUser(channelId)
                         }
                         if (liveNotificationsEnabled) {
                             startedAt.takeUnless { it.isNullOrBlank() }?.let {
@@ -529,14 +530,14 @@ class PlayerViewModel(
                         } else {
                             _isFollowing.value = false
                             follow.value = Pair(false, null)
-                            notificationsRepository.deleteUser(NotificationUser(channelId))
+                            deleteNotificationUser(channelId)
                             streamFeedRefreshCoordinator.invalidateFollowedFeeds()
                         }
                     } else {
                         localChannelFollowsRepository.getById(channelId)?.let { localChannelFollowsRepository.delete(it) }
                         _isFollowing.value = false
                         follow.value = Pair(false, null)
-                        notificationsRepository.deleteUser(NotificationUser(channelId))
+                        deleteNotificationUser(channelId)
                     }
                 }
             } catch (e: CancellationException) {
@@ -546,6 +547,22 @@ class PlayerViewModel(
             } catch (e: Exception) {
             }
         }
+    }
+
+    private suspend fun saveNotificationUser(channelId: String) {
+        notificationsRepository.saveUser(NotificationUser(channelId))
+        LiveNotificationScheduler.requestImmediateReconciliation(
+            XtraApp.INSTANCE,
+            reason = "notification_users_changed",
+        )
+    }
+
+    private suspend fun deleteNotificationUser(channelId: String) {
+        notificationsRepository.deleteUser(NotificationUser(channelId))
+        LiveNotificationScheduler.requestImmediateReconciliation(
+            XtraApp.INSTANCE,
+            reason = "notification_users_changed",
+        )
     }
 
     companion object {

--- a/app/src/test/java/com/github/andreyasadchy/xtra/repository/auth/AuthSessionMaintainerTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/repository/auth/AuthSessionMaintainerTest.kt
@@ -1,8 +1,27 @@
 package com.github.andreyasadchy.xtra.repository.auth
 
+import android.content.Context
+import android.content.ContextWrapper
+import android.content.SharedPreferences
+import android.net.http.HttpEngine
+import com.github.andreyasadchy.xtra.repository.AuthRepository
+import com.github.andreyasadchy.xtra.util.C
+import com.github.andreyasadchy.xtra.util.tokenPrefs
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.launch
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeoutOrNull
+import kotlinx.serialization.json.Json
+import okhttp3.OkHttpClient
+import org.chromium.net.CronetEngine
+import java.util.concurrent.Executors
 
 class AuthSessionMaintainerTest {
     @Test
@@ -13,4 +32,221 @@ class AuthSessionMaintainerTest {
         assertFalse(AuthHealth.UNKNOWN.requiresUserAction)
     }
 
+    @Test
+    fun signedOutAndReauthorizationStatesWaitForAnExplicitWake() {
+        assertNull(
+            authSessionValidationWaitMs(
+                sessionPresent = false,
+                webTokenPresent = false,
+                maintenanceState = AuthSessionMaintenanceState.IDLE,
+                validatedNetwork = true,
+                validationChecked = false,
+                lastValidatedAtMs = 0L,
+                nowMs = 100L,
+            ),
+        )
+        assertNull(
+            authSessionValidationWaitMs(
+                sessionPresent = true,
+                webTokenPresent = true,
+                maintenanceState = AuthSessionMaintenanceState.REAUTHORIZATION_REQUIRED,
+                validatedNetwork = true,
+                validationChecked = true,
+                lastValidatedAtMs = 100L,
+                nowMs = 100L,
+            ),
+        )
+    }
+
+    @Test
+    fun initializationDoesNotEmitButHealthyToHealthyAccountChangeDoes() = runBlocking {
+        val preferences = AuthMaintainerMemoryPreferences()
+        val context = TestContext(preferences)
+        putSession(context, accessToken = "account-a-token", userId = "account-a")
+        val maintainer = AuthSessionMaintainer(context, unusedAuthRepository())
+        val changes = Channel<Long>(Channel.UNLIMITED)
+        val collector = launch {
+            maintainer.authenticationChangeGeneration
+                .filter { it > 0L }
+                .collect { changes.send(it) }
+        }
+
+        assertEquals(0L, maintainer.authenticationChangeGeneration.value)
+        assertNull(withTimeoutOrNull(50L) { changes.receive() })
+
+        putSession(context, accessToken = "account-b-token", userId = "account-b")
+        maintainer.onAuthenticationStateChanged()
+
+        assertEquals(1L, withTimeoutOrNull(500L) { changes.receive() })
+        assertNull(withTimeoutOrNull(50L) { changes.receive() })
+        collector.cancel()
+    }
+
+    @Test
+    fun freshValidationWaitsUntilOneHourBoundary() {
+        val validatedAt = 100_000L
+        assertEquals(
+            AUTH_SESSION_VALIDATION_INTERVAL_MILLIS - 1L,
+            authSessionValidationWaitMs(
+                sessionPresent = true,
+                webTokenPresent = true,
+                maintenanceState = AuthSessionMaintenanceState.VALID,
+                validatedNetwork = true,
+                validationChecked = true,
+                lastValidatedAtMs = validatedAt,
+                nowMs = validatedAt + 1L,
+            ),
+        )
+        assertEquals(
+            0L,
+            authSessionValidationWaitMs(
+                sessionPresent = true,
+                webTokenPresent = true,
+                maintenanceState = AuthSessionMaintenanceState.VALID,
+                validatedNetwork = true,
+                validationChecked = true,
+                lastValidatedAtMs = validatedAt,
+                nowMs = validatedAt + AUTH_SESSION_VALIDATION_INTERVAL_MILLIS,
+            ),
+        )
+    }
+
+    @Test
+    fun missingNetworkWaitsForConnectivityInsteadOfRetrying() {
+        assertNull(
+            authSessionValidationWaitMs(
+                sessionPresent = true,
+                webTokenPresent = true,
+                maintenanceState = AuthSessionMaintenanceState.TRANSIENT_FAILURE,
+                validatedNetwork = false,
+                validationChecked = true,
+                lastValidatedAtMs = 0L,
+                nowMs = 100L,
+                transientRetryDeadlineMs = 200L,
+            ),
+        )
+    }
+
+    @Test
+    fun missingNetworkUsesBoundedFallbackWhenWakeCallbackRegistrationFails() {
+        assertEquals(
+            AUTH_SESSION_NETWORK_RETRY_DELAY_MILLIS,
+            authSessionValidationWaitMs(
+                sessionPresent = true,
+                webTokenPresent = true,
+                maintenanceState = AuthSessionMaintenanceState.VALID,
+                validatedNetwork = false,
+                validationChecked = true,
+                lastValidatedAtMs = 100L,
+                nowMs = 100L,
+                networkWakeAvailable = false,
+            ),
+        )
+    }
+
+    @Test
+    fun transientFailureUsesBoundedFiveMinuteRetry() {
+        assertEquals(
+            AUTH_SESSION_TRANSIENT_RETRY_DELAY_MILLIS,
+            authSessionValidationWaitMs(
+                sessionPresent = true,
+                webTokenPresent = true,
+                maintenanceState = AuthSessionMaintenanceState.TRANSIENT_FAILURE,
+                validatedNetwork = true,
+                validationChecked = true,
+                lastValidatedAtMs = 100L,
+                nowMs = 100L,
+                transientRetryDeadlineMs = 100L + AUTH_SESSION_TRANSIENT_RETRY_DELAY_MILLIS,
+            ),
+        )
+    }
+
+    private fun putSession(context: Context, accessToken: String, userId: String) {
+        context.tokenPrefs().edit()
+            .putString(C.GQL_TOKEN_WEB, accessToken)
+            .putString(C.USER_ID, userId)
+            .putString(C.USERNAME, userId)
+            .commit()
+    }
+
+    private fun unusedAuthRepository() = AuthRepository(
+        httpEngine = lazy<HttpEngine?> { null },
+        cronetEngine = lazy<CronetEngine?> { null },
+        cronetExecutor = lazy { Executors.newSingleThreadExecutor() },
+        okHttpClient = lazy { OkHttpClient() },
+        json = Json,
+    )
+}
+
+private class TestContext(
+    private val preferences: SharedPreferences,
+) : ContextWrapper(null) {
+    override fun getPackageName(): String = "com.github.andreyasadchy.xtra.test"
+
+    override fun getSharedPreferences(name: String?, mode: Int): SharedPreferences = preferences
+
+    override fun getApplicationContext(): Context = this
+}
+
+private class AuthMaintainerMemoryPreferences(
+    initialValues: MutableMap<String, Any> = mutableMapOf(),
+) : SharedPreferences {
+    private val values = initialValues.toMutableMap()
+
+    override fun getAll(): MutableMap<String, *> = values.toMutableMap()
+    override fun getString(key: String?, defValue: String?): String? = values[key] as? String ?: defValue
+
+    @Suppress("UNCHECKED_CAST")
+    override fun getStringSet(key: String?, defValues: MutableSet<String>?): MutableSet<String>? =
+        (values[key] as? Set<String>)?.toMutableSet() ?: defValues
+
+    override fun getInt(key: String?, defValue: Int): Int = values[key] as? Int ?: defValue
+    override fun getLong(key: String?, defValue: Long): Long = values[key] as? Long ?: defValue
+    override fun getFloat(key: String?, defValue: Float): Float = values[key] as? Float ?: defValue
+    override fun getBoolean(key: String?, defValue: Boolean): Boolean = values[key] as? Boolean ?: defValue
+    override fun contains(key: String?): Boolean = values.containsKey(key)
+    override fun edit(): SharedPreferences.Editor = Editor()
+    override fun registerOnSharedPreferenceChangeListener(listener: SharedPreferences.OnSharedPreferenceChangeListener?) = Unit
+    override fun unregisterOnSharedPreferenceChangeListener(listener: SharedPreferences.OnSharedPreferenceChangeListener?) = Unit
+
+    private inner class Editor : SharedPreferences.Editor {
+        private val changes = mutableMapOf<String, Any?>()
+        private var clear = false
+
+        override fun putString(key: String?, value: String?): SharedPreferences.Editor = put(key, value)
+        override fun putStringSet(key: String?, values: MutableSet<String>?): SharedPreferences.Editor = put(key, values?.toMutableSet())
+        override fun putInt(key: String?, value: Int): SharedPreferences.Editor = put(key, value)
+        override fun putLong(key: String?, value: Long): SharedPreferences.Editor = put(key, value)
+        override fun putFloat(key: String?, value: Float): SharedPreferences.Editor = put(key, value)
+        override fun putBoolean(key: String?, value: Boolean): SharedPreferences.Editor = put(key, value)
+
+        override fun remove(key: String?): SharedPreferences.Editor {
+            if (key != null) changes[key] = null
+            return this
+        }
+
+        override fun clear(): SharedPreferences.Editor {
+            clear = true
+            return this
+        }
+
+        override fun commit(): Boolean {
+            applyChanges()
+            return true
+        }
+
+        override fun apply() = applyChanges()
+
+        private fun <T> put(key: String?, value: T): SharedPreferences.Editor {
+            if (key != null) changes[key] = value
+            return this
+        }
+
+        private fun applyChanges() {
+            if (clear) values.clear()
+            changes.forEach { (key, value) ->
+                if (value == null) values.remove(key) else values[key] = value
+            }
+        }
+    }
 }

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/main/LiveNotificationPolicyTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/main/LiveNotificationPolicyTest.kt
@@ -48,7 +48,7 @@ class LiveNotificationPolicyTest {
             reconcileIntervalMs(10, 10, eventSubConnected = true, eventSubSuspended = true),
         )
         assertEquals(
-            PARTIAL_EVENTSUB_RECONCILE_INTERVAL_MS,
+            NO_CHANNELS_RECONCILE_INTERVAL_MS,
             reconcileIntervalMs(0, 0, eventSubConnected = false, eventSubSuspended = false),
         )
     }
@@ -106,6 +106,24 @@ class LiveNotificationPolicyTest {
     }
 
     @Test
+    fun failedNetworkWakeRegistrationKeepsOfflineRecoveryBounded() {
+        assertEquals(
+            NETWORK_RETRY_INTERVAL_MS,
+            offlineLiveNotificationRetryDelayMs(
+                cachedChannelCount = 0,
+                networkWakeAvailable = false,
+            ),
+        )
+        assertEquals(
+            NO_CHANNELS_RECONCILE_INTERVAL_MS,
+            offlineLiveNotificationRetryDelayMs(
+                cachedChannelCount = 0,
+                networkWakeAvailable = true,
+            ),
+        )
+    }
+
+    @Test
     fun coverageExposesCompleteAndPartialStates() {
         assertTrue(
             LiveEventSubCoverage(10, 10, connected = true, suspended = false).complete,
@@ -115,6 +133,40 @@ class LiveNotificationPolicyTest {
         )
         assertFalse(
             LiveEventSubCoverage(10, 0, connected = false, suspended = false).partial,
+        )
+    }
+
+    @Test
+    fun coverageSeparatesIdleFromIncompleteMonitoring() {
+        assertEquals(
+            LiveNotificationCoverageState.NO_CHANNELS,
+            liveNotificationCoverageState(0, 0, eventSubConnected = false, eventSubSuspended = false),
+        )
+        assertEquals(
+            LiveNotificationCoverageState.PARTIAL,
+            liveNotificationCoverageState(10, 8, eventSubConnected = true, eventSubSuspended = false),
+        )
+        assertEquals(
+            LiveNotificationCoverageState.COMPLETE,
+            liveNotificationCoverageState(10, 10, eventSubConnected = true, eventSubSuspended = false),
+        )
+    }
+
+    @Test
+    fun notificationUserSyncWaitsUntilTheActualNextMeaningfulDeadline() {
+        val now = 100_000L
+        assertEquals(0L, nextNotificationUserSyncDelayMs(0L, 0L, now))
+        assertEquals(
+            LIVE_NOTIFICATION_FOLLOW_SYNC_RETRY_INTERVAL_MS,
+            nextNotificationUserSyncDelayMs(
+                now - LIVE_NOTIFICATION_FOLLOW_SYNC_INTERVAL_MS,
+                now,
+                now,
+            ),
+        )
+        assertEquals(
+            LIVE_NOTIFICATION_FOLLOW_SYNC_INTERVAL_MS,
+            nextNotificationUserSyncDelayMs(now, 0L, now),
         )
     }
 }

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/main/LiveNotificationRealtimeEngineTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/main/LiveNotificationRealtimeEngineTest.kt
@@ -1,6 +1,7 @@
 package com.github.andreyasadchy.xtra.ui.main
 
 import com.github.andreyasadchy.xtra.util.C
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -53,5 +54,102 @@ class LiveNotificationRealtimeEngineTest {
                 persistentServiceRunning = false,
             )
         )
+    }
+
+    @Test
+    fun onlyAnActiveRunnerWithAWorkingNetworkWakeSourceIsHealthy() {
+        assertTrue(liveNotificationOwnerIsHealthy(runnerRunning = true, networkWakeAvailable = true))
+        assertFalse(liveNotificationOwnerIsHealthy(runnerRunning = false, networkWakeAvailable = true))
+        assertFalse(liveNotificationOwnerIsHealthy(runnerRunning = true, networkWakeAvailable = false))
+    }
+
+    @Test
+    fun fastOwnerWakeAvoidsFallback() {
+        var processWakeCalls = 0
+        var fallbackCalls = 0
+
+        LiveNotificationScheduler.routeImmediateReconciliation(
+            mode = C.LIVE_NOTIFICATIONS_MODE_FAST,
+            wakePersistentOwner = { error("Fast mode must not wake the persistent owner") },
+            wakeProcessOwner = {
+                processWakeCalls++
+                true
+            },
+            enqueueFallback = { fallbackCalls++ },
+        )
+
+        assertEquals(1, processWakeCalls)
+        assertEquals(0, fallbackCalls)
+    }
+
+    @Test
+    fun persistentOwnerWakeDoesNotStartACompetingProcessRunner() {
+        var processWakeCalls = 0
+        var fallbackCalls = 0
+
+        LiveNotificationScheduler.routeImmediateReconciliation(
+            mode = C.LIVE_NOTIFICATIONS_MODE_PERSISTENT,
+            wakePersistentOwner = { true },
+            wakeProcessOwner = {
+                processWakeCalls++
+                true
+            },
+            enqueueFallback = { fallbackCalls++ },
+        )
+
+        assertEquals(0, processWakeCalls)
+        assertEquals(0, fallbackCalls)
+    }
+
+    @Test
+    fun stalePersistentAndFastOwnersUseWorkManagerFallback() {
+        var persistentWakeCalls = 0
+        var processWakeCalls = 0
+        var fallbackCalls = 0
+
+        LiveNotificationScheduler.routeImmediateReconciliation(
+            mode = C.LIVE_NOTIFICATIONS_MODE_PERSISTENT,
+            wakePersistentOwner = {
+                persistentWakeCalls++
+                false
+            },
+            wakeProcessOwner = {
+                processWakeCalls++
+                false
+            },
+            enqueueFallback = { fallbackCalls++ },
+        )
+        LiveNotificationScheduler.routeImmediateReconciliation(
+            mode = C.LIVE_NOTIFICATIONS_MODE_FAST,
+            wakePersistentOwner = { error("Fast mode must not wake the persistent owner") },
+            wakeProcessOwner = { false },
+            enqueueFallback = { fallbackCalls++ },
+        )
+
+        assertEquals(1, persistentWakeCalls)
+        assertEquals(1, processWakeCalls)
+        assertEquals(2, fallbackCalls)
+    }
+
+    @Test
+    fun batteryModeUsesFallbackWithoutAnOwnerWake() {
+        var ownerWakeCalls = 0
+        var fallbackCalls = 0
+
+        LiveNotificationScheduler.routeImmediateReconciliation(
+            mode = C.LIVE_NOTIFICATIONS_MODE_BATTERY,
+            wakePersistentOwner = {
+                ownerWakeCalls++
+                true
+            },
+            wakeProcessOwner = {
+                ownerWakeCalls++
+                true
+            },
+            enqueueFallback = { fallbackCalls++ },
+        )
+
+        assertEquals(0, ownerWakeCalls)
+        assertEquals(1, fallbackCalls)
     }
 }

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/main/LiveNotificationRunnerTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/main/LiveNotificationRunnerTest.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeoutOrNull
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -74,5 +75,24 @@ class LiveNotificationRunnerTest {
         assertFalse(isLiveNotificationRetryInterruptible(TwitchApiException(429, null, message = "rate limited")))
         assertFalse(isLiveNotificationRetryInterruptible(TwitchApiException(500, 123L, message = "server error")))
         assertTrue(isLiveNotificationRetryInterruptible(TwitchApiException(500, null, message = "server error")))
+    }
+
+    @Test
+    fun staleRunnerCannotClaimAnImmediateWake() {
+        val wakeController = LiveNotificationWakeController()
+
+        assertFalse(wakeController.request(isRunnerActive = false, reason = "notification_users_changed"))
+        assertTrue(wakeController.signal.tryReceive().isFailure)
+    }
+
+    @Test
+    fun immediateWakeReasonsAreConflated() = runBlocking {
+        val wakeController = LiveNotificationWakeController()
+
+        assertTrue(wakeController.request(isRunnerActive = true, reason = "first"))
+        assertTrue(wakeController.request(isRunnerActive = true, reason = "latest"))
+        wakeController.signal.receive()
+        assertEquals("latest", wakeController.consumeReason())
+        assertTrue(wakeController.signal.tryReceive().isFailure)
     }
 }


### PR DESCRIPTION
Reduce idle auth validation and live-notification reconciliation work while preserving monitored-channel recovery and the WorkManager safety fallback.