### PR TITLE
Optimize Chat v2 rendering and asset caching

### DIFF
--- a/app/src/androidTest/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatMessageTextViewTest.kt
+++ b/app/src/androidTest/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatMessageTextViewTest.kt
@@ -337,6 +337,56 @@ class ChatMessageTextViewTest {
     }
 
     @Test
+    fun stagedRowSurvivesDetachAndReattachUntilItsAssetCompletes() = runBlocking {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val releaseCandidate = CompletableDeferred<ChatImageHandle?>()
+        val repository = ChatAssetRepository(scope, ChatAssetLoader { key ->
+            when (key.value) {
+                "visible-staged" -> ChatImageHandle { SolidDrawable(Color.RED) }
+                "pending-staged" -> releaseCandidate.await()
+                else -> null
+            }
+        })
+        val attached = attachView(repository)
+        val view = attached.view
+        val id = ChatMessageId("detach-reattach-staged")
+        val visibleSpec = ChatAssetSpec(ChatAssetKey("visible-staged"), 16, 16, 24)
+        val pendingSpec = ChatAssetSpec(ChatAssetKey("pending-staged"), 16, 16, 24)
+        try {
+            runOnMain { view.bind(row(visibleSpec, fallback = "VISIBLE", animated = false).copy(id = id)) }
+            awaitSettled(repository, listOf(visibleSpec.key))
+            awaitPreDraw(view)
+            runOnMain {
+                val spanned = view.text as Spanned
+                val span = spanned.getSpans(0, spanned.length, ReplacementSpan::class.java).single()
+                assertTrue(containsColor(draw(span, spanned, Paint.FontMetricsInt()), Color.RED))
+            }
+
+            runOnMain {
+                view.bind(row(pendingSpec, fallback = "STAGED", animated = false).copy(id = id))
+                view.detachedForTest()
+                view.attachedForTest()
+            }
+            awaitAssetRequested(repository, pendingSpec.key)
+
+            releaseCandidate.complete(ChatImageHandle { SolidDrawable(Color.BLUE) })
+            withTimeout(2_000) {
+                while (repository.peek(pendingSpec.key) !is ChatAssetState.Ready) delay(1)
+            }
+            awaitPreDraw(view)
+
+            runOnMain {
+                val spanned = view.text as Spanned
+                val span = spanned.getSpans(0, spanned.length, ReplacementSpan::class.java).single()
+                assertTrue(containsColor(draw(span, spanned, Paint.FontMetricsInt()), Color.BLUE))
+            }
+        } finally {
+            attached.close()
+            scope.cancel()
+        }
+    }
+
+    @Test
     fun sameIdRebindStagesComposedOverlayUntilTheOverlayIsReady() = runBlocking {
         val context = InstrumentationRegistry.getInstrumentation().targetContext
         val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
@@ -963,17 +1013,21 @@ class ChatMessageTextViewTest {
     fun failedClipMetadataDoesNotGrowLaterOnSameBinding() = runBlocking {
         val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
         val loads = AtomicInteger()
-        val clipRepository = ChatClipPreviewRepository(scope) {
-            if (loads.incrementAndGet() == 1) null else ChatClipPreview(
-                title = "clip",
-                broadcasterName = "broadcaster",
-                creatorName = "creator",
-                thumbnailUrl = null,
-                gameName = null,
-                durationSeconds = null,
-                createdAt = null,
-            )
-        }
+        val clipRepository = ChatClipPreviewRepository(
+            scope = scope,
+            loader = {
+                if (loads.incrementAndGet() == 1) null else ChatClipPreview(
+                    title = "clip",
+                    broadcasterName = "broadcaster",
+                    creatorName = "creator",
+                    thumbnailUrl = null,
+                    gameName = null,
+                    durationSeconds = null,
+                    createdAt = null,
+                )
+            },
+            negativeTtlMs = 0,
+        )
         val assetRepository = ChatAssetRepository(scope, ChatAssetLoader { null })
         val attached = attachView(assetRepository, clipRepository)
         val view = attached.view
@@ -1431,6 +1485,25 @@ class ChatMessageTextViewTest {
             view.bind(row(second))
             assertEquals(0, repository.observerCount(first.key))
             assertEquals(1, repository.observerCount(second.key))
+        }
+        scope.cancel()
+    }
+
+    @Test
+    fun attachingAlreadyBoundViewDoesNotDuplicateAssetObservers() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+        val repository = ChatAssetRepository(scope, ChatAssetLoader { null })
+        val view = TestTextView(context, repository)
+        val spec = ChatAssetSpec(ChatAssetKey("bound-before-attach"), 16, 16, 24)
+
+        runOnMain {
+            view.bind(row(spec))
+            assertEquals(1, repository.observerCount(spec.key))
+            view.attachedForTest()
+            assertEquals(1, repository.observerCount(spec.key))
+            view.detachedForTest()
+            assertEquals(0, repository.observerCount(spec.key))
         }
         scope.cancel()
     }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/EmoteRecommendationAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/EmoteRecommendationAdapter.kt
@@ -50,8 +50,15 @@ class EmoteRecommendationAdapter(
                     if (binding.image.tag != key) return@post
                     when (val state = assets.peek(key)) {
                         is ChatAssetState.Ready -> {
-                            binding.image.setImageDrawable(state.image.newDrawable())
-                            binding.image.isVisible = true
+                            val drawable = state.image.newDrawable()
+                            if (drawable == null) {
+                                assets.retryIfDrawableUnavailable(key)
+                                binding.image.setImageDrawable(null)
+                                binding.image.isVisible = false
+                            } else {
+                                binding.image.setImageDrawable(drawable)
+                                binding.image.isVisible = true
+                            }
                         }
                         else -> {
                             binding.image.setImageDrawable(null)

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/assets/ChatAssetRepository.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/assets/ChatAssetRepository.kt
@@ -1,7 +1,9 @@
 package com.github.andreyasadchy.xtra.ui.chat.v2.assets
 
 import android.os.SystemClock
+import com.github.andreyasadchy.xtra.BuildConfig
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatAssetKey
+import com.github.andreyasadchy.xtra.util.ChatRenderDiagnostics
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.CoroutineScope
@@ -43,6 +45,7 @@ class ChatAssetRepository(
             listeners.getOrPut(key) { LinkedHashSet() }.add(listener)
             if (states[key] == null) states[key] = ChatAssetState.Missing
             trimCacheLocked()
+            updateDiagnosticsLocked()
         }
         request(key)
     }
@@ -56,8 +59,12 @@ class ChatAssetRepository(
                 retryJobs.remove(key)?.cancel()
                 loadJob = loadJobs.remove(key)
                 if (states[key] is ChatAssetState.Loading) states.remove(key)
+                if ((states[key] as? ChatAssetState.Ready)?.image?.holdsDecodedImage() == true) {
+                    states.remove(key)
+                }
             }
             trimCacheLocked()
+            updateDiagnosticsLocked()
         }
         loadJob?.cancel()
     }
@@ -67,6 +74,7 @@ class ChatAssetRepository(
         val interested = synchronized(this) {
             keys.forEach { key -> if (states[key] is ChatAssetState.Failed) states.remove(key) }
             trimCacheLocked()
+            updateDiagnosticsLocked()
             keys.filter { !listeners[it].isNullOrEmpty() }
         }
         interested.forEach(::request)
@@ -128,6 +136,7 @@ class ChatAssetRepository(
                             states[key] = state
                             retryJobs.remove(key)
                             trimCacheLocked()
+                            updateDiagnosticsLocked()
                             listeners[key]?.toList().orEmpty()
                         }
                     } ?: return@launch
@@ -136,10 +145,16 @@ class ChatAssetRepository(
                     if (state is ChatAssetState.Failed) scheduleRetry(key, state.nextRetryAtMs - nowMs())
                 } finally {
                     synchronized(this@ChatAssetRepository) {
-                        if (loadJobs[key] === currentJob) loadJobs.remove(key)
+                        if (loadJobs[key] === currentJob) {
+                            loadJobs.remove(key)
+                            updateDiagnosticsLocked()
+                        }
                     }
                 }
-            }.also { loadJobs[key] = it }
+            }.also {
+                loadJobs[key] = it
+                updateDiagnosticsLocked()
+            }
         }
         if (!loadJob.start()) {
             synchronized(this) {
@@ -148,9 +163,24 @@ class ChatAssetRepository(
                     if (listeners[key].isNullOrEmpty() && states[key] is ChatAssetState.Loading) {
                         states.remove(key)
                     }
+                    updateDiagnosticsLocked()
                 }
             }
         }
+    }
+
+    /** Reopens a Ready state if Coil evicted the decoded value before this row needed a drawable. */
+    internal fun retryIfDrawableUnavailable(key: ChatAssetKey) {
+        val shouldRequest = synchronized(this) {
+            if (listeners[key].isNullOrEmpty() || states[key] !is ChatAssetState.Ready) {
+                false
+            } else {
+                states[key] = ChatAssetState.Missing
+                updateDiagnosticsLocked()
+                true
+            }
+        }
+        if (shouldRequest) request(key)
     }
 
     private fun scheduleRetry(key: ChatAssetKey, delayMs: Long) {
@@ -180,5 +210,17 @@ class ChatAssetRepository(
                 iterator.remove()
             }
         }
+    }
+
+    private fun updateDiagnosticsLocked() {
+        if (!BuildConfig.PERF_DIAGNOSTICS) return
+        ChatRenderDiagnostics.setAssetRepositoryState(
+            activeObservers = listeners.values.sumOf { it.size },
+            inFlightLoads = loadJobs.size,
+            cachedStates = states.size,
+            decodedHandles = states.values.count { state ->
+                (state as? ChatAssetState.Ready)?.image?.holdsDecodedImage() == true
+            },
+        )
     }
 }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/assets/ChatAssetState.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/assets/ChatAssetState.kt
@@ -14,7 +14,18 @@ sealed interface ChatAssetState {
     }
 }
 
-fun interface ChatImageHandle { fun newDrawable(): Drawable }
+/**
+ * Lightweight reference to an image owned by the image loader. Shareable implementations must
+ * not retain the decoded image themselves. A drawable is created per consumer where the image
+ * format provides an independent drawable factory; Coil's non-shareable animated fallback is
+ * the documented exception because Coil does not cache that decoded value.
+ */
+fun interface ChatImageHandle {
+    fun newDrawable(): Drawable?
+
+    /** True only for Coil formats which cannot be recreated from Coil's decoded memory cache. */
+    fun holdsDecodedImage(): Boolean = false
+}
 
 class ChatAssetLoadException(val statusCode: Int? = null, cause: Throwable? = null) : Exception(cause)
 

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/assets/CoilChatAssetLoader.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/assets/CoilChatAssetLoader.kt
@@ -2,9 +2,11 @@ package com.github.andreyasadchy.xtra.ui.chat.v2.assets
 
 import android.content.Context
 import android.net.Uri
+import coil3.Image
 import coil3.ImageLoader
 import coil3.asDrawable
 import coil3.imageLoader
+import coil3.memory.MemoryCache
 import coil3.network.HttpException
 import coil3.network.NetworkHeaders
 import coil3.network.httpHeaders
@@ -31,7 +33,7 @@ class CoilChatAssetLoader(
         val result = imageLoader.execute(
             ImageRequest.Builder(context)
                 .data(url)
-                .memoryCacheKey("xtra:chat-v2:$url")
+                .memoryCacheKey(memoryCacheKey(url))
                 .diskCacheKey(url)
                 .memoryCachePolicy(CachePolicy.ENABLED)
                 .diskCachePolicy(CachePolicy.ENABLED)
@@ -48,14 +50,36 @@ class CoilChatAssetLoader(
         )
         return when (result) {
             is SuccessResult -> {
-                // Keep the decoded image handle, not a mutable Drawable. Every bound TextView
-                // asks Coil for its own Drawable instance, which is required for animated assets.
-                ChatImageHandle {
-                    result.image.asDrawable(context.resources).mutate()
+                val image = result.image
+                if (image.shareable) {
+                    // Shareable images are retained by Coil. The repository keeps only this
+                    // cache key, and each bound TextView creates its own drawable instance.
+                    ChatImageHandle {
+                        imageLoader.memoryCache
+                            ?.get(MemoryCache.Key(memoryCacheKey(url)))
+                            ?.image
+                            ?.let(::newIndependentDrawable)
+                    }
+                } else {
+                    // Coil deliberately does not put non-shareable animated DrawableImages in
+                    // memory cache. Retain this one decoded handle as the current animated
+                    // fallback, matching the old behavior, and clone through ConstantState when
+                    // the platform drawable supports it.
+                    object : ChatImageHandle {
+                        override fun newDrawable() = newIndependentDrawable(image)
+                        override fun holdsDecodedImage() = true
+                    }
                 }
             }
             is ErrorResult -> throw ChatAssetLoadException(result.throwable.httpStatusCode(), result.throwable)
         }
+    }
+
+    private fun memoryCacheKey(url: String): String = "xtra:chat-v2:$url"
+
+    private fun newIndependentDrawable(image: Image): android.graphics.drawable.Drawable? {
+        val drawable = image.asDrawable(context.resources)
+        return drawable.constantState?.newDrawable(context.resources)?.mutate() ?: drawable.mutate()
     }
 
     private fun isHttpUrl(value: String): Boolean {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/presentation/ChatPresentationSnapshot.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/presentation/ChatPresentationSnapshot.kt
@@ -28,6 +28,7 @@ internal data class ChatMetadataSettlement(
 internal class ChatPresentationSnapshot {
     private var sessionKey: ChatSessionKey? = null
     private val catalogsByMessage = HashMap<ChatMessageId, FrozenCatalog>()
+    private val activeMessageIds = HashSet<ChatMessageId>()
 
     @Synchronized
     fun catalogsFor(
@@ -44,8 +45,9 @@ internal class ChatPresentationSnapshot {
             sessionKey = key
             catalogsByMessage.clear()
         }
-        val messageIds = messages.asSequence().map(ChatMessage::id).toSet()
-        catalogsByMessage.keys.retainAll(messageIds)
+        activeMessageIds.clear()
+        messages.forEach { activeMessageIds += it.id }
+        catalogsByMessage.keys.retainAll(activeMessageIds)
         val settlement = ChatMetadataSettlement(structuralSettled, badgesSettled, rewardsSettled)
         return messages.map { message ->
             val frozen = catalogsByMessage[message.id]
@@ -93,27 +95,50 @@ internal class ChatPresentationSnapshot {
         private var badgesSettled: Boolean,
         private var rewardsSettled: Boolean,
     ) {
+        private var resolvedCatalog: ChatCatalogSnapshot? = null
+        private var resolvedRevision: Long? = null
+        private var resolvedCurrentBadges: Map<String, ChatCatalogBadge>? = null
+
         fun update(
             catalog: ChatCatalogSnapshot,
             captureBadges: Boolean,
             settlement: ChatMetadataSettlement,
             forceUpgrade: Boolean,
         ) {
-            if (captureBadges && badges == null) badges = catalog.badges
+            var changed = false
+            if (captureBadges && badges == null) {
+                badges = catalog.badges
+                changed = true
+            }
 
             if (forceUpgrade || !structuralSettled && settlement.structuralSettled) {
                 captureStructural(catalog)
+                changed = true
             }
             if (captureBadges && (forceUpgrade || !badgesSettled && settlement.badgesSettled)) {
                 badges = catalog.badges
+                changed = true
             }
             if (forceUpgrade || !rewardsSettled && settlement.rewardsSettled) {
                 captureRewards(catalog)
+                changed = true
             }
 
-            structuralSettled = structuralSettled || settlement.structuralSettled
-            badgesSettled = badgesSettled || settlement.badgesSettled
-            rewardsSettled = rewardsSettled || settlement.rewardsSettled
+            val nextStructuralSettled = structuralSettled || settlement.structuralSettled
+            val nextBadgesSettled = badgesSettled || settlement.badgesSettled
+            val nextRewardsSettled = rewardsSettled || settlement.rewardsSettled
+            changed = changed ||
+                structuralSettled != nextStructuralSettled ||
+                badgesSettled != nextBadgesSettled ||
+                rewardsSettled != nextRewardsSettled
+            structuralSettled = nextStructuralSettled
+            badgesSettled = nextBadgesSettled
+            rewardsSettled = nextRewardsSettled
+            if (changed) {
+                resolvedCatalog = null
+                resolvedRevision = null
+                resolvedCurrentBadges = null
+            }
         }
 
         private fun captureStructural(catalog: ChatCatalogSnapshot) {
@@ -134,21 +159,33 @@ internal class ChatPresentationSnapshot {
             channelPointRewardsRevision = catalog.channelPointRewardsRevision
         }
 
-        fun toCatalog(current: ChatCatalogSnapshot): ChatCatalogSnapshot = current.copy(
-            twitch = twitch,
-            sevenTv = sevenTv,
-            sevenTvChannelSetId = sevenTvChannelSetId,
-            bttv = bttv,
-            ffz = ffz,
-            badges = badges ?: current.badges,
-            cheermotes = cheermotes,
-            userDecorations = userDecorations,
-            namePaints = namePaints,
-            sevenTvBadges = sevenTvBadges,
-            channelPointRewards = channelPointRewards,
-            automaticChannelPointRewards = automaticChannelPointRewards,
-            channelPointRewardsRevision = channelPointRewardsRevision,
-        )
+        fun toCatalog(current: ChatCatalogSnapshot): ChatCatalogSnapshot {
+            val cached = resolvedCatalog
+            if (cached != null && resolvedRevision == current.revision &&
+                (badges != null || resolvedCurrentBadges === current.badges)
+            ) {
+                return cached
+            }
+            return current.copy(
+                twitch = twitch,
+                sevenTv = sevenTv,
+                sevenTvChannelSetId = sevenTvChannelSetId,
+                bttv = bttv,
+                ffz = ffz,
+                badges = badges ?: current.badges,
+                cheermotes = cheermotes,
+                userDecorations = userDecorations,
+                namePaints = namePaints,
+                sevenTvBadges = sevenTvBadges,
+                channelPointRewards = channelPointRewards,
+                automaticChannelPointRewards = automaticChannelPointRewards,
+                channelPointRewardsRevision = channelPointRewardsRevision,
+            ).also {
+                resolvedCatalog = it
+                resolvedRevision = current.revision
+                resolvedCurrentBadges = current.badges
+            }
+        }
 
         companion object {
             fun from(

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/preview/ChatClipPreviewRepository.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/preview/ChatClipPreviewRepository.kt
@@ -1,7 +1,13 @@
 package com.github.andreyasadchy.xtra.ui.chat.v2.preview
 
+import android.os.SystemClock
+import com.github.andreyasadchy.xtra.util.ChatRenderDiagnostics
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
+import java.util.LinkedHashMap
 
 data class ChatClipPreview(
     val title: String?,
@@ -68,41 +74,86 @@ fun parseClipTimestamp(createdAt: String?): Long? {
 class ChatClipPreviewRepository(
     private val scope: CoroutineScope,
     private val loader: suspend (String) -> ChatClipPreview?,
+    private val maxEntries: Int = DEFAULT_MAX_ENTRIES,
+    private val successTtlMs: Long = DEFAULT_SUCCESS_TTL_MS,
+    private val negativeTtlMs: Long = DEFAULT_NEGATIVE_TTL_MS,
+    private val nowMs: () -> Long = { SystemClock.elapsedRealtime() },
 ) {
-    private val cache = HashMap<String, ChatClipPreview>()
-    private val states = HashMap<String, ChatClipPreviewState>()
+    /** Source-compatible overload for the original `(scope) { loader }` call shape. */
+    constructor(
+        scope: CoroutineScope,
+        loader: suspend (String) -> ChatClipPreview?,
+    ) : this(scope, loader, DEFAULT_MAX_ENTRIES, DEFAULT_SUCCESS_TTL_MS, DEFAULT_NEGATIVE_TTL_MS)
+
+    private data class CacheEntry(
+        val preview: ChatClipPreview?,
+        val cachedAtMs: Long,
+        val retryAfterMs: Long? = null,
+    ) {
+        fun isStale(nowMs: Long, successTtlMs: Long, negativeTtlMs: Long): Boolean =
+            nowMs - cachedAtMs >= if (preview == null) negativeTtlMs else successTtlMs
+
+        fun refreshDue(nowMs: Long, successTtlMs: Long, negativeTtlMs: Long): Boolean =
+            isStale(nowMs, successTtlMs, negativeTtlMs) &&
+                (retryAfterMs == null || nowMs >= retryAfterMs)
+
+        fun shouldPrune(nowMs: Long, successTtlMs: Long, negativeTtlMs: Long): Boolean =
+            if (preview == null) {
+                isStale(nowMs, successTtlMs, negativeTtlMs)
+            } else {
+                nowMs - cachedAtMs >= successTtlMs.coerceAtLeast(1L) * 2
+            }
+    }
+
+    /** Visible rows are normally a small fraction of the 600-message timeline. */
+    private val cache = object : LinkedHashMap<String, CacheEntry>(maxEntries.coerceAtLeast(1), .75f, true) {}
     private val listeners = HashMap<String, MutableSet<() -> Unit>>()
-    private val loading = HashSet<String>()
+    private val loadJobs = HashMap<String, Job>()
 
     @Synchronized
-    fun peek(slug: String): ChatClipPreview? = cache[slug]
+    fun peek(slug: String): ChatClipPreview? = cache[slug]?.preview
 
     @Synchronized
-    fun peekState(slug: String): ChatClipPreviewState = states[slug] ?: ChatClipPreviewState.Missing
+    fun peekState(slug: String): ChatClipPreviewState = when {
+        cache.containsKey(slug) -> ChatClipPreviewState.Ready(cache[slug]?.preview)
+        loadJobs[slug]?.isActive == true -> ChatClipPreviewState.Loading
+        else -> ChatClipPreviewState.Missing
+    }
+
+    @Synchronized internal fun cacheSize(): Int = cache.size
+    @Synchronized internal fun listenerCount(slug: String): Int = listeners[slug]?.size ?: 0
+    @Synchronized internal fun inFlightCount(): Int = loadJobs.count { it.value.isActive }
 
     fun observe(slug: String, listener: () -> Unit) {
-        val shouldLoad: Boolean
-        val cached: Boolean
+        var notifyCached = false
+        var refresh = false
+        var jobToStart: Job? = null
         synchronized(this) {
+            pruneExpiredUnobservedLocked(nowMs())
             val slugListeners = listeners.getOrPut(slug) { LinkedHashSet() }
-            val alreadyObserved = listener in slugListeners
             slugListeners.add(listener)
-            cached = cache.containsKey(slug)
-            shouldLoad = !cached && !alreadyObserved && loading.add(slug)
-            if (shouldLoad) states[slug] = ChatClipPreviewState.Loading
+            val entry = cache[slug]
+            if (entry != null) {
+                val now = nowMs()
+                val stale = entry.isStale(now, successTtlMs, negativeTtlMs)
+                val negative = entry.preview == null
+                ChatRenderDiagnostics.recordClipCacheHit(stale, negative)
+                notifyCached = true
+                refresh = entry.refreshDue(now, successTtlMs, negativeTtlMs)
+            } else {
+                ChatRenderDiagnostics.recordClipCacheMiss()
+                refresh = true
+            }
+            if (refresh && loadJobs[slug] == null) {
+                jobToStart = createLoadJobLocked(slug, cache.containsKey(slug))
+            }
         }
-        if (cached) listener()
-        if (shouldLoad) {
-            scope.launch {
-                val preview = runCatching { loader(slug) }.getOrNull()
-                val callbacks = synchronized(this@ChatClipPreviewRepository) {
-                    // A failed request must remain retryable when the same clip is seen again.
-                    if (preview != null) cache[slug] = preview
-                    loading.remove(slug)
-                    states[slug] = ChatClipPreviewState.Ready(preview)
-                    listeners[slug]?.toList().orEmpty()
+        if (notifyCached) listener()
+        jobToStart?.let { job ->
+            if (!job.start()) {
+                synchronized(this) {
+                    if (loadJobs[slug] === job) loadJobs.remove(slug)
                 }
-                callbacks.forEach { it() }
             }
         }
     }
@@ -111,5 +162,80 @@ class ChatClipPreviewRepository(
     fun removeObserver(slug: String, listener: () -> Unit) {
         listeners[slug]?.remove(listener)
         if (listeners[slug].isNullOrEmpty()) listeners.remove(slug)
+        trimCacheLocked()
+    }
+
+    private fun createLoadJobLocked(slug: String, refreshing: Boolean): Job =
+        scope.launch(start = CoroutineStart.LAZY) {
+            val currentJob = coroutineContext[Job]
+            try {
+                if (refreshing) ChatRenderDiagnostics.recordClipRefresh()
+                val preview = try {
+                    loader(slug)
+                } catch (error: CancellationException) {
+                    throw error
+                } catch (_: Throwable) {
+                    null
+                }
+                val callbacks = synchronized(this@ChatClipPreviewRepository) {
+                    if (loadJobs[slug] !== currentJob) {
+                        emptyList()
+                    } else {
+                        loadJobs.remove(slug)
+                        val previous = cache[slug]
+                        val now = nowMs()
+                        val next = if (refreshing && previous?.preview != null && preview == null) {
+                            // A failed refresh must not blank a preview that was already visible.
+                            previous.copy(retryAfterMs = now + negativeTtlMs)
+                        } else {
+                            CacheEntry(preview, now)
+                        }
+                        val changed = previous == null || previous.preview != next.preview
+                        cache[slug] = next
+                        trimCacheLocked()
+                        if (changed) {
+                            if (refreshing) ChatRenderDiagnostics.recordClipRefreshChanged()
+                            listeners[slug]?.toList().orEmpty()
+                        } else {
+                            if (refreshing) ChatRenderDiagnostics.recordClipRefreshUnchanged()
+                            emptyList()
+                        }
+                    }
+                }
+                callbacks.forEach { it() }
+            } finally {
+                synchronized(this@ChatClipPreviewRepository) {
+                    if (loadJobs[slug] === currentJob) loadJobs.remove(slug)
+                }
+            }
+        }.also { loadJobs[slug] = it }
+
+    private fun trimCacheLocked() {
+        pruneExpiredUnobservedLocked(nowMs())
+        val limit = maxEntries.coerceAtLeast(1)
+        while (cache.size > limit) {
+            val eldest = cache.entries.iterator().next()
+            cache.remove(eldest.key)
+            ChatRenderDiagnostics.recordClipEviction()
+        }
+    }
+
+    private fun pruneExpiredUnobservedLocked(nowMs: Long) {
+        val iterator = cache.entries.iterator()
+        while (iterator.hasNext()) {
+            val entry = iterator.next()
+            if (listeners[entry.key].isNullOrEmpty() && loadJobs[entry.key] == null &&
+                entry.value.shouldPrune(nowMs, successTtlMs, negativeTtlMs)
+            ) {
+                iterator.remove()
+                ChatRenderDiagnostics.recordClipEviction()
+            }
+        }
+    }
+
+    private companion object {
+        const val DEFAULT_MAX_ENTRIES = 192
+        const val DEFAULT_SUCCESS_TTL_MS = 6 * 60 * 60 * 1_000L
+        const val DEFAULT_NEGATIVE_TTL_MS = 30_000L
     }
 }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatMessageTextView.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatMessageTextView.kt
@@ -47,6 +47,7 @@ import com.github.andreyasadchy.xtra.XtraApp
 import com.github.andreyasadchy.xtra.BuildConfig
 import com.github.andreyasadchy.xtra.ui.chat.v2.assets.ChatAssetRepository
 import com.github.andreyasadchy.xtra.ui.chat.v2.assets.ChatAssetState
+import com.github.andreyasadchy.xtra.ui.chat.v2.assets.ChatImageHandle
 import com.github.andreyasadchy.xtra.util.ChatRenderDiagnostics
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatAssetKey
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatAssetSpec
@@ -109,32 +110,18 @@ open class ChatMessageTextView private constructor(
     private val initialLineSpacingMultiplier = lineSpacingMultiplier
     private var keys = emptySet<ChatAssetKey>()
     private val drawables = HashMap<ChatAssetKey, Drawable>()
-    private val drawableHandles = HashMap<ChatAssetKey, Any>()
-    private val assetInvalidator: () -> Unit = {
-        post {
-            latchTerminalAssetFailures()
-            maybeApplyStagedRow()
-            requestLayout()
-            postInvalidateOnAnimation()
-            maybeRevealInitialAssetFrame()
-        }
-    }
-    private val clipMetadataInvalidator: () -> Unit = {
-        post {
-            refreshClipPreviewAssets()
-            requestLayout()
-            postInvalidateOnAnimation()
-            maybeRevealInitialAssetFrame()
-        }
-    }
-    private val clipThumbnailInvalidator: () -> Unit = {
-        post {
-            latchTerminalAssetFailures()
-            requestLayout()
-            postInvalidateOnAnimation()
-            maybeRevealInitialAssetFrame()
-        }
-    }
+    private val drawableHandles = HashMap<ChatAssetKey, ChatImageHandle>()
+    private val assetObservers = HashMap<ChatAssetKey, ChatObserverRegistration>()
+    private val stagedAssetObservers = HashMap<ChatAssetKey, ChatObserverRegistration>()
+    private val clipMetadataObservers = HashMap<String, ChatObserverRegistration>()
+    private val clipThumbnailObservers = HashMap<ChatAssetKey, ChatObserverRegistration>()
+    private val visualRefreshes = ChatVisualRefreshCoalescer(
+        scheduleFrame = { runnable -> postOnAnimation(runnable) },
+        currentGeneration = { externalBindGeneration },
+        onRefresh = ::applyVisualRefresh,
+        onCoalesced = ChatRenderDiagnostics::recordAssetCallbackCoalesced,
+        onStale = ChatRenderDiagnostics::recordStaleCallbackDiscarded,
+    )
     private var renderingActive = true
     private var animateGifs = true
     private var windowAttached = false
@@ -163,6 +150,7 @@ open class ChatMessageTextView private constructor(
     private var stagedObservedAssetKeys = emptySet<ChatAssetKey>()
     private var externalBindGeneration = 0L
     private var initialAssetSpecs = emptyList<ChatAssetSpec>()
+    private var geometryChangingCompositionKeys = emptySet<String>()
     private var initialDirectAssetKeys = emptySet<ChatAssetKey>()
     private val latchedFailedCompositionKeys = HashSet<String>()
     private val latchedFailedDirectKeys = HashSet<ChatAssetKey>()
@@ -230,34 +218,38 @@ open class ChatMessageTextView private constructor(
         previousObservedKeys
             .filterNot(nextKeys::contains)
             .filterNot(keys::contains)
-            .forEach { assets.removeObserver(it, assetInvalidator) }
+            .forEach(::removeStagedAssetObserver)
 
         stagedRow = row
         stagedBindGeneration = externalBindGeneration
         stagedAssetKeys = nextKeys
         stagedObservedAssetKeys = nextKeys - keys
         stagedObservedAssetKeys
+            .filter(previousObservedKeys::contains)
+            .forEach { stagedAssetObservers[it]?.rebind(externalBindGeneration) }
+        stagedObservedAssetKeys
             .filterNot(previousObservedKeys::contains)
-            .forEach { assets.observe(it, assetInvalidator) }
+            .forEach(::observeStagedAsset)
         maybeApplyStagedRow()
     }
 
-    private fun maybeApplyStagedRow() {
-        val row = stagedRow ?: return
+    private fun maybeApplyStagedRow(): Boolean {
+        val row = stagedRow ?: return false
         if (stagedBindGeneration != externalBindGeneration) {
             clearStagedRow()
-            return
+            return false
         }
-        if (hasPendingAssets(stagedAssetKeys)) return
+        if (hasPendingAssets(stagedAssetKeys)) return false
         clearStagedRow()
         bindRow(row)
+        return true
     }
 
     private fun clearStagedRow() {
         val activeKeys = keys
         stagedObservedAssetKeys
             .filterNot(activeKeys::contains)
-            .forEach { assets.removeObserver(it, assetInvalidator) }
+            .forEach(::removeStagedAssetObserver)
         stagedRow = null
         stagedBindGeneration = 0L
         stagedAssetKeys = emptySet()
@@ -285,9 +277,12 @@ open class ChatMessageTextView private constructor(
         drawables.clear()
         drawableHandles.clear()
         val newKeys = row.assetKeys()
-        oldKeys.filterNot(newKeys::contains).forEach { assets.removeObserver(it, assetInvalidator) }
-        newKeys.filterNot(oldKeys::contains).forEach { assets.observe(it, assetInvalidator) }
+        oldKeys.filterNot(newKeys::contains).forEach(::removeAssetObserver)
         keys = newKeys
+        newKeys
+            .filter(oldKeys::contains)
+            .forEach { assetObservers[it]?.rebind(externalBindGeneration) }
+        newKeys.filterNot(oldKeys::contains).forEach(::observeAsset)
         animatedAssetKeys = row.pieces.flatMap { piece ->
             val spec = when (piece) {
                 is ChatPiece.Emote -> piece.asset.takeIf { piece.animated }
@@ -308,19 +303,29 @@ open class ChatMessageTextView private constructor(
                 else -> null
             }
         }
+        geometryChangingCompositionKeys = row.pieces.mapNotNull { piece ->
+            when (piece) {
+                is ChatPiece.Emote -> piece.asset.compositionKey
+                is ChatPiece.Gif -> piece.asset.compositionKey
+                else -> null
+            }
+        }.toSet()
         initialDirectAssetKeys = row.pieces.mapNotNull { piece ->
             (piece as? ChatPiece.Username)?.paint?.imageUrl
                 ?.takeIf { it.isNotBlank() }
                 ?.let(::ChatAssetKey)
         }.toSet()
         val newClipPreviewSlugs = row.clipPreviews.map { it.slug }.toSet()
-        oldClipPreviewSlugs.filterNot(newClipPreviewSlugs::contains).forEach { slug ->
-            clipPreviews?.removeObserver(slug, clipMetadataInvalidator)
-        }
-        newClipPreviewSlugs.filterNot(oldClipPreviewSlugs::contains).forEach { slug ->
-            clipPreviews?.observe(slug, clipMetadataInvalidator)
-        }
         clipPreviewSlugs = newClipPreviewSlugs
+        oldClipPreviewSlugs.filterNot(newClipPreviewSlugs::contains).forEach { slug ->
+            removeClipMetadataObserver(slug)
+        }
+        newClipPreviewSlugs
+            .filter(oldClipPreviewSlugs::contains)
+            .forEach { clipMetadataObservers[it]?.rebind(externalBindGeneration) }
+        newClipPreviewSlugs.filterNot(oldClipPreviewSlugs::contains).forEach { slug ->
+            observeClipMetadata(slug)
+        }
         refreshClipPreviewAssets()
         latchTerminalAssetFailures()
         val density = resources.displayMetrics.density
@@ -510,23 +515,31 @@ open class ChatMessageTextView private constructor(
         }
     }
 
-    private fun latchTerminalAssetFailures() {
+    private fun latchTerminalAssetFailures(): Boolean {
+        var geometryChanged = false
         initialAssetSpecs
             .filter { assetRenderState(it) == ChatAssetRenderState.FAILED }
-            .forEach { latchedFailedCompositionKeys += it.compositionKey }
+            .forEach { spec ->
+                if (latchedFailedCompositionKeys.add(spec.compositionKey) &&
+                    spec.compositionKey in geometryChangingCompositionKeys
+                ) {
+                    geometryChanged = true
+                }
+            }
         (initialDirectAssetKeys + clipPreviewAssetKeys).forEach { key ->
             val state = assets.peek(key)
             if (state is ChatAssetState.Failed && state.isPresentationTerminal) {
                 latchedFailedDirectKeys += key
             }
         }
+        return geometryChanged
     }
 
-    private fun latchFailedClipMetadata() {
+    private fun latchFailedClipMetadata(): Boolean {
         val failed = clipPreviewSlugs.filter { slug ->
             clipPreviews?.peekState(slug) == ChatClipPreviewState.Ready(null)
         }
-        if (latchedFailedClipMetadataSlugs.addAll(failed)) requestLayout()
+        return latchedFailedClipMetadataSlugs.addAll(failed)
     }
 
     private fun refreshClipPreviewAssets() {
@@ -534,11 +547,126 @@ open class ChatMessageTextView private constructor(
             clipPreviews?.peek(link.slug)?.thumbnailUrl?.takeIf { it.isNotBlank() }?.let(::ChatAssetKey)
         }.toSet()
         initialDirectAssetKeys = (initialDirectAssetKeys - clipPreviewAssetKeys) + nextKeys
-        clipPreviewAssetKeys.filterNot(nextKeys::contains).forEach { assets.removeObserver(it, clipThumbnailInvalidator) }
-        if (isAttachedToWindow && renderingActive) {
-            nextKeys.filterNot(clipPreviewAssetKeys::contains).forEach { assets.observe(it, clipThumbnailInvalidator) }
-        }
+        val previousKeys = clipPreviewAssetKeys
+        previousKeys.filterNot(nextKeys::contains).forEach(::removeClipThumbnailObserver)
         clipPreviewAssetKeys = nextKeys
+        nextKeys
+            .filter(previousKeys::contains)
+            .forEach { clipThumbnailObservers[it]?.rebind(externalBindGeneration) }
+        if (isAttachedToWindow && renderingActive) {
+            nextKeys.filterNot(previousKeys::contains).forEach(::observeClipThumbnail)
+        }
+    }
+
+    private fun applyVisualRefresh(kind: ChatVisualRefreshKind) {
+        if (!renderingActive || !isAttachedToWindow || boundRow == null) return
+        var requiresLayout = kind == ChatVisualRefreshKind.LAYOUT_AND_DRAW
+        requiresLayout = latchTerminalAssetFailures() || requiresLayout
+        requiresLayout = maybeApplyStagedRow() || requiresLayout
+        requiresLayout = latchFailedClipMetadata() || requiresLayout
+        refreshClipPreviewAssets()
+        if (requiresLayout) {
+            ChatRenderDiagnostics.recordLayoutAndDrawInvalidation()
+            requestLayout()
+        } else {
+            ChatRenderDiagnostics.recordDrawOnlyInvalidation()
+        }
+        postInvalidateOnAnimation()
+        maybeRevealInitialAssetFrame()
+    }
+
+    private fun observeAsset(key: ChatAssetKey) {
+        observeAsset(key, staged = false)
+    }
+
+    private fun observeStagedAsset(key: ChatAssetKey) {
+        observeAsset(key, staged = true)
+    }
+
+    private fun observeAsset(key: ChatAssetKey, staged: Boolean) {
+        val observers = if (staged) stagedAssetObservers else assetObservers
+        val registration = ChatObserverRegistration(
+            initialGeneration = externalBindGeneration,
+            onValid = { generation ->
+                ChatRenderDiagnostics.recordAssetCallbackReceived()
+                visualRefreshes.request(ChatVisualRefreshKind.DRAW, generation)
+            },
+            onStale = ChatRenderDiagnostics::recordStaleCallbackDiscarded,
+        )
+        synchronized(observers) {
+            if (observers.containsKey(key)) return
+            observers[key] = registration
+        }
+        assets.observe(key, registration.listener)
+    }
+
+    private fun removeAssetObserver(key: ChatAssetKey) {
+        removeObserver(assetObservers, key) { listener -> assets.removeObserver(key, listener) }
+        removeStagedAssetObserver(key)
+    }
+
+    private fun removeStagedAssetObserver(key: ChatAssetKey) {
+        removeObserver(stagedAssetObservers, key) { listener -> assets.removeObserver(key, listener) }
+    }
+
+    private fun observeClipMetadata(slug: String) {
+        val repository = clipPreviews ?: return
+        val registration = ChatObserverRegistration(
+            initialGeneration = externalBindGeneration,
+            onValid = { generation ->
+                ChatRenderDiagnostics.recordAssetCallbackReceived()
+                val kind = if (repository.peekState(slug) == ChatClipPreviewState.Ready(null)) {
+                    ChatVisualRefreshKind.LAYOUT_AND_DRAW
+                } else {
+                    ChatVisualRefreshKind.DRAW
+                }
+                visualRefreshes.request(kind, generation)
+            },
+            onStale = ChatRenderDiagnostics::recordStaleCallbackDiscarded,
+        )
+        synchronized(clipMetadataObservers) {
+            if (clipMetadataObservers.containsKey(slug)) return
+            clipMetadataObservers[slug] = registration
+        }
+        repository.observe(slug, registration.listener)
+    }
+
+    private fun removeClipMetadataObserver(slug: String) {
+        val registration = synchronized(clipMetadataObservers) {
+            clipMetadataObservers.remove(slug)
+        } ?: return
+        registration.deactivate()
+        clipPreviews?.removeObserver(slug, registration.listener)
+    }
+
+    private fun observeClipThumbnail(key: ChatAssetKey) {
+        val registration = ChatObserverRegistration(
+            initialGeneration = externalBindGeneration,
+            onValid = { generation ->
+                ChatRenderDiagnostics.recordAssetCallbackReceived()
+                visualRefreshes.request(ChatVisualRefreshKind.DRAW, generation)
+            },
+            onStale = ChatRenderDiagnostics::recordStaleCallbackDiscarded,
+        )
+        synchronized(clipThumbnailObservers) {
+            if (clipThumbnailObservers.containsKey(key)) return
+            clipThumbnailObservers[key] = registration
+        }
+        assets.observe(key, registration.listener)
+    }
+
+    private fun removeClipThumbnailObserver(key: ChatAssetKey) {
+        removeObserver(clipThumbnailObservers, key) { listener -> assets.removeObserver(key, listener) }
+    }
+
+    private fun removeObserver(
+        observers: MutableMap<ChatAssetKey, ChatObserverRegistration>,
+        key: ChatAssetKey,
+        remove: (() -> Unit) -> Unit,
+    ) {
+        val registration = synchronized(observers) { observers.remove(key) } ?: return
+        registration.deactivate()
+        remove(registration.listener)
     }
 
     private fun resolvedClipPreviews(): List<Pair<ChatClipPreviewLink, ChatClipPreview>> =
@@ -997,7 +1125,13 @@ open class ChatMessageTextView private constructor(
         val drawable = if (drawableHandles[key] !== handle) {
             drawables.remove(key)?.also { it.stopIfNeeded(); it.callback = null }
             drawableHandles[key] = handle
-            handle.newDrawable().also { drawables[key] = it }
+            val created = handle.newDrawable()
+            if (created == null) {
+                drawableHandles.remove(key)
+                assets.retryIfDrawableUnavailable(key)
+                return null
+            }
+            created.also { drawables[key] = it }
         } else {
             drawables[key] ?: return null
         }
@@ -1010,9 +1144,10 @@ open class ChatMessageTextView private constructor(
         longPressRunnable?.let(mainHandler::removeCallbacks)
         longPressRunnable = null
         clearStagedRow()
-        keys.forEach { assets.removeObserver(it, assetInvalidator) }
-        clipPreviewSlugs.forEach { slug -> clipPreviews?.removeObserver(slug, clipMetadataInvalidator) }
-        clipPreviewAssetKeys.forEach { assets.removeObserver(it, clipThumbnailInvalidator) }
+        assetObservers.keys.toList().forEach(::removeAssetObserver)
+        stagedAssetObservers.keys.toList().forEach(::removeStagedAssetObserver)
+        clipMetadataObservers.keys.toList().forEach(::removeClipMetadataObserver)
+        clipThumbnailObservers.keys.toList().forEach(::removeClipThumbnailObserver)
         drawables.values.forEach { it.stopIfNeeded(); it.callback = null }
         drawables.clear()
         drawableHandles.clear()
@@ -1026,6 +1161,7 @@ open class ChatMessageTextView private constructor(
         stagedObservedAssetKeys = emptySet()
         externalBindGeneration++
         initialAssetSpecs = emptyList()
+        geometryChangingCompositionKeys = emptySet()
         initialDirectAssetKeys = emptySet()
         latchedFailedCompositionKeys.clear()
         latchedFailedDirectKeys.clear()
@@ -1091,10 +1227,10 @@ open class ChatMessageTextView private constructor(
         if (renderingActive == active) return
         renderingActive = active
         if (active) {
-            if (isAttachedToWindow) keys.forEach { assets.observe(it, assetInvalidator) }
-            if (isAttachedToWindow) stagedObservedAssetKeys.forEach { assets.observe(it, assetInvalidator) }
-            if (isAttachedToWindow) clipPreviewSlugs.forEach { slug -> clipPreviews?.observe(slug, clipMetadataInvalidator) }
-            if (isAttachedToWindow) clipPreviewAssetKeys.forEach { assets.observe(it, clipThumbnailInvalidator) }
+            if (isAttachedToWindow) keys.forEach(::observeAsset)
+            if (isAttachedToWindow) stagedObservedAssetKeys.forEach(::observeStagedAsset)
+            if (isAttachedToWindow) clipPreviewSlugs.forEach(::observeClipMetadata)
+            if (isAttachedToWindow) clipPreviewAssetKeys.forEach(::observeClipThumbnail)
             if (isAttachedToWindow) {
                 refreshClipPreviewAssets()
                 maybeApplyStagedRow()
@@ -1102,22 +1238,24 @@ open class ChatMessageTextView private constructor(
             }
             if (isAttachedToWindow) updateDrawableAnimations()
         } else {
-            keys.forEach { assets.removeObserver(it, assetInvalidator) }
-            stagedObservedAssetKeys.forEach { assets.removeObserver(it, assetInvalidator) }
-            clipPreviewSlugs.forEach { slug -> clipPreviews?.removeObserver(slug, clipMetadataInvalidator) }
-            clipPreviewAssetKeys.forEach { assets.removeObserver(it, clipThumbnailInvalidator) }
+            assetObservers.keys.toList().forEach(::removeAssetObserver)
+            stagedAssetObservers.keys.toList().forEach(::removeStagedAssetObserver)
+            clipMetadataObservers.keys.toList().forEach(::removeClipMetadataObserver)
+            clipThumbnailObservers.keys.toList().forEach(::removeClipThumbnailObserver)
             drawables.forEach { (key, drawable) -> updateAnimationState(key, drawable) }
         }
     }
 
     override fun onDetachedFromWindow() {
         windowAttached = false
+        // Detach only unregisters callbacks. Keep the bind generation so a staged row can survive
+        // a detach/reattach cycle and still be applied when its assets finish loading.
         longPressRunnable?.let(mainHandler::removeCallbacks)
         longPressRunnable = null
-        keys.forEach { assets.removeObserver(it, assetInvalidator) }
-        stagedObservedAssetKeys.forEach { assets.removeObserver(it, assetInvalidator) }
-        clipPreviewSlugs.forEach { slug -> clipPreviews?.removeObserver(slug, clipMetadataInvalidator) }
-        clipPreviewAssetKeys.forEach { assets.removeObserver(it, clipThumbnailInvalidator) }
+        assetObservers.keys.toList().forEach(::removeAssetObserver)
+        stagedAssetObservers.keys.toList().forEach(::removeStagedAssetObserver)
+        clipMetadataObservers.keys.toList().forEach(::removeClipMetadataObserver)
+        clipThumbnailObservers.keys.toList().forEach(::removeClipThumbnailObserver)
         drawables.values.forEach { it.stopIfNeeded(); it.callback = null }
         super.onDetachedFromWindow()
     }
@@ -1126,10 +1264,10 @@ open class ChatMessageTextView private constructor(
         super.onAttachedToWindow()
         windowAttached = true
         if (renderingActive) {
-            keys.forEach { assets.observe(it, assetInvalidator) }
-            stagedObservedAssetKeys.forEach { assets.observe(it, assetInvalidator) }
-            clipPreviewSlugs.forEach { slug -> clipPreviews?.observe(slug, clipMetadataInvalidator) }
-            clipPreviewAssetKeys.forEach { assets.observe(it, clipThumbnailInvalidator) }
+            keys.forEach(::observeAsset)
+            stagedObservedAssetKeys.forEach(::observeStagedAsset)
+            clipPreviewSlugs.forEach(::observeClipMetadata)
+            clipPreviewAssetKeys.forEach(::observeClipThumbnail)
             refreshClipPreviewAssets()
             maybeApplyStagedRow()
             maybeRevealInitialAssetFrame()
@@ -1279,7 +1417,9 @@ private class ChatNamePaintSpan(
             }
             if (handle !== imageHandle) {
                 imageHandle = handle
-                imageShader = (handle?.newDrawable() as? BitmapDrawable)?.bitmap?.let { bitmap ->
+                val drawable = handle?.newDrawable()
+                if (handle != null && drawable == null) assets.retryIfDrawableUnavailable(key)
+                imageShader = (drawable as? BitmapDrawable)?.bitmap?.let { bitmap ->
                     android.graphics.BitmapShader(bitmap, Shader.TileMode.CLAMP, Shader.TileMode.CLAMP)
                 }
             }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatPresentationReuse.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatPresentationReuse.kt
@@ -1,0 +1,60 @@
+package com.github.andreyasadchy.xtra.ui.chat.v2.ui
+
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessage
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessageId
+import com.github.andreyasadchy.xtra.ui.chat.v2.presentation.ChatRowUiModel
+import java.util.HashMap
+
+/** Reusable indexes for the last accepted publication. The backing tables are kept between publications. */
+internal class ChatPresentationReuseIndex {
+    private val messagesById = HashMap<ChatMessageId, ChatMessage>()
+    private val rowsById = HashMap<ChatMessageId, ChatRowUiModel>()
+
+    fun rowFor(message: ChatMessage): ChatRowUiModel? =
+        rowsById[message.id]?.takeIf { messagesById[message.id] == message }
+
+    /** Updates stable tables without allocating a new associateBy map on every publication. */
+    fun replace(messages: List<ChatMessage>, rows: List<ChatRowUiModel>) {
+        messagesById.clear()
+        rowsById.clear()
+        messages.forEachIndexed { index, message ->
+            messagesById[message.id] = message
+            rows.getOrNull(index)?.let { row -> rowsById[row.id] = row }
+        }
+    }
+
+    fun clear() {
+        messagesById.clear()
+        rowsById.clear()
+    }
+}
+
+internal data class ChatRowCompileResult(
+    val rows: List<ChatRowUiModel>,
+    val messagesChanged: Int,
+    val rowsCompiled: Int,
+    val rowsReused: Int,
+)
+
+internal fun compileChatRows(
+    messages: List<ChatMessage>,
+    resolve: (ChatMessage, Int) -> ChatRowUiModel,
+    reuseIndex: ChatPresentationReuseIndex? = null,
+): ChatRowCompileResult {
+    val rows = ArrayList<ChatRowUiModel>(messages.size)
+    var changed = 0
+    var compiled = 0
+    var reused = 0
+    messages.forEachIndexed { index, message ->
+        val reusable = reuseIndex?.rowFor(message)
+        if (reusable != null) {
+            rows += reusable
+            reused++
+        } else {
+            changed++
+            compiled++
+            rows += resolve(message, index)
+        }
+    }
+    return ChatRowCompileResult(rows, changed, compiled, reused)
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatV2RendererController.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatV2RendererController.kt
@@ -1,5 +1,6 @@
 package com.github.andreyasadchy.xtra.ui.chat.v2.ui
 
+import android.os.SystemClock
 import android.os.Trace
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
@@ -27,6 +28,7 @@ import com.github.andreyasadchy.xtra.ui.chat.v2.session.ActiveChatSession
 import com.github.andreyasadchy.xtra.ui.chat.ChatRenderStyle
 import com.github.andreyasadchy.xtra.ui.chat.ChatProfilePopoutGesture
 import com.github.andreyasadchy.xtra.ui.chat.resolveChatHighlightSettings
+import com.github.andreyasadchy.xtra.util.ChatRenderDiagnostics
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.combine
@@ -135,10 +137,12 @@ class ChatV2RendererController(
     private var styleRefreshJob: Job? = null
     private var lifecycleOwner: LifecycleOwner? = null
     private var currentKey: com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatSessionKey? = null
-    private var previousIds: Set<ChatMessageId>? = null
+    private val previousIds = HashSet<ChatMessageId>()
+    private var hasPreviousIds = false
     private var previousTailId: ChatMessageId? = null
     private var latestRows: List<ChatRowUiModel> = emptyList()
     private var latestPublication: PresentationPublication? = null
+    private val reuseIndex = ChatPresentationReuseIndex()
     private val presentationSnapshot = ChatPresentationSnapshot()
     private val rendererVisible = MutableStateFlow(true)
     private var translateAllMessages = translateAllMessages
@@ -207,9 +211,11 @@ class ChatV2RendererController(
         recyclerView.adapter = null
         adapter.submitList(emptyList())
         latestRows = emptyList()
-        previousIds = null
+        previousIds.clear()
+        hasPreviousIds = false
         previousTailId = null
         currentKey = null
+        reuseIndex.clear()
         presentationSnapshot.clear()
         requestedTranslationIds.clear()
     }
@@ -250,12 +256,26 @@ class ChatV2RendererController(
         presentation.invalidate()
         styleRefreshJob?.cancel()
         styleRefreshJob = owner.lifecycleScope.launch {
-            val rows = compileCurrent(publication)
+            val compiled = compileCurrent(publication)
+            val rows = compiled.result.rows
             withContext(Dispatchers.Main.immediate) {
                 if (!rendererVisible.value || latestPublication !== publication) return@withContext
+                val uiChanged = !sameRows(latestRows, rows)
                 latestRows = rows
-                onPublicationChanged(publication.messages, rows)
-                adapter.submitList(rows)
+                reuseIndex.replace(publication.messages, rows)
+                ChatRenderDiagnostics.recordPublication(
+                    messageCount = publication.messages.size,
+                    changed = compiled.result.messagesChanged,
+                    compiled = compiled.result.rowsCompiled,
+                    reused = compiled.result.rowsReused,
+                    compileNanos = compiled.durationNanos,
+                    fullRebuild = compiled.fullRebuild,
+                    uiChanged = uiChanged,
+                )
+                if (uiChanged) {
+                    onPublicationChanged(publication.messages, rows)
+                    adapter.submitList(rows)
+                }
             }
         }
     }
@@ -273,7 +293,9 @@ class ChatV2RendererController(
             if (!rendererVisible.value) return@withContext
             latestPublication = publication
         }
-        val rows = compileCurrent(publication, previousPublication, previousRows)
+        styleRefreshJob?.cancel()
+        val compiled = compileCurrent(publication, previousPublication)
+        val rows = compiled.result.rows
         if (!rendererVisible.value) return
         withContext(Dispatchers.Main.immediate) {
             if (!rendererVisible.value) return@withContext
@@ -281,32 +303,59 @@ class ChatV2RendererController(
             if (currentKey != publication.key) {
                 if (currentKey != null) viewport.resetForNewSession()
                 currentKey = publication.key
-                previousIds = null
+                hasPreviousIds = false
+                previousIds.clear()
                 previousTailId = null
+                reuseIndex.clear()
             }
             latestPublication = publication
             requestTranslations(publication.messages)
             val oldIds = previousIds
-            val previousAnchor = if (oldIds == null) null else viewport.captureAnchor(adapter)
+            val previousAnchor = if (!hasPreviousIds) null else viewport.captureAnchor(adapter)
             // Reconciliation can insert older messages into the middle/front of the timeline.
             // Only messages newer than the previous tail are live appends.
-            val appendedCount = countNewLiveMessages(oldIds, previousTailId, publication.messages)
-            previousIds = rows.asSequence().map(ChatRowUiModel::id).toSet()
+            val appendedCount = countNewLiveMessages(
+                oldIds.takeIf { hasPreviousIds },
+                previousTailId,
+                publication.messages,
+            )
+            previousIds.clear()
+            rows.forEach { previousIds += it.id }
+            hasPreviousIds = true
             previousTailId = publication.messages.lastOrNull()?.id
             latestRows = rows
-            onPublicationChanged(publication.messages, rows)
-            adapter.submitList(rows) {
-                viewport.onSnapshotCommitted(previousAnchor, rows, appendedCount)
-                onStateChanged(viewport.state)
+            reuseIndex.replace(publication.messages, rows)
+            val uiChanged = !sameRows(previousRows, rows)
+            ChatRenderDiagnostics.recordPublication(
+                messageCount = publication.messages.size,
+                changed = compiled.result.messagesChanged,
+                compiled = compiled.result.rowsCompiled,
+                reused = compiled.result.rowsReused,
+                compileNanos = compiled.durationNanos,
+                fullRebuild = compiled.fullRebuild,
+                uiChanged = uiChanged,
+            )
+            if (uiChanged) {
+                onPublicationChanged(publication.messages, rows)
+                adapter.submitList(rows) {
+                    viewport.onSnapshotCommitted(previousAnchor, rows, appendedCount)
+                    onStateChanged(viewport.state)
+                }
             }
         }
     }
 
+    private data class CompiledRows(
+        val result: ChatRowCompileResult,
+        val durationNanos: Long,
+        val fullRebuild: Boolean,
+    )
+
     private suspend fun compileCurrent(
         publication: PresentationPublication,
         previousPublication: PresentationPublication? = null,
-        previousRows: List<ChatRowUiModel> = emptyList(),
-    ): List<ChatRowUiModel> {
+    ): CompiledRows {
+        val startedAt = SystemClock.elapsedRealtimeNanos()
         while (true) {
             val compiler = presentation.snapshot()
             val forceCatalogUpgrade = previousPublication?.let { previous ->
@@ -332,29 +381,21 @@ class ChatV2RendererController(
             val rows = withContext(Dispatchers.Default) {
                 if (BuildConfig.PERF_DIAGNOSTICS) Trace.beginSection("Xtra.ChatV2.compileCurrent")
                 try {
-                    val previousMessages = if (reusablePublication != null) {
-                        reusablePublication.messages.associateBy { it.id }
-                    } else {
-                        emptyMap()
-                    }
-                    val reusableRows = if (reusablePublication != null) {
-                        previousRows.associateBy { it.id }
-                    } else {
-                        emptyMap()
-                    }
-                    publication.messages.mapIndexed { index, message ->
-                        if (previousMessages[message.id] == message) {
-                            reusableRows[message.id]
-                        } else {
-                            null
-                        } ?: compiler.resolve(message, catalogs[index])
-                    }
+                    compileChatRows(
+                        messages = publication.messages,
+                        reuseIndex = reuseIndex.takeIf { reusablePublication != null },
+                        resolve = { message, index -> compiler.resolve(message, catalogs[index]) },
+                    )
                 } finally {
                     if (BuildConfig.PERF_DIAGNOSTICS) Trace.endSection()
                 }
             }
             if (presentation.isCurrent(compiler)) {
-                return rows
+                return CompiledRows(
+                    result = rows,
+                    durationNanos = SystemClock.elapsedRealtimeNanos() - startedAt,
+                    fullRebuild = reusablePublication == null,
+                )
             }
         }
     }
@@ -365,6 +406,16 @@ class ChatV2RendererController(
             if (translation(message).isNullOrBlank() && requestedTranslationIds.add(message.id)) {
                 onTranslateMessage(message)
             }
+        }
+    }
+
+    private fun sameRows(previous: List<ChatRowUiModel>, current: List<ChatRowUiModel>): Boolean {
+        if (previous === current) return true
+        if (previous.size != current.size) return false
+        return previous.indices.all { index ->
+            val before = previous[index]
+            val after = current[index]
+            before === after || before == after
         }
     }
 

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatVisualRefreshCoalescer.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatVisualRefreshCoalescer.kt
@@ -1,0 +1,106 @@
+package com.github.andreyasadchy.xtra.ui.chat.v2.ui
+
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicLong
+
+/** The strongest refresh needed by a row before its next frame. */
+internal enum class ChatVisualRefreshKind {
+    DRAW,
+    LAYOUT_AND_DRAW,
+}
+
+/**
+ * Thread-safe validity for one repository observer. The owner updates the generation on the UI
+ * thread when a shared key survives a rebind; repository callbacks only read these atomics.
+ */
+internal class ChatObserverRegistration(
+    initialGeneration: Long,
+    onValid: (Long) -> Unit,
+    private val onStale: () -> Unit = {},
+) {
+    private val active = AtomicBoolean(true)
+    private val generation = AtomicLong(initialGeneration)
+
+    val listener: () -> Unit = {
+        val currentGeneration = generation.takeIf { active.get() }?.get()
+        if (currentGeneration == null) onStale() else onValid(currentGeneration)
+    }
+
+    fun rebind(nextGeneration: Long) {
+        generation.set(nextGeneration)
+        active.set(true)
+    }
+
+    fun deactivate() {
+        active.set(false)
+    }
+}
+
+/**
+ * Coalesces callbacks which arrive between two frames. The generation is part of the request so
+ * a callback that was already queued when a holder was rebound cannot refresh the new message.
+ */
+internal class ChatVisualRefreshCoalescer(
+    private val scheduleFrame: (Runnable) -> Unit,
+    private val currentGeneration: () -> Long,
+    private val onRefresh: (ChatVisualRefreshKind) -> Unit,
+    private val onCoalesced: () -> Unit = {},
+    private val onStale: () -> Unit = {},
+) {
+    private val lock = Any()
+    private var pendingKind: ChatVisualRefreshKind? = null
+    private var pendingGeneration = Long.MIN_VALUE
+    private var frameScheduled = false
+
+    fun request(kind: ChatVisualRefreshKind, generation: Long) {
+        var shouldSchedule = false
+        var coalesced = false
+        var stale = false
+        synchronized(lock) {
+            when {
+                pendingKind == null -> {
+                    pendingGeneration = generation
+                    pendingKind = kind
+                }
+                generation > pendingGeneration -> {
+                    coalesced = frameScheduled
+                    pendingGeneration = generation
+                    pendingKind = kind
+                }
+                generation == pendingGeneration -> {
+                    coalesced = frameScheduled
+                    if (kind.ordinal > pendingKind!!.ordinal) {
+                        pendingKind = kind
+                    }
+                }
+                else -> {
+                    stale = true
+                }
+            }
+            if (!stale && !frameScheduled) {
+                frameScheduled = true
+                shouldSchedule = true
+            }
+        }
+        if (stale) onStale()
+        if (coalesced) onCoalesced()
+        if (shouldSchedule) scheduleFrame(Runnable(::dispatch))
+    }
+
+    private fun dispatch() {
+        val kind: ChatVisualRefreshKind
+        val generation: Long
+        synchronized(lock) {
+            frameScheduled = false
+            kind = pendingKind ?: return
+            generation = pendingGeneration
+            pendingKind = null
+            pendingGeneration = Long.MIN_VALUE
+        }
+        if (generation != currentGeneration()) {
+            onStale()
+        } else {
+            onRefresh(kind)
+        }
+    }
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/ChatRenderDiagnostics.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/ChatRenderDiagnostics.kt
@@ -11,11 +11,49 @@ internal data class ChatRenderDiagnosticsSnapshot(
     val animationStarts: Long,
     val animationStops: Long,
     val activeAnimations: Int,
+    val publications: Long,
+    val publicationMessages: Long,
+    val maxPublicationMessages: Long,
+    val messagesChanged: Long,
+    val rowsCompiled: Long,
+    val rowsReused: Long,
+    val compileCurrentNanos: Long,
+    val fullPresentationRebuilds: Long,
+    val unchangedPublications: Long,
+    val assetCallbacks: Long,
+    val assetCallbacksCoalesced: Long,
+    val drawOnlyInvalidations: Long,
+    val layoutAndDrawInvalidations: Long,
+    val staleCallbacksDiscarded: Long,
+    val activeAssetObservers: Int,
+    val inFlightAssetLoads: Int,
+    val cachedAssetStates: Int,
+    val retainedDecodedAssetHandles: Int,
+    val clipCacheHits: Long,
+    val clipStaleHits: Long,
+    val clipMisses: Long,
+    val clipRefreshes: Long,
+    val clipRefreshUnchanged: Long,
+    val clipRefreshChanged: Long,
+    val clipEvictions: Long,
+    val clipNegativeCacheHits: Long,
 ) {
     override fun toString(): String =
         "binds=$binds draws=$draws animationInvalidations=$animationInvalidations " +
             "animationStarts=$animationStarts animationStops=$animationStops " +
-            "activeAnimations=$activeAnimations"
+            "activeAnimations=$activeAnimations publications=$publications " +
+            "publicationMessages=$publicationMessages maxPublicationMessages=$maxPublicationMessages " +
+            "messagesChanged=$messagesChanged rowsCompiled=$rowsCompiled rowsReused=$rowsReused " +
+            "compileCurrentNanos=$compileCurrentNanos fullPresentationRebuilds=$fullPresentationRebuilds " +
+            "unchangedPublications=$unchangedPublications assetCallbacks=$assetCallbacks " +
+            "assetCallbacksCoalesced=$assetCallbacksCoalesced drawOnlyInvalidations=$drawOnlyInvalidations " +
+            "layoutAndDrawInvalidations=$layoutAndDrawInvalidations staleCallbacksDiscarded=$staleCallbacksDiscarded " +
+            "activeAssetObservers=$activeAssetObservers inFlightAssetLoads=$inFlightAssetLoads " +
+            "cachedAssetStates=$cachedAssetStates retainedDecodedAssetHandles=$retainedDecodedAssetHandles " +
+            "clipCacheHits=$clipCacheHits clipStaleHits=$clipStaleHits " +
+            "clipMisses=$clipMisses clipRefreshes=$clipRefreshes clipRefreshUnchanged=$clipRefreshUnchanged " +
+            "clipRefreshChanged=$clipRefreshChanged clipEvictions=$clipEvictions " +
+            "clipNegativeCacheHits=$clipNegativeCacheHits"
 }
 
 /** Per-report chat rendering counters for performance builds. */
@@ -26,6 +64,32 @@ internal object ChatRenderDiagnostics {
     private val animationStarts = AtomicLong()
     private val animationStops = AtomicLong()
     private val activeAnimations = AtomicInteger()
+    private val publications = AtomicLong()
+    private val publicationMessages = AtomicLong()
+    private val maxPublicationMessages = AtomicLong()
+    private val messagesChanged = AtomicLong()
+    private val rowsCompiled = AtomicLong()
+    private val rowsReused = AtomicLong()
+    private val compileCurrentNanos = AtomicLong()
+    private val fullPresentationRebuilds = AtomicLong()
+    private val unchangedPublications = AtomicLong()
+    private val assetCallbacks = AtomicLong()
+    private val assetCallbacksCoalesced = AtomicLong()
+    private val drawOnlyInvalidations = AtomicLong()
+    private val layoutAndDrawInvalidations = AtomicLong()
+    private val staleCallbacksDiscarded = AtomicLong()
+    private val activeAssetObservers = AtomicInteger()
+    private val inFlightAssetLoads = AtomicInteger()
+    private val cachedAssetStates = AtomicInteger()
+    private val retainedDecodedAssetHandles = AtomicInteger()
+    private val clipCacheHits = AtomicLong()
+    private val clipStaleHits = AtomicLong()
+    private val clipMisses = AtomicLong()
+    private val clipRefreshes = AtomicLong()
+    private val clipRefreshUnchanged = AtomicLong()
+    private val clipRefreshChanged = AtomicLong()
+    private val clipEvictions = AtomicLong()
+    private val clipNegativeCacheHits = AtomicLong()
 
     fun recordBind() {
         if (BuildConfig.PERF_DIAGNOSTICS) binds.incrementAndGet()
@@ -53,6 +117,86 @@ internal object ChatRenderDiagnostics {
         }
     }
 
+    fun recordPublication(
+        messageCount: Int,
+        changed: Int,
+        compiled: Int,
+        reused: Int,
+        compileNanos: Long,
+        fullRebuild: Boolean,
+        uiChanged: Boolean,
+    ) {
+        if (!BuildConfig.PERF_DIAGNOSTICS) return
+        publications.incrementAndGet()
+        publicationMessages.addAndGet(messageCount.toLong())
+        maxPublicationMessages.accumulateAndGet(messageCount.toLong()) { current, value -> maxOf(current, value) }
+        messagesChanged.addAndGet(changed.toLong())
+        rowsCompiled.addAndGet(compiled.toLong())
+        rowsReused.addAndGet(reused.toLong())
+        compileCurrentNanos.addAndGet(compileNanos)
+        if (fullRebuild) fullPresentationRebuilds.incrementAndGet()
+        if (!uiChanged) unchangedPublications.incrementAndGet()
+    }
+
+    fun recordAssetCallbackReceived() {
+        if (BuildConfig.PERF_DIAGNOSTICS) assetCallbacks.incrementAndGet()
+    }
+
+    fun recordAssetCallbackCoalesced() {
+        if (BuildConfig.PERF_DIAGNOSTICS) assetCallbacksCoalesced.incrementAndGet()
+    }
+
+    fun recordDrawOnlyInvalidation() {
+        if (BuildConfig.PERF_DIAGNOSTICS) drawOnlyInvalidations.incrementAndGet()
+    }
+
+    fun recordLayoutAndDrawInvalidation() {
+        if (BuildConfig.PERF_DIAGNOSTICS) layoutAndDrawInvalidations.incrementAndGet()
+    }
+
+    fun recordStaleCallbackDiscarded() {
+        if (BuildConfig.PERF_DIAGNOSTICS) staleCallbacksDiscarded.incrementAndGet()
+    }
+
+    fun setAssetRepositoryState(
+        activeObservers: Int,
+        inFlightLoads: Int,
+        cachedStates: Int,
+        decodedHandles: Int,
+    ) {
+        if (!BuildConfig.PERF_DIAGNOSTICS) return
+        activeAssetObservers.set(activeObservers)
+        inFlightAssetLoads.set(inFlightLoads)
+        cachedAssetStates.set(cachedStates)
+        retainedDecodedAssetHandles.set(decodedHandles)
+    }
+
+    fun recordClipCacheHit(stale: Boolean, negative: Boolean) {
+        if (!BuildConfig.PERF_DIAGNOSTICS) return
+        if (stale) clipStaleHits.incrementAndGet() else clipCacheHits.incrementAndGet()
+        if (negative) clipNegativeCacheHits.incrementAndGet()
+    }
+
+    fun recordClipCacheMiss() {
+        if (BuildConfig.PERF_DIAGNOSTICS) clipMisses.incrementAndGet()
+    }
+
+    fun recordClipRefresh() {
+        if (BuildConfig.PERF_DIAGNOSTICS) clipRefreshes.incrementAndGet()
+    }
+
+    fun recordClipRefreshUnchanged() {
+        if (BuildConfig.PERF_DIAGNOSTICS) clipRefreshUnchanged.incrementAndGet()
+    }
+
+    fun recordClipRefreshChanged() {
+        if (BuildConfig.PERF_DIAGNOSTICS) clipRefreshChanged.incrementAndGet()
+    }
+
+    fun recordClipEviction() {
+        if (BuildConfig.PERF_DIAGNOSTICS) clipEvictions.incrementAndGet()
+    }
+
     fun snapshotAndReset(): ChatRenderDiagnosticsSnapshot = ChatRenderDiagnosticsSnapshot(
         binds = binds.getAndSet(0),
         draws = draws.getAndSet(0),
@@ -60,5 +204,31 @@ internal object ChatRenderDiagnostics {
         animationStarts = animationStarts.getAndSet(0),
         animationStops = animationStops.getAndSet(0),
         activeAnimations = activeAnimations.get(),
+        publications = publications.getAndSet(0),
+        publicationMessages = publicationMessages.getAndSet(0),
+        maxPublicationMessages = maxPublicationMessages.getAndSet(0),
+        messagesChanged = messagesChanged.getAndSet(0),
+        rowsCompiled = rowsCompiled.getAndSet(0),
+        rowsReused = rowsReused.getAndSet(0),
+        compileCurrentNanos = compileCurrentNanos.getAndSet(0),
+        fullPresentationRebuilds = fullPresentationRebuilds.getAndSet(0),
+        unchangedPublications = unchangedPublications.getAndSet(0),
+        assetCallbacks = assetCallbacks.getAndSet(0),
+        assetCallbacksCoalesced = assetCallbacksCoalesced.getAndSet(0),
+        drawOnlyInvalidations = drawOnlyInvalidations.getAndSet(0),
+        layoutAndDrawInvalidations = layoutAndDrawInvalidations.getAndSet(0),
+        staleCallbacksDiscarded = staleCallbacksDiscarded.getAndSet(0),
+        activeAssetObservers = activeAssetObservers.get(),
+        inFlightAssetLoads = inFlightAssetLoads.get(),
+        cachedAssetStates = cachedAssetStates.get(),
+        retainedDecodedAssetHandles = retainedDecodedAssetHandles.get(),
+        clipCacheHits = clipCacheHits.getAndSet(0),
+        clipStaleHits = clipStaleHits.getAndSet(0),
+        clipMisses = clipMisses.getAndSet(0),
+        clipRefreshes = clipRefreshes.getAndSet(0),
+        clipRefreshUnchanged = clipRefreshUnchanged.getAndSet(0),
+        clipRefreshChanged = clipRefreshChanged.getAndSet(0),
+        clipEvictions = clipEvictions.getAndSet(0),
+        clipNegativeCacheHits = clipNegativeCacheHits.getAndSet(0),
     )
 }

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatAssetRepositoryTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatAssetRepositoryTest.kt
@@ -171,4 +171,48 @@ class ChatAssetRepositoryTest {
         assertTrue(!secondStarted.isCompleted)
         scope.cancel()
     }
+
+    @Test
+    fun readyStateCanReloadWhenCoilHasEvictedTheDecodedImage() = runBlocking {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        try {
+            val key = ChatAssetKey("evicted")
+            var attempts = 0
+            val repository = ChatAssetRepository(scope, ChatAssetLoader {
+                if (++attempts == 1) ChatImageHandle { null } else ChatImageHandle { ColorDrawable(1) }
+            })
+            val listener: () -> Unit = {}
+            repository.observe(key, listener)
+            withTimeout(2_000) { while (repository.peek(key) !is ChatAssetState.Ready) delay(1) }
+
+            repository.retryIfDrawableUnavailable(key)
+            withTimeout(2_000) { while (attempts < 2) delay(1) }
+            assertTrue(repository.peek(key) is ChatAssetState.Ready)
+            assertEquals(2, attempts)
+            repository.removeObserver(key, listener)
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun nonShareableDecodedHandleIsReleasedWithItsLastObserver() = runBlocking {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        try {
+            val key = ChatAssetKey("animated")
+            val decodedHandle = object : ChatImageHandle {
+                override fun newDrawable() = ColorDrawable(1)
+                override fun holdsDecodedImage() = true
+            }
+            val repository = ChatAssetRepository(scope, ChatAssetLoader { decodedHandle })
+            val listener: () -> Unit = {}
+            repository.observe(key, listener)
+            withTimeout(2_000) { while (repository.peek(key) !is ChatAssetState.Ready) delay(1) }
+            repository.removeObserver(key, listener)
+
+            assertEquals(ChatAssetState.Missing, repository.peek(key))
+        } finally {
+            scope.cancel()
+        }
+    }
 }

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatClipPreviewRepositoryTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatClipPreviewRepositoryTest.kt
@@ -2,6 +2,7 @@ package com.github.andreyasadchy.xtra.ui.chat.v2
 
 import com.github.andreyasadchy.xtra.ui.chat.v2.preview.ChatClipPreview
 import com.github.andreyasadchy.xtra.ui.chat.v2.preview.ChatClipPreviewRepository
+import com.github.andreyasadchy.xtra.ui.chat.v2.preview.ChatClipPreviewState
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -11,6 +12,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Assert.assertNull
 import org.junit.Test
 
@@ -31,9 +33,11 @@ class ChatClipPreviewRepositoryTest {
         val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
         try {
             var attempts = 0
-            val repository = ChatClipPreviewRepository(scope) {
-                if (++attempts == 1) null else preview
-            }
+            val repository = ChatClipPreviewRepository(
+                scope = scope,
+                loader = { if (++attempts == 1) null else preview },
+                negativeTtlMs = 0,
+            )
             val first = CompletableDeferred<Unit>()
             repository.observe("slug") { first.complete(Unit) }
             withTimeout(5_000) { first.await() }
@@ -58,11 +62,185 @@ class ChatClipPreviewRepositoryTest {
             val listener: () -> Unit = { calls++ }
             repository.observe("slug", listener)
             repository.removeObserver("slug", listener)
+            assertEquals(0, repository.listenerCount("slug"))
             gate.complete(preview)
             withTimeout(5_000) {
                 while (repository.peek("slug") == null) delay(10)
             }
             assertEquals(0, calls)
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun freshHitReturnsImmediatelyWithoutAnotherLoad() = runBlocking {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        try {
+            var now = 0L
+            var attempts = 0
+            val repository = ChatClipPreviewRepository(
+                scope = scope,
+                loader = { attempts++; preview },
+                successTtlMs = 100,
+                negativeTtlMs = 10,
+                nowMs = { now },
+            )
+            val first = CompletableDeferred<Unit>()
+            val listener: () -> Unit = { first.complete(Unit) }
+            repository.observe("slug", listener)
+            withTimeout(5_000) { first.await() }
+            repository.removeObserver("slug", listener)
+
+            now = 99
+            val second = CompletableDeferred<Unit>()
+            repository.observe("slug") { second.complete(Unit) }
+            withTimeout(5_000) { second.await() }
+            assertEquals(preview, repository.peek("slug"))
+            assertEquals(1, attempts)
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun staleHitIsReturnedBeforeOneBackgroundRefresh() = runBlocking {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        try {
+            var now = 0L
+            var attempts = 0
+            val refreshGate = CompletableDeferred<ChatClipPreview?>()
+            val repository = ChatClipPreviewRepository(
+                scope = scope,
+                loader = {
+                    if (++attempts == 1) preview else refreshGate.await()
+                },
+                successTtlMs = 100,
+                negativeTtlMs = 10,
+                nowMs = { now },
+            )
+            val first = CompletableDeferred<Unit>()
+            val firstListener: () -> Unit = { first.complete(Unit) }
+            repository.observe("slug", firstListener)
+            withTimeout(5_000) { first.await() }
+            repository.removeObserver("slug", firstListener)
+
+            now = 101
+            var callbacks = 0
+            repository.observe("slug") { callbacks++ }
+            assertEquals(preview, repository.peek("slug"))
+            withTimeout(5_000) { while (attempts < 2) delay(1) }
+            assertEquals(1, callbacks)
+            assertEquals(1, repository.inFlightCount())
+            refreshGate.complete(preview)
+            withTimeout(5_000) { while (repository.inFlightCount() != 0) delay(1) }
+            assertEquals(1, callbacks)
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun changedRefreshNotifiesInterestedRowsOnly() = runBlocking {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        try {
+            var now = 0L
+            var attempts = 0
+            val changed = preview.copy(title = "changed")
+            val repository = ChatClipPreviewRepository(
+                scope = scope,
+                loader = { if (++attempts == 1) preview else changed },
+                successTtlMs = 100,
+                nowMs = { now },
+            )
+            val first = CompletableDeferred<Unit>()
+            val firstListener: () -> Unit = { first.complete(Unit) }
+            repository.observe("slug", firstListener)
+            withTimeout(5_000) { first.await() }
+            repository.removeObserver("slug", firstListener)
+            now = 101
+
+            var callbacks = 0
+            repository.observe("slug") { callbacks++ }
+            withTimeout(5_000) { while (repository.peek("slug") != changed) delay(1) }
+            assertEquals(2, callbacks)
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun concurrentObserversShareOneLoad() = runBlocking {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        try {
+            val gate = CompletableDeferred<ChatClipPreview?>()
+            var attempts = 0
+            val repository = ChatClipPreviewRepository(scope) {
+                attempts++
+                gate.await()
+            }
+            var firstCalls = 0
+            var secondCalls = 0
+            repository.observe("slug") { firstCalls++ }
+            repository.observe("slug") { secondCalls++ }
+            withTimeout(5_000) { while (attempts < 1) delay(1) }
+            assertEquals(1, attempts)
+            assertEquals(ChatClipPreviewState.Loading, repository.peekState("slug"))
+            gate.complete(preview)
+            withTimeout(5_000) { while (repository.peek("slug") == null) delay(1) }
+            assertEquals(1, firstCalls)
+            assertEquals(1, secondCalls)
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun negativeEntriesUseShortTtlAndBecomeRetryable() = runBlocking {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        try {
+            var now = 0L
+            var attempts = 0
+            val repository = ChatClipPreviewRepository(
+                scope = scope,
+                loader = { if (++attempts == 1) null else preview },
+                negativeTtlMs = 10,
+                nowMs = { now },
+            )
+            val first = CompletableDeferred<Unit>()
+            val firstListener: () -> Unit = { first.complete(Unit) }
+            repository.observe("slug", firstListener)
+            withTimeout(5_000) { first.await() }
+            repository.removeObserver("slug", firstListener)
+            assertEquals(ChatClipPreviewState.Ready(null), repository.peekState("slug"))
+
+            now = 9
+            repository.observe("slug") {}
+            assertEquals(1, attempts)
+            now = 10
+            repository.observe("slug") {}
+            withTimeout(5_000) { while (attempts < 2 || repository.peek("slug") == null) delay(1) }
+            assertTrue(repository.peekState("slug") is ChatClipPreviewState.Ready)
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun lruEvictsOldestEntryAtConfiguredBound() = runBlocking {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        try {
+            val repository = ChatClipPreviewRepository(scope, { preview }, maxEntries = 2)
+            for (slug in listOf("one", "two", "three")) {
+                val done = CompletableDeferred<Unit>()
+                val listener: () -> Unit = { done.complete(Unit) }
+                repository.observe(slug, listener)
+                withTimeout(5_000) { done.await() }
+                repository.removeObserver(slug, listener)
+            }
+            assertEquals(2, repository.cacheSize())
+            assertNull(repository.peek("one"))
+            assertEquals(preview, repository.peek("three"))
         } finally {
             scope.cancel()
         }

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatPresentationReuseTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatPresentationReuseTest.kt
@@ -1,0 +1,105 @@
+package com.github.andreyasadchy.xtra.ui.chat.v2
+
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessage
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessageId
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessageKind
+import com.github.andreyasadchy.xtra.ui.chat.v2.presentation.ChatPiece
+import com.github.andreyasadchy.xtra.ui.chat.v2.presentation.ChatRowBackground
+import com.github.andreyasadchy.xtra.ui.chat.v2.presentation.ChatRowUiModel
+import com.github.andreyasadchy.xtra.ui.chat.v2.ui.ChatPresentationReuseIndex
+import com.github.andreyasadchy.xtra.ui.chat.v2.ui.compileChatRows
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Test
+
+class ChatPresentationReuseTest {
+    @Test
+    fun normalAppendCompilesOnlyTheChangedRow() {
+        val previous = (0 until 600).map(::message)
+        val previousRows = previous.map(::row)
+        val index = ChatPresentationReuseIndex()
+        index.replace(previous, previousRows)
+
+        var resolveCalls = 0
+        val current = previous + message(600)
+        val result = compileChatRows(
+            messages = current,
+            reuseIndex = index,
+            resolve = { message, _ ->
+                resolveCalls++
+                row(message)
+            },
+        )
+
+        assertEquals(1, result.messagesChanged)
+        assertEquals(1, result.rowsCompiled)
+        assertEquals(600, result.rowsReused)
+        assertEquals(1, resolveCalls)
+        previousRows.forEachIndexed { index, oldRow -> assertSame(oldRow, result.rows[index]) }
+    }
+
+    @Test
+    fun equivalentPublicationReusesEveryRow() {
+        val messages = (0 until 600).map(::message)
+        val rows = messages.map(::row)
+        val index = ChatPresentationReuseIndex()
+        index.replace(messages, rows)
+
+        val result = compileChatRows(
+            messages = messages.toList(),
+            reuseIndex = index,
+            resolve = { message, _ -> row(message) },
+        )
+
+        assertEquals(0, result.messagesChanged)
+        assertEquals(0, result.rowsCompiled)
+        assertEquals(600, result.rowsReused)
+        rows.forEachIndexed { index, oldRow -> assertSame(oldRow, result.rows[index]) }
+    }
+
+    @Test
+    fun tenThousandSuccessiveAppendPublicationsCompileOnlyTheNewRow() {
+        var messages = (0 until 600).map(::message)
+        var rows = messages.map(::row)
+        val index = ChatPresentationReuseIndex()
+        index.replace(messages, rows)
+
+        repeat(10_000) { publication ->
+            val nextMessages = messages.drop(1) + message(600 + publication)
+            val result = compileChatRows(
+                messages = nextMessages,
+                reuseIndex = index,
+                resolve = { message, _ -> row(message) },
+            )
+
+            assertEquals(1, result.rowsCompiled)
+            assertEquals(599, result.rowsReused)
+            rows = result.rows
+            messages = nextMessages
+            index.replace(messages, rows)
+        }
+    }
+
+    private fun message(index: Int) = ChatMessage(
+        id = ChatMessageId(index.toString()),
+        channelId = "channel",
+        timestampMs = index.toLong(),
+        user = null,
+        badges = emptyList(),
+        segments = emptyList(),
+        kind = ChatMessageKind.CHAT,
+    )
+
+    private fun row(message: ChatMessage) = ChatRowUiModel(
+        id = message.id,
+        channelId = message.channelId,
+        timestampText = null,
+        pieces = listOf(ChatPiece.Text(message.id.value)),
+        background = 0,
+        backgroundStyle = ChatRowBackground.NORMAL,
+        accessibilityText = message.id.value,
+        reply = null,
+        source = null,
+        isAction = false,
+    )
+}

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatVisualRefreshCoalescerTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatVisualRefreshCoalescerTest.kt
@@ -1,0 +1,198 @@
+package com.github.andreyasadchy.xtra.ui.chat.v2
+
+import com.github.andreyasadchy.xtra.ui.chat.v2.ui.ChatVisualRefreshCoalescer
+import com.github.andreyasadchy.xtra.ui.chat.v2.ui.ChatVisualRefreshKind
+import com.github.andreyasadchy.xtra.ui.chat.v2.ui.ChatObserverRegistration
+import java.util.ArrayDeque
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ChatVisualRefreshCoalescerTest {
+    @Test
+    fun severalAssetCompletionsBeforeAFrameScheduleOneRefresh() {
+        val scheduled = ArrayDeque<Runnable>()
+        val refreshes = mutableListOf<ChatVisualRefreshKind>()
+        var coalesced = 0
+        var generation = 7L
+        val coalescer = ChatVisualRefreshCoalescer(
+            scheduleFrame = scheduled::add,
+            currentGeneration = { generation },
+            onRefresh = refreshes::add,
+            onCoalesced = { coalesced++ },
+        )
+
+        coalescer.request(ChatVisualRefreshKind.DRAW, generation)
+        coalescer.request(ChatVisualRefreshKind.DRAW, generation)
+        coalescer.request(ChatVisualRefreshKind.LAYOUT_AND_DRAW, generation)
+
+        assertEquals(1, scheduled.size)
+        assertEquals(2, coalesced)
+        scheduled.removeFirst().run()
+        assertEquals(listOf(ChatVisualRefreshKind.LAYOUT_AND_DRAW), refreshes)
+    }
+
+    @Test
+    fun olderGenerationCannotReplaceAQueuedCurrentGenerationRefresh() {
+        val scheduled = ArrayDeque<Runnable>()
+        val refreshes = mutableListOf<ChatVisualRefreshKind>()
+        var stale = 0
+        val coalescer = ChatVisualRefreshCoalescer(
+            scheduleFrame = scheduled::add,
+            currentGeneration = { 11L },
+            onRefresh = refreshes::add,
+            onStale = { stale++ },
+        )
+
+        coalescer.request(ChatVisualRefreshKind.DRAW, 11L)
+        coalescer.request(ChatVisualRefreshKind.LAYOUT_AND_DRAW, 10L)
+        scheduled.removeFirst().run()
+
+        assertEquals(listOf(ChatVisualRefreshKind.DRAW), refreshes)
+        assertEquals(1, stale)
+    }
+
+    @Test
+    fun drawOnlyAssetDoesNotBecomeLayoutRefresh() {
+        val scheduled = ArrayDeque<Runnable>()
+        val refreshes = mutableListOf<ChatVisualRefreshKind>()
+        val coalescer = ChatVisualRefreshCoalescer(
+            scheduleFrame = scheduled::add,
+            currentGeneration = { 1L },
+            onRefresh = refreshes::add,
+        )
+
+        coalescer.request(ChatVisualRefreshKind.DRAW, 1L)
+        scheduled.removeFirst().run()
+
+        assertEquals(listOf(ChatVisualRefreshKind.DRAW), refreshes)
+    }
+
+    @Test
+    fun requestDoesNotReadBindingGenerationUntilTheUiFrame() {
+        val scheduled = ArrayDeque<Runnable>()
+        var generationReads = 0
+        val coalescer = ChatVisualRefreshCoalescer(
+            scheduleFrame = scheduled::add,
+            currentGeneration = {
+                generationReads++
+                1L
+            },
+            onRefresh = {},
+        )
+
+        coalescer.request(ChatVisualRefreshKind.DRAW, 1L)
+
+        assertEquals(0, generationReads)
+        scheduled.removeFirst().run()
+        assertEquals(1, generationReads)
+    }
+
+    @Test
+    fun callbackFromRecycledGenerationDoesNoWork() {
+        val scheduled = ArrayDeque<Runnable>()
+        val refreshes = mutableListOf<ChatVisualRefreshKind>()
+        var generation = 1L
+        var stale = 0
+        val coalescer = ChatVisualRefreshCoalescer(
+            scheduleFrame = scheduled::add,
+            currentGeneration = { generation },
+            onRefresh = refreshes::add,
+            onStale = { stale++ },
+        )
+
+        coalescer.request(ChatVisualRefreshKind.DRAW, generation)
+        generation = 2L
+        scheduled.removeFirst().run()
+
+        assertTrue(refreshes.isEmpty())
+        assertEquals(1, stale)
+    }
+
+    @Test
+    fun retainedAssetObserverUsesTheCurrentGenerationAfterRebind() {
+        val scheduled = ArrayDeque<Runnable>()
+        val refreshes = mutableListOf<ChatVisualRefreshKind>()
+        var generation = 10L
+        var stale = 0
+        val coalescer = ChatVisualRefreshCoalescer(
+            scheduleFrame = scheduled::add,
+            currentGeneration = { generation },
+            onRefresh = refreshes::add,
+        )
+        val registration = ChatObserverRegistration(
+            initialGeneration = generation,
+            onValid = { callbackGeneration ->
+                coalescer.request(ChatVisualRefreshKind.DRAW, callbackGeneration)
+            },
+            onStale = { stale++ },
+        )
+
+        generation = 11L
+        registration.rebind(generation)
+        registration.listener()
+        scheduled.removeFirst().run()
+
+        assertEquals(listOf(ChatVisualRefreshKind.DRAW), refreshes)
+        assertEquals(0, stale)
+    }
+
+    @Test
+    fun removedAssetObserverDoesNotRefreshTheReboundRow() {
+        val refreshes = mutableListOf<Long>()
+        var stale = 0
+        val registration = ChatObserverRegistration(
+            initialGeneration = 10L,
+            onValid = refreshes::add,
+            onStale = { stale++ },
+        )
+
+        registration.deactivate()
+        registration.listener()
+
+        assertTrue(refreshes.isEmpty())
+        assertEquals(1, stale)
+    }
+
+    @Test
+    fun retainedStagedObserverUsesTheCurrentGenerationAfterRebind() {
+        val refreshes = mutableListOf<Long>()
+        var stale = 0
+        val registration = ChatObserverRegistration(
+            initialGeneration = 20L,
+            onValid = refreshes::add,
+            onStale = { stale++ },
+        )
+
+        registration.rebind(21L)
+        registration.listener()
+
+        assertEquals(listOf(21L), refreshes)
+        assertEquals(0, stale)
+    }
+
+    @Test
+    fun stagedObserverCanBeReattachedWithoutLosingItsBindingGeneration() {
+        val refreshes = mutableListOf<Long>()
+        var stale = 0
+        val detached = ChatObserverRegistration(
+            initialGeneration = 30L,
+            onValid = refreshes::add,
+            onStale = { stale++ },
+        )
+        detached.deactivate()
+        val reattached = ChatObserverRegistration(
+            initialGeneration = 30L,
+            onValid = refreshes::add,
+            onStale = { stale++ },
+        )
+
+        // Detach removes the old repository registration. Reattach creates a new one at the
+        // unchanged binding generation, so the staged row remains eligible for application.
+        detached.listener()
+        reattached.listener()
+
+        assertEquals(listOf(30L), refreshes)
+        assertEquals(1, stale)
+    }
+}


### PR DESCRIPTION
## Summary
- coalesce Chat v2 asset refreshes and avoid layout work when geometry is unchanged
- reuse unchanged rows and skip unchanged list submissions
- keep clip previews cache-first with bounded stale refreshes
- keep decoded image ownership with Coil where possible