### PR TITLE
Reduce redundant chat and preload work

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/XtraModule.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/XtraModule.kt
@@ -36,6 +36,7 @@ import com.github.andreyasadchy.xtra.repository.OfflineVideosRepository
 import com.github.andreyasadchy.xtra.repository.PlayerRepository
 import com.github.andreyasadchy.xtra.repository.preload.StreamPreloadCoordinator
 import com.github.andreyasadchy.xtra.repository.preload.StreamMedia3Runtime
+import com.github.andreyasadchy.xtra.repository.preload.StreamPlaybackConfigurationStore
 import com.github.andreyasadchy.xtra.repository.RecentSearchesRepository
 import com.github.andreyasadchy.xtra.repository.RecommendationsRepository
 import com.github.andreyasadchy.xtra.repository.SavedFiltersRepository
@@ -148,7 +149,11 @@ class XtraModule(application: Application) {
     }
 
     val streamMedia3Runtime by lazy {
-        StreamMedia3Runtime(application, this)
+        StreamMedia3Runtime(application, this, configurationStore = streamPlaybackConfigurationStore)
+    }
+
+    val streamPlaybackConfigurationStore by lazy {
+        StreamPlaybackConfigurationStore(application)
     }
 
     private val streamPreloadCoordinatorLazy = lazy {
@@ -157,6 +162,7 @@ class XtraModule(application: Application) {
             playerRepository = playerRepository,
             streamFeedRefreshCoordinator = streamFeedRefreshCoordinator,
             mediaPreloadRuntime = streamMedia3Runtime,
+            configurationStore = streamPlaybackConfigurationStore,
         )
     }
 

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/preload/StreamMedia3Runtime.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/preload/StreamMedia3Runtime.kt
@@ -61,6 +61,7 @@ class StreamMedia3Runtime(
     context: Context,
     private val xtraModule: XtraModule,
     private val elapsedRealtimeMs: () -> Long = { SystemClock.elapsedRealtime() },
+    private val configurationStore: StreamPlaybackConfigurationStore = StreamPlaybackConfigurationStore(context),
 ) {
     companion object {
         private const val TAG = "StreamMedia3"
@@ -283,7 +284,7 @@ class StreamMedia3Runtime(
                 entry = MediaPreloadPlanEntry(entry.channelLogin, entry.url, entry.rank, entry.samplesLoadedAtMs, entry.addedAtMs),
                 requestedChannelLogin = login,
                 requestedUrl = url,
-                configurationMatches = generation.configuration.fingerprint == StreamPlaybackConfiguration.from(context).fingerprint,
+                configurationMatches = generation.configuration.fingerprint == configurationStore.current.fingerprint,
                 nowMs = now,
         )) return null
         val age = now - (entry.samplesLoadedAtMs ?: entry.addedAtMs)
@@ -399,7 +400,7 @@ class StreamMedia3Runtime(
     }
 
     private fun ensureGeneration(): Generation {
-        val configuration = StreamPlaybackConfiguration.from(context)
+        val configuration = configurationStore.current
         currentGeneration?.takeIf { it.configuration.fingerprint == configuration.fingerprint }?.let { return it }
         currentGeneration?.let { old ->
             if (shouldResetPreloadManager(old.player != null)) {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/preload/StreamPlaybackConfiguration.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/preload/StreamPlaybackConfiguration.kt
@@ -1,11 +1,13 @@
 package com.github.andreyasadchy.xtra.repository.preload
 
 import android.content.Context
+import android.content.SharedPreferences
 import com.github.andreyasadchy.xtra.util.C
 import com.github.andreyasadchy.xtra.util.TwitchApiHelper
 import com.github.andreyasadchy.xtra.util.httpProxyHost
 import com.github.andreyasadchy.xtra.util.httpProxyPort
 import com.github.andreyasadchy.xtra.util.prefs
+import com.github.andreyasadchy.xtra.util.tokenPrefs
 import java.security.MessageDigest
 
 /** Immutable network/playback inputs shared by URL resolution and Media3 sources. */
@@ -73,6 +75,100 @@ data class StreamPlaybackConfiguration(
                 customStreamProxyUrl = prefs.getString(C.PLAYER_PROXY_URL, null),
             )
         }
+    }
+}
+
+data class StreamPlaybackConfigurationState(
+    val revision: Long,
+    val configuration: StreamPlaybackConfiguration,
+)
+
+/**
+ * Process-owned configuration snapshot. Preference callbacks rebuild it only when an input
+ * changes; preload and playback hot paths read the already parsed immutable value.
+ */
+class StreamPlaybackConfigurationStore private constructor(
+    private val playbackPreferences: SharedPreferences,
+    private val tokenPreferences: SharedPreferences,
+    private val configurationLoader: () -> StreamPlaybackConfiguration,
+    initialConfiguration: StreamPlaybackConfiguration,
+) {
+    constructor(context: Context) : this(
+        playbackPreferences = context.applicationContext.prefs(),
+        tokenPreferences = context.applicationContext.tokenPrefs(),
+        configurationLoader = { StreamPlaybackConfiguration.from(context.applicationContext) },
+        initialConfiguration = StreamPlaybackConfiguration.from(context.applicationContext),
+    )
+
+    internal constructor(
+        playbackPreferences: SharedPreferences,
+        tokenPreferences: SharedPreferences,
+        initialConfiguration: StreamPlaybackConfiguration,
+        loadConfiguration: () -> StreamPlaybackConfiguration,
+    ) : this(playbackPreferences, tokenPreferences, loadConfiguration, initialConfiguration)
+
+    @Volatile
+    private var state = StreamPlaybackConfigurationState(
+        revision = 0L,
+        configuration = initialConfiguration,
+    )
+
+    private val listener = SharedPreferences.OnSharedPreferenceChangeListener { _, key ->
+        if (key == null || key in CONFIGURATION_KEYS) refresh()
+    }
+
+    init {
+        playbackPreferences.registerOnSharedPreferenceChangeListener(listener)
+        tokenPreferences.registerOnSharedPreferenceChangeListener(listener)
+    }
+
+    val current: StreamPlaybackConfiguration
+        get() = state.configuration
+
+    val currentState: StreamPlaybackConfigurationState
+        get() = state
+
+    @Synchronized
+    fun refresh(): StreamPlaybackConfigurationState {
+        val next = configurationLoader()
+        val previous = state
+        if (next != previous.configuration) {
+            state = StreamPlaybackConfigurationState(previous.revision + 1L, next)
+        }
+        return state
+    }
+
+    private companion object {
+        val CONFIGURATION_KEYS = setOf(
+            C.NETWORK_LIBRARY,
+            C.PLAYER_STREAM_HEADERS,
+            C.PLAYER_STREAM_PROXY,
+            C.PLAYER_PROXY_URL,
+            C.PROXY_PLAYBACK_ACCESS_TOKEN,
+            C.PROXY_MULTIVARIANT_PLAYLIST,
+            C.PROXY_HOST,
+            C.PROXY_PORT,
+            C.PROXY_USER,
+            C.PROXY_PASSWORD,
+            C.PLAYER_LOW_LATENCY,
+            C.TOKEN_INCLUDE_TOKEN_STREAM,
+            C.TOKEN_RANDOM_DEVICE_ID,
+            C.TOKEN_X_DEVICE_ID,
+            C.TOKEN_PLAYER_TYPE,
+            C.TOKEN_SUPPORTED_CODECS,
+            C.GQL_TOKEN_WEB,
+            C.TWITCH_WEB_COOKIE_HEADER,
+            C.GQL_CLIENT_ID_WEB,
+            C.GECKO_GQL_AUTHORIZATION,
+            C.GECKO_GQL_CLIENT_ID,
+            C.GECKO_GQL_CLIENT_INTEGRITY,
+            C.GECKO_GQL_X_DEVICE_ID,
+            C.GECKO_GQL_CLIENT_SESSION_ID,
+            C.GECKO_GQL_CLIENT_VERSION,
+            C.GECKO_GQL_USER_ID,
+            C.GECKO_GQL_AUTH_TOKEN_FINGERPRINT,
+            C.GECKO_GQL_CAPTURED_AT,
+        )
     }
 }
 

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/preload/StreamPreloadCoordinator.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/preload/StreamPreloadCoordinator.kt
@@ -45,6 +45,7 @@ class StreamPreloadCoordinator(
     private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO),
     private val elapsedRealtimeMs: () -> Long = { SystemClock.elapsedRealtime() },
     private val mediaPreloadRuntime: StreamMedia3Runtime? = null,
+    private val configurationStore: StreamPlaybackConfigurationStore = StreamPlaybackConfigurationStore(context),
 ) {
     private val context = context.applicationContext
     private val cache = StreamPreloadUrlCache(elapsedRealtimeMs = elapsedRealtimeMs)
@@ -355,7 +356,7 @@ class StreamPreloadCoordinator(
                 return@scheduleMediaOperation
             }
 
-            val currentConfig = StreamPlaybackConfiguration.from(context)
+            val currentConfig = configurationStore.current
             if (configuration?.fingerprint != currentConfig.fingerprint) {
                 refreshConfiguration()
                 return@scheduleMediaOperation
@@ -472,7 +473,7 @@ class StreamPreloadCoordinator(
     }
 
     private fun refreshConfiguration(): StreamPlaybackConfiguration {
-        val next = StreamPlaybackConfiguration.from(context)
+        val next = configurationStore.current
         if (configuration?.fingerprint != next.fingerprint) {
             cache.setConfiguration(next.fingerprint)
             vodPreviewUrls.clear()

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/streamfeed/StreamFeedPrewarmScheduler.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/streamfeed/StreamFeedPrewarmScheduler.kt
@@ -9,16 +9,33 @@ import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkManager
 import com.github.andreyasadchy.xtra.util.C
 import com.github.andreyasadchy.xtra.util.prefs
+import com.github.andreyasadchy.xtra.XtraApp
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import java.util.concurrent.TimeUnit
 
 object StreamFeedPrewarmScheduler {
     private const val WORK_NAME = "stream-feed-prewarm"
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    private val armController = StreamFeedPrewarmArmController(scope)
 
     fun schedule(context: Context) {
         val appContext = context.applicationContext
         val predictedReturn = appContext.prefs().getLong(C.STREAM_FEED_RETURN_INTERVAL_MS, 0L)
             .takeIf { it > 0L }
-        val delay = StreamFeedFreshnessPolicy.prewarmDelayMs(predictedReturn)
+        val delayMs = StreamFeedFreshnessPolicy.prewarmDelayMs(predictedReturn)
+        armController.schedule(delayMs) {
+            if ((appContext as? XtraApp)?.isInForeground != true) {
+                enqueueWork(appContext)
+            }
+        }
+    }
+
+    private fun enqueueWork(appContext: Context) {
         val request = OneTimeWorkRequestBuilder<StreamFeedPrewarmWorker>()
             .setConstraints(
                 Constraints.Builder()
@@ -26,7 +43,7 @@ object StreamFeedPrewarmScheduler {
                     .setRequiresBatteryNotLow(true)
                     .build()
             )
-            .setInitialDelay(delay, TimeUnit.MILLISECONDS)
+            .setInitialDelay(0L, TimeUnit.MILLISECONDS)
             .build()
         WorkManager.getInstance(appContext).enqueueUniqueWork(
             WORK_NAME,
@@ -36,6 +53,7 @@ object StreamFeedPrewarmScheduler {
     }
 
     fun cancel(context: Context) {
+        armController.cancel()
         WorkManager.getInstance(context.applicationContext).cancelUniqueWork(WORK_NAME)
     }
 
@@ -50,6 +68,38 @@ object StreamFeedPrewarmScheduler {
                 StreamFeedFreshnessPolicy.updateReturnIntervalEwma(previous, awayMs),
             )
             putInt(C.STREAM_FEED_RETURN_SAMPLE_COUNT, (samples + 1).coerceAtMost(Int.MAX_VALUE))
+        }
+    }
+}
+
+internal class StreamFeedPrewarmArmController(
+    private val scope: CoroutineScope,
+    private val delayBlock: suspend (Long) -> Unit = { delay(it) },
+) {
+    private val lock = Any()
+    private var armEpoch = 0L
+    private var armJob: Job? = null
+
+    fun schedule(delayMs: Long, onReadyToEnqueue: () -> Unit) {
+        synchronized(lock) {
+            val epoch = ++armEpoch
+            armJob?.cancel()
+            armJob = scope.launch {
+                delayBlock(delayMs)
+                synchronized(lock) {
+                    if (epoch != armEpoch) return@launch
+                    armJob = null
+                    onReadyToEnqueue()
+                }
+            }
+        }
+    }
+
+    fun cancel() {
+        synchronized(lock) {
+            ++armEpoch
+            armJob?.cancel()
+            armJob = null
         }
     }
 }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/catalog/ChatCatalogRepository.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/catalog/ChatCatalogRepository.kt
@@ -134,6 +134,7 @@ class ChatCatalogRepository(
     private var closed = false
     private var cacheJob: Job? = null
     private var persistenceJob: Job? = null
+    private var pendingPersistence: PersistenceRequest? = null
     private var cacheFetchedAtMs: Long? = null
     private var badgesFetchedAtMs: Long? = null
     private var cacheCatalogConfigFingerprint: String? = null
@@ -143,38 +144,84 @@ class ChatCatalogRepository(
     private var networkProvidersObserved = emptySet<Provider>()
     private val networkEmoteScopesObserved = mutableMapOf<Provider, MutableSet<ChatEmoteScope>>()
     private var runtimeDecorations = ChatDecorationSnapshot()
+    private var pendingDecorationUpdates = ArrayList<ChatDecorationUpdate>()
+    private var decorationPublishJob: Job? = null
 
     /** Applies live 7TV cosmetics without replacing the provider-loaded emote catalog. */
     @Synchronized
     fun applyDecorationUpdate(update: ChatDecorationUpdate) {
         if (closed) return
-        if (update is ChatDecorationUpdate.EmoteSet) {
-            applyEmoteSetUpdate(update)
-            return
-        }
-        runtimeDecorations = runtimeDecorations.apply(update)
-        val currentState = _state.value
-        val current = currentState.snapshot
-        val next = current.withRuntimeDecorations(runtimeDecorations)
-        if (next != current) {
-            _state.value = currentState.copy(snapshot = next.copy(revision = current.revision + 1))
+        pendingDecorationUpdates += update
+        if (decorationPublishJob?.isActive != true) {
+            decorationPublishJob = scope.launch {
+                delay(16L)
+                publishPendingDecorationUpdates()
+            }
         }
         update.userPersonalEmoteSetId()?.let { setId ->
-            promotePendingPersonalSet(setId)
             loadPersonalEmoteSet(setId)
         }
     }
 
-    private fun applyEmoteSetUpdate(update: ChatDecorationUpdate.EmoteSet) {
-        val currentState = _state.value
-        val current = currentState.snapshot
+    private fun publishPendingDecorationUpdates() {
+        synchronized(this) {
+            if (closed || pendingDecorationUpdates.isEmpty()) {
+                decorationPublishJob = null
+                return
+            }
+            val updates = pendingDecorationUpdates
+            pendingDecorationUpdates = ArrayList()
+            decorationPublishJob = null
+            var working = _state.value.snapshot
+            val mutableRuntime = MutableDecorationSnapshot(runtimeDecorations)
+            var persistedChange = false
+            updates.forEach { update ->
+                when (update) {
+                    is ChatDecorationUpdate.EmoteSet -> {
+                        val next = applyEmoteSetSnapshot(
+                            current = working,
+                            update = update,
+                            runtimeUsers = mutableRuntime.users,
+                        )
+                        if (next !== working && next != working) {
+                            working = next
+                            persistedChange = true
+                        }
+                    }
+                    else -> mutableRuntime.apply(update)
+                }
+                update.userPersonalEmoteSetId()?.let { setId ->
+                    val promoted = promotePendingPersonalSetSnapshot(working, setId)
+                    if (promoted !== working && promoted != working) {
+                        working = promoted
+                        persistedChange = true
+                    }
+                }
+            }
+            val nextRuntime = mutableRuntime.snapshot()
+            val next = working.withRuntimeDecorations(nextRuntime)
+            val currentState = _state.value
+            if (next != currentState.snapshot) {
+                runtimeDecorations = nextRuntime
+                _state.value = currentState.copy(snapshot = next.copy(revision = currentState.snapshot.revision + 1))
+                if (persistedChange) enqueuePersistence(_state.value.snapshot)
+            }
+        }
+    }
+
+    private fun applyEmoteSetSnapshot(
+        current: ChatCatalogSnapshot,
+        update: ChatDecorationUpdate.EmoteSet,
+        runtimeUsers: Map<String, ChatUserDecoration>,
+    ): ChatCatalogSnapshot {
         val sevenTv = current.sevenTv
         val channelSet = !current.sevenTvChannelSetId.isNullOrBlank() &&
                 update.setId == current.sevenTvChannelSetId
         val personalSet = !channelSet && (
-                update.setId in sevenTv.personal ||
-                        current.userDecorations.values.any { it.personalEmoteSetId == update.setId }
-                )
+            update.setId in sevenTv.personal ||
+                    current.userDecorations.values.any { it.personalEmoteSetId == update.setId } ||
+                    runtimeUsers.values.any { it.personalEmoteSetId == update.setId }
+        )
         val pending = sevenTv.pending[update.setId].orEmpty()
         val addedFor = { scope: ChatEmoteScope ->
             update.added.mapValues { (_, emote) -> emote.copy(scope = scope) }
@@ -201,20 +248,19 @@ class ChatCatalogRepository(
                         )),
             )
         }
-        if (nextSevenTv == sevenTv) return
-        val next = current.copy(revision = current.revision + 1, sevenTv = nextSevenTv)
-        _state.value = currentState.copy(snapshot = next)
-        enqueuePersistence(next)
+        if (nextSevenTv == sevenTv) return current
+        return current.copy(revision = current.revision + 1, sevenTv = nextSevenTv)
     }
 
-    private fun promotePendingPersonalSet(setId: String) {
-        if (setId.isBlank()) return
-        val currentState = _state.value
-        val current = currentState.snapshot
+    private fun promotePendingPersonalSetSnapshot(
+        current: ChatCatalogSnapshot,
+        setId: String,
+    ): ChatCatalogSnapshot {
+        if (setId.isBlank()) return current
         val pending = current.sevenTv.pending[setId].orEmpty()
-        if (pending.isEmpty()) return
+        if (pending.isEmpty()) return current
         val personal = current.sevenTv.personal[setId].orEmpty()
-        val next = current.copy(
+        return current.copy(
             revision = current.revision + 1,
             sevenTv = current.sevenTv.copy(
                 personal = current.sevenTv.personal + (setId to (personal + pending.mapValues { (_, emote) ->
@@ -223,8 +269,34 @@ class ChatCatalogRepository(
                 pending = current.sevenTv.pending - setId,
             ),
         )
-        _state.value = currentState.copy(snapshot = next)
-        enqueuePersistence(next)
+    }
+
+    private class MutableDecorationSnapshot(initial: ChatDecorationSnapshot) {
+        val users = HashMap(initial.users)
+        private val paints = HashMap(initial.paints)
+        private val badges = HashMap(initial.badges)
+
+        fun apply(update: ChatDecorationUpdate) {
+            when (update) {
+                is ChatDecorationUpdate.EmoteSet -> Unit
+                is ChatDecorationUpdate.Paint -> paints[update.id] = update.paint
+                is ChatDecorationUpdate.Badge -> badges[update.id] = update.badge
+                is ChatDecorationUpdate.User -> {
+                    val previous = users[update.userId] ?: ChatUserDecoration()
+                    users[update.userId] = previous.copy(
+                        paintId = update.paintId ?: previous.paintId,
+                        badgeId = update.badgeId ?: previous.badgeId,
+                        personalEmoteSetId = update.personalEmoteSetId ?: previous.personalEmoteSetId,
+                    )
+                }
+            }
+        }
+
+        fun snapshot() = ChatDecorationSnapshot(
+            users = users.toMap(),
+            paints = paints.toMap(),
+            badges = badges.toMap(),
+        )
     }
 
     /** Loads a sender's 7TV set once when the live decoration stream reveals it. */
@@ -425,6 +497,9 @@ class ChatCatalogRepository(
         closed = true
         cacheJob?.cancel()
         cacheJob = null
+        decorationPublishJob?.cancel()
+        decorationPublishJob = null
+        pendingDecorationUpdates.clear()
         refreshJob?.cancel()
         refreshJob = null
         badgeRefreshJob?.cancel()
@@ -619,26 +694,54 @@ class ChatCatalogRepository(
         }
     }
 
-    /**
-     * Serialize writes in publication order. Independent launches allow an older slow write to
-     * finish after a newer one and leave stale metadata on disk.
-     */
+    private data class PersistenceRequest(
+        val snapshot: ChatCatalogSnapshot,
+        val fetchedAtMs: Long,
+        val badgeFetchedAtMs: Long,
+        val catalogConfigFingerprint: String?,
+        val badgeConfigFingerprint: String?,
+    )
+
+    /** One writer plus one latest pending snapshot. Intermediate cache revisions are disposable. */
     private fun enqueuePersistence(next: ChatCatalogSnapshot) {
         val persistence = cache ?: return
-        val fetchedAtMs = cacheFetchedAtMs ?: 0L
-        val badgeFetchedAtMs = badgesFetchedAtMs ?: 0L
-        val catalogConfigFingerprint = cacheCatalogConfigFingerprint
-        val badgeConfigFingerprint = cacheBadgeConfigFingerprint
-        val previous = persistenceJob
-        persistenceJob = scope.launch {
-            previous?.join()
+        val request = PersistenceRequest(
+            snapshot = next,
+            fetchedAtMs = cacheFetchedAtMs ?: 0L,
+            badgeFetchedAtMs = badgesFetchedAtMs ?: 0L,
+            catalogConfigFingerprint = cacheCatalogConfigFingerprint,
+            badgeConfigFingerprint = cacheBadgeConfigFingerprint,
+        )
+        synchronized(this) {
+            pendingPersistence = request
+            if (persistenceJob?.isActive == true) return
+            persistenceJob = scope.launch {
+                drainPersistence(persistence)
+            }
+        }
+    }
+
+    private suspend fun drainPersistence(persistence: ChatCatalogCache) {
+        while (true) {
+            val request = synchronized(this) {
+                pendingPersistence.also { pendingPersistence = null }
+            }
+            if (request == null) {
+                synchronized(this) {
+                    if (pendingPersistence == null) {
+                        persistenceJob = null
+                        return
+                    }
+                }
+                continue
+            }
             try {
                 persistence.write(
-                    next,
-                    fetchedAtMs,
-                    badgeFetchedAtMs,
-                    catalogConfigFingerprint,
-                    badgeConfigFingerprint,
+                    request.snapshot,
+                    request.fetchedAtMs,
+                    request.badgeFetchedAtMs,
+                    request.catalogConfigFingerprint,
+                    request.badgeConfigFingerprint,
                 )
             } catch (e: CancellationException) {
                 throw e

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/presentation/ChatPresentationSnapshot.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/presentation/ChatPresentationSnapshot.kt
@@ -11,6 +11,7 @@ import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessage
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessageId
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatReward
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatSessionKey
+import com.github.andreyasadchy.xtra.util.ChatRenderDiagnostics
 
 internal data class ChatMetadataSettlement(
     val structuralSettled: Boolean,
@@ -29,6 +30,7 @@ internal class ChatPresentationSnapshot {
     private var sessionKey: ChatSessionKey? = null
     private val catalogsByMessage = HashMap<ChatMessageId, FrozenCatalog>()
     private val activeMessageIds = HashSet<ChatMessageId>()
+    private val orderedMessageIds = ArrayDeque<ChatMessageId>()
 
     @Synchronized
     fun catalogsFor(
@@ -40,14 +42,45 @@ internal class ChatPresentationSnapshot {
         badgesSettled: Boolean = true,
         rewardsSettled: Boolean = true,
         forceUpgrade: Boolean = false,
+        appendOnly: Boolean = false,
+        appendedCount: Int = 0,
+        evictedCount: Int = 0,
     ): List<ChatCatalogSnapshot> {
         if (sessionKey != key) {
             sessionKey = key
             catalogsByMessage.clear()
+            activeMessageIds.clear()
+            orderedMessageIds.clear()
         }
-        activeMessageIds.clear()
-        messages.forEach { activeMessageIds += it.id }
-        catalogsByMessage.keys.retainAll(activeMessageIds)
+        val canAppend = appendOnly && !forceUpgrade && appendedCount > 0 &&
+            orderedMessageIds.size - evictedCount == messages.size - appendedCount
+        ChatRenderDiagnostics.recordCatalogIndexUpdate(canAppend)
+        if (canAppend) {
+            repeat(evictedCount.coerceAtMost(orderedMessageIds.size)) {
+                val evicted = orderedMessageIds.removeFirst()
+                activeMessageIds.remove(evicted)
+                catalogsByMessage.remove(evicted)
+            }
+            val start = (messages.size - appendedCount).coerceAtLeast(0)
+            for (index in start until messages.size) {
+                val message = messages[index]
+                activeMessageIds += message.id
+                orderedMessageIds += message.id
+                catalogsByMessage[message.id] = FrozenCatalog.from(
+                    catalog = catalog,
+                    captureBadges = captureBadges,
+                    settlement = ChatMetadataSettlement(structuralSettled, badgesSettled, rewardsSettled),
+                )
+            }
+        } else {
+            activeMessageIds.clear()
+            orderedMessageIds.clear()
+            messages.forEach {
+                activeMessageIds += it.id
+                orderedMessageIds += it.id
+            }
+            catalogsByMessage.keys.retainAll(activeMessageIds)
+        }
         val settlement = ChatMetadataSettlement(structuralSettled, badgesSettled, rewardsSettled)
         return messages.map { message ->
             val frozen = catalogsByMessage[message.id]
@@ -75,6 +108,8 @@ internal class ChatPresentationSnapshot {
     fun clear() {
         sessionKey = null
         catalogsByMessage.clear()
+        activeMessageIds.clear()
+        orderedMessageIds.clear()
     }
 
     private class FrozenCatalog(

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatMessageTextView.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatMessageTextView.kt
@@ -155,6 +155,16 @@ open class ChatMessageTextView private constructor(
     private val latchedFailedCompositionKeys = HashSet<String>()
     private val latchedFailedDirectKeys = HashSet<ChatAssetKey>()
     private val latchedFailedClipMetadataSlugs = HashSet<String>()
+    private val clipFillPaint = Paint(Paint.ANTI_ALIAS_FLAG)
+    private val clipAccentPaint = Paint(Paint.ANTI_ALIAS_FLAG)
+    private val clipTitlePaint = TextPaint(Paint.ANTI_ALIAS_FLAG)
+    private val clipSecondaryPaint = TextPaint(Paint.ANTI_ALIAS_FLAG)
+    private val clipCardRect = RectF()
+    private val clipAccentRect = RectF()
+    private var clipDrawCards = emptyList<ClipDrawCard>()
+    private var clipDrawCacheWidth = -1
+    private var clipDrawCacheTimeBucket = Long.MIN_VALUE
+    private var clipRelativeTimeRefresh: Runnable? = null
 
     fun setInteractionCallbacks(
         onMessageLongClick: ((ChatMessageId) -> Unit)?,
@@ -177,6 +187,7 @@ open class ChatMessageTextView private constructor(
 
     fun setMessageTextSizeSp(value: Float) {
         setTextSize(TypedValue.COMPLEX_UNIT_SP, value)
+        invalidateClipDrawCache()
     }
 
     fun setAnimateGifs(value: Boolean) {
@@ -257,6 +268,7 @@ open class ChatMessageTextView private constructor(
     }
 
     private fun bindRow(row: ChatRowUiModel) {
+        invalidateClipDrawCache()
         val sameRevealedMessage = boundMessageId == row.id && !awaitingInitialAssetFrame
         if (!sameRevealedMessage) {
             awaitingInitialAssetFrame = true
@@ -327,6 +339,7 @@ open class ChatMessageTextView private constructor(
             observeClipMetadata(slug)
         }
         refreshClipPreviewAssets()
+        invalidateClipDrawCache()
         latchTerminalAssetFailures()
         val density = resources.displayMetrics.density
         val event = row.eventPresentation
@@ -565,6 +578,7 @@ open class ChatMessageTextView private constructor(
         requiresLayout = maybeApplyStagedRow() || requiresLayout
         requiresLayout = latchFailedClipMetadata() || requiresLayout
         refreshClipPreviewAssets()
+        invalidateClipDrawCache()
         if (requiresLayout) {
             ChatRenderDiagnostics.recordLayoutAndDrawInvalidation()
             requestLayout()
@@ -692,13 +706,13 @@ open class ChatMessageTextView private constructor(
         }
         try {
             super.onDraw(canvas)
-            val previews = resolvedClipPreviews()
-            if (previews.isEmpty()) return
+            ensureClipDrawCache()
+            if (clipDrawCards.isEmpty()) return
             val left = totalPaddingLeft.toFloat()
             val right = (width - totalPaddingRight).toFloat()
             var top = (paddingTop + layout?.height.orZero() + clipPreviewGap()).toFloat()
-            previews.forEach { (link, preview) ->
-                drawClipPreview(canvas, left, top, right, link, preview)
+            clipDrawCards.forEach { card ->
+                drawClipPreview(canvas, left, top, right, card)
                 top += clipPreviewBlockHeight() + clipPreviewGap()
             }
         } finally {
@@ -706,64 +720,117 @@ open class ChatMessageTextView private constructor(
         }
     }
 
+    private data class ClipDrawCard(
+        val thumbnailSpec: ChatAssetSpec?,
+        val title: String,
+        val subtitle: String,
+        val attribution: String,
+        val hasRelativeTime: Boolean,
+    )
+
+    private fun invalidateClipDrawCache() {
+        clipDrawCacheWidth = -1
+        clipDrawCacheTimeBucket = Long.MIN_VALUE
+        clipDrawCards = emptyList()
+    }
+
+    private fun ensureClipDrawCache() {
+        val width = width
+        val timeBucket = System.currentTimeMillis() / DateUtils.MINUTE_IN_MILLIS
+        if (width <= 0 || (clipDrawCacheWidth == width && clipDrawCacheTimeBucket == timeBucket)) return
+        val density = resources.displayMetrics.density
+        val left = totalPaddingLeft.toFloat()
+        val right = (width - totalPaddingEnd).toFloat()
+        val thumbRight = left + 6 * density + 72 * density
+        val textLeft = thumbRight + 6 * density
+        val textRight = right - 9 * density
+        clipFillPaint.color = com.google.android.material.color.MaterialColors.getColor(
+            this,
+            com.google.android.material.R.attr.colorSurfaceContainerHigh,
+        )
+        clipAccentPaint.color = com.google.android.material.color.MaterialColors.getColor(this, R.attr.chatMessageSpecialAccentColor)
+        clipTitlePaint.color = com.google.android.material.color.MaterialColors.getColor(
+            this,
+            com.google.android.material.R.attr.colorOnSurface,
+        )
+        clipTitlePaint.textSize = paint.textSize
+        clipTitlePaint.typeface = Typeface.create(Typeface.DEFAULT, Typeface.BOLD)
+        clipSecondaryPaint.color = com.google.android.material.color.MaterialColors.getColor(
+            this,
+            com.google.android.material.R.attr.colorOnSurfaceVariant,
+        )
+        clipSecondaryPaint.textSize = paint.textSize
+        val availableTextWidth = (textRight - textLeft).coerceAtLeast(0f)
+        clipDrawCards = buildList {
+            boundRow?.clipPreviews.orEmpty().forEach { link ->
+                if (link.slug in latchedFailedClipMetadataSlugs) return@forEach
+                val preview = clipPreviews?.peek(link.slug) ?: return@forEach
+                val imageUrl = preview.thumbnailUrl?.takeIf { it.isNotBlank() }
+                val thumbnailSpec = imageUrl?.let { url ->
+                    ChatAssetSpec(ChatAssetKey(url), 16, 9, (clipPreviewCardHeight() - 12 * density).toInt())
+                }
+                val title = preview.title?.takeIf { it.isNotBlank() } ?: link.slug
+                val subtitle = clipSubtitle(preview)
+                val attribution = clipAttribution(preview)
+                add(
+                    ClipDrawCard(
+                        thumbnailSpec = thumbnailSpec,
+                        title = TextUtils.ellipsize(title, clipTitlePaint, availableTextWidth, TextUtils.TruncateAt.END).toString(),
+                        subtitle = TextUtils.ellipsize(subtitle, clipSecondaryPaint, availableTextWidth, TextUtils.TruncateAt.END).toString(),
+                        attribution = TextUtils.ellipsize(attribution, clipSecondaryPaint, availableTextWidth, TextUtils.TruncateAt.END).toString(),
+                        hasRelativeTime = parseClipTimestamp(preview.createdAt) != null,
+                    ),
+                )
+            }
+        }
+        clipDrawCacheWidth = width
+        clipDrawCacheTimeBucket = timeBucket
+        scheduleClipRelativeTimeRefresh()
+    }
+
+    private fun scheduleClipRelativeTimeRefresh() {
+        clipRelativeTimeRefresh?.let(mainHandler::removeCallbacks)
+        clipRelativeTimeRefresh = null
+        if (!windowAttached || clipDrawCards.none { it.hasRelativeTime }) return
+        val now = System.currentTimeMillis()
+        val delayMs = (DateUtils.MINUTE_IN_MILLIS - (now % DateUtils.MINUTE_IN_MILLIS) + 50L)
+        clipRelativeTimeRefresh = Runnable {
+            clipRelativeTimeRefresh = null
+            invalidateClipDrawCache()
+            postInvalidateOnAnimation()
+        }.also { mainHandler.postDelayed(it, delayMs) }
+    }
+
     private fun drawClipPreview(
         canvas: Canvas,
         left: Float,
         top: Float,
         right: Float,
-        link: ChatClipPreviewLink,
-        preview: ChatClipPreview,
+        card: ClipDrawCard,
     ) {
         val density = resources.displayMetrics.density
         val height = clipPreviewCardHeight().toFloat()
         val radius = (3 * density)
-        val card = RectF(left, top, right, top + height)
-        val fill = Paint(Paint.ANTI_ALIAS_FLAG).apply {
-            color = com.google.android.material.color.MaterialColors.getColor(
-                this@ChatMessageTextView,
-                com.google.android.material.R.attr.colorSurfaceContainerHigh,
-            )
-        }
-        canvas.drawRoundRect(card, radius, radius, fill)
-        fill.color = com.google.android.material.color.MaterialColors.getColor(this, R.attr.chatMessageSpecialAccentColor)
-        canvas.drawRoundRect(RectF(right - 4 * density, top, right, top + height), radius, radius, fill)
+        clipCardRect.set(left, top, right, top + height)
+        canvas.drawRoundRect(clipCardRect, radius, radius, clipFillPaint)
+        clipAccentRect.set(right - 4 * density, top, right, top + height)
+        canvas.drawRoundRect(clipAccentRect, radius, radius, clipAccentPaint)
 
-        val imageUrl = preview.thumbnailUrl?.takeIf { it.isNotBlank() }
         val thumbLeft = left + 6 * density
         val thumbTop = top + 6 * density
         val thumbRight = thumbLeft + 72 * density
         val thumbBottom = top + height - 6 * density
-        if (imageUrl != null) {
-            val spec = com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatAssetSpec(
-                ChatAssetKey(imageUrl), 16, 9, (thumbBottom - thumbTop).toInt(),
-            )
-            val key = ChatAssetKey(imageUrl)
-            if (!isDirectAssetFailureLatched(key)) drawableFor(key, spec)?.let { drawable ->
+        card.thumbnailSpec?.let { spec ->
+            if (!isDirectAssetFailureLatched(spec.key)) drawableFor(spec.key, spec)?.let { drawable ->
                 drawable.setBounds(thumbLeft.toInt(), thumbTop.toInt(), thumbRight.toInt(), thumbBottom.toInt())
                 drawable.draw(canvas)
             }
         }
 
         val textLeft = thumbRight + 6 * density
-        val textRight = right - 9 * density
-        val titlePaint = TextPaint(Paint.ANTI_ALIAS_FLAG).apply {
-            color = com.google.android.material.color.MaterialColors.getColor(
-                this@ChatMessageTextView,
-                com.google.android.material.R.attr.colorOnSurface,
-            )
-            textSize = paint.textSize
-            typeface = Typeface.create(Typeface.DEFAULT, Typeface.BOLD)
-        }
-        val secondaryPaint = TextPaint(Paint.ANTI_ALIAS_FLAG).apply {
-            color = com.google.android.material.color.MaterialColors.getColor(
-                this@ChatMessageTextView,
-                com.google.android.material.R.attr.colorOnSurfaceVariant,
-            )
-            textSize = paint.textSize
-        }
-        drawClipLine(canvas, preview.title?.takeIf { it.isNotBlank() } ?: link.slug, titlePaint, textLeft, textRight, top + 18 * density)
-        drawClipLine(canvas, clipSubtitle(preview), secondaryPaint, textLeft, textRight, top + 36 * density)
-        drawClipLine(canvas, clipAttribution(preview), secondaryPaint, textLeft, textRight, top + 54 * density)
+        drawClipLine(canvas, card.title, clipTitlePaint, textLeft, top + 18 * density)
+        drawClipLine(canvas, card.subtitle, clipSecondaryPaint, textLeft, top + 36 * density)
+        drawClipLine(canvas, card.attribution, clipSecondaryPaint, textLeft, top + 54 * density)
     }
 
     private fun clipSubtitle(preview: ChatClipPreview): String {
@@ -786,8 +853,8 @@ open class ChatMessageTextView private constructor(
         return DateUtils.getRelativeTimeSpanString(epochMs, System.currentTimeMillis(), DateUtils.MINUTE_IN_MILLIS).toString()
     }
 
-    private fun drawClipLine(canvas: Canvas, value: String, paint: TextPaint, left: Float, right: Float, baseline: Float) {
-        canvas.drawText(TextUtils.ellipsize(value, paint, (right - left).coerceAtLeast(0f), TextUtils.TruncateAt.END).toString(), left, baseline, paint)
+    private fun drawClipLine(canvas: Canvas, value: String, paint: TextPaint, left: Float, baseline: Float) {
+        canvas.drawText(value, left, baseline, paint)
     }
 
     private fun clipPreviewCardHeight() = (68 * resources.displayMetrics.density).roundToInt()
@@ -850,6 +917,7 @@ open class ChatMessageTextView private constructor(
 
     override fun onSizeChanged(w: Int, h: Int, oldw: Int, oldh: Int) {
         super.onSizeChanged(w, h, oldw, oldh)
+        if (w != oldw) invalidateClipDrawCache()
         if (w != oldw && !bindingRow && boundRow?.pieces?.any { it is ChatPiece.Reply } == true) {
             boundRow?.let { bindInternal(it, stagePendingCandidate = false) }
         }
@@ -1155,6 +1223,9 @@ open class ChatMessageTextView private constructor(
         animatedAssetKeys = emptySet()
         clipPreviewSlugs = emptySet()
         clipPreviewAssetKeys = emptySet()
+        clipRelativeTimeRefresh?.let(mainHandler::removeCallbacks)
+        clipRelativeTimeRefresh = null
+        invalidateClipDrawCache()
         stagedRow = null
         stagedBindGeneration = 0L
         stagedAssetKeys = emptySet()
@@ -1248,6 +1319,8 @@ open class ChatMessageTextView private constructor(
 
     override fun onDetachedFromWindow() {
         windowAttached = false
+        clipRelativeTimeRefresh?.let(mainHandler::removeCallbacks)
+        clipRelativeTimeRefresh = null
         // Detach only unregisters callbacks. Keep the bind generation so a staged row can survive
         // a detach/reattach cycle and still be applied when its assets finish loading.
         longPressRunnable?.let(mainHandler::removeCallbacks)
@@ -1263,6 +1336,7 @@ open class ChatMessageTextView private constructor(
     override fun onAttachedToWindow() {
         super.onAttachedToWindow()
         windowAttached = true
+        invalidateClipDrawCache()
         if (renderingActive) {
             keys.forEach(::observeAsset)
             stagedObservedAssetKeys.forEach(::observeStagedAsset)

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatPresentationReuse.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatPresentationReuse.kt
@@ -9,6 +9,7 @@ import java.util.HashMap
 internal class ChatPresentationReuseIndex {
     private val messagesById = HashMap<ChatMessageId, ChatMessage>()
     private val rowsById = HashMap<ChatMessageId, ChatRowUiModel>()
+    private val orderedIds = ArrayDeque<ChatMessageId>()
 
     fun rowFor(message: ChatMessage): ChatRowUiModel? =
         rowsById[message.id]?.takeIf { messagesById[message.id] == message }
@@ -17,16 +18,80 @@ internal class ChatPresentationReuseIndex {
     fun replace(messages: List<ChatMessage>, rows: List<ChatRowUiModel>) {
         messagesById.clear()
         rowsById.clear()
+        orderedIds.clear()
         messages.forEachIndexed { index, message ->
             messagesById[message.id] = message
-            rows.getOrNull(index)?.let { row -> rowsById[row.id] = row }
+            rows.getOrNull(index)?.let { row ->
+                rowsById[row.id] = row
+                orderedIds += row.id
+            }
         }
+    }
+
+    /** Updates only the head evictions and newly appended rows for the common live-chat path. */
+    fun append(
+        messages: List<ChatMessage>,
+        rows: List<ChatRowUiModel>,
+        appendedCount: Int,
+        evictedCount: Int,
+    ): Boolean {
+        if (orderedIds.size != messages.size - appendedCount + evictedCount) return false
+        repeat(evictedCount.coerceAtMost(orderedIds.size)) {
+            val evicted = orderedIds.removeFirst()
+            messagesById.remove(evicted)
+            rowsById.remove(evicted)
+        }
+        val start = (messages.size - appendedCount).coerceAtLeast(0)
+        for (index in 0 until start) {
+            val message = messages[index]
+            if (messagesById[message.id] != message) {
+                messagesById[message.id] = message
+                rows.getOrNull(index)?.let { row -> rowsById[row.id] = row }
+            }
+        }
+        for (index in start until messages.size) {
+            val message = messages[index]
+            val row = rows.getOrNull(index) ?: continue
+            messagesById[message.id] = message
+            rowsById[row.id] = row
+            orderedIds += row.id
+        }
+        return true
     }
 
     fun clear() {
         messagesById.clear()
         rowsById.clear()
+        orderedIds.clear()
     }
+}
+
+internal data class ChatAppendInfo(
+    val appendedCount: Int,
+    val evictedCount: Int,
+)
+
+/**
+ * Recognizes the stable tail append shape without allocating a second ID map. All other
+ * publications use the existing full reconciliation path.
+ */
+internal fun findChatAppendInfo(
+    previous: List<ChatMessage>,
+    current: List<ChatMessage>,
+): ChatAppendInfo? {
+    if (previous.isEmpty() || current.isEmpty()) return null
+    val previousTail = previous.last().id
+    val retainedTailIndex = current.indexOfFirst { it.id == previousTail }
+    if (retainedTailIndex < 0 || retainedTailIndex >= current.lastIndex) return null
+    val evictedCount = previous.size - retainedTailIndex - 1
+    if (evictedCount < 0 || evictedCount > previous.size) return null
+    val retainedCount = previous.size - evictedCount
+    if (retainedCount == 0) return null
+    for (index in 0 until retainedCount) {
+        if (previous[index + evictedCount].id != current[index].id) return null
+    }
+    val appendedCount = current.size - retainedCount
+    return ChatAppendInfo(appendedCount, evictedCount)
 }
 
 internal data class ChatRowCompileResult(

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatV2RendererController.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatV2RendererController.kt
@@ -263,6 +263,7 @@ class ChatV2RendererController(
                 val uiChanged = !sameRows(latestRows, rows)
                 latestRows = rows
                 reuseIndex.replace(publication.messages, rows)
+                ChatRenderDiagnostics.recordReuseIndexUpdate(incremental = false)
                 ChatRenderDiagnostics.recordPublication(
                     messageCount = publication.messages.size,
                     changed = compiled.result.messagesChanged,
@@ -319,12 +320,33 @@ class ChatV2RendererController(
                 previousTailId,
                 publication.messages,
             )
-            previousIds.clear()
-            rows.forEach { previousIds += it.id }
+            val appendInfo = previousPublication
+                ?.takeIf { it.key == publication.key }
+                ?.let { findChatAppendInfo(it.messages, publication.messages) }
+            if (appendInfo != null && hasPreviousIds) {
+                repeat(appendInfo.evictedCount) {
+                    previousPublication.messages.getOrNull(it)?.id?.let(previousIds::remove)
+                }
+                publication.messages.takeLast(appendInfo.appendedCount).forEach { previousIds += it.id }
+            } else {
+                previousIds.clear()
+                publication.messages.forEach { previousIds += it.id }
+            }
             hasPreviousIds = true
             previousTailId = publication.messages.lastOrNull()?.id
             latestRows = rows
-            reuseIndex.replace(publication.messages, rows)
+            val incrementallyUpdated = appendInfo?.let {
+                reuseIndex.append(
+                    messages = publication.messages,
+                    rows = rows,
+                    appendedCount = it.appendedCount,
+                    evictedCount = it.evictedCount,
+                )
+            } == true
+            if (!incrementallyUpdated) {
+                reuseIndex.replace(publication.messages, rows)
+            }
+            ChatRenderDiagnostics.recordReuseIndexUpdate(incrementallyUpdated)
             val uiChanged = !sameRows(previousRows, rows)
             ChatRenderDiagnostics.recordPublication(
                 messageCount = publication.messages.size,
@@ -361,6 +383,16 @@ class ChatV2RendererController(
             val forceCatalogUpgrade = previousPublication?.let { previous ->
                 publication.forceRefreshRevision != previous.forceRefreshRevision
             } == true
+            val appendInfo = previousPublication
+                ?.takeIf { it.key == publication.key && !forceCatalogUpgrade }
+                ?.let { findChatAppendInfo(it.messages, publication.messages) }
+            val metadataSettlementChanged = previousPublication?.metadataSettlement !=
+                    publication.metadataSettlement
+            val reusablePublication = previousPublication?.takeIf {
+                !forceCatalogUpgrade &&
+                        !metadataSettlementChanged &&
+                        it.key == publication.key
+            }
             val catalogs = presentationSnapshot.catalogsFor(
                 publication.key,
                 publication.messages,
@@ -370,14 +402,10 @@ class ChatV2RendererController(
                 badgesSettled = publication.metadataSettlement.badgesSettled,
                 rewardsSettled = publication.metadataSettlement.rewardsSettled,
                 forceUpgrade = forceCatalogUpgrade,
+                appendOnly = reusablePublication != null && appendInfo != null,
+                appendedCount = appendInfo?.appendedCount ?: 0,
+                evictedCount = appendInfo?.evictedCount ?: 0,
             )
-            val metadataSettlementChanged = previousPublication?.metadataSettlement !=
-                    publication.metadataSettlement
-            val reusablePublication = previousPublication?.takeIf {
-                !forceCatalogUpgrade &&
-                        !metadataSettlementChanged &&
-                        it.key == publication.key
-            }
             val rows = withContext(Dispatchers.Default) {
                 if (BuildConfig.PERF_DIAGNOSTICS) Trace.beginSection("Xtra.ChatV2.compileCurrent")
                 try {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/ChatRenderDiagnostics.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/ChatRenderDiagnostics.kt
@@ -19,6 +19,10 @@ internal data class ChatRenderDiagnosticsSnapshot(
     val rowsReused: Long,
     val compileCurrentNanos: Long,
     val fullPresentationRebuilds: Long,
+    val incrementalReuseIndexUpdates: Long,
+    val fullReuseIndexRebuilds: Long,
+    val incrementalCatalogIndexUpdates: Long,
+    val fullCatalogIndexRebuilds: Long,
     val unchangedPublications: Long,
     val assetCallbacks: Long,
     val assetCallbacksCoalesced: Long,
@@ -45,6 +49,10 @@ internal data class ChatRenderDiagnosticsSnapshot(
             "publicationMessages=$publicationMessages maxPublicationMessages=$maxPublicationMessages " +
             "messagesChanged=$messagesChanged rowsCompiled=$rowsCompiled rowsReused=$rowsReused " +
             "compileCurrentNanos=$compileCurrentNanos fullPresentationRebuilds=$fullPresentationRebuilds " +
+            "incrementalReuseIndexUpdates=$incrementalReuseIndexUpdates " +
+            "fullReuseIndexRebuilds=$fullReuseIndexRebuilds " +
+            "incrementalCatalogIndexUpdates=$incrementalCatalogIndexUpdates " +
+            "fullCatalogIndexRebuilds=$fullCatalogIndexRebuilds " +
             "unchangedPublications=$unchangedPublications assetCallbacks=$assetCallbacks " +
             "assetCallbacksCoalesced=$assetCallbacksCoalesced drawOnlyInvalidations=$drawOnlyInvalidations " +
             "layoutAndDrawInvalidations=$layoutAndDrawInvalidations staleCallbacksDiscarded=$staleCallbacksDiscarded " +
@@ -72,6 +80,10 @@ internal object ChatRenderDiagnostics {
     private val rowsReused = AtomicLong()
     private val compileCurrentNanos = AtomicLong()
     private val fullPresentationRebuilds = AtomicLong()
+    private val incrementalReuseIndexUpdates = AtomicLong()
+    private val fullReuseIndexRebuilds = AtomicLong()
+    private val incrementalCatalogIndexUpdates = AtomicLong()
+    private val fullCatalogIndexRebuilds = AtomicLong()
     private val unchangedPublications = AtomicLong()
     private val assetCallbacks = AtomicLong()
     private val assetCallbacksCoalesced = AtomicLong()
@@ -136,6 +148,18 @@ internal object ChatRenderDiagnostics {
         compileCurrentNanos.addAndGet(compileNanos)
         if (fullRebuild) fullPresentationRebuilds.incrementAndGet()
         if (!uiChanged) unchangedPublications.incrementAndGet()
+    }
+
+    fun recordReuseIndexUpdate(incremental: Boolean) {
+        if (!BuildConfig.PERF_DIAGNOSTICS) return
+        if (incremental) incrementalReuseIndexUpdates.incrementAndGet()
+        else fullReuseIndexRebuilds.incrementAndGet()
+    }
+
+    fun recordCatalogIndexUpdate(incremental: Boolean) {
+        if (!BuildConfig.PERF_DIAGNOSTICS) return
+        if (incremental) incrementalCatalogIndexUpdates.incrementAndGet()
+        else fullCatalogIndexRebuilds.incrementAndGet()
     }
 
     fun recordAssetCallbackReceived() {
@@ -212,6 +236,10 @@ internal object ChatRenderDiagnostics {
         rowsReused = rowsReused.getAndSet(0),
         compileCurrentNanos = compileCurrentNanos.getAndSet(0),
         fullPresentationRebuilds = fullPresentationRebuilds.getAndSet(0),
+        incrementalReuseIndexUpdates = incrementalReuseIndexUpdates.getAndSet(0),
+        fullReuseIndexRebuilds = fullReuseIndexRebuilds.getAndSet(0),
+        incrementalCatalogIndexUpdates = incrementalCatalogIndexUpdates.getAndSet(0),
+        fullCatalogIndexRebuilds = fullCatalogIndexRebuilds.getAndSet(0),
         unchangedPublications = unchangedPublications.getAndSet(0),
         assetCallbacks = assetCallbacks.getAndSet(0),
         assetCallbacksCoalesced = assetCallbacksCoalesced.getAndSet(0),

--- a/app/src/test/java/com/github/andreyasadchy/xtra/repository/preload/StreamPlaybackConfigurationTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/repository/preload/StreamPlaybackConfigurationTest.kt
@@ -1,7 +1,11 @@
 package com.github.andreyasadchy.xtra.repository.preload
 
+import android.content.SharedPreferences
+import com.github.andreyasadchy.xtra.util.C
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
 import org.junit.Test
+import java.util.concurrent.CopyOnWriteArraySet
 
 class StreamPlaybackConfigurationTest {
     @Test
@@ -9,9 +13,78 @@ class StreamPlaybackConfigurationTest {
         assertNotEquals(configuration(lowLatency = false).fingerprint, configuration(lowLatency = true).fingerprint)
     }
 
-    private fun configuration(lowLatency: Boolean) = StreamPlaybackConfiguration(
+    @Test
+    fun geckoIdentityPreferencesRefreshTheCachedConfiguration() {
+        val playbackPreferences = ObservablePreferences()
+        val tokenPreferences = ObservablePreferences()
+        val fallback = configuration(gqlHeaders = mapOf(C.HEADER_CLIENT_ID to "fallback"))
+        val store = StreamPlaybackConfigurationStore(
+            playbackPreferences = playbackPreferences,
+            tokenPreferences = tokenPreferences,
+            initialConfiguration = fallback,
+            loadConfiguration = { configurationFor(tokenPreferences, fallback) },
+        )
+
+        putGeckoIdentity(tokenPreferences, integrity = "integrity-a")
+        assertEquals("integrity-a", store.current.gqlHeaders["Client-Integrity"])
+        val acquiredRevision = store.currentState.revision
+
+        tokenPreferences.edit().putString(C.GECKO_GQL_CLIENT_INTEGRITY, "integrity-b").commit()
+        assertEquals("integrity-b", store.current.gqlHeaders["Client-Integrity"])
+        assertNotEquals(acquiredRevision, store.currentState.revision)
+
+        listOf(
+            C.GECKO_GQL_AUTHORIZATION,
+            C.GECKO_GQL_CLIENT_ID,
+            C.GECKO_GQL_CLIENT_INTEGRITY,
+            C.GECKO_GQL_X_DEVICE_ID,
+            C.GECKO_GQL_USER_ID,
+            C.GECKO_GQL_AUTH_TOKEN_FINGERPRINT,
+        ).forEach { tokenPreferences.edit().remove(it).commit() }
+        assertEquals(fallback.gqlHeaders, store.current.gqlHeaders)
+        assertNotEquals("integrity-b", store.current.gqlHeaders["Client-Integrity"])
+    }
+
+    private fun configurationFor(
+        tokenPreferences: SharedPreferences,
+        fallback: StreamPlaybackConfiguration,
+    ): StreamPlaybackConfiguration {
+        val required = listOf(
+            C.GECKO_GQL_AUTHORIZATION,
+            C.GECKO_GQL_CLIENT_ID,
+            C.GECKO_GQL_CLIENT_INTEGRITY,
+            C.GECKO_GQL_X_DEVICE_ID,
+            C.GECKO_GQL_USER_ID,
+            C.GECKO_GQL_AUTH_TOKEN_FINGERPRINT,
+        )
+        if (required.any { tokenPreferences.getString(it, null).isNullOrBlank() }) return fallback
+        return fallback.copy(
+            gqlHeaders = buildMap {
+                put(C.HEADER_TOKEN, tokenPreferences.getString(C.GECKO_GQL_AUTHORIZATION, null)!!)
+                put(C.HEADER_CLIENT_ID, tokenPreferences.getString(C.GECKO_GQL_CLIENT_ID, null)!!)
+                put("Client-Integrity", tokenPreferences.getString(C.GECKO_GQL_CLIENT_INTEGRITY, null)!!)
+                put("X-Device-Id", tokenPreferences.getString(C.GECKO_GQL_X_DEVICE_ID, null)!!)
+            },
+        )
+    }
+
+    private fun putGeckoIdentity(preferences: SharedPreferences, integrity: String) {
+        preferences.edit()
+            .putString(C.GECKO_GQL_AUTHORIZATION, "OAuth token")
+            .putString(C.GECKO_GQL_CLIENT_ID, "gecko-client")
+            .putString(C.GECKO_GQL_CLIENT_INTEGRITY, integrity)
+            .putString(C.GECKO_GQL_X_DEVICE_ID, "gecko-device")
+            .putString(C.GECKO_GQL_USER_ID, "user")
+            .putString(C.GECKO_GQL_AUTH_TOKEN_FINGERPRINT, "fingerprint")
+            .commit()
+    }
+
+    private fun configuration(
+        lowLatency: Boolean = false,
+        gqlHeaders: Map<String, String> = emptyMap(),
+    ) = StreamPlaybackConfiguration(
         networkLibrary = "okhttp",
-        gqlHeaders = emptyMap(),
+        gqlHeaders = gqlHeaders,
         randomDeviceId = true,
         xDeviceId = "device",
         playerType = "site",
@@ -27,4 +100,79 @@ class StreamPlaybackConfigurationTest {
         customStreamProxyEnabled = false,
         customStreamProxyUrl = null,
     )
+}
+
+private class ObservablePreferences : SharedPreferences {
+    private val values = mutableMapOf<String, Any?>()
+    private val listeners = CopyOnWriteArraySet<SharedPreferences.OnSharedPreferenceChangeListener>()
+
+    override fun getAll(): MutableMap<String, *> = values.toMutableMap()
+    override fun getString(key: String?, defValue: String?): String? = values[key] as? String ?: defValue
+
+    @Suppress("UNCHECKED_CAST")
+    override fun getStringSet(key: String?, defValues: MutableSet<String>?): MutableSet<String>? =
+        (values[key] as? Set<String>)?.toMutableSet() ?: defValues
+
+    override fun getInt(key: String?, defValue: Int): Int = values[key] as? Int ?: defValue
+    override fun getLong(key: String?, defValue: Long): Long = values[key] as? Long ?: defValue
+    override fun getFloat(key: String?, defValue: Float): Float = values[key] as? Float ?: defValue
+    override fun getBoolean(key: String?, defValue: Boolean): Boolean = values[key] as? Boolean ?: defValue
+    override fun contains(key: String?): Boolean = values.containsKey(key)
+    override fun edit(): SharedPreferences.Editor = Editor()
+
+    override fun registerOnSharedPreferenceChangeListener(listener: SharedPreferences.OnSharedPreferenceChangeListener?) {
+        listener?.let(listeners::add)
+    }
+
+    override fun unregisterOnSharedPreferenceChangeListener(listener: SharedPreferences.OnSharedPreferenceChangeListener?) {
+        listener?.let(listeners::remove)
+    }
+
+    private inner class Editor : SharedPreferences.Editor {
+        private val changes = mutableMapOf<String, Any?>()
+        private var clear = false
+
+        override fun putString(key: String?, value: String?): SharedPreferences.Editor = put(key, value)
+        override fun putStringSet(key: String?, values: MutableSet<String>?): SharedPreferences.Editor =
+            put(key, values?.toMutableSet())
+        override fun putInt(key: String?, value: Int): SharedPreferences.Editor = put(key, value)
+        override fun putLong(key: String?, value: Long): SharedPreferences.Editor = put(key, value)
+        override fun putFloat(key: String?, value: Float): SharedPreferences.Editor = put(key, value)
+        override fun putBoolean(key: String?, value: Boolean): SharedPreferences.Editor = put(key, value)
+
+        override fun remove(key: String?): SharedPreferences.Editor {
+            if (key != null) changes[key] = null
+            return this
+        }
+
+        override fun clear(): SharedPreferences.Editor {
+            clear = true
+            return this
+        }
+
+        override fun commit(): Boolean {
+            applyChanges()
+            return true
+        }
+
+        override fun apply() = applyChanges()
+
+        private fun <T> put(key: String?, value: T): SharedPreferences.Editor {
+            if (key != null) changes[key] = value
+            return this
+        }
+
+        private fun applyChanges() {
+            val clearedKeys = if (clear) values.keys.toSet() else emptySet()
+            if (clear) values.clear()
+            changes.forEach { (key, value) ->
+                if (value == null) values.remove(key) else values[key] = value
+            }
+            listeners.forEach { listener ->
+                (clearedKeys + changes.keys).forEach { key ->
+                    listener.onSharedPreferenceChanged(this@ObservablePreferences, key)
+                }
+            }
+        }
+    }
 }

--- a/app/src/test/java/com/github/andreyasadchy/xtra/repository/streamfeed/StreamFeedPrewarmSchedulerTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/repository/streamfeed/StreamFeedPrewarmSchedulerTest.kt
@@ -1,0 +1,33 @@
+package com.github.andreyasadchy.xtra.repository.streamfeed
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class StreamFeedPrewarmSchedulerTest {
+    @Test
+    fun cancellationAfterDelayBeforeEnqueueInvalidatesTheArm() {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Unconfined)
+        var armController: StreamFeedPrewarmArmController? = null
+        var enqueueCount = 0
+
+        try {
+            armController = StreamFeedPrewarmArmController(
+                scope = scope,
+                delayBlock = {
+                    armController?.cancel()
+                },
+            )
+            armController.schedule(delayMs = 1L) {
+                enqueueCount++
+            }
+
+            assertEquals(0, enqueueCount)
+        } finally {
+            scope.cancel()
+        }
+    }
+}

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatCatalogRepositoryTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatCatalogRepositoryTest.kt
@@ -73,6 +73,94 @@ class ChatCatalogRepositoryTest {
     }
 
     @Test
+    fun liveDecorationBurstPublishesOneCatalogRevision() = runBlocking {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val repository = ChatCatalogRepository(
+            scope = scope,
+            source = ChatCatalogSource { ChatCatalogLoadResult() },
+        )
+        val initialRevision = repository.state.value.snapshot.revision
+        repeat(20) { index ->
+            repository.applyDecorationUpdate(
+                ChatDecorationUpdate.User(
+                    userId = "user",
+                    paintId = "paint-$index",
+                ),
+            )
+        }
+
+        withTimeout(1_000) {
+            while (repository.state.value.snapshot.revision == initialRevision) delay(1)
+        }
+        delay(32)
+        assertEquals(initialRevision + 1L, repository.state.value.snapshot.revision)
+        assertEquals("paint-19", repository.state.value.snapshot.userDecorations["user"]?.paintId)
+        repository.close()
+        scope.cancel()
+    }
+
+    @Test
+    fun catalogPersistenceKeepsOnlyTheLatestPendingRevision() = runBlocking {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val firstWriteStarted = CompletableDeferred<Unit>()
+        val releaseFirstWrite = CompletableDeferred<Unit>()
+        val writes = CopyOnWriteArrayList<ChatCatalogSnapshot>()
+        val cache = object : ChatCatalogCache {
+            override suspend fun read(): ChatCatalogSnapshot? = null
+
+            override suspend fun write(snapshot: ChatCatalogSnapshot) {
+                writes += snapshot
+                if (writes.size == 1) {
+                    firstWriteStarted.complete(Unit)
+                    releaseFirstWrite.await()
+                }
+            }
+        }
+        val repository = ChatCatalogRepository(
+            scope = scope,
+            source = ChatCatalogSource {
+                ChatCatalogLoadResult(
+                    twitch = ChatCatalogProviderUpdate(emptyMap()),
+                    sevenTv = ChatCatalogProviderUpdate(emptyMap()),
+                    bttv = ChatCatalogProviderUpdate(emptyMap()),
+                    ffz = ChatCatalogProviderUpdate(emptyMap()),
+                    badges = ChatCatalogProviderUpdate(emptyMap()),
+                    cheermotes = ChatCatalogProviderUpdate(emptyMap()),
+                )
+            },
+            cache = cache,
+        )
+        repository.refresh()
+        withTimeout(1_000) { firstWriteStarted.await() }
+
+        repository.applyDecorationUpdate(
+            ChatDecorationUpdate.EmoteSet(
+                setId = "set",
+                added = mapOf("first" to emote("first", ChatAssetProvider.SEVEN_TV)),
+            ),
+        )
+        withTimeout(1_000) {
+            while (repository.state.value.snapshot.sevenTv.pending["set"]?.containsKey("first") != true) delay(1)
+        }
+        repository.applyDecorationUpdate(
+            ChatDecorationUpdate.EmoteSet(
+                setId = "set",
+                added = mapOf("second" to emote("second", ChatAssetProvider.SEVEN_TV)),
+            ),
+        )
+        withTimeout(1_000) {
+            while (repository.state.value.snapshot.sevenTv.pending["set"]?.containsKey("second") != true) delay(1)
+        }
+
+        repository.close()
+        releaseFirstWrite.complete(Unit)
+        withTimeout(1_000) { while (writes.size < 2) delay(1) }
+        assertEquals(2, writes.size)
+        assertTrue(writes.last().sevenTv.pending["set"]?.containsKey("second") == true)
+        scope.cancel()
+    }
+
+    @Test
     fun independentBadgeSettlementDoesNotWaitForUnrelatedProviders() = runBlocking {
         val aggregateStarted = CompletableDeferred<Unit>()
         val releaseUnrelatedProviders = CompletableDeferred<Unit>()
@@ -743,6 +831,9 @@ class ChatCatalogRepositoryTest {
             setId = "channel-set",
             added = mapOf("ChannelLive" to emote("ChannelLive", ChatAssetProvider.SEVEN_TV)),
         ))
+        withTimeout(1_000) {
+            while (repository.state.value.snapshot.sevenTv.channel["ChannelLive"] == null) delay(1)
+        }
         assertEquals(ChatEmoteScope.CHANNEL, repository.state.value.snapshot.sevenTv.channel["ChannelLive"]?.scope)
         assertTrue(repository.state.value.snapshot.sevenTv.pending.isEmpty())
 
@@ -751,6 +842,9 @@ class ChatCatalogRepositoryTest {
             setId = "personal-set",
             added = mapOf("PersonalLive" to emote("PersonalLive", ChatAssetProvider.SEVEN_TV)),
         ))
+        withTimeout(1_000) {
+            while (repository.state.value.snapshot.sevenTv.personal["personal-set"]?.get("PersonalLive") == null) delay(1)
+        }
         assertEquals(ChatEmoteScope.PERSONAL, repository.state.value.snapshot.sevenTv.personal["personal-set"]?.get("PersonalLive")?.scope)
         assertTrue(repository.state.value.snapshot.sevenTv.channel["PersonalLive"] == null)
 
@@ -758,10 +852,16 @@ class ChatCatalogRepositoryTest {
             setId = "unseen-personal-set",
             added = mapOf("PendingLive" to emote("PendingLive", ChatAssetProvider.SEVEN_TV)),
         ))
+        withTimeout(1_000) {
+            while (repository.state.value.snapshot.sevenTv.pending["unseen-personal-set"]?.containsKey("PendingLive") != true) delay(1)
+        }
         assertTrue(repository.state.value.snapshot.sevenTv.channel["PendingLive"] == null)
         assertTrue(repository.state.value.snapshot.sevenTv.pending["unseen-personal-set"]?.containsKey("PendingLive") == true)
 
         repository.applyDecorationUpdate(ChatDecorationUpdate.User("other-user", personalEmoteSetId = "unseen-personal-set"))
+        withTimeout(1_000) {
+            while (repository.state.value.snapshot.sevenTv.personal["unseen-personal-set"]?.get("PendingLive") == null) delay(1)
+        }
         assertEquals(ChatEmoteScope.PERSONAL, repository.state.value.snapshot.sevenTv.personal["unseen-personal-set"]?.get("PendingLive")?.scope)
         assertTrue(repository.state.value.snapshot.sevenTv.pending["unseen-personal-set"].isNullOrEmpty())
 

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatPresentationReuseTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatPresentationReuseTest.kt
@@ -7,9 +7,12 @@ import com.github.andreyasadchy.xtra.ui.chat.v2.presentation.ChatPiece
 import com.github.andreyasadchy.xtra.ui.chat.v2.presentation.ChatRowBackground
 import com.github.andreyasadchy.xtra.ui.chat.v2.presentation.ChatRowUiModel
 import com.github.andreyasadchy.xtra.ui.chat.v2.ui.ChatPresentationReuseIndex
+import com.github.andreyasadchy.xtra.ui.chat.v2.ui.ChatAppendInfo
 import com.github.andreyasadchy.xtra.ui.chat.v2.ui.compileChatRows
+import com.github.andreyasadchy.xtra.ui.chat.v2.ui.findChatAppendInfo
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class ChatPresentationReuseTest {
@@ -58,6 +61,65 @@ class ChatPresentationReuseTest {
     }
 
     @Test
+    fun appendIndexUpdatesOnlyTheNewTailAndEvictedHead() {
+        val previous = (0 until 600).map(::message)
+        val previousRows = previous.map(::row)
+        val index = ChatPresentationReuseIndex()
+        index.replace(previous, previousRows)
+        val current = previous.drop(1) + message(600)
+        val currentRows = current.map(::row)
+
+        assertTrue(index.append(current, currentRows, appendedCount = 1, evictedCount = 1))
+        val result = compileChatRows(
+            messages = current,
+            reuseIndex = index,
+            resolve = { message, _ -> row(message) },
+        )
+
+        assertEquals(0, result.rowsCompiled)
+        assertEquals(600, result.rowsReused)
+        assertSame(previousRows[1], result.rows.first())
+        assertSame(currentRows.last(), result.rows.last())
+    }
+
+    @Test
+    fun appendIndexRefreshesAChangedRetainedMessage() {
+        val previous = (0 until 3).map(::message)
+        val previousRows = previous.map(::row)
+        val index = ChatPresentationReuseIndex()
+        index.replace(previous, previousRows)
+        val changed = message(1).copy(systemText = "updated")
+        val current = listOf(previous[0], changed, previous[2], message(3))
+        val result = compileChatRows(
+            messages = current,
+            reuseIndex = index,
+            resolve = { message, _ -> row(message) },
+        )
+
+        assertEquals(2, result.rowsCompiled)
+        assertTrue(index.append(current, result.rows, appendedCount = 1, evictedCount = 0))
+        val next = compileChatRows(
+            messages = current,
+            reuseIndex = index,
+            resolve = { message, _ -> row(message) },
+        )
+        assertEquals(0, next.rowsCompiled)
+        assertEquals(4, next.rowsReused)
+    }
+
+    @Test
+    fun appendShapeRejectsReplacementAndReconciliation() {
+        val previous = (0 until 600).map(::message)
+        assertEquals(
+            ChatAppendInfo(appendedCount = 1, evictedCount = 1),
+            findChatAppendInfo(previous, previous.drop(1) + message(600)),
+        )
+        val replaced = previous.drop(1).toMutableList().apply { this[100] = message(10_000) } + message(600)
+        assertEquals(null, findChatAppendInfo(previous, replaced))
+        assertEquals(null, findChatAppendInfo(previous, previous.take(599)))
+    }
+
+    @Test
     fun tenThousandSuccessiveAppendPublicationsCompileOnlyTheNewRow() {
         var messages = (0 until 600).map(::message)
         var rows = messages.map(::row)
@@ -74,9 +136,9 @@ class ChatPresentationReuseTest {
 
             assertEquals(1, result.rowsCompiled)
             assertEquals(599, result.rowsReused)
+            assertTrue(index.append(nextMessages, result.rows, appendedCount = 1, evictedCount = 1))
             rows = result.rows
             messages = nextMessages
-            index.replace(messages, rows)
         }
     }
 


### PR DESCRIPTION
Reduce redundant Chat v2 publication work, batch live catalog updates, reuse clip drawing state, cache playback configuration, and defer speculative prewarm scheduling.