### PR TITLE
Fix Twitch live chat history decoding

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/XtraModule.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/XtraModule.kt
@@ -69,6 +69,7 @@ import com.github.andreyasadchy.xtra.ui.chat.v2.session.RecentChatHistoryPage
 import com.github.andreyasadchy.xtra.ui.chat.v2.session.RecentChatHistorySource
 import com.github.andreyasadchy.xtra.ui.chat.v2.session.paginateRecentChatPages
 import com.github.andreyasadchy.xtra.ui.chat.v2.session.toV2
+import com.github.andreyasadchy.xtra.model.gql.video.nextCursor
 import com.github.andreyasadchy.xtra.ui.chat.v2.preview.ChatClipPreview
 import com.github.andreyasadchy.xtra.ui.chat.v2.preview.ChatClipPreviewRepository
 import com.github.andreyasadchy.xtra.ui.player.findCurrentRecordingVod
@@ -843,15 +844,15 @@ class XtraModule(application: Application) {
                                 RecentChatHistoryPage(
                                     items = comments?.edges.orEmpty(),
                                     hasNextPage = comments?.pageInfo?.hasNextPage == true,
-                                    nextCursor = comments?.edges?.lastOrNull()?.cursor,
+                                    nextCursor = comments?.nextCursor,
                                 )
                             },
                             isAtLiveEdge = { comment ->
-                                comment.node.contentOffsetSeconds?.let { it >= currentOffset } == true
+                                comment?.node?.contentOffsetSeconds?.let { it >= currentOffset } == true
                             },
                         )
                         if (!pagination.reachedLiveEdge) return@RecentChatHistorySource emptyList()
-                        pagination.items.mapNotNull { it.node.toV2(liveSpec.channelId, vodStartTimestampMs = vodStartMs) }
+                        pagination.items.mapNotNull { it?.node?.toV2(liveSpec.channelId, vodStartTimestampMs = vodStartMs) }
                             .filter { it.timestampMs <= System.currentTimeMillis() }
                             .sortedBy { it.timestampMs }
                             .takeLast(100)

--- a/app/src/main/java/com/github/andreyasadchy/xtra/model/gql/video/VideoMessagesResponse.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/model/gql/video/VideoMessagesResponse.kt
@@ -11,23 +11,23 @@ class VideoMessagesResponse(
 ) {
     @Serializable
     class Data(
-        val video: Video,
+        val video: Video? = null,
     )
 
     @Serializable
     class Video(
-        val comments: Comments,
+        val comments: Comments? = null,
     )
 
     @Serializable
     class Comments(
-        val edges: List<Item>,
+        val edges: List<Item?>? = null,
         val pageInfo: PageInfo? = null,
     )
 
     @Serializable
     class Item(
-        val node: Comment,
+        val node: Comment? = null,
         val cursor: String? = null,
     )
 
@@ -71,3 +71,13 @@ class VideoMessagesResponse(
         val displayName: String? = null,
     )
 }
+
+val VideoMessagesResponse.Comments.nextCursor: String?
+    get() = edges.orEmpty()
+        .asReversed()
+        .firstNotNullOfOrNull { edge -> edge?.cursor?.takeIf(String::isNotBlank) }
+
+val VideoMessagesResponse.Comments.lastNode: VideoMessagesResponse.Comment?
+    get() = edges.orEmpty()
+        .asReversed()
+        .firstNotNullOfOrNull { edge -> edge?.node }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatReplayManager.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatReplayManager.kt
@@ -4,6 +4,7 @@ import com.github.andreyasadchy.xtra.model.chat.Badge
 import com.github.andreyasadchy.xtra.model.chat.ChatMessage
 import com.github.andreyasadchy.xtra.model.chat.TwitchEmote
 import com.github.andreyasadchy.xtra.model.chat.VideoChatMessage
+import com.github.andreyasadchy.xtra.model.gql.video.nextCursor
 import com.github.andreyasadchy.xtra.repository.GraphQLRepository
 import com.github.andreyasadchy.xtra.util.C
 import kotlinx.coroutines.CoroutineScope
@@ -113,7 +114,10 @@ class ChatReplayManager(
                 }
                 messageJob?.cancel()
                 list.addAll(messages)
-                cursor = if (comments.pageInfo?.hasNextPage != false) comments.edges.lastOrNull()?.cursor else null
+                val edges = comments.edges.orEmpty()
+                cursor = if (comments.pageInfo?.hasNextPage != false) {
+                    edges.asReversed().firstNotNullOfOrNull { edge -> edge?.cursor?.takeIf(String::isNotBlank) }
+                } else null
                 isLoading = false
                 startJob()
             } catch (e: Exception) {
@@ -123,9 +127,12 @@ class ChatReplayManager(
                     } else {
                         graphQLRepository.loadVideoMessages(networkLibrary, gqlHeaders, videoId, cursor = cursor)
                     }
-                    val comments = response.data!!.video.comments
-                    val messages = comments.edges.mapNotNull { comment ->
-                        comment.node.let { item ->
+                    val comments = response.data?.video?.comments ?: run {
+                        isLoading = false
+                        return@launch
+                    }
+                    val messages = comments.edges.orEmpty().mapNotNull { comment ->
+                        comment?.node?.let { item ->
                             item.message?.let { message ->
                                 val chatMessage = StringBuilder()
                                 val emotes = message.fragments?.mapNotNull { fragment ->
@@ -167,7 +174,7 @@ class ChatReplayManager(
                     }
                     messageJob?.cancel()
                     list.addAll(messages)
-                    cursor = if (comments.pageInfo?.hasNextPage != false) comments.edges.lastOrNull()?.cursor else null
+                    cursor = if (comments.pageInfo?.hasNextPage != false) comments.nextCursor else null
                     isLoading = false
                     startJob()
                 } catch (e: Exception) {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/download/VideoDownloadService.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/download/VideoDownloadService.kt
@@ -33,6 +33,8 @@ import com.github.andreyasadchy.xtra.model.chat.TwitchBadge
 import com.github.andreyasadchy.xtra.model.chat.TwitchEmote
 import com.github.andreyasadchy.xtra.model.ui.DownloadProgress
 import com.github.andreyasadchy.xtra.model.ui.OfflineVideo
+import com.github.andreyasadchy.xtra.model.gql.video.lastNode
+import com.github.andreyasadchy.xtra.model.gql.video.nextCursor
 import com.github.andreyasadchy.xtra.ui.main.MainActivity
 import com.github.andreyasadchy.xtra.util.C
 import com.github.andreyasadchy.xtra.util.DownloadStorageException
@@ -1258,17 +1260,20 @@ class VideoDownloadService : LifecycleService() {
                     } else {
                         xtraModule.graphQLRepository.loadQueryVideoCommentsDownload(networkLibrary, CRONET_TIMEOUT, okHttpClient, gqlHeaders, videoId, cursor = cursor)
                     }
-                    val comments = response.data!!.video.comments
+                    val comments = response.data?.video?.comments
+                        ?: throw IllegalStateException("Video comments were unavailable")
+                    val edges = comments.edges.orEmpty()
                     val messages = if (cursor == null && resumed) {
-                        comments.edges.filter { item ->
-                            val id = item.node.id
-                            val offset = item.node.contentOffsetSeconds
-                            id != null && offset != null && ((offset == startOffset && !latestSavedMessageIds.contains(id)) || offset > startOffset)
+                        edges.mapNotNull { item ->
+                            val node = item?.node ?: return@mapNotNull null
+                            val id = node.id
+                            val offset = node.contentOffsetSeconds
+                            node.takeIf { id != null && offset != null && ((offset == startOffset && !latestSavedMessageIds.contains(id)) || offset > startOffset) }
                         }
                     } else {
-                        comments.edges
+                        edges.mapNotNull { it?.node }
                     }
-                    cursor = if (comments.pageInfo?.hasNextPage != false) comments.edges.lastOrNull()?.cursor else null
+                    cursor = if (comments.pageInfo?.hasNextPage != false) comments.nextCursor else null
                     if (messages.isNotEmpty()) {
                         if (isShared) {
                             openOutputStream(fileUri.toUri(), "wa").bufferedWriter()
@@ -1278,11 +1283,11 @@ class VideoDownloadService : LifecycleService() {
                             writer.write(",".also { position += 1 })
                             writer.write("\"comments\":".also { position += it.length })
                             writer.write("[".also { position += 1 })
-                            messages.forEachIndexed { index, message ->
+                            messages.forEachIndexed { index, node ->
                                 if (index > 0) {
                                     writer.write(",".also { position += 1 })
                                 }
-                                writer.write(xtraModule.json.encodeToString(message.node).also { position += it.toByteArray().size })
+                                writer.write(xtraModule.json.encodeToString(node).also { position += it.toByteArray().size })
                             }
                             writer.write("]".also { position += 1 })
                         }
@@ -1292,54 +1297,52 @@ class VideoDownloadService : LifecycleService() {
                             val cheerEmotes = mutableListOf<CheerEmote>()
                             val emotes = mutableListOf<Emote>()
                             val words = mutableListOf<String>()
-                            messages.forEach { comment ->
-                                comment.node.let { item ->
-                                    item.message?.let { message ->
-                                        val chatMessage = StringBuilder()
-                                        message.fragments?.forEach { fragment ->
-                                            fragment.text?.let { text ->
-                                                fragment.emote?.emoteID?.let { id ->
-                                                    if (!savedTwitchEmotes.contains(id)) {
-                                                        savedTwitchEmotes.add(id)
-                                                        twitchEmotes.add(TwitchEmote(id = id))
-                                                    }
-                                                }
-                                                chatMessage.append(text)
-                                            }
-                                        }
-                                        message.userBadges?.forEach { badge ->
-                                            badge.setID?.let { setId ->
-                                                badge.version?.let { version ->
-                                                    val pair = Pair(setId, version)
-                                                    if (!savedBadges.contains(pair)) {
-                                                        savedBadges.add(pair)
-                                                        val badge = channelBadgeList.find { badge -> badge.setId == setId && badge.version == version }
-                                                            ?: globalBadgeList.find { badge -> badge.setId == setId && badge.version == version }
-                                                        if (badge != null) {
-                                                            twitchBadges.add(badge)
-                                                        }
-                                                    }
+                            messages.forEach { item ->
+                                item.message?.let { message ->
+                                    val chatMessage = StringBuilder()
+                                    message.fragments?.forEach { fragment ->
+                                        fragment.text?.let { text ->
+                                            fragment.emote?.emoteID?.let { id ->
+                                                if (!savedTwitchEmotes.contains(id)) {
+                                                    savedTwitchEmotes.add(id)
+                                                    twitchEmotes.add(TwitchEmote(id = id))
                                                 }
                                             }
+                                            chatMessage.append(text)
                                         }
-                                        chatMessage.toString().split(" ").forEach { string ->
-                                            if (!words.contains(string)) {
-                                                words.add(string)
-                                                if (!savedEmotes.contains(string)) {
-                                                    val bitsCount = string.takeLastWhile { it.isDigit() }
-                                                    val cheerEmote = if (bitsCount.isNotEmpty()) {
-                                                        val bitsName = string.substringBeforeLast(bitsCount)
-                                                        cheerEmoteList.findLast { it.name.equals(bitsName, true) && it.minBits <= bitsCount.toInt() }
-                                                    } else null
-                                                    if (cheerEmote != null) {
+                                    }
+                                    message.userBadges?.forEach { badge ->
+                                        badge.setID?.let { setId ->
+                                            badge.version?.let { version ->
+                                                val pair = Pair(setId, version)
+                                                if (!savedBadges.contains(pair)) {
+                                                    savedBadges.add(pair)
+                                                    val badge = channelBadgeList.find { badge -> badge.setId == setId && badge.version == version }
+                                                        ?: globalBadgeList.find { badge -> badge.setId == setId && badge.version == version }
+                                                    if (badge != null) {
+                                                        twitchBadges.add(badge)
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                    chatMessage.toString().split(" ").forEach { string ->
+                                        if (!words.contains(string)) {
+                                            words.add(string)
+                                            if (!savedEmotes.contains(string)) {
+                                                val bitsCount = string.takeLastWhile { it.isDigit() }
+                                                val cheerEmote = if (bitsCount.isNotEmpty()) {
+                                                    val bitsName = string.substringBeforeLast(bitsCount)
+                                                    cheerEmoteList.findLast { it.name.equals(bitsName, true) && it.minBits <= bitsCount.toInt() }
+                                                } else null
+                                                if (cheerEmote != null) {
+                                                    savedEmotes.add(string)
+                                                    cheerEmotes.add(cheerEmote)
+                                                } else {
+                                                    val emote = emoteList.find { it.name == string }
+                                                    if (emote != null) {
                                                         savedEmotes.add(string)
-                                                        cheerEmotes.add(cheerEmote)
-                                                    } else {
-                                                        val emote = emoteList.find { it.name == string }
-                                                        if (emote != null) {
-                                                            savedEmotes.add(string)
-                                                            emotes.add(emote)
-                                                        }
+                                                        emotes.add(emote)
                                                     }
                                                 }
                                             }
@@ -1718,7 +1721,7 @@ class VideoDownloadService : LifecycleService() {
                             emoteJobs?.joinAll()
                         }
                     }
-                    val lastOffsetSeconds = comments.edges.lastOrNull()?.node?.contentOffsetSeconds
+                    val lastOffsetSeconds = comments.lastNode?.contentOffsetSeconds
                     if (lastOffsetSeconds != null && lastOffsetSeconds < endTimeSeconds && !cursor.isNullOrBlank()) {
                         downloadProgress.chatProgress = lastOffsetSeconds - startTimeSeconds
                         downloadProgress.chatBytes = position

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/RecentChatHistoryRepositoryTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/RecentChatHistoryRepositoryTest.kt
@@ -1,6 +1,8 @@
 package com.github.andreyasadchy.xtra.ui.chat.v2
 
 import com.github.andreyasadchy.xtra.model.gql.video.VideoMessagesResponse
+import com.github.andreyasadchy.xtra.model.gql.video.lastNode
+import com.github.andreyasadchy.xtra.model.gql.video.nextCursor
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessage
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessageId
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessageKind
@@ -13,7 +15,9 @@ import com.github.andreyasadchy.xtra.ui.chat.v2.session.paginateRecentChatPages
 import com.github.andreyasadchy.xtra.ui.chat.v2.session.toV2
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -66,6 +70,47 @@ class RecentChatHistoryRepositoryTest {
             robottyTimeoutMs = 100,
         ).load(spec)
         assertEquals(listOf(message), result)
+    }
+
+    @Test fun twitchSerializationFailureFallsBackToRobotty() = runBlocking {
+        val json = Json { ignoreUnknownKeys = true }
+        var robottyCalls = 0
+        val logs = mutableListOf<String>()
+        val result = RecentChatHistoryRepository(
+            twitch = RecentChatHistorySource {
+                json.decodeFromString<VideoMessagesResponse>(
+                    """{"data":{"video":{"comments":{"edges":{"invalid":true}}}}}""",
+                )
+                error("unreachable")
+            },
+            robotty = RecentChatHistorySource {
+                robottyCalls += 1
+                listOf(message)
+            },
+            log = logs::add,
+        ).load(spec)
+
+        assertEquals(listOf(message), result)
+        assertEquals(1, robottyCalls)
+        assertTrue(logs.contains("history fallback=twitch-failed reason=JsonDecodingException"))
+    }
+
+    @Test fun twitchResponseAcceptsNullableHistoryContainersAndEntries() {
+        val json = Json { ignoreUnknownKeys = true }
+        fun decode(payload: String) = json.decodeFromString<VideoMessagesResponse>(payload)
+
+        assertNull(decode("""{"data":null}""").data)
+        assertNull(decode("""{"data":{"video":null}}""").data?.video)
+        assertNull(decode("""{"data":{"video":{"comments":null}}}""").data?.video?.comments)
+        assertNull(decode("""{"data":{"video":{"comments":{"edges":null}}}}""").data?.video?.comments?.edges)
+        assertNull(decode("""{"data":{"video":{"comments":{"edges":[null]}}}}""").data?.video?.comments?.edges?.single())
+        assertNull(decode("""{"data":{"video":{"comments":{"edges":[{"cursor":"cursor-node-null","node":null}]}}}}""").data?.video?.comments?.edges?.single()?.node)
+
+        val comments = decode(
+            """{"data":{"video":{"comments":{"edges":[{"cursor":"cursor-valid","node":{"id":"valid"}},null],"pageInfo":{"hasNextPage":true}}}}}""",
+        ).data!!.video!!.comments!!
+        assertEquals("cursor-valid", comments.nextCursor)
+        assertEquals("valid", comments.lastNode?.id)
     }
 
     @Test fun gqlFragmentsKeepTheirEmotePositions() {


### PR DESCRIPTION
Twitch's live VOD chat response can contain null video, comments, edges, and nodes. The decoder now accepts that shape. Pagination uses the last usable cursor and the last valid node, so a trailing null edge cannot truncate replay, downloads, or recent-history loading. The history repository already catches Twitch serialization failures and invokes Robotty. This change does not claim to explain an originally observed session where both sources returned no messages. On-device testing reproduced Twitch SerializationException followed by Robotty returning 100 messages before this fix. After the fix, Twitch returned 59 messages and rendered them. The original all-empty Robotty failure remains unconfirmed. Tests cover nullable response shapes, trailing null edges with hasNextPage=true, cursor and last-node selection, and Twitch SerializationException followed by a successful Robotty result.