### PR TITLE
Make viewing stats persistence bounded

### DIFF
--- a/app/src/androidTest/java/com/github/andreyasadchy/xtra/db/ViewingStatsAggregationTest.kt
+++ b/app/src/androidTest/java/com/github/andreyasadchy/xtra/db/ViewingStatsAggregationTest.kt
@@ -93,6 +93,95 @@ class ViewingStatsAggregationTest {
     }
 
     @Test
+    fun overlapBoundariesRemainHalfOpenAndUnfilteredFastPathMatches() = runBlocking {
+        suspend fun insertBoundaryInterval(startAt: Long, endAt: Long, watchedMs: Long) {
+            val sessionId = insertSession(
+                channelId = "boundary-$startAt",
+                startedAt = startAt,
+                endedAt = endAt,
+                watchedMs = watchedMs,
+            )
+            database.viewingStats().insertInterval(
+                ViewingInterval(
+                    sessionId = sessionId,
+                    channelId = "boundary-$startAt",
+                    channelLogin = null,
+                    channelName = null,
+                    channelImage = null,
+                    contentType = "live",
+                    startAt = startAt,
+                    endAt = endAt,
+                    watchedMs = watchedMs,
+                    lastCheckpointAt = endAt,
+                ),
+            )
+        }
+
+        insertBoundaryInterval(0L, 100L, 100L)
+        insertBoundaryInterval(100L, 200L, 100L)
+        insertBoundaryInterval(200L, 300L, 100L)
+        insertBoundaryInterval(50L, 250L, 200L)
+        insertBoundaryInterval(199L, 201L, 2L)
+
+        val dao = database.viewingStats()
+        val overview = dao.getOverview(100L, 200L)
+
+        assertEquals(201L, overview.totalWatchMs)
+        assertEquals(overview, dao.getUnfilteredOverview(100L, 200L))
+        assertEquals(201L, dao.getUnfilteredTotalWatchMs(100L, 200L))
+    }
+
+    @Test
+    fun channelCategoryAndContentFiltersKeepTheirExistingResults() = runBlocking {
+        val firstSession = insertSession("channel-a", 0L, 100L, 100L)
+        val secondSession = insertSession("channel-b", 0L, 100L, 100L)
+        database.viewingStats().insertInterval(
+            interval(
+                sessionId = firstSession,
+                startAt = 0L,
+                endAt = 100L,
+                channelName = "Channel A",
+                watchedMs = 100L,
+            ).copy(categoryId = null, categoryName = "Game A", contentType = "live"),
+        )
+        database.viewingStats().insertInterval(
+            interval(
+                sessionId = secondSession,
+                startAt = 0L,
+                endAt = 100L,
+                channelName = "Channel B",
+                watchedMs = 100L,
+            ).copy(
+                channelId = "channel-b",
+                channelLogin = "channel-b",
+                categoryId = "game-b",
+                categoryName = "Game B",
+                contentType = "vod",
+            ),
+        )
+
+        val dao = database.viewingStats()
+        assertEquals(200L, dao.getOverview(0L, 100L).totalWatchMs)
+        assertEquals(100L, dao.getOverview(0L, 100L, channelId = "channel-a").totalWatchMs)
+        assertEquals(100L, dao.getOverview(0L, 100L, categoryKey = "name:game a").totalWatchMs)
+        assertEquals(100L, dao.getOverview(0L, 100L, contentType = "vod").totalWatchMs)
+    }
+
+    @Test
+    fun emptyHistoryRetainsTheEmptySnapshot() = runBlocking {
+        val snapshot = repository.loadStatistics(
+            range = ViewingStatsRange.LAST_7_DAYS,
+            now = 1_720_000_000_000L,
+            timeZone = TimeZone.getTimeZone("UTC"),
+        )
+
+        assertEquals(0L, snapshot.totalWatchMs)
+        assertEquals(0, snapshot.sessionCount)
+        assertTrue(snapshot.timeline.isEmpty())
+        assertTrue(snapshot.topChannels.isEmpty())
+    }
+
+    @Test
     fun selectedRangeClipsAnIntervalWithoutLoadingRawHistoryIntoRepository() = runBlocking {
         val now = 1_720_000_000_000L
         val sessionId = database.viewingStats().insertSession(

--- a/app/src/main/java/com/github/andreyasadchy/xtra/db/ViewingStatsDao.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/db/ViewingStatsDao.kt
@@ -27,6 +27,15 @@ interface ViewingStatsDao {
     @Update
     suspend fun updateInterval(interval: ViewingInterval)
 
+    @Transaction
+    suspend fun updateCheckpoints(
+        intervals: List<ViewingInterval>,
+        sessions: List<ViewingSession>,
+    ) {
+        intervals.forEach { updateInterval(it) }
+        sessions.forEach { updateSession(it) }
+    }
+
     @Query(
         "SELECT * FROM viewing_intervals " +
                 "WHERE watched_ms > 0 AND start_at < :toExclusive AND end_at > :fromInclusive " +
@@ -87,6 +96,27 @@ interface ViewingStatsDao {
 
     @Query(
         """
+        SELECT COALESCE(SUM(CASE
+            WHEN end_at <= start_at THEN watched_ms
+            ELSE CAST(ROUND(
+                watched_ms * 1.0 *
+                (MIN(end_at, :toExclusive) - MAX(start_at, :fromInclusive)) /
+                NULLIF(end_at - start_at, 0)
+            ) AS INTEGER)
+        END), 0)
+        FROM viewing_intervals
+        WHERE watched_ms > 0
+          AND start_at < :toExclusive
+          AND end_at > :fromInclusive
+        """
+    )
+    suspend fun getUnfilteredTotalWatchMs(
+        fromInclusive: Long,
+        toExclusive: Long,
+    ): Long
+
+    @Query(
+        """
         WITH filtered AS (
             SELECT
                 session_id,
@@ -137,6 +167,48 @@ interface ViewingStatsDao {
         channelId: String? = null,
         categoryKey: String? = null,
         contentType: String? = null,
+    ): ViewingStatsOverviewRow
+
+    @Query(
+        """
+        WITH filtered AS (
+            SELECT
+                session_id,
+                channel_id,
+                category_id,
+                category_name,
+                content_type,
+                CASE
+                    WHEN end_at <= start_at THEN watched_ms
+                    ELSE CAST(ROUND(
+                        watched_ms * 1.0 *
+                        (MIN(end_at, :toExclusive) - MAX(start_at, :fromInclusive)) /
+                        NULLIF(end_at - start_at, 0)
+                    ) AS INTEGER)
+                END AS clipped_watched_ms,
+                COALESCE(
+                    NULLIF(category_id, ''),
+                    CASE
+                        WHEN category_name IS NOT NULL AND TRIM(category_name) != ''
+                        THEN 'name:' || LOWER(TRIM(category_name))
+                    END
+                ) AS category_key
+            FROM viewing_intervals
+            WHERE watched_ms > 0
+              AND start_at < :toExclusive
+              AND end_at > :fromInclusive
+        )
+        SELECT
+            COALESCE(SUM(clipped_watched_ms), 0) AS total_watch_ms,
+            COUNT(DISTINCT session_id) AS session_count,
+            COUNT(DISTINCT channel_id) AS channel_count,
+            COUNT(DISTINCT CASE WHEN category_key IS NOT NULL THEN category_key END) AS category_count
+        FROM filtered
+        """
+    )
+    suspend fun getUnfilteredOverview(
+        fromInclusive: Long,
+        toExclusive: Long,
     ): ViewingStatsOverviewRow
 
     @Query(

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/ViewingStatsRepository.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/ViewingStatsRepository.kt
@@ -26,6 +26,13 @@ interface ViewingStatsStore {
     suspend fun updateSession(session: ViewingSession)
     suspend fun insertInterval(metadata: ViewingPlaybackMetadata, sessionId: Long, startAt: Long): Long
     suspend fun updateInterval(interval: ViewingInterval)
+    suspend fun updateCheckpoints(
+        intervals: List<ViewingInterval>,
+        sessions: List<ViewingSession>,
+    ) {
+        intervals.forEach { updateInterval(it) }
+        sessions.forEach { updateSession(it) }
+    }
     suspend fun resetAll()
 }
 
@@ -57,6 +64,13 @@ class ViewingStatsRepository(
         dao.updateInterval(interval)
     }
 
+    override suspend fun updateCheckpoints(
+        intervals: List<ViewingInterval>,
+        sessions: List<ViewingSession>,
+    ) {
+        dao.updateCheckpoints(intervals, sessions)
+    }
+
     override suspend fun resetAll() {
         dao.deleteAll()
     }
@@ -86,7 +100,7 @@ class ViewingStatsRepository(
             if (previousTo <= previousFrom) {
                 0L
             } else {
-                dao.getOverview(
+                dao.getUnfilteredOverview(
                     fromInclusive = previousFrom,
                     toExclusive = previousTo,
                 ).totalWatchMs
@@ -179,7 +193,7 @@ class ViewingStatsRepository(
     ): Long {
         val earliest = dao.getEarliestRecordedAt() ?: return 0L
         val bounds = ViewingStatsRanges.bounds(range, now, earliest, timeZone)
-        return dao.getTotalWatchMs(
+        return dao.getUnfilteredTotalWatchMs(
             fromInclusive = bounds.fromInclusive,
             toExclusive = bounds.toExclusive,
         )
@@ -292,7 +306,7 @@ class ViewingStatsRepository(
         topLimit: Int,
         earliestRecordedAt: Long,
     ): ViewingStatsSnapshot {
-        val overview = dao.getOverview(
+        val overview = dao.getUnfilteredOverview(
             fromInclusive = filter.fromInclusive,
             toExclusive = filter.toExclusive,
         )

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/viewingstats/ViewingStatsRecorder.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/viewingstats/ViewingStatsRecorder.kt
@@ -5,15 +5,20 @@ import com.github.andreyasadchy.xtra.model.stats.ViewingSession
 import com.github.andreyasadchy.xtra.model.stats.ViewingInterval
 import com.github.andreyasadchy.xtra.repository.ViewingStatsStore
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.trySendBlocking
 import kotlinx.coroutines.cancel
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.locks.ReentrantLock
 import kotlin.math.max
 
 /**
@@ -32,27 +37,70 @@ class ViewingStatsRecorder(
 
     private val ownedScope = scope == null
     private val scope = scope ?: CoroutineScope(SupervisorJob() + Dispatchers.IO)
-    private val commands = Channel<Command>(Channel.UNLIMITED)
+    /**
+     * Only ordered transitions are sent here. Producer callbacks are
+     * non-suspending, so a pathological full-channel stall applies
+     * synchronous backpressure to the caller until a slot is available. This
+     * is intentional: preserving every semantic transition is more important
+     * than returning immediately after the bounded queue is saturated.
+     */
+    private val commands = Channel<Command>(SEMANTIC_COMMAND_CAPACITY)
+    /** Repeated metadata refreshes share one coalesced wake-up. */
+    private val refreshWork = Channel<Unit>(Channel.CONFLATED)
+    /** Timer wakes are separate so a refresh cannot hide a forced checkpoint. */
+    private val timerWork = Channel<Unit>(Channel.CONFLATED)
+    private val schedulerWake = Channel<Unit>(Channel.CONFLATED)
+    /**
+     * There is one synchronous backpressure boundary for semantic commands.
+     * Keeping the sender serialized is important: a bounded channel alone is
+     * not enough if every full-channel send creates another suspended job.
+     */
+    private val orderedIngressLock = ReentrantLock()
+    private val commandDepth = AtomicInteger(0)
+    private val maxCommandDepth = AtomicInteger(0)
+    private val activeSourceCount = AtomicInteger(0)
+    private val closed = AtomicBoolean(false)
+    private val ingressLock = Any()
+    private val latestInputs = mutableMapOf<String, IngressState>()
+    private val pendingRefreshes = mutableMapOf<String, Command.StateChanged>()
     private val states = linkedMapOf<String, SourceState>()
     private val worker = this.scope.launch {
-        for (command in commands) {
-            when (command) {
-                is Command.StateChanged -> handleStateChanged(command)
-                is Command.SourceReleased -> handleSourceReleased(command)
-                is Command.Checkpoint -> {
-                    handleCheckpoint(command.reading)
-                    command.completed?.complete(Unit)
+        while (isActive) {
+            val work = nextWork() ?: break
+            when (work) {
+                is Work.Semantic -> if (processSemanticCommand(work.command)) break
+                Work.Timer -> {
+                    drainPendingRefreshes()
+                    runCheckpoint(reading(), force = true)
                 }
-                is Command.Reset -> handleReset(command)
-                is Command.Barrier -> command.completed.complete(Unit)
-                Command.Close -> break
+                Work.Refresh -> {
+                    drainPendingRefreshes()
+                    runCheckpoint(reading())
+                }
             }
         }
     }
     private val ticker = this.scope.launch {
+        var nextCheckpointAt = NO_DEADLINE
         while (isActive) {
-            delay(checkpointIntervalMs)
-            commands.send(Command.Checkpoint(reading()))
+            if (activeSourceCount.get() == 0) {
+                nextCheckpointAt = NO_DEADLINE
+                schedulerWake.receive()
+            } else {
+                val now = clock.elapsedRealtime()
+                if (nextCheckpointAt == NO_DEADLINE || nextCheckpointAt <= now) {
+                    nextCheckpointAt = safeAdd(now, checkpointIntervalMs)
+                }
+                val waitMs = (nextCheckpointAt - now).coerceAtLeast(1L)
+                val schedulerWoke = withTimeoutOrNull(waitMs) {
+                    schedulerWake.receive()
+                }
+                val wakeTime = clock.elapsedRealtime()
+                if (schedulerWoke == null || wakeTime >= nextCheckpointAt) {
+                    timerWork.trySend(Unit)
+                    nextCheckpointAt = safeAdd(wakeTime, checkpointIntervalMs)
+                }
+            }
         }
     }
 
@@ -62,45 +110,188 @@ class ViewingStatsRecorder(
         isPlaying: Boolean,
         isBuffering: Boolean,
     ) {
-        commands.trySend(
-            Command.StateChanged(
-                sourceId = sourceId,
-                metadata = metadata,
-                shouldPlay = isPlaying && !isBuffering,
-                reading = reading(),
-            )
-        )
+        var isSemantic = false
+        var semanticCommand: Command.StateChanged? = null
+        orderedIngressLock.lock()
+        try {
+            val accepted = synchronized(ingressLock) {
+                if (closed.get()) {
+                    false
+                } else {
+                    val command = Command.StateChanged(
+                        sourceId = sourceId,
+                        metadata = metadata,
+                        shouldPlay = isPlaying && !isBuffering,
+                        reading = reading(),
+                    )
+                    val previous = latestInputs[sourceId]
+                    latestInputs[sourceId] = IngressState(command.metadata, command.shouldPlay)
+                    isSemantic = isSemanticTransition(previous, command)
+                    if (isSemantic) {
+                        pendingRefreshes.remove(sourceId)
+                        semanticCommand = command
+                    } else {
+                        pendingRefreshes[sourceId] = command
+                    }
+                    true
+                }
+            }
+            if (accepted) {
+                // The channel send may block, but ingressLock is deliberately
+                // not held here so the worker can drain pending refreshes.
+                semanticCommand?.let(::sendOrderedBlocking)
+            }
+            if (accepted && !isSemantic) {
+                refreshWork.trySend(Unit)
+            }
+        } finally {
+            orderedIngressLock.unlock()
+        }
     }
 
     fun release(sourceId: String) {
-        commands.trySend(Command.SourceReleased(sourceId, reading()))
+        orderedIngressLock.lock()
+        try {
+            val command = synchronized(ingressLock) {
+                if (closed.get()) {
+                    null
+                } else {
+                    latestInputs.remove(sourceId)
+                    pendingRefreshes.remove(sourceId)
+                    Command.SourceReleased(sourceId, reading())
+                }
+            }
+            command?.let(::sendOrderedBlocking)
+        } finally {
+            orderedIngressLock.unlock()
+        }
     }
 
     /** Deletes persisted rows and creates new zero-based sessions for active sources. */
     suspend fun reset() {
         val completed = CompletableDeferred<Unit>()
-        commands.send(Command.Reset(reading(), completed))
+        sendOrdered(Command.Reset(reading(), completed))
         completed.await()
     }
 
     suspend fun awaitIdle() {
         val completed = CompletableDeferred<Unit>()
-        commands.send(Command.Barrier(completed))
+        sendOrdered(Command.Barrier(completed))
         completed.await()
     }
 
     /** Persists the current playback baseline before a foreground stats query. */
     suspend fun flush() {
         val completed = CompletableDeferred<Unit>()
-        commands.send(Command.Checkpoint(reading(), completed))
+        sendOrdered(Command.Checkpoint(reading(), completed))
         completed.await()
     }
 
     fun close() {
-        commands.trySend(Command.Close)
-        ticker.cancel()
+        orderedIngressLock.lock()
+        try {
+            val shouldClose = synchronized(ingressLock) {
+                if (closed.get()) {
+                    false
+                } else {
+                    closed.set(true)
+                    ticker.cancel()
+                    true
+                }
+            }
+            if (shouldClose) {
+                sendOrderedBlocking(Command.Close)
+            }
+        } finally {
+            orderedIngressLock.unlock()
+        }
         if (ownedScope) {
-            scope.cancel()
+            scope.launch {
+                worker.join()
+                scope.cancel()
+            }
+        }
+    }
+
+    private suspend fun nextWork(): Work? {
+        commands.tryReceive().getOrNull()?.let {
+            commandDepth.decrementAndGet()
+            return Work.Semantic(it)
+        }
+        timerWork.tryReceive().getOrNull()?.let {
+            return Work.Timer
+        }
+        return kotlinx.coroutines.selects.select {
+            commands.onReceiveCatching { result ->
+                result.getOrNull()?.let {
+                    commandDepth.decrementAndGet()
+                    Work.Semantic(it)
+                }
+            }
+            timerWork.onReceive { Work.Timer }
+            refreshWork.onReceive { Work.Refresh }
+        }
+    }
+
+    private suspend fun processSemanticCommand(command: Command): Boolean {
+        var retried = false
+        while (true) {
+            try {
+                when (command) {
+                    is Command.StateChanged -> handleStateChanged(command)
+                    is Command.SourceReleased -> handleSourceReleased(command)
+                    is Command.Checkpoint -> {
+                        drainPendingRefreshes()
+                        runCheckpoint(command.reading, force = true)
+                        command.completed?.complete(Unit)
+                    }
+                    is Command.Reset -> {
+                        drainPendingRefreshes()
+                        handleReset(command)
+                        command.completed.complete(Unit)
+                    }
+                    is Command.Barrier -> {
+                        drainPendingRefreshes()
+                        val timerPending = timerWork.tryReceive().isSuccess
+                        val refreshPending = refreshWork.tryReceive().isSuccess
+                        if (timerPending || refreshPending) {
+                            drainPendingRefreshes()
+                            runCheckpoint(reading(), force = timerPending)
+                        }
+                        command.completed.complete(Unit)
+                    }
+                    Command.Close -> {
+                        drainPendingRefreshes()
+                        finishAll(reading())
+                        return true
+                    }
+                }
+                return false
+            } catch (cancelled: CancellationException) {
+                when (command) {
+                    is Command.Checkpoint -> command.completed?.completeExceptionally(cancelled)
+                    is Command.Reset -> command.completed.completeExceptionally(cancelled)
+                    is Command.Barrier -> command.completed.completeExceptionally(cancelled)
+                    else -> Unit
+                }
+                throw cancelled
+            } catch (failure: Exception) {
+                if (!retried &&
+                    (command is Command.StateChanged || command is Command.SourceReleased)
+                ) {
+                    retried = true
+                    continue
+                }
+                when (command) {
+                    is Command.Checkpoint -> command.completed?.completeExceptionally(failure)
+                    is Command.Reset -> command.completed.completeExceptionally(failure)
+                    is Command.Barrier -> command.completed.completeExceptionally(failure)
+                    else -> Unit
+                }
+                // A single failed Room write must not permanently stop later
+                // transitions. The in-memory state remains the retry baseline.
+                return false
+            }
         }
     }
 
@@ -136,8 +327,7 @@ class ViewingStatsRecorder(
             // viewing session. The elapsed time accrued above belongs to the
             // previous category before we checkpoint it.
             if (state.actualPlaying) {
-                closeActiveInterval(state, command.reading)
-                persistSession(state, command.reading.wallTimeMillis)
+                closeActiveIntervalAndPersistSession(state, command.reading)
             }
             state.metadata = metadata
         } else {
@@ -157,24 +347,135 @@ class ViewingStatsRecorder(
                 persistCheckpoint(state, command.reading)
             }
         } else if (state.actualPlaying) {
-            closeActiveInterval(state, command.reading)
-            persistSession(state, command.reading.wallTimeMillis)
-            state.actualPlaying = false
+            closeActiveIntervalAndPersistSession(state, command.reading)
             state.lastPersistElapsed = command.reading.elapsedRealtime
         }
     }
 
     private suspend fun handleSourceReleased(command: Command.SourceReleased) {
-        states.remove(command.sourceId)?.let { finish(it, command.reading) }
+        states[command.sourceId]?.let {
+            finish(it, command.reading)
+            states.remove(command.sourceId)
+        }
     }
 
-    private suspend fun handleCheckpoint(reading: ClockReading) {
-        states.values.toList().forEach { state ->
-            if (state.actualPlaying) {
-                accrue(state, reading)
-                persistCheckpoint(state, reading)
+    private suspend fun runCheckpoint(reading: ClockReading, force: Boolean = false) {
+        val activeStates = states.values.filter { it.actualPlaying }
+        activeStates.forEach { accrue(it, reading) }
+        val dueStates = activeStates.filter { force || shouldCheckpoint(it, reading) }
+        if (dueStates.isEmpty()) return
+
+        try {
+            repository.updateCheckpoints(
+                intervals = dueStates.mapNotNull { it.checkpointInterval(reading) },
+                sessions = dueStates.mapNotNull { it.checkpointSession(reading.wallTimeMillis) },
+            )
+            dueStates.forEach { it.lastPersistElapsed = reading.elapsedRealtime }
+        } catch (cancelled: CancellationException) {
+            throw cancelled
+        } catch (_: Exception) {
+            // Keep the state and its elapsed baseline intact so the next
+            // checkpoint or transition can retry the write.
+        }
+    }
+
+    private suspend fun drainPendingRefreshes() {
+        val refreshes = synchronized(ingressLock) {
+            pendingRefreshes.values.toList().also { pendingRefreshes.clear() }
+        }
+        refreshes.forEach { command ->
+            try {
+                handleStateChanged(command)
+            } catch (cancelled: CancellationException) {
+                throw cancelled
+            } catch (_: Exception) {
+                // Retain a failed metadata refresh for a future coalesced
+                // wake, but never let one Room failure kill the worker.
+                synchronized(ingressLock) {
+                    val latest = latestInputs[command.sourceId]
+                    if (latest == IngressState(command.metadata, command.shouldPlay)) {
+                        pendingRefreshes[command.sourceId] = command
+                    }
+                }
             }
         }
+    }
+
+    private suspend fun finishAll(reading: ClockReading) {
+        states.values.toList().forEach { state ->
+            try {
+                finish(state, reading)
+            } catch (cancelled: CancellationException) {
+                throw cancelled
+            } catch (_: Exception) {
+                // Close must still drain the other sources. A failed row can
+                // be recovered by the next application session's normal DB
+                // state, while this recorder is no longer usable.
+            }
+        }
+        states.clear()
+    }
+
+    private fun isSemanticTransition(
+        previous: IngressState?,
+        next: Command.StateChanged,
+    ): Boolean {
+        if (previous == null || previous.metadata == null || next.metadata == null) {
+            return true
+        }
+        return previous.shouldPlay != next.shouldPlay ||
+                !previous.metadata.hasSamePlaybackAs(next.metadata) ||
+                !previous.metadata.hasSameAttributionAs(next.metadata)
+    }
+
+    private fun enqueueOrdered(command: Command) {
+        // Do not replace this with one coroutine per send. A full channel must
+        // backpressure the producer rather than move an unbounded backlog into
+        // suspended sender jobs.
+        orderedIngressLock.lock()
+        try {
+            sendOrderedBlocking(command)
+        } finally {
+            orderedIngressLock.unlock()
+        }
+    }
+
+    private suspend fun sendOrdered(command: Command) {
+        withContext(Dispatchers.IO) {
+            enqueueOrdered(command)
+        }
+    }
+
+    private fun sendOrderedBlocking(command: Command) {
+        val pending = commandDepth.incrementAndGet()
+        // A rendezvous receiver can resume the sender just before its select
+        // callback decrements commandDepth. Do not count that bookkeeping
+        // handoff as an additional pending command.
+        maxCommandDepth.updateAndGet {
+            max(it, pending.coerceAtMost(SEMANTIC_COMMAND_CAPACITY + 1))
+        }
+        val result = commands.trySend(command).let { initial ->
+            if (initial.isSuccess) initial else commands.trySendBlocking(command)
+        }
+        if (result.isFailure) {
+            commandDepth.decrementAndGet()
+            error("Viewing stats recorder command channel is unavailable")
+        }
+    }
+
+    internal fun pendingSemanticWorkForTest(): Int = commandDepth.get()
+
+    internal fun maxPendingSemanticWorkForTest(): Int = maxCommandDepth.get()
+
+    private fun setActualPlaying(state: SourceState, actualPlaying: Boolean) {
+        if (state.actualPlaying == actualPlaying) return
+        state.actualPlaying = actualPlaying
+        if (actualPlaying) {
+            activeSourceCount.incrementAndGet()
+        } else {
+            activeSourceCount.decrementAndGet()
+        }
+        schedulerWake.trySend(Unit)
     }
 
     private suspend fun handleReset(command: Command.Reset) {
@@ -187,16 +488,14 @@ class ViewingStatsRecorder(
             state.sessionWatchedMs = 0L
             state.intervalStartWall = 0L
             state.intervalWatchedMs = 0L
-            state.actualPlaying = false
+            setActualPlaying(state, false)
             state.lastElapsed = command.reading.elapsedRealtime
             state.lastWall = command.reading.wallTimeMillis
             state.lastPersistElapsed = command.reading.elapsedRealtime
         }
         states.values.filter { it.metadata.hasTrackableChannel() && it.wasPlayingBeforeReset }.forEach {
-            it.actualPlaying = false
             startSession(it, command.reading)
         }
-        command.completed.complete(Unit)
     }
 
     private suspend fun startSession(state: SourceState, reading: ClockReading) {
@@ -214,7 +513,7 @@ class ViewingStatsRecorder(
         state.intervalStartWall = reading.wallTimeMillis
         state.intervalWatchedMs = 0L
         state.intervalId = repository.insertInterval(state.metadata, state.sessionId!!, reading.wallTimeMillis)
-        state.actualPlaying = true
+        setActualPlaying(state, true)
         state.lastElapsed = reading.elapsedRealtime
         state.lastWall = reading.wallTimeMillis
         state.lastPersistElapsed = reading.elapsedRealtime
@@ -223,87 +522,85 @@ class ViewingStatsRecorder(
     private suspend fun finish(state: SourceState, reading: ClockReading) {
         accrue(state, reading)
         if (state.intervalId != null) {
-            closeActiveInterval(state, reading)
-        }
-        if (state.sessionId != null) {
+            closeActiveIntervalAndPersistSession(state, reading)
+        } else if (state.sessionId != null) {
             persistSession(state, reading.wallTimeMillis)
         }
-        state.actualPlaying = false
+        setActualPlaying(state, false)
     }
 
-    private suspend fun closeActiveInterval(state: SourceState, reading: ClockReading) {
+    private suspend fun closeActiveIntervalAndPersistSession(
+        state: SourceState,
+        reading: ClockReading,
+    ) {
         val intervalId = state.intervalId ?: return
         val endAt = normalizeIntervalStart(state, reading.wallTimeMillis)
-        repository.updateInterval(
-            ViewingInterval(
-                id = intervalId,
-                sessionId = state.sessionId!!,
-                channelId = state.metadata.normalizedChannelId!!,
-                channelLogin = state.metadata.channelLogin,
-                channelName = state.metadata.channelName,
-                channelImage = state.metadata.channelImage,
-                categoryId = state.metadata.categoryId,
-                categoryName = state.metadata.categoryName,
-                categoryImage = state.metadata.categoryImage,
-                contentType = state.metadata.contentType,
-                contentId = state.metadata.contentId,
-                streamTitle = state.metadata.title,
-                startAt = state.intervalStartWall,
-                endAt = endAt,
-                watchedMs = state.intervalWatchedMs,
-                lastCheckpointAt = reading.wallTimeMillis,
-            )
+        repository.updateCheckpoints(
+            intervals = listOf(state.interval(endAt, reading.wallTimeMillis, intervalId)),
+            sessions = listOfNotNull(state.checkpointSession(reading.wallTimeMillis)),
         )
         state.intervalId = null
         state.intervalWatchedMs = 0L
-        state.actualPlaying = false
+        setActualPlaying(state, false)
     }
 
     private suspend fun persistCheckpoint(state: SourceState, reading: ClockReading) {
-        val intervalId = state.intervalId
-        if (intervalId != null) {
-            val endAt = normalizeIntervalStart(state, reading.wallTimeMillis)
-            repository.updateInterval(
-                ViewingInterval(
-                    id = intervalId,
-                    sessionId = state.sessionId!!,
-                    channelId = state.metadata.normalizedChannelId!!,
-                    channelLogin = state.metadata.channelLogin,
-                    channelName = state.metadata.channelName,
-                    channelImage = state.metadata.channelImage,
-                    categoryId = state.metadata.categoryId,
-                    categoryName = state.metadata.categoryName,
-                    categoryImage = state.metadata.categoryImage,
-                    contentType = state.metadata.contentType,
-                    contentId = state.metadata.contentId,
-                    streamTitle = state.metadata.title,
-                    startAt = state.intervalStartWall,
-                    endAt = endAt,
-                    watchedMs = state.intervalWatchedMs,
-                    lastCheckpointAt = reading.wallTimeMillis,
-                )
-            )
-        }
-        persistSession(state, reading.wallTimeMillis)
+        repository.updateCheckpoints(
+            intervals = listOfNotNull(state.checkpointInterval(reading)),
+            sessions = listOfNotNull(state.checkpointSession(reading.wallTimeMillis)),
+        )
         state.lastPersistElapsed = reading.elapsedRealtime
     }
 
     private suspend fun persistSession(state: SourceState, endedAt: Long) {
-        val sessionId = state.sessionId ?: return
-        repository.updateSession(
-            ViewingSession(
-                id = sessionId,
-                channelId = state.metadata.normalizedChannelId!!,
-                channelLogin = state.metadata.channelLogin,
-                channelName = state.metadata.channelName,
-                channelImage = state.metadata.channelImage,
-                contentType = state.metadata.contentType,
-                contentId = state.metadata.contentId,
-                startedAt = state.sessionStartedAt,
-                endedAt = max(state.sessionStartedAt, endedAt),
-                watchedMs = state.sessionWatchedMs,
-                lastCheckpointAt = endedAt,
-            )
+        state.checkpointSession(endedAt)?.let { repository.updateSession(it) }
+    }
+
+    private fun SourceState.checkpointInterval(reading: ClockReading): ViewingInterval? {
+        val intervalId = intervalId ?: return null
+        val endAt = normalizeIntervalStart(this, reading.wallTimeMillis)
+        return interval(endAt, reading.wallTimeMillis, intervalId)
+    }
+
+    private fun SourceState.interval(
+        endAt: Long,
+        lastCheckpointAt: Long,
+        intervalId: Long = this.intervalId!!,
+    ): ViewingInterval {
+        return ViewingInterval(
+            id = intervalId,
+            sessionId = sessionId!!,
+            channelId = metadata.normalizedChannelId!!,
+            channelLogin = metadata.channelLogin,
+            channelName = metadata.channelName,
+            channelImage = metadata.channelImage,
+            categoryId = metadata.categoryId,
+            categoryName = metadata.categoryName,
+            categoryImage = metadata.categoryImage,
+            contentType = metadata.contentType,
+            contentId = metadata.contentId,
+            streamTitle = metadata.title,
+            startAt = intervalStartWall,
+            endAt = endAt,
+            watchedMs = intervalWatchedMs,
+            lastCheckpointAt = lastCheckpointAt,
+        )
+    }
+
+    private fun SourceState.checkpointSession(endedAt: Long): ViewingSession? {
+        val sessionId = sessionId ?: return null
+        return ViewingSession(
+            id = sessionId,
+            channelId = metadata.normalizedChannelId!!,
+            channelLogin = metadata.channelLogin,
+            channelName = metadata.channelName,
+            channelImage = metadata.channelImage,
+            contentType = metadata.contentType,
+            contentId = metadata.contentId,
+            startedAt = sessionStartedAt,
+            endedAt = max(sessionStartedAt, endedAt),
+            watchedMs = sessionWatchedMs,
+            lastCheckpointAt = endedAt,
         )
     }
 
@@ -398,8 +695,21 @@ class ViewingStatsRecorder(
         }
     }
 
+    private data class IngressState(
+        val metadata: ViewingPlaybackMetadata?,
+        val shouldPlay: Boolean,
+    )
+
+    private sealed interface Work {
+        data class Semantic(val command: Command) : Work
+        data object Timer : Work
+        data object Refresh : Work
+    }
+
     private companion object {
-        const val DEFAULT_CHECKPOINT_INTERVAL_MS = 45_000L
+        const val SEMANTIC_COMMAND_CAPACITY = 128
+        const val DEFAULT_CHECKPOINT_INTERVAL_MS = 120_000L
         const val CLOCK_SKEW_TOLERANCE_MS = 5 * 60 * 1000L
+        const val NO_DEADLINE = Long.MAX_VALUE
     }
 }

--- a/app/src/test/java/com/github/andreyasadchy/xtra/util/viewingstats/ViewingStatsRecorderTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/util/viewingstats/ViewingStatsRecorderTest.kt
@@ -8,7 +8,11 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.joinAll
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -93,6 +97,348 @@ class ViewingStatsRecorderTest {
 
         assertEquals(30.seconds, store.intervals.single().watchedMs)
         assertEquals(30.seconds, store.sessions.single().watchedMs)
+    }
+
+    @Test
+    fun immediateStopPersistsBeforeThePeriodicCheckpoint() = runBlocking {
+        recorder.update("service", metadata("channel-a"), true, false)
+        recorder.awaitIdle()
+        clock.advance(30.seconds)
+
+        recorder.update("service", metadata("channel-a"), false, false)
+        recorder.awaitIdle()
+
+        assertEquals(30.seconds, store.intervals.single().watchedMs)
+    }
+
+    @Test
+    fun repeatedCurrentStateUpdatesCoalesceIntoOneCheckpoint() = runBlocking {
+        recorder.update("service", metadata("channel-a"), true, false)
+        recorder.awaitIdle()
+        repeat(100) {
+            recorder.update("service", metadata("channel-a"), true, false)
+        }
+        clock.advance(100.seconds)
+        // Capture the current reading once after the time advance. The
+        // preceding identical updates are coalesced, so they intentionally
+        // retain the old reading and cannot account for the elapsed time.
+        recorder.update("service", metadata("channel-a"), true, false)
+
+        recorder.awaitIdle()
+
+        assertEquals(1, store.checkpointCalls)
+        assertEquals(100.seconds, store.intervals.single().watchedMs)
+    }
+
+    @Test
+    fun simultaneousSourcesShareOneCheckpointPass() = runBlocking {
+        val localStore = FakeViewingStatsStore()
+        val localScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val localRecorder = ViewingStatsRecorder(
+            repository = localStore,
+            clock = clock,
+            checkpointIntervalMs = 1.hours,
+            scope = localScope,
+        )
+        try {
+            localRecorder.update("source-a", metadata("channel-a"), true, false)
+            localRecorder.update("source-b", metadata("channel-b"), true, false)
+            localRecorder.awaitIdle()
+            clock.advance(1.minutes)
+
+            localRecorder.flush()
+
+            assertEquals(1, localStore.checkpointCalls)
+            assertEquals(2.minutes, localStore.intervals.sumOf { it.watchedMs })
+            assertEquals(setOf("channel-a", "channel-b"), localStore.intervals.map { it.channelId }.toSet())
+        } finally {
+            localRecorder.close()
+            delay(20L)
+            localScope.cancel()
+        }
+    }
+
+    @Test
+    fun semanticTransitionsAndStopSurviveAFullBoundedCommandPath() = runBlocking {
+        store.writeDelayMs = 1L
+        recorder.update("service", metadata("channel-a"), true, false)
+        recorder.awaitIdle()
+
+        repeat(150) { index ->
+            clock.advance(1.milliseconds)
+            recorder.update(
+                sourceId = "service",
+                metadata = metadata(if (index % 2 == 0) "channel-b" else "channel-a"),
+                isPlaying = true,
+                isBuffering = false,
+            )
+        }
+        clock.advance(1.milliseconds)
+        recorder.release("service")
+        recorder.awaitIdle()
+
+        assertTrue(store.intervals.isNotEmpty())
+        assertEquals(151.milliseconds, store.intervals.sumOf { it.watchedMs })
+        assertEquals(
+            buildList {
+                add("channel-a")
+                repeat(150) { index ->
+                    add(if (index % 2 == 0) "channel-b" else "channel-a")
+                }
+            },
+            store.intervals.map { it.channelId },
+        )
+    }
+
+    @Test
+    fun semanticIngressHasBoundedPendingWorkWhenPersistenceStalls() = runBlocking {
+        val localStore = FakeViewingStatsStore().also { it.writeDelayMs = 8L }
+        val localScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val localRecorder = ViewingStatsRecorder(
+            repository = localStore,
+            clock = clock,
+            scope = localScope,
+        )
+        try {
+            val producers = List(4) { producer ->
+                launch(Dispatchers.Default) {
+                    repeat(40) { update ->
+                        localRecorder.update(
+                            sourceId = "source-$producer",
+                            metadata = metadata("channel-${update % 2}"),
+                            isPlaying = true,
+                            isBuffering = false,
+                        )
+                    }
+                }
+            }
+            delay(40L)
+
+            assertTrue(localRecorder.pendingSemanticWorkForTest() <= 129)
+
+            producers.joinAll()
+            repeat(4) { localRecorder.release("source-$it") }
+            localRecorder.awaitIdle()
+
+            assertTrue(
+                "max pending: ${localRecorder.maxPendingSemanticWorkForTest()}",
+                localRecorder.maxPendingSemanticWorkForTest() <= 129,
+            )
+        } finally {
+            localRecorder.close()
+            delay(40L)
+            localScope.cancel()
+        }
+    }
+
+    @Test
+    fun noActiveSourcesMeansNoPeriodicPersistence() = runBlocking {
+        val localStore = FakeViewingStatsStore()
+        val localScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val localRecorder = ViewingStatsRecorder(
+            repository = localStore,
+            clock = clock,
+            checkpointIntervalMs = 10L,
+            scope = localScope,
+        )
+        try {
+            localRecorder.update("service", metadata("channel-a"), false, false)
+            localRecorder.awaitIdle()
+            clock.advance(10.minutes)
+            delay(80L)
+
+            assertEquals(0, localStore.checkpointCalls)
+        } finally {
+            localRecorder.close()
+            delay(20L)
+            localScope.cancel()
+        }
+    }
+
+    @Test
+    fun twoMinuteCadenceIsUsedForCheckpointEligibility() = runBlocking {
+        val localStore = FakeViewingStatsStore()
+        val localScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val localRecorder = ViewingStatsRecorder(
+            repository = localStore,
+            clock = clock,
+            scope = localScope,
+        )
+        try {
+            localRecorder.update("service", metadata("channel-a"), true, false)
+            localRecorder.awaitIdle()
+            clock.advance(119.seconds)
+            localRecorder.update("service", metadata("channel-a"), true, false)
+            localRecorder.awaitIdle()
+            assertEquals(0, localStore.checkpointCalls)
+
+            clock.advance(1.seconds)
+            localRecorder.update("service", metadata("channel-a"), true, false)
+            localRecorder.awaitIdle()
+
+            assertEquals(1, localStore.checkpointCalls)
+            assertEquals(120.seconds, localStore.intervals.single().watchedMs)
+        } finally {
+            localRecorder.close()
+            delay(20L)
+            localScope.cancel()
+        }
+    }
+
+    @Test
+    fun sourceChurnDoesNotDelayAnotherSourcesCheckpointDeadline() = runBlocking {
+        val localStore = FakeViewingStatsStore()
+        val localScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val localRecorder = ViewingStatsRecorder(
+            repository = localStore,
+            clock = clock,
+            checkpointIntervalMs = 5_000L,
+            scope = localScope,
+        )
+        try {
+            localRecorder.update("source-a", metadata("channel-a"), true, false)
+            localRecorder.awaitIdle()
+            // Let the scheduler establish A's deadline without waiting for it
+            // in real time. The test advances only the fake monotonic clock.
+            delay(100L)
+
+            // These B transitions continually change the active-source set.
+            // A's deadline must remain anchored to its own start instead of
+            // restarting after every B transition.
+            repeat(8) {
+                localRecorder.update("source-b", metadata("channel-b"), true, false)
+                localRecorder.update("source-b", metadata("channel-b"), false, false)
+            }
+            clock.advance(5.seconds)
+            // This source change wakes the scheduler exactly at A's original
+            // deadline. It must emit the overdue timer rather than move the
+            // deadline another 5 seconds into the future.
+            localRecorder.update("source-b", metadata("channel-b"), true, false)
+            localRecorder.awaitIdle()
+            withTimeout(1.seconds) {
+                while (localStore.checkpointBatches.none { "channel-a" in it }) {
+                    delay(10L)
+                }
+            }
+
+            assertTrue(
+                "A was never included in a timer checkpoint: ${localStore.checkpointBatches}",
+                localStore.checkpointBatches.any { "channel-a" in it },
+            )
+        } finally {
+            localRecorder.close()
+            delay(40L)
+            localScope.cancel()
+        }
+    }
+
+    @Test
+    fun sharedTimerCheckpointsSourcesThatStartAfterThePreviousTick() = runBlocking {
+        val localStore = FakeViewingStatsStore()
+        val localScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val localRecorder = ViewingStatsRecorder(
+            repository = localStore,
+            clock = clock,
+            checkpointIntervalMs = 40L,
+            scope = localScope,
+        )
+        try {
+            localRecorder.update("source-a", metadata("channel-a"), true, false)
+            localRecorder.awaitIdle()
+            delay(20L)
+            clock.advance(40.milliseconds)
+            delay(60L)
+
+            localRecorder.update("source-b", metadata("channel-b"), true, false)
+            localRecorder.awaitIdle()
+            clock.advance(39.milliseconds)
+            delay(60L)
+
+            assertTrue(
+                "B was not included in the next shared timer checkpoint: ${localStore.checkpointBatches}",
+                localStore.checkpointBatches.any { "channel-b" in it },
+            )
+        } finally {
+            localRecorder.close()
+            delay(40L)
+            localScope.cancel()
+        }
+    }
+
+    @Test
+    fun activeSourcesUseTheConfiguredSharedCadence() = runBlocking {
+        val localStore = FakeViewingStatsStore()
+        val localScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val localRecorder = ViewingStatsRecorder(
+            repository = localStore,
+            clock = clock,
+            checkpointIntervalMs = 25L,
+            scope = localScope,
+        )
+        try {
+            localRecorder.update("service", metadata("channel-a"), true, false)
+            localRecorder.awaitIdle()
+            delay(20L)
+            clock.advance(25.milliseconds)
+            delay(100L)
+            assertTrue(localStore.checkpointCalls >= 1)
+
+            val checkpointsAfterFirstTimer = localStore.checkpointCalls
+            clock.advance(25.milliseconds)
+            delay(100L)
+            assertTrue(localStore.checkpointCalls > checkpointsAfterFirstTimer)
+        } finally {
+            localRecorder.close()
+            delay(20L)
+            localScope.cancel()
+        }
+    }
+
+    @Test
+    fun recorderCloseFinishesTheOpenInterval() = runBlocking {
+        val localStore = FakeViewingStatsStore()
+        val localScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val localRecorder = ViewingStatsRecorder(
+            repository = localStore,
+            clock = clock,
+            scope = localScope,
+        )
+        localRecorder.update("service", metadata("channel-a"), true, false)
+        localRecorder.awaitIdle()
+        clock.advance(30.seconds)
+
+        localRecorder.close()
+        delay(80L)
+
+        assertEquals(30.seconds, localStore.intervals.single().watchedMs)
+        localScope.cancel()
+    }
+
+    @Test
+    fun checkpointFailureDoesNotLoseTheFollowingStop() = runBlocking {
+        recorder.update("service", metadata("channel-a"), true, false)
+        recorder.awaitIdle()
+        clock.advance(30.seconds)
+        store.failNextCheckpoint = true
+
+        recorder.flush()
+        recorder.release("service")
+        recorder.awaitIdle()
+
+        assertEquals(30.seconds, store.intervals.single().watchedMs)
+    }
+
+    @Test
+    fun semanticStopRetriesAfterItsPersistenceFails() = runBlocking {
+        recorder.update("service", metadata("channel-a"), true, false)
+        recorder.awaitIdle()
+        clock.advance(30.seconds)
+        store.failNextCheckpoint = true
+
+        recorder.update("service", metadata("channel-a"), false, false)
+        recorder.awaitIdle()
+
+        assertEquals(30.seconds, store.intervals.single().watchedMs)
     }
 
     @Test
@@ -198,10 +544,15 @@ class ViewingStatsRecorderTest {
 
     private class FakeViewingStatsStore : ViewingStatsStore {
         private var nextId = 1L
+        var checkpointCalls = 0
+        var failNextCheckpoint = false
+        var writeDelayMs = 0L
         val sessions = mutableListOf<ViewingSession>()
         val intervals = mutableListOf<ViewingInterval>()
+        val checkpointBatches = mutableListOf<List<String>>()
 
         override suspend fun insertSession(metadata: ViewingPlaybackMetadata, startedAt: Long): Long {
+            delayIfNeeded()
             val id = nextId++
             sessions += ViewingSession(
                 id = id,
@@ -220,10 +571,12 @@ class ViewingStatsRecorderTest {
         }
 
         override suspend fun updateSession(session: ViewingSession) {
+            delayIfNeeded()
             sessions.replaceById(session.id, session)
         }
 
         override suspend fun insertInterval(metadata: ViewingPlaybackMetadata, sessionId: Long, startAt: Long): Long {
+            delayIfNeeded()
             val id = nextId++
             intervals += ViewingInterval(
                 id = id,
@@ -247,12 +600,31 @@ class ViewingStatsRecorderTest {
         }
 
         override suspend fun updateInterval(interval: ViewingInterval) {
+            delayIfNeeded()
             intervals.replaceById(interval.id, interval)
+        }
+
+        override suspend fun updateCheckpoints(
+            intervals: List<ViewingInterval>,
+            sessions: List<ViewingSession>,
+        ) {
+            checkpointCalls++
+            checkpointBatches += intervals.map { it.channelId }
+            if (failNextCheckpoint) {
+                failNextCheckpoint = false
+                throw IllegalStateException("injected checkpoint failure")
+            }
+            intervals.forEach { updateInterval(it) }
+            sessions.forEach { updateSession(it) }
         }
 
         override suspend fun resetAll() {
             sessions.clear()
             intervals.clear()
+        }
+
+        private suspend fun delayIfNeeded() {
+            if (writeDelayMs > 0L) delay(writeDelayMs)
         }
 
         private fun <T> MutableList<T>.replaceById(id: Long, value: T) {
@@ -269,4 +641,6 @@ class ViewingStatsRecorderTest {
 
     private val Int.minutes: Long get() = this * 60_000L
     private val Int.seconds: Long get() = this * 1_000L
+    private val Int.hours: Long get() = this * 3_600_000L
+    private val Int.milliseconds: Long get() = this.toLong()
 }


### PR DESCRIPTION
Viewing statistics now keep their work bounded while preserving every start, stop, source switch, and category change. Repeated refreshes are coalesced, active playback is saved every two minutes, and clean stops save immediately. Analytics keeps the same results while using safer no-filter reads and batched checkpoint writes.