### PR TITLE
Fix live chat history default and diagnostics

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/XtraModule.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/XtraModule.kt
@@ -79,6 +79,7 @@ import com.github.andreyasadchy.xtra.ui.chat.v2.transport.TwitchChatTransportCon
 import com.github.andreyasadchy.xtra.ui.chat.v2.transport.SevenTvPresenceReporter
 import com.github.andreyasadchy.xtra.util.C
 import com.github.andreyasadchy.xtra.util.TwitchApiHelper
+import com.github.andreyasadchy.xtra.util.isRecentChatHistoryEnabled
 import com.github.andreyasadchy.xtra.util.prefs
 import com.github.andreyasadchy.xtra.util.tokenPrefs
 import com.github.andreyasadchy.xtra.util.viewingstats.ViewingStatsRecorder
@@ -102,6 +103,7 @@ import javax.net.ssl.TrustManagerFactory
 import javax.net.ssl.X509TrustManager
 
 private const val RECENT_HISTORY_WINDOW_SECONDS = 10 * 60
+private const val RECENT_HISTORY_LOG_TAG = "RecentChatHistory"
 
 @OptIn(UnstableApi::class)
 class XtraModule(application: Application) {
@@ -861,13 +863,18 @@ class XtraModule(application: Application) {
                         val url = liveSpec.recentMessagesUrl
                             ?: "https://recent-messages.robotty.de/api/v2/recent-messages/\$channel"
                         val network = appContext.prefs().getString(C.NETWORK_LIBRARY, C.OKHTTP)
-                        playerRepository.loadRecentMessages(network, url, liveSpec.channelLogin, "100")
-                            .messages.asSequence()
+                        val rawMessages = playerRepository
+                            .loadRecentMessages(network, url, liveSpec.channelLogin, "100")
+                            .messages
+                        Log.d(RECENT_HISTORY_LOG_TAG, "history stage=robotty raw_count=${rawMessages.size}")
+                        val parsedMessages = rawMessages.asSequence()
                             .mapNotNull { raw -> TwitchChatEventParser.fromIrc(com.github.andreyasadchy.xtra.util.chat.ChatUtils.parseIRCMessage(raw), liveSpec.channelId) }
                             .mapNotNull { (it as? com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatEvent.Message)?.message }
                             .toList()
+                        Log.d(RECENT_HISTORY_LOG_TAG, "history stage=robotty parsed_count=${parsedMessages.size}")
+                        parsedMessages
                     },
-                    enabled = { appContext.prefs().getBoolean(C.CHAT_RECENT, true) },
+                    enabled = { appContext.prefs().isRecentChatHistoryEnabled() },
                 ).load(spec)
             },
             initialSettings = { spec ->

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/session/RecentChatHistoryRepository.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/session/RecentChatHistoryRepository.kt
@@ -61,11 +61,17 @@ class RecentChatHistoryRepository(
     private val robottyTimeoutMs: Long = 10_000,
 ) : RecentChatHistorySource {
     override suspend fun load(spec: LiveChatSessionSpec): List<ChatMessage> {
-        if (!enabled()) return emptyList()
+        if (!enabled()) {
+            log("history disabled")
+            return emptyList()
+        }
         try {
             val result = withTimeout(twitchTimeoutMs) { twitch.load(spec) }
-            log("history source=twitch count=${result.size}")
-            if (result.isNotEmpty()) return result
+            log("history stage=twitch result_count=${result.size}")
+            if (result.isNotEmpty()) {
+                log("history stage=final reconciled_count=${result.size}")
+                return result
+            }
             log("history fallback=twitch-empty")
         } catch (error: TimeoutCancellationException) {
             log("history fallback=twitch-timeout")
@@ -76,15 +82,17 @@ class RecentChatHistoryRepository(
         }
         return try {
             val result = withTimeout(robottyTimeoutMs) { robotty.load(spec) }
-            log("history source=robotty count=${result.size}")
+            log("history stage=final reconciled_count=${result.size}")
             result
         } catch (error: TimeoutCancellationException) {
             log("history unavailable reason=robotty-timeout")
+            log("history stage=final reconciled_count=0")
             emptyList()
         } catch (error: CancellationException) {
             throw error
         } catch (error: Throwable) {
             log("history unavailable reason=${error.javaClass.simpleName}")
+            log("history stage=final reconciled_count=0")
             emptyList()
         }
     }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/C.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/C.kt
@@ -295,6 +295,7 @@ object C {
     const val CHAT_TIMESTAMPS = "chat_timestamps"
     const val CHAT_TIMESTAMP_FORMAT = "chat_timestamp_format"
     const val CHAT_RECENT = "chat_recent"
+    const val CHAT_RECENT_DEFAULT = true
     const val CHAT_TRANSLATE = "chat_translate"
     const val CHAT_TRANSLATE_TARGET = "chat_translate_target"
     const val CHAT_SHOW_USER_NOTICE = "chat_show_usernotice"

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/ContextExtensions.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/ContextExtensions.kt
@@ -233,6 +233,10 @@ fun SharedPreferences.isChatEnabled(): Boolean = if (contains(C.SETTINGS_CHAT_EN
     !getBoolean(C.CHAT_DISABLE, false)
 }
 
+/** Matches chat_history_preferences.xml when the preference has not been stored yet. */
+fun SharedPreferences.isRecentChatHistoryEnabled(): Boolean =
+    getBoolean(C.CHAT_RECENT, C.CHAT_RECENT_DEFAULT)
+
 /** HTTP proxy credentials are retained when disabled so the user can turn the proxy back on later. */
 fun SharedPreferences.httpProxyEnabled(): Boolean = if (contains(C.SETTINGS_HTTP_PROXY_ENABLED)) {
     getBoolean(C.SETTINGS_HTTP_PROXY_ENABLED, false)

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/SettingsMigration.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/SettingsMigration.kt
@@ -388,6 +388,13 @@ object SettingsMigration {
         // marker already says current; AndroidX ListPreference requires a
         // String and reads the raw SharedPreferences value directly.
         normalizeCaptionIntervalPreference(preferences)
+        if (!preferences.contains(C.CHAT_RECENT)) {
+            // chat_history_preferences.xml enables recent history by default. Seed the
+            // key here because this app does not initialize PreferenceManager defaults.
+            preferences.edit {
+                putBoolean(C.CHAT_RECENT, C.CHAT_RECENT_DEFAULT)
+            }
+        }
         if (preferences.getInt(C.SETTINGS_VERSION, 0) >= C.SETTINGS_SCHEMA_VERSION) return
         val isFreshInstall = freshInstall ?: inferFreshInstall(preferences)
 

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/RecentChatHistoryRepositoryTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/RecentChatHistoryRepositoryTest.kt
@@ -51,14 +51,29 @@ class RecentChatHistoryRepositoryTest {
 
     @Test fun disabledHistoryDoesNotQueryEitherSource() = runBlocking {
         var calls = 0
+        val logs = mutableListOf<String>()
         val result = RecentChatHistoryRepository(
             twitch = RecentChatHistorySource { calls++; listOf(message) },
             robotty = RecentChatHistorySource { calls++; listOf(message) },
             enabled = { false },
-            log = {},
+            log = logs::add,
         ).load(spec)
         assertTrue(result.isEmpty())
         assertEquals(0, calls)
+        assertEquals(listOf("history disabled"), logs)
+    }
+
+    @Test fun logsSourceAndFinalHistoryCounts() = runBlocking {
+        val logs = mutableListOf<String>()
+        val result = RecentChatHistoryRepository(
+            twitch = RecentChatHistorySource { emptyList() },
+            robotty = RecentChatHistorySource { listOf(message) },
+            log = logs::add,
+        ).load(spec)
+
+        assertEquals(listOf(message), result)
+        assertTrue(logs.contains("history stage=twitch result_count=0"))
+        assertTrue(logs.contains("history stage=final reconciled_count=1"))
     }
 
     @Test fun twitchTimeoutFallsBackToRobotty() = runBlocking {

--- a/app/src/test/java/com/github/andreyasadchy/xtra/util/SettingsMigrationTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/util/SettingsMigrationTest.kt
@@ -78,6 +78,35 @@ class SettingsMigrationTest {
     }
 
     @Test
+    fun `missing chat history preference uses the enabled default and is seeded`() {
+        val preferences = MemoryPreferences(
+            mutableMapOf(C.SETTINGS_VERSION to C.SETTINGS_SCHEMA_VERSION),
+        )
+
+        assertTrue(preferences.isRecentChatHistoryEnabled())
+        assertTrue(!preferences.contains(C.CHAT_RECENT))
+
+        SettingsMigration.migratePreferences(preferences, freshInstall = false)
+
+        assertTrue(preferences.contains(C.CHAT_RECENT))
+        assertTrue(preferences.isRecentChatHistoryEnabled())
+    }
+
+    @Test
+    fun `explicitly disabled chat history is preserved by migration`() {
+        val preferences = MemoryPreferences(
+            mutableMapOf(
+                C.SETTINGS_VERSION to C.SETTINGS_SCHEMA_VERSION,
+                C.CHAT_RECENT to false,
+            ),
+        )
+
+        SettingsMigration.migratePreferences(preferences, freshInstall = false)
+
+        assertTrue(!preferences.isRecentChatHistoryEnabled())
+    }
+
+    @Test
     fun `a preference set without a schema marker is still treated as an upgrade`() {
         val preferences = MemoryPreferences(mutableMapOf(C.UI_LANGUAGE to "en"))
 


### PR DESCRIPTION
Enable live chat history by default when its preference is absent, log each history source stage, and add regression coverage for first-run settings.