### PR TITLE
Optimize chat and process-local performance paths

### DIFF
--- a/app/src/androidTest/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatMessageTextViewTest.kt
+++ b/app/src/androidTest/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatMessageTextViewTest.kt
@@ -1390,9 +1390,13 @@ class ChatMessageTextViewTest {
             onMessageLongClick = { clickedIds += it },
         )
         lateinit var holder: ChatTimelineAdapter.Holder
+        val firstCommitted = CountDownLatch(1)
         runOnMain {
             holder = adapter.onCreateViewHolder(FrameLayout(context), 0)
-            adapter.submitList(listOf(textRow("first", ChatMessageId("first"))))
+            adapter.submitList(listOf(textRow("first", ChatMessageId("first")))) { firstCommitted.countDown() }
+        }
+        assertTrue(firstCommitted.await(1, TimeUnit.SECONDS))
+        runOnMain {
             adapter.onBindViewHolder(holder, 0)
             assertTrue(holder.view.performLongClick())
         }

--- a/app/src/androidTest/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatTimelineAdapterTest.kt
+++ b/app/src/androidTest/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatTimelineAdapterTest.kt
@@ -1,0 +1,180 @@
+package com.github.andreyasadchy.xtra.ui.chat.v2.ui
+
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import androidx.test.platform.app.InstrumentationRegistry
+import com.github.andreyasadchy.xtra.ui.chat.v2.assets.ChatAssetLoader
+import com.github.andreyasadchy.xtra.ui.chat.v2.assets.ChatAssetRepository
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessageId
+import com.github.andreyasadchy.xtra.ui.chat.v2.presentation.ChatPiece
+import com.github.andreyasadchy.xtra.ui.chat.v2.presentation.ChatRowUiModel
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+@RunWith(AndroidJUnit4::class)
+class ChatTimelineAdapterTest {
+    @Test
+    fun appendOnlyNotifiesHeadRemovalAndTailInsertion() {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val adapter = adapter(scope)
+        try {
+            submitAndWait(adapter, listOf(row("a"), row("b"), row("c")))
+            val observer = RecordingObserver()
+            onMain { adapter.registerAdapterDataObserver(observer) }
+
+            var applied = false
+            onMain { applied = adapter.append(listOf(row("b"), row("c"), row("d")), 1, 1) }
+
+            assertTrue(applied)
+            assertEquals(listOf("b", "c", "d"), adapter.currentList.map { it.id.value })
+            assertEquals(listOf("remove:0:1", "insert:2:1"), observer.events.toList())
+        } finally {
+            dispose(adapter, scope)
+        }
+    }
+
+    @Test
+    fun retainedRowMutationRejectsDirectAppendAndUsesFallback() {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val adapter = adapter(scope)
+        try {
+            submitAndWait(adapter, listOf(row("a", "old"), row("b")))
+            val next = listOf(row("a", "changed"), row("c"))
+            var applied = true
+            onMain { applied = adapter.append(next, evictedHeadCount = 1, appendedCount = 1) }
+
+            assertFalse(applied)
+            submitAndWait(adapter, next)
+            assertEquals(next, adapter.currentList)
+        } finally {
+            dispose(adapter, scope)
+        }
+    }
+
+    @Test
+    fun reconciliationFallbackReplacesRowsByStableId() {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val adapter = adapter(scope)
+        try {
+            submitAndWait(adapter, listOf(row("a"), row("b")))
+            submitAndWait(adapter, listOf(row("b"), row("a")))
+            assertEquals(listOf("b", "a"), adapter.currentList.map { it.id.value })
+        } finally {
+            dispose(adapter, scope)
+        }
+    }
+
+    @Test
+    fun staleFallbackDiffCannotOverwriteNewerSubmission() {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val dispatcher = ManualDispatcher()
+        val adapter = adapter(scope, dispatcher)
+        try {
+            val oldRows = (0 until 600).map { row("old-$it") }
+            val newRows = listOf(row("new"))
+            val committed = CountDownLatch(1)
+            onMain { adapter.submitList(oldRows) }
+            onMain { adapter.submitList(newRows) { committed.countDown() } }
+
+            dispatcher.runNext()
+            dispatcher.runNext()
+            assertTrue(committed.await(1, TimeUnit.SECONDS))
+            assertEquals(newRows, adapter.currentList)
+        } finally {
+            dispose(adapter, scope)
+        }
+    }
+
+    @Test
+    fun viewportKeepsTheExistingAnchorWhenAppendingWhileScrolledUp() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val recyclerView = RecyclerView(context)
+        recyclerView.layoutManager = LinearLayoutManager(context)
+        val anchor = ChatViewportAnchor(ChatMessageId("b"), 37)
+        val controller = ChatViewportController(
+            recyclerView,
+            ChatViewportState(FollowMode.USER_SCROLLED_UP, anchor = anchor),
+        )
+        val rows = listOf(row("a"), row("b"), row("c"), row("d"))
+
+        onMain { controller.onSnapshotCommitted(anchor, rows, appendedCount = 1) }
+
+        assertEquals(anchor, controller.state.anchor)
+        assertEquals(1, controller.state.newMessageCount)
+        assertEquals(FollowMode.USER_SCROLLED_UP, controller.state.followMode)
+    }
+
+    private fun adapter(
+        scope: CoroutineScope,
+        diffDispatcher: CoroutineDispatcher = Dispatchers.Default,
+    ) = ChatTimelineAdapter(
+        assets = ChatAssetRepository(scope, ChatAssetLoader { null }),
+        textSizeSp = 14f,
+        animateGifs = false,
+        diffDispatcher = diffDispatcher,
+    )
+
+    private fun submitAndWait(adapter: ChatTimelineAdapter, rows: List<ChatRowUiModel>) {
+        val committed = CountDownLatch(1)
+        onMain { adapter.submitList(rows) { committed.countDown() } }
+        assertTrue(committed.await(1, TimeUnit.SECONDS))
+    }
+
+    private fun dispose(adapter: ChatTimelineAdapter, scope: CoroutineScope) {
+        onMain { adapter.dispose() }
+        scope.cancel()
+    }
+
+    private fun onMain(block: () -> Unit) {
+        InstrumentationRegistry.getInstrumentation().runOnMainSync(block)
+    }
+
+    private fun row(id: String, text: String = id) = ChatRowUiModel(
+        id = ChatMessageId(id),
+        channelId = "channel",
+        timestampText = null,
+        pieces = listOf(ChatPiece.Text(text)),
+        background = 0,
+        accessibilityText = text,
+        reply = null,
+        source = null,
+        isAction = false,
+    )
+
+    private class RecordingObserver : RecyclerView.AdapterDataObserver() {
+        val events = ConcurrentLinkedQueue<String>()
+
+        override fun onItemRangeRemoved(positionStart: Int, itemCount: Int) {
+            events += "remove:$positionStart:$itemCount"
+        }
+
+        override fun onItemRangeInserted(positionStart: Int, itemCount: Int) {
+            events += "insert:$positionStart:$itemCount"
+        }
+    }
+
+    private class ManualDispatcher : CoroutineDispatcher() {
+        private val queue = ConcurrentLinkedQueue<Runnable>()
+
+        override fun dispatch(context: kotlin.coroutines.CoroutineContext, block: Runnable) {
+            queue += block
+        }
+
+        fun runNext() {
+            val task = checkNotNull(queue.poll()) { "No queued diff" }
+            task.run()
+        }
+    }
+}

--- a/app/src/androidTest/java/com/github/andreyasadchy/xtra/util/StreamingUrlCallbackTest.kt
+++ b/app/src/androidTest/java/com/github/andreyasadchy/xtra/util/StreamingUrlCallbackTest.kt
@@ -1,0 +1,185 @@
+package com.github.andreyasadchy.xtra.util
+
+import android.net.http.HttpEngine
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.runBlocking
+import okio.Buffer
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.IOException
+import java.net.ServerSocket
+import java.net.Socket
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.concurrent.thread
+
+@RunWith(AndroidJUnit4::class)
+class StreamingUrlCallbackTest {
+    @Test
+    fun httpEngineStreamsUnknownLengthChunksAndEof() = runBlocking {
+        withResponse(
+            responseHeaders = "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n",
+            writeBody = { output, _ ->
+                output.write("one".toByteArray())
+                output.flush()
+                output.write("two".toByteArray())
+                output.flush()
+            },
+        ) { response, _ ->
+            val output = Buffer()
+            while (response.body.read(output, 2) != -1L) { }
+            assertEquals("onetwo", output.readUtf8())
+        }
+    }
+
+    @Test
+    fun httpEngineRejectsDeclaredOversizeAndStreamOverflow() = runBlocking {
+        val declaredError = org.junit.Assert.assertThrows(IOException::class.java) {
+            runBlocking {
+                withResponse(
+                    responseHeaders = "HTTP/1.1 200 OK\r\nContent-Length: 5\r\nConnection: close\r\n\r\n",
+                    maxBodyBytes = 4,
+                    writeBody = { _, _ -> },
+                ) { _, _ -> error("response should not be delivered") }
+            }
+        }
+        assertTrue(declaredError.message.orEmpty().contains("4 byte limit"))
+
+        val overflowError = org.junit.Assert.assertThrows(IOException::class.java) {
+            runBlocking {
+                withResponse(
+                    responseHeaders = "HTTP/1.1 200 OK\r\nContent-Length: 5\r\nConnection: close\r\n\r\n",
+                    maxBodyBytes = 4,
+                    writeBody = { output, _ -> output.write("12345".toByteArray()); output.flush() },
+                ) { response, _ ->
+                    response.body.read(Buffer(), 1)
+                }
+            }
+        }
+        assertTrue(overflowError.message.orEmpty().contains("4 byte limit"))
+    }
+
+    @Test
+    fun httpEnginePropagatesPostHeaderFailureTimeoutAndConsumerClose() = runBlocking {
+        val postHeaderError = org.junit.Assert.assertThrows(IOException::class.java) {
+            runBlocking {
+                withResponse(
+                    responseHeaders = "HTTP/1.1 200 OK\r\nContent-Length: 10\r\nConnection: close\r\n\r\n",
+                    writeBody = { output, _ -> output.write('x'.code); output.flush() },
+                ) { response, _ ->
+                    val output = Buffer()
+                    while (response.body.read(output, 1) != -1L) { }
+                }
+            }
+        }
+        assertTrue(postHeaderError is IOException)
+
+        val timedOut = org.junit.Assert.assertThrows(IOException::class.java) {
+            runBlocking {
+                withResponse(
+                    responseHeaders = "HTTP/1.1 200 OK\r\nContent-Length: 10\r\nConnection: keep-alive\r\n\r\n",
+                    timeoutMs = 100L,
+                    writeBody = { _, _ -> Thread.sleep(1_000L) },
+                ) { response, _ ->
+                    response.body.read(Buffer(), 1)
+                }
+            }
+        }
+        assertTrue(timedOut is IOException)
+
+        val closeObserved = CountDownLatch(1)
+        withResponse(
+            responseHeaders = "HTTP/1.1 200 OK\r\nContent-Length: 1048576\r\nConnection: keep-alive\r\n\r\n",
+            writeBody = { output, socket ->
+                try {
+                    output.write(ByteArray(512 * 1024))
+                    output.flush()
+                    if (socket.getInputStream().read() < 0) closeObserved.countDown()
+                } catch (_: IOException) {
+                    closeObserved.countDown()
+                }
+            },
+        ) { response, _ -> response.body.close() }
+        assertTrue(closeObserved.await(2, TimeUnit.SECONDS))
+    }
+
+    private suspend fun <T> withResponse(
+        responseHeaders: String,
+        maxBodyBytes: Int = 64 * 1024 * 1024,
+        timeoutMs: Long = 20_000L,
+        writeBody: (java.io.OutputStream, Socket) -> Unit,
+        block: suspend (NetworkUtils.HttpEngineStreamingResponse, NetworkUtils.HttpEngineStreamingTimeout) -> T,
+    ): T {
+        val server = ServerSocket(0)
+        val serverFailure = AtomicReference<Throwable?>()
+        val serverThread = thread(start = true, isDaemon = true, name = "streaming-test-server") {
+            try {
+                server.accept().use { socket ->
+                    socket.soTimeout = 2_000
+                    readRequest(socket)
+                    socket.getOutputStream().apply {
+                        write(responseHeaders.toByteArray())
+                        flush()
+                        writeBody(this, socket)
+                    }
+                }
+            } catch (error: Throwable) {
+                serverFailure.set(error)
+            }
+        }
+        val executor = Executors.newSingleThreadExecutor()
+        val engine = HttpEngine.Builder(InstrumentationRegistry.getInstrumentation().targetContext)
+            .setEnableHttpCache(HttpEngine.Builder.HTTP_CACHE_DISABLED, 0L)
+            .setEnableQuic(false)
+            .setEnableHttp2(false)
+            .build()
+        try {
+            lateinit var timeout: NetworkUtils.HttpEngineStreamingTimeout
+            val response = suspendCancellableCoroutine<NetworkUtils.HttpEngineStreamingResponse> { continuation ->
+                timeout = NetworkUtils.HttpEngineStreamingTimeout(timeoutMs)
+                val request = engine.newUrlRequestBuilder(
+                    "http://localhost:${server.localPort}/image",
+                    executor,
+                    NetworkUtils.StreamingUrlCallback(continuation, timeout, maxBodyBytes),
+                ).build()
+                timeout.start(request)
+                request.start()
+                continuation.invokeOnCancellation {
+                    request.cancel()
+                    timeout.stop()
+                }
+            }
+            return block(response, timeout)
+        } finally {
+            engine.shutdown()
+            executor.shutdownNow()
+            server.close()
+            serverThread.join(2_000)
+            serverFailure.get()?.let { error ->
+                if (error !is IOException) throw error
+            }
+        }
+    }
+
+    private fun readRequest(socket: Socket) {
+        var matched = 0
+        while (matched < 4) {
+            val next = socket.getInputStream().read()
+            if (next < 0) return
+            matched = when {
+                matched == 0 && next == '\r'.code -> 1
+                matched == 1 && next == '\n'.code -> 2
+                matched == 2 && next == '\r'.code -> 3
+                matched == 3 && next == '\n'.code -> 4
+                next == '\r'.code -> 1
+                else -> 0
+            }
+        }
+    }
+}

--- a/app/src/debug/res/xml/network_security_config.xml
+++ b/app/src/debug/res/xml/network_security_config.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="false">localhost</domain>
+    </domain-config>
     <base-config>
         <trust-anchors>
             <certificates src="@raw/isrgrootx1" />

--- a/app/src/main/java/com/github/andreyasadchy/xtra/XtraApp.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/XtraApp.kt
@@ -37,8 +37,6 @@ import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.filter
 import okio.Buffer
-import okio.buffer
-import okio.source
 import org.chromium.net.apihelpers.UploadDataProviders
 import org.conscrypt.Conscrypt
 import java.security.Security
@@ -199,11 +197,11 @@ class XtraApp : Application(), SingletonImageLoader.Factory {
                                         }
                                         val requestMillis = System.currentTimeMillis()
                                         val response = suspendCancellableCoroutine { continuation ->
-                                            val timeout = NetworkUtils.HttpEngineTimeout()
+                                            val timeout = NetworkUtils.HttpEngineStreamingTimeout()
                                             val request = xtraModule.httpEngine.value!!.newUrlRequestBuilder(
                                                 request.url,
                                                 xtraModule.cronetExecutor.value,
-                                                NetworkUtils.ByteArrayUrlCallback(continuation, timeout)
+                                                NetworkUtils.StreamingUrlCallback(continuation, timeout)
                                             ).apply {
                                                 request.headers.asMap().forEach { entry ->
                                                     entry.value.forEach {
@@ -215,7 +213,7 @@ class XtraApp : Application(), SingletonImageLoader.Factory {
                                                 }
                                                 setHttpMethod(request.method)
                                             }.build()
-                                            timeout.start(request, continuation)
+                                            timeout.start(request)
                                             request.start()
                                             continuation.invokeOnCancellation {
                                                 request.cancel()
@@ -233,7 +231,7 @@ class XtraApp : Application(), SingletonImageLoader.Factory {
                                                         add(it.key, it.value)
                                                     }
                                                 }.build(),
-                                                body = response.body.inputStream().source().buffer().let(::NetworkResponseBody),
+                                                body = response.body.let(::NetworkResponseBody),
                                             )
                                         )
                                     }
@@ -254,10 +252,10 @@ class XtraApp : Application(), SingletonImageLoader.Factory {
                                         }
                                         val requestMillis = System.currentTimeMillis()
                                         val response = suspendCancellableCoroutine { continuation ->
-                                            val timeout = NetworkUtils.CronetTimeout()
+                                            val timeout = NetworkUtils.CronetStreamingTimeout()
                                             val request = xtraModule.cronetEngine.value!!.newUrlRequestBuilder(
                                                 request.url,
-                                                NetworkUtils.ByteArrayCronetCallback(continuation, timeout),
+                                                NetworkUtils.StreamingCronetCallback(continuation, timeout),
                                                 xtraModule.cronetExecutor.value
                                             ).apply {
                                                 request.headers.asMap().forEach { entry ->
@@ -270,7 +268,7 @@ class XtraApp : Application(), SingletonImageLoader.Factory {
                                                 }
                                                 setHttpMethod(request.method)
                                             }.build()
-                                            timeout.start(request, continuation)
+                                            timeout.start(request)
                                             request.start()
                                             continuation.invokeOnCancellation {
                                                 request.cancel()
@@ -288,7 +286,7 @@ class XtraApp : Application(), SingletonImageLoader.Factory {
                                                         add(it.key, it.value)
                                                     }
                                                 }.build(),
-                                                body = response.body.inputStream().source().buffer().let(::NetworkResponseBody),
+                                                body = response.body.let(::NetworkResponseBody),
                                             )
                                         )
                                     }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/ProcessLocalFeedSnapshot.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/ProcessLocalFeedSnapshot.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicLong
 
 /**
@@ -21,50 +22,106 @@ internal class ProcessLocalFeedSnapshot<T> {
         val items: List<T> = emptyList(),
     )
 
-    private val snapshots = ConcurrentHashMap<String, MutableStateFlow<Snapshot<T>>>()
-    private val loadLocks = ConcurrentHashMap<String, Mutex>()
-    private val revisions = ConcurrentHashMap<String, AtomicLong>()
+    private class Entry<T> {
+        val state = MutableStateFlow(Snapshot<T>())
+        val loadLock = Mutex()
+        val revision = AtomicLong()
+        val collectors = AtomicInteger()
+        var evictionPending = false
+    }
+
+    private val entries = ConcurrentHashMap<String, Entry<T>>()
 
     fun flow(
         key: String,
         limit: Int,
         load: suspend () -> List<T>,
     ): Flow<List<T>> = flow {
-        val state = snapshots.computeIfAbsent(key) { MutableStateFlow(Snapshot()) }
-        val revision = revisions.computeIfAbsent(key) { AtomicLong() }
-        if (!state.value.loaded) {
-            loadLocks.computeIfAbsent(key) { Mutex() }.withLock {
-                if (!state.value.loaded) {
-                    val revisionAtStart = revision.get()
-                    val items = load()
-                    // A refresh can publish while the bootstrap query is in
-                    // flight. Never overwrite that newer process-local state
-                    // with the older Room result.
-                    if (!state.value.loaded && revision.get() == revisionAtStart) {
-                        state.value = Snapshot(loaded = true, items = items.toList())
+        val entry = acquire(key)
+        try {
+            if (!entry.state.value.loaded) {
+                entry.loadLock.withLock {
+                    if (!entry.state.value.loaded) {
+                        val revisionAtStart = entry.revision.get()
+                        val items = load()
+                        // A refresh or eviction can publish while the bootstrap query is in
+                        // flight. Never overwrite that newer process-local state with Room data.
+                        synchronized(entry) {
+                            if (
+                                !entry.state.value.loaded &&
+                                !entry.evictionPending &&
+                                entry.revision.get() == revisionAtStart
+                            ) {
+                                entry.state.value = Snapshot(loaded = true, items = items.toList())
+                            }
+                        }
                     }
                 }
             }
+            emitAll(entry.state.map { snapshot -> snapshot.items.take(limit) })
+        } finally {
+            release(key, entry)
         }
-        emitAll(state.map { snapshot -> snapshot.items.take(limit) })
     }
 
     fun publish(key: String, items: List<T>) {
-        val state = snapshots.computeIfAbsent(key) { MutableStateFlow(Snapshot()) }
-        revisions.computeIfAbsent(key) { AtomicLong() }.incrementAndGet()
-        state.value = Snapshot(loaded = true, items = items.toList())
+        while (true) {
+            val entry = entries.computeIfAbsent(key) { Entry() }
+            synchronized(entry) {
+                if (entries[key] !== entry) continue
+                if (entry.evictionPending && entry.collectors.get() == 0) {
+                    entries.remove(key, entry)
+                    continue
+                }
+                entry.revision.incrementAndGet()
+                entry.state.value = Snapshot(loaded = true, items = items.toList())
+                return
+            }
+        }
     }
 
     /** Returns the full in-process snapshot without applying a UI limit. */
-    fun current(key: String): List<T>? = snapshots[key]
-        ?.value
-        ?.takeIf { it.loaded }
-        ?.items
+    fun current(key: String): List<T>? {
+        val entry = entries[key] ?: return null
+        return synchronized(entry) {
+            if (entries[key] !== entry) return@synchronized null
+            entry.state.value.takeIf { it.loaded }?.items
+        }
+    }
 
-    fun clear(key: String) {
-        snapshots[key]?.let { state ->
-            revisions.computeIfAbsent(key) { AtomicLong() }.incrementAndGet()
-            state.value = Snapshot(loaded = true)
+    /** Removes all process-local state for a feed after durable cleanup. */
+    fun evict(key: String) {
+        val entry = entries[key] ?: return
+        synchronized(entry) {
+            if (entries[key] !== entry) return
+            entry.revision.incrementAndGet()
+            entry.evictionPending = true
+            entry.state.value = Snapshot(loaded = true)
+            if (entry.collectors.get() == 0) {
+                entries.remove(key, entry)
+            }
+        }
+    }
+
+    private fun acquire(key: String): Entry<T> {
+        while (true) {
+            val entry = entries.computeIfAbsent(key) { Entry() }
+            synchronized(entry) {
+                if (entries[key] !== entry) continue
+                if (!entry.evictionPending || entry.collectors.get() > 0) {
+                    entry.collectors.incrementAndGet()
+                    return entry
+                }
+            }
+        }
+    }
+
+    private fun release(key: String, entry: Entry<T>) {
+        synchronized(entry) {
+            val remaining = entry.collectors.decrementAndGet()
+            if (remaining == 0 && entry.evictionPending) {
+                entries.remove(key, entry)
+            }
         }
     }
 }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/gamefeed/GameFeedCache.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/gamefeed/GameFeedCache.kt
@@ -285,7 +285,7 @@ class GameFeedCache(
                 removedKeys += state.feedKey
             }
         }
-        removedKeys.forEach(activeSnapshot::clear)
+        removedKeys.forEach(activeSnapshot::evict)
     }
 
     private fun staleTailExpired(state: GameFeedState?, nowMs: Long): Boolean = state != null &&

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/preload/StreamPreviewPolicy.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/preload/StreamPreviewPolicy.kt
@@ -16,7 +16,7 @@ enum class StreamPreviewMode(val preferenceValue: String) {
 
     companion object {
         fun fromPreference(value: String?): StreamPreviewMode =
-            entries.firstOrNull { it.preferenceValue == value } ?: if (value == null) WIFI_AND_MOBILE else OFF
+            entries.firstOrNull { it.preferenceValue == value } ?: if (value == null) WIFI_ONLY else OFF
     }
 }
 
@@ -58,7 +58,7 @@ object StreamPreviewPolicy {
         return if (preferences.contains(C.STREAM_PREVIEW_MODE)) {
             StreamPreviewMode.fromPreference(preferences.getString(C.STREAM_PREVIEW_MODE, null))
         } else {
-            StreamPreviewMode.WIFI_AND_MOBILE
+            StreamPreviewMode.WIFI_ONLY
         }
     }
 

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/streamfeed/StreamFeedCache.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/streamfeed/StreamFeedCache.kt
@@ -403,6 +403,6 @@ class StreamFeedCache(
                     removedKeys += state.feedKey
                 }
         }
-        removedKeys.forEach(activeSnapshot::clear)
+        removedKeys.forEach(activeSnapshot::evict)
     }
 }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/catalog/ChatCatalogRepository.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/catalog/ChatCatalogRepository.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.delay
+import java.util.LinkedHashMap
 
 sealed interface ScopeUpdate<out T> {
     data class Success<T>(val value: T) : ScopeUpdate<T>
@@ -115,6 +116,7 @@ class ChatCatalogRepository(
     private val wait: suspend (Long) -> Unit = { delay(it) },
     private val personalEmoteSetLoader: (suspend (String) -> Map<String, ChatCatalogEmote>)? = null,
     private val cacheFreshnessMs: Long = 60 * 60 * 1000L,
+    private val personalEmoteFailureTtlMs: Long = 60_000L,
 ) {
     private enum class Provider { TWITCH, SEVEN_TV, BTTV, FFZ, BADGES, CHEERMOTES }
 
@@ -141,6 +143,7 @@ class ChatCatalogRepository(
     private var cacheBadgeConfigFingerprint: String? = null
     private val personalEmoteSetJobs = mutableMapOf<String, Job>()
     private val loadedPersonalEmoteSets = mutableSetOf<String>()
+    private val failedPersonalEmoteSets = LinkedHashMap<String, Long>(16, 0.75f, true)
     private var networkProvidersObserved = emptySet<Provider>()
     private val networkEmoteScopesObserved = mutableMapOf<Provider, MutableSet<ChatEmoteScope>>()
     private var runtimeDecorations = ChatDecorationSnapshot()
@@ -304,6 +307,9 @@ class ChatCatalogRepository(
     private fun loadPersonalEmoteSet(setId: String) {
         val loader = personalEmoteSetLoader ?: return
         if (setId.isBlank() || setId in loadedPersonalEmoteSets || setId in personalEmoteSetJobs) return
+        val now = System.currentTimeMillis()
+        pruneFailedPersonalEmoteSets(now)
+        if (failedPersonalEmoteSets[setId] != null) return
         personalEmoteSetJobs[setId] = scope.launch {
             val emotes = try {
                 loader(setId)
@@ -314,7 +320,17 @@ class ChatCatalogRepository(
             }
             synchronized(this@ChatCatalogRepository) {
                 personalEmoteSetJobs.remove(setId)
-                if (closed || emotes.isEmpty()) return@synchronized
+                if (closed) return@synchronized
+                if (emotes.isEmpty()) {
+                    val failedAt = System.currentTimeMillis()
+                    pruneFailedPersonalEmoteSets(failedAt)
+                    failedPersonalEmoteSets[setId] = failedAt
+                    while (failedPersonalEmoteSets.size > MAX_FAILED_PERSONAL_EMOTE_SETS) {
+                        failedPersonalEmoteSets.remove(failedPersonalEmoteSets.entries.first().key)
+                    }
+                    return@synchronized
+                }
+                failedPersonalEmoteSets.remove(setId)
                 loadedPersonalEmoteSets += setId
                 val currentState = _state.value
                 val current = currentState.snapshot
@@ -331,6 +347,18 @@ class ChatCatalogRepository(
         }
     }
 
+    private fun pruneFailedPersonalEmoteSets(now: Long) {
+        val iterator = failedPersonalEmoteSets.entries.iterator()
+        while (iterator.hasNext()) {
+            if (now - iterator.next().value >= personalEmoteFailureTtlMs) iterator.remove()
+        }
+        while (failedPersonalEmoteSets.size > MAX_FAILED_PERSONAL_EMOTE_SETS) {
+            val oldest = failedPersonalEmoteSets.entries.iterator()
+            oldest.next()
+            oldest.remove()
+        }
+    }
+
     private fun ChatDecorationUpdate.userPersonalEmoteSetId(): String? =
         (this as? ChatDecorationUpdate.User)?.personalEmoteSetId
 
@@ -339,6 +367,10 @@ class ChatCatalogRepository(
         namePaints = namePaints + value.paints,
         sevenTvBadges = sevenTvBadges + value.badges,
     )
+
+    private companion object {
+        const val MAX_FAILED_PERSONAL_EMOTE_SETS = 128
+    }
 
     private fun ChatDecorationSnapshot.apply(update: ChatDecorationUpdate): ChatDecorationSnapshot = when (update) {
         is ChatDecorationUpdate.EmoteSet -> this

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/catalog/TwitchChatCatalogSource.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/catalog/TwitchChatCatalogSource.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.CancellationException
 import org.json.JSONArray
 import org.json.JSONObject
 import java.io.File
+import java.util.LinkedHashMap
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.async
@@ -425,9 +426,17 @@ private enum class GlobalCatalogKey {
 }
 
 /** Process-scoped single-flight cache for provider data shared by every live chat session. */
-internal class ExpiringSingleFlightCache<K>(private val ttlMs: Long = 5 * 60 * 1000L) {
+internal class ExpiringSingleFlightCache<K>(
+    private val ttlMs: Long = 5 * 60 * 1000L,
+    private val maxSize: Int = 128,
+) {
+    init {
+        require(ttlMs > 0L) { "Cache TTL must be positive" }
+        require(maxSize > 0) { "Cache size must be positive" }
+    }
+
     private val mutex = Mutex()
-    private val entries = mutableMapOf<K, Entry>()
+    private val entries = LinkedHashMap<K, Entry>(0, 0.75f, true)
     private val inFlight = mutableMapOf<K, CompletableDeferred<Any>>()
 
     @Suppress("UNCHECKED_CAST")
@@ -435,6 +444,10 @@ internal class ExpiringSingleFlightCache<K>(private val ttlMs: Long = 5 * 60 * 1
         data class Lookup(val deferred: CompletableDeferred<Any>, val owner: Boolean)
         val lookup = mutex.withLock {
             val now = System.currentTimeMillis()
+            val iterator = entries.entries.iterator()
+            while (iterator.hasNext()) {
+                if (now - iterator.next().value.createdAtMs >= ttlMs) iterator.remove()
+            }
             entries[key]?.takeIf { !force && now - it.createdAtMs < ttlMs }?.let {
                 return@withLock Lookup(CompletableDeferred(it.value), owner = false)
             }
@@ -448,6 +461,9 @@ internal class ExpiringSingleFlightCache<K>(private val ttlMs: Long = 5 * 60 * 1
             val value = loader()
             mutex.withLock {
                 entries[key] = Entry(System.currentTimeMillis(), value)
+                while (entries.size > maxSize) {
+                    entries.entries.iterator().apply { next(); remove() }
+                }
                 inFlight.remove(key)?.complete(value)
             }
             value
@@ -461,7 +477,7 @@ internal class ExpiringSingleFlightCache<K>(private val ttlMs: Long = 5 * 60 * 1
 }
 
 private val GlobalBadgeCache = ExpiringSingleFlightCache<GlobalCatalogKey>()
-private val PersonalEmoteSetCache = ExpiringSingleFlightCache<String>()
+private val PersonalEmoteSetCache = ExpiringSingleFlightCache<String>(maxSize = 128)
 
 private object GlobalCatalogCacheRegistry {
     @Volatile

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatTimelineAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatTimelineAdapter.kt
@@ -2,13 +2,19 @@ package com.github.andreyasadchy.xtra.ui.chat.v2.ui
 
 import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
-import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.github.andreyasadchy.xtra.ui.chat.v2.assets.ChatAssetRepository
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatEmoteInteraction
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatGifInteraction
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessageId
 import com.github.andreyasadchy.xtra.ui.chat.v2.presentation.ChatRowUiModel
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 class ChatTimelineAdapter(
     private val assets: ChatAssetRepository,
@@ -18,7 +24,17 @@ class ChatTimelineAdapter(
     private val onEmoteClick: ((ChatEmoteInteraction) -> Unit)? = null,
     private val onGifClick: ((ChatGifInteraction) -> Unit)? = null,
     private val onMessageClick: ((ChatMessageId) -> Unit)? = null,
-) : ListAdapter<ChatRowUiModel, ChatTimelineAdapter.Holder>(DIFF) {
+    private val diffDispatcher: CoroutineDispatcher = Dispatchers.Default,
+) : RecyclerView.Adapter<ChatTimelineAdapter.Holder>() {
+    private val rows = ArrayList<ChatRowUiModel>()
+    private val diffScope = CoroutineScope(SupervisorJob() + diffDispatcher)
+    private var submitGeneration = 0L
+
+    val currentList: List<ChatRowUiModel>
+        get() = rows
+
+    override fun getItemCount(): Int = rows.size
+
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): Holder = Holder(
         ChatMessageTextView(parent.context, assets).also {
             it.setMessageTextSizeSp(textSizeSp)
@@ -31,15 +47,85 @@ class ChatTimelineAdapter(
     override fun onBindViewHolder(holder: Holder, position: Int) {
         holder.view.setMessageTextSizeSp(textSizeSp)
         holder.view.setAnimateGifs(animateGifs)
-        holder.bind(getItem(position))
+        holder.bind(rows[position])
     }
+
+    /**
+     * Correctness fallback for reconciliation, session changes, and presentation-wide updates.
+     * The common live append path uses [append] and never reaches DiffUtil.
+     */
+    fun submitList(newRows: List<ChatRowUiModel>, commitCallback: (() -> Unit)? = null) {
+        val oldRows = rows.toList()
+        val nextRows = newRows.toList()
+        val generation = ++submitGeneration
+        diffScope.launch {
+            val diff = DiffUtil.calculateDiff(object : DiffUtil.Callback() {
+                override fun getOldListSize(): Int = oldRows.size
+                override fun getNewListSize(): Int = nextRows.size
+
+                override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean =
+                    oldRows[oldItemPosition].id == nextRows[newItemPosition].id
+
+                override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean =
+                    oldRows[oldItemPosition] == nextRows[newItemPosition]
+            })
+            withContext(Dispatchers.Main.immediate) {
+                if (generation != submitGeneration) return@withContext
+                rows.clear()
+                rows.addAll(nextRows)
+                diff.dispatchUpdatesTo(this@ChatTimelineAdapter)
+                commitCallback?.invoke()
+            }
+        }
+    }
+
+    /**
+     * Applies a stable head eviction followed by a tail append. The complete new snapshot is
+     * used for validation, but only the known changed ranges are sent to RecyclerView.
+     */
+    fun append(
+        newRows: List<ChatRowUiModel>,
+        evictedHeadCount: Int,
+        appendedCount: Int,
+    ): Boolean {
+        ++submitGeneration
+        if (evictedHeadCount < 0 || appendedCount < 0 || appendedCount > newRows.size) return false
+        val retainedCount = newRows.size - appendedCount
+        if (rows.size != retainedCount + evictedHeadCount || evictedHeadCount > rows.size) return false
+        for (index in 0 until retainedCount) {
+            if (rows[index + evictedHeadCount] != newRows[index]) return false
+        }
+
+        rows.subList(0, evictedHeadCount).clear()
+        if (appendedCount > 0) {
+            rows.addAll(newRows.subList(retainedCount, newRows.size))
+        }
+        if (evictedHeadCount > 0) notifyItemRangeRemoved(0, evictedHeadCount)
+        if (appendedCount > 0) notifyItemRangeInserted(retainedCount, appendedCount)
+        return true
+    }
+
+    /** Clears the adapter synchronously when its RecyclerView is being detached. */
+    fun clear() {
+        ++submitGeneration
+        if (rows.isEmpty()) return
+        val oldSize = rows.size
+        rows.clear()
+        notifyItemRangeRemoved(0, oldSize)
+    }
+
+    fun dispose() {
+        diffScope.cancel()
+        clear()
+    }
+
     fun setMessageTextSizeSp(value: Float) {
         textSizeSp = value
-        for (index in 0 until itemCount) notifyItemChanged(index)
+        if (itemCount > 0) notifyItemRangeChanged(0, itemCount)
     }
     fun setAnimateGifs(value: Boolean) {
         animateGifs = value
-        for (index in 0 until itemCount) notifyItemChanged(index)
+        if (itemCount > 0) notifyItemRangeChanged(0, itemCount)
     }
     override fun onViewRecycled(holder: Holder) { holder.view.recycle(); super.onViewRecycled(holder) }
 
@@ -47,10 +133,4 @@ class ChatTimelineAdapter(
         fun bind(row: ChatRowUiModel) = view.bind(row)
     }
 
-    companion object {
-        val DIFF = object : DiffUtil.ItemCallback<ChatRowUiModel>() {
-            override fun areItemsTheSame(a: ChatRowUiModel, b: ChatRowUiModel) = a.id == b.id
-            override fun areContentsTheSame(a: ChatRowUiModel, b: ChatRowUiModel) = a == b
-        }
-    }
 }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatV2RendererController.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatV2RendererController.kt
@@ -209,7 +209,7 @@ class ChatV2RendererController(
             (recyclerView.getChildAt(index) as? ChatMessageTextView)?.setRenderingActive(false)
         }
         recyclerView.adapter = null
-        adapter.submitList(emptyList())
+        adapter.dispose()
         latestRows = emptyList()
         previousIds.clear()
         hasPreviousIds = false
@@ -359,9 +359,21 @@ class ChatV2RendererController(
             )
             if (uiChanged) {
                 onPublicationChanged(publication.messages, rows)
-                adapter.submitList(rows) {
+                val appliedIncrementally = appendInfo?.let {
+                    adapter.append(
+                        newRows = rows,
+                        evictedHeadCount = it.evictedCount,
+                        appendedCount = it.appendedCount,
+                    )
+                } == true
+                if (appliedIncrementally) {
                     viewport.onSnapshotCommitted(previousAnchor, rows, appendedCount)
                     onStateChanged(viewport.state)
+                } else {
+                    adapter.submitList(rows) {
+                        viewport.onSnapshotCommitted(previousAnchor, rows, appendedCount)
+                        onStateChanged(viewport.state)
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/captions/LiveCaptionManager.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/captions/LiveCaptionManager.kt
@@ -60,6 +60,8 @@ internal class CaptionAudioQueue(capacity: Int = 128) {
 
     fun clear() = queue.clear()
 
+    fun isFull(): Boolean = queue.remainingCapacity() == 0
+
     val size: Int get() = queue.size
 }
 
@@ -198,6 +200,13 @@ class LiveCaptionManager(
                     if (format.encoding != C.ENCODING_PCM_16BIT &&
                         format.encoding != C.ENCODING_PCM_FLOAT
                     ) return
+
+                    // Admission must happen before copying PCM. The queue is intentionally
+                    // lossy under ASR overload, so a full queue has no use for another buffer.
+                    if (audioQueue.isFull()) {
+                        droppedAudioBuffers.incrementAndGet()
+                        return
+                    }
 
                     val copy = ByteArray(buffer.remaining())
                     buffer.duplicate().get(copy)

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/NetworkUtils.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/NetworkUtils.kt
@@ -18,6 +18,8 @@ import okhttp3.internal.closeQuietly
 import okio.Buffer
 import okio.BufferedSource
 import okio.ForwardingSource
+import okio.Pipe
+import okio.Sink
 import okio.buffer
 import org.chromium.net.CronetException
 import java.io.ByteArrayOutputStream
@@ -47,6 +49,7 @@ object NetworkUtils {
     private const val DEFAULT_MAX_BODY_BYTES = 64 * 1024 * 1024
     internal const val MAX_STREAM_BYTES = 8L * 1024 * 1024 * 1024
     private const val BYTE_BUFFER_CAPACITY = 32 * 1024
+    private const val STREAM_PIPE_BUFFER_BYTES = 256L * 1024L
 
     /** Copies a streaming response without allowing an unknown-length body to fill storage. */
     fun copyToLimited(input: InputStream, output: OutputStream, maxBytes: Long = MAX_STREAM_BYTES): Long {
@@ -84,6 +87,248 @@ object NetworkUtils {
         val info: UrlResponseInfo,
         val bytes: Long,
     )
+
+    class HttpEngineStreamingResponse(
+        val info: UrlResponseInfo,
+        val body: BufferedSource,
+    )
+
+    class CronetStreamingResponse(
+        val info: org.chromium.net.UrlResponseInfo,
+        val body: BufferedSource,
+    )
+
+    /** A bounded handoff from a network callback to a consumer-owned response source. */
+    internal class StreamingResponseBody(
+        maxBytes: Long,
+        onSourceClosed: () -> Unit,
+    ) {
+        private val maxBytes = maxBytes.coerceAtLeast(0L)
+        private val pipe = Pipe(STREAM_PIPE_BUFFER_BYTES)
+        private val sink: Sink = pipe.sink
+        val source: BufferedSource = object : ForwardingSource(pipe.source) {
+            override fun close() {
+                onSourceClosed()
+                super.close()
+            }
+        }.buffer()
+        private var bytes = 0L
+
+        fun write(byteBuffer: ByteBuffer) {
+            val count = byteBuffer.remaining().toLong()
+            if (count > maxBytes - bytes) {
+                throw IOException("Response body exceeds the $maxBytes byte limit")
+            }
+            val chunk = Buffer()
+            chunk.write(byteBuffer)
+            sink.write(chunk, count)
+            bytes += count
+        }
+
+        fun complete() {
+            sink.close()
+        }
+
+        fun cancel() {
+            pipe.cancel()
+        }
+    }
+
+    @RequiresExtension(extension = Build.VERSION_CODES.S, version = 7)
+    class HttpEngineStreamingTimeout(timeout: Long = DEFAULT_TIMEOUT_MS): Timeout(timeout) {
+        lateinit var request: UrlRequest
+        var onTimeout: (() -> Unit)? = null
+
+        fun start(request: UrlRequest) {
+            this.request = request
+            updateTimeout()
+        }
+
+        override fun timeout() {
+            complete {
+                onTimeout?.invoke()
+                request.cancel()
+            }
+        }
+    }
+
+    class CronetStreamingTimeout(timeout: Long = DEFAULT_TIMEOUT_MS): Timeout(timeout) {
+        lateinit var request: org.chromium.net.UrlRequest
+        var onTimeout: (() -> Unit)? = null
+
+        fun start(request: org.chromium.net.UrlRequest) {
+            this.request = request
+            updateTimeout()
+        }
+
+        override fun timeout() {
+            complete {
+                onTimeout?.invoke()
+                request.cancel()
+            }
+        }
+    }
+
+    /** Resumes at response headers and lets Coil consume the body through a bounded pipe. */
+    @RequiresExtension(extension = Build.VERSION_CODES.S, version = 7)
+    class StreamingUrlCallback(
+        private val continuation: CancellableContinuation<HttpEngineStreamingResponse>,
+        private val timeout: HttpEngineStreamingTimeout,
+        private val maxBodyBytes: Int = DEFAULT_MAX_BODY_BYTES,
+        private val throwOnHttpError: Boolean = false,
+    ): UrlRequest.Callback {
+        private var body: StreamingResponseBody? = null
+
+        @Volatile
+        private var responseDelivered = false
+
+        init {
+            timeout.onTimeout = ::onTimeout
+        }
+
+        override fun onRedirectReceived(request: UrlRequest, info: UrlResponseInfo, newLocationUrl: String) {
+            request.followRedirect()
+        }
+
+        override fun onResponseStarted(request: UrlRequest, info: UrlResponseInfo) {
+            if (throwOnHttpError && info.httpStatusCode !in 200..299) {
+                request.cancel()
+                fail(HttpStatusException(info.httpStatusCode))
+                return
+            }
+            val bodyLength = info.headers.asMap[CONTENT_LENGTH_HEADER_NAME]
+                ?.singleOrNull()
+                ?.toLongOrNull()
+                ?: -1L
+            if (bodyLength > maxBodyBytes || bodyLength > MAX_ARRAY_SIZE) {
+                request.cancel()
+                fail(IOException("Response body exceeds the $maxBodyBytes byte limit"))
+                return
+            }
+            val responseBody = StreamingResponseBody(maxBodyBytes.toLong(), request::cancel)
+            body = responseBody
+            responseDelivered = true
+            continuation.resume(HttpEngineStreamingResponse(info, responseBody.source))
+            request.read(ByteBuffer.allocateDirect(BYTE_BUFFER_CAPACITY))
+        }
+
+        override fun onReadCompleted(request: UrlRequest, info: UrlResponseInfo, byteBuffer: ByteBuffer) {
+            byteBuffer.flip()
+            try {
+                body?.write(byteBuffer) ?: throw IOException("Response body was not initialized")
+                timeout.updateTimeout()
+                byteBuffer.clear()
+                request.read(byteBuffer)
+            } catch (error: Throwable) {
+                request.cancel()
+                fail(error)
+            }
+        }
+
+        override fun onSucceeded(request: UrlRequest, info: UrlResponseInfo) {
+            timeout.complete { body?.complete() }
+        }
+
+        override fun onFailed(request: UrlRequest, info: UrlResponseInfo?, error: HttpException) {
+            fail(error)
+        }
+
+        override fun onCanceled(request: UrlRequest, info: UrlResponseInfo?) {
+            fail(IOException("Request canceled"))
+        }
+
+        private fun onTimeout() {
+            body?.cancel()
+            if (!responseDelivered) continuation.resumeWithException(IOException("Timed out"))
+        }
+
+        private fun fail(error: Throwable) {
+            timeout.complete {
+                body?.cancel()
+                if (!responseDelivered) continuation.resumeWithException(error)
+            }
+        }
+    }
+
+    /** Cronet counterpart to [StreamingUrlCallback]. */
+    class StreamingCronetCallback(
+        private val continuation: CancellableContinuation<CronetStreamingResponse>,
+        private val timeout: CronetStreamingTimeout,
+        private val maxBodyBytes: Int = DEFAULT_MAX_BODY_BYTES,
+        private val throwOnHttpError: Boolean = false,
+    ): org.chromium.net.UrlRequest.Callback() {
+        private var body: StreamingResponseBody? = null
+
+        @Volatile
+        private var responseDelivered = false
+
+        init {
+            timeout.onTimeout = ::onTimeout
+        }
+
+        override fun onRedirectReceived(request: org.chromium.net.UrlRequest, info: org.chromium.net.UrlResponseInfo, newLocationUrl: String) {
+            request.followRedirect()
+        }
+
+        override fun onResponseStarted(request: org.chromium.net.UrlRequest, info: org.chromium.net.UrlResponseInfo) {
+            if (throwOnHttpError && info.httpStatusCode !in 200..299) {
+                request.cancel()
+                fail(HttpStatusException(info.httpStatusCode))
+                return
+            }
+            val bodyLength = info.allHeaders[CONTENT_LENGTH_HEADER_NAME]
+                ?.singleOrNull()
+                ?.toLongOrNull()
+                ?: -1L
+            if (bodyLength > maxBodyBytes || bodyLength > MAX_ARRAY_SIZE) {
+                request.cancel()
+                fail(IOException("Response body exceeds the $maxBodyBytes byte limit"))
+                return
+            }
+            val responseBody = StreamingResponseBody(maxBodyBytes.toLong(), request::cancel)
+            body = responseBody
+            responseDelivered = true
+            continuation.resume(CronetStreamingResponse(info, responseBody.source))
+            request.read(ByteBuffer.allocateDirect(BYTE_BUFFER_CAPACITY))
+        }
+
+        override fun onReadCompleted(request: org.chromium.net.UrlRequest, info: org.chromium.net.UrlResponseInfo, byteBuffer: ByteBuffer) {
+            byteBuffer.flip()
+            try {
+                body?.write(byteBuffer) ?: throw IOException("Response body was not initialized")
+                timeout.updateTimeout()
+                byteBuffer.clear()
+                request.read(byteBuffer)
+            } catch (error: Throwable) {
+                request.cancel()
+                fail(error)
+            }
+        }
+
+        override fun onSucceeded(request: org.chromium.net.UrlRequest, info: org.chromium.net.UrlResponseInfo) {
+            timeout.complete { body?.complete() }
+        }
+
+        override fun onFailed(request: org.chromium.net.UrlRequest, info: org.chromium.net.UrlResponseInfo?, error: CronetException) {
+            fail(error)
+        }
+
+        override fun onCanceled(request: org.chromium.net.UrlRequest, info: org.chromium.net.UrlResponseInfo?) {
+            fail(IOException("Request canceled"))
+        }
+
+        private fun onTimeout() {
+            body?.cancel()
+            if (!responseDelivered) continuation.resumeWithException(IOException("Timed out"))
+        }
+
+        private fun fail(error: Throwable) {
+            timeout.complete {
+                body?.cancel()
+                if (!responseDelivered) continuation.resumeWithException(error)
+            }
+        }
+    }
 
     @RequiresExtension(extension = Build.VERSION_CODES.S, version = 7)
     class ByteArrayUrlCallback(

--- a/app/src/main/res/xml/ui_preferences.xml
+++ b/app/src/main/res/xml/ui_preferences.xml
@@ -1,7 +1,7 @@
 <androidx.preference.PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
     <PreferenceCategory android:title="@string/settings_feed_previews" app:iconSpaceReserved="false" />
-    <ListPreference android:defaultValue="all" android:entries="@array/streamPreviewEntries" android:entryValues="@array/streamPreviewValues" android:key="stream_preview_mode" android:summary="%s" android:title="@string/settings_in_feed_previews" app:iconSpaceReserved="false" />
+    <ListPreference android:defaultValue="wifi" android:entries="@array/streamPreviewEntries" android:entryValues="@array/streamPreviewValues" android:key="stream_preview_mode" android:summary="%s" android:title="@string/settings_in_feed_previews" app:iconSpaceReserved="false" />
     <SwitchPreferenceCompat android:defaultValue="false" android:key="stream_preview_multiple" android:summary="@string/settings_multiple_previews_summary" android:title="@string/settings_multiple_previews" app:iconSpaceReserved="false" />
     <ListPreference android:defaultValue="360" android:entries="@array/previewQualityEntries" android:entryValues="@array/previewQualityValues" android:key="stream_preview_quality" android:summary="%s" android:title="@string/settings_preview_quality" app:iconSpaceReserved="false" />
     <ListPreference android:defaultValue="fast" android:entries="@array/previewDelayEntries" android:entryValues="@array/previewDelayValues" android:key="stream_preview_delay" android:summary="%s" android:title="@string/settings_preview_delay" app:iconSpaceReserved="false" />

--- a/app/src/test/java/com/github/andreyasadchy/xtra/repository/ProcessLocalFeedSnapshotTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/repository/ProcessLocalFeedSnapshotTest.kt
@@ -1,0 +1,104 @@
+package com.github.andreyasadchy.xtra.repository
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ProcessLocalFeedSnapshotTest {
+
+    @Test
+    fun evictionInvalidatesAnInFlightRoomBootstrap() = runBlocking {
+        val snapshot = ProcessLocalFeedSnapshot<String>()
+        val loadStarted = CompletableDeferred<Unit>()
+        val releaseLoad = CompletableDeferred<Unit>()
+        val collector = launch(Dispatchers.Default) {
+            snapshot.flow("feed", Int.MAX_VALUE) {
+                loadStarted.complete(Unit)
+                releaseLoad.await()
+                listOf("stale-room-row")
+            }.collect { }
+        }
+
+        withTimeout(1_000L) { loadStarted.await() }
+        snapshot.evict("feed")
+        assertEquals(emptyList<String>(), snapshot.current("feed"))
+
+        releaseLoad.complete(Unit)
+        collector.cancelAndJoin()
+        assertNull(snapshot.current("feed"))
+    }
+
+    @Test
+    fun anActiveCollectorStaysConnectedToPublishAfterEviction() = runBlocking {
+        val snapshot = ProcessLocalFeedSnapshot<String>()
+        val initialSeen = CompletableDeferred<Unit>()
+        val evictionSeen = CompletableDeferred<Unit>()
+        val freshSeen = CompletableDeferred<Unit>()
+        val collector = launch(Dispatchers.Default) {
+            snapshot.flow("feed", Int.MAX_VALUE) {
+                listOf("initial")
+            }.collect { items ->
+                when {
+                    items == listOf("initial") -> initialSeen.complete(Unit)
+                    items.isEmpty() -> evictionSeen.complete(Unit)
+                    items == listOf("fresh") -> freshSeen.complete(Unit)
+                }
+            }
+        }
+
+        withTimeout(1_000L) { initialSeen.await() }
+        snapshot.evict("feed")
+        withTimeout(1_000L) { evictionSeen.await() }
+        snapshot.publish("feed", listOf("fresh"))
+        withTimeout(1_000L) { freshSeen.await() }
+        assertEquals(listOf("fresh"), snapshot.current("feed"))
+
+        collector.cancelAndJoin()
+        assertNull(snapshot.current("feed"))
+    }
+
+    @Test
+    fun pendingEvictionRemovesTheEntryWhenTheLastCollectorEnds() = runBlocking {
+        val snapshot = ProcessLocalFeedSnapshot<String>()
+        val loadStarted = CompletableDeferred<Unit>()
+        val releaseLoad = CompletableDeferred<Unit>()
+        val collector = launch(Dispatchers.Default) {
+            snapshot.flow("feed", Int.MAX_VALUE) {
+                loadStarted.complete(Unit)
+                releaseLoad.await()
+                listOf("room-row")
+            }.first()
+        }
+
+        withTimeout(1_000L) { loadStarted.await() }
+        snapshot.evict("feed")
+        releaseLoad.complete(Unit)
+        collector.join()
+
+        assertNull(snapshot.current("feed"))
+    }
+
+    @Test
+    fun aNewCollectorBootstrapsAfterTrueEviction() = runBlocking {
+        val snapshot = ProcessLocalFeedSnapshot<String>()
+        snapshot.publish("feed", listOf("old"))
+        snapshot.evict("feed")
+
+        var loads = 0
+        val result = snapshot.flow("feed", Int.MAX_VALUE) {
+            loads++
+            listOf("fresh")
+        }.first()
+
+        assertEquals(listOf("fresh"), result)
+        assertEquals(1, loads)
+    }
+}

--- a/app/src/test/java/com/github/andreyasadchy/xtra/repository/preload/StreamPreviewPolicyTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/repository/preload/StreamPreviewPolicyTest.kt
@@ -6,8 +6,8 @@ import org.junit.Test
 
 class StreamPreviewPolicyTest {
     @Test
-    fun missingPreviewModeUsesAConservativeBrowsingDefault() {
-        assertEquals(StreamPreviewMode.WIFI_AND_MOBILE, StreamPreviewMode.fromPreference(null))
+    fun missingPreviewModeUsesAWifiOnlyBrowsingDefault() {
+        assertEquals(StreamPreviewMode.WIFI_ONLY, StreamPreviewMode.fromPreference(null))
         assertEquals(StreamPreviewQuality.P360, StreamPreviewQuality.fromPreference(null))
         assertEquals(StreamPreviewDelay.FAST, StreamPreviewDelay.fromPreference(null))
         assertEquals(750L, StreamPreviewDelay.FAST.delayMs)

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatCatalogRepositoryTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatCatalogRepositoryTest.kt
@@ -759,6 +759,21 @@ class ChatCatalogRepositoryTest {
     }
 
     @Test
+    fun singleFlightCacheEvictsTheLeastRecentlyUsedPersonalSet() = runBlocking {
+        val cache = ExpiringSingleFlightCache<String>(ttlMs = 60_000L, maxSize = 2)
+        val calls = AtomicInteger()
+
+        cache.get("a") { calls.incrementAndGet(); "a" }
+        cache.get("b") { calls.incrementAndGet(); "b" }
+        cache.get("a") { calls.incrementAndGet(); "unexpected" }
+        cache.get("c") { calls.incrementAndGet(); "c" }
+
+        assertEquals("a", cache.get("a") { calls.incrementAndGet(); "unexpected" })
+        assertEquals("reloaded-b", cache.get("b") { calls.incrementAndGet(); "reloaded-b" })
+        assertEquals(4, calls.get())
+    }
+
+    @Test
     fun newlyObservedPersonalSetIsLoadedOnceAndAttachedToItsSetId() = runBlocking {
         val calls = AtomicInteger()
         val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
@@ -796,6 +811,40 @@ class ChatCatalogRepositoryTest {
 
         assertEquals(1, calls.get())
         assertEquals(personal, repository.state.value.snapshot.sevenTv.personal["set-a"]?.get("VIPWave"))
+        repository.close()
+        scope.cancel()
+    }
+
+    @Test
+    fun failedPersonalSetLoadIsSuppressedUntilTheNegativeTtlExpires() = runBlocking {
+        val calls = AtomicInteger()
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val loadedEmote = emote("Recovered", ChatAssetProvider.SEVEN_TV).copy(scope = ChatEmoteScope.PERSONAL)
+        val repository = ChatCatalogRepository(
+            scope = scope,
+            source = ChatCatalogSource { ChatCatalogLoadResult() },
+            personalEmoteFailureTtlMs = 50L,
+            personalEmoteSetLoader = {
+                if (calls.incrementAndGet() == 1) emptyMap() else mapOf(loadedEmote.name to loadedEmote)
+            },
+        )
+        val update = ChatDecorationUpdate.User("user", personalEmoteSetId = "failed-set")
+
+        repository.applyDecorationUpdate(update)
+        withTimeout(1_000) { while (calls.get() < 1) delay(1) }
+        delay(20)
+        repository.applyDecorationUpdate(update)
+        delay(20)
+        assertEquals(1, calls.get())
+
+        delay(60)
+        repository.applyDecorationUpdate(update)
+        withTimeout(1_000) { while (calls.get() < 2) delay(1) }
+        withTimeout(1_000) {
+            while (repository.state.value.snapshot.sevenTv.personal["failed-set"].isNullOrEmpty()) delay(1)
+        }
+        assertEquals(loadedEmote, repository.state.value.snapshot.sevenTv.personal["failed-set"]?.get("Recovered"))
+
         repository.close()
         scope.cancel()
     }

--- a/app/src/test/java/com/github/andreyasadchy/xtra/util/NetworkUtilsStreamingResponseBodyTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/util/NetworkUtilsStreamingResponseBodyTest.kt
@@ -1,0 +1,219 @@
+package com.github.andreyasadchy.xtra.util
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import okio.Buffer
+import org.chromium.net.CronetException
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.IOException
+import java.nio.ByteBuffer
+import java.util.AbstractMap
+import java.util.concurrent.atomic.AtomicBoolean
+
+class NetworkUtilsStreamingResponseBodyTest {
+    @Test
+    fun multipleChunksAreReadInOrderAndEndWithEof() = runBlocking {
+        val body = NetworkUtils.StreamingResponseBody(1024) {}
+        val writer = launch(Dispatchers.Default) {
+            body.write(ByteBuffer.wrap("first".toByteArray()))
+            body.write(ByteBuffer.wrap("-second".toByteArray()))
+            body.complete()
+        }
+        val output = Buffer()
+        while (body.source.read(output, 3) != -1L) { }
+
+        writer.join()
+        assertEquals("first-second", output.readUtf8())
+        assertEquals(-1L, body.source.read(Buffer(), 1))
+    }
+
+    @Test
+    fun unknownLengthStyleStreamingDoesNotRequireAWholeBodyBuffer() = runBlocking {
+        val body = NetworkUtils.StreamingResponseBody(512 * 1024) {}
+        val writer = launch(Dispatchers.Default) {
+            repeat(32) { body.write(ByteBuffer.wrap(ByteArray(16 * 1024) { it.toByte() })) }
+            body.complete()
+        }
+        val output = Buffer()
+        var total = 0L
+        while (true) {
+            val read = body.source.read(output, 8 * 1024)
+            if (read == -1L) break
+            total += read
+            output.clear()
+        }
+
+        writer.join()
+        assertEquals(512 * 1024L, total)
+    }
+
+    @Test
+    fun aResponseThatExceedsTheLimitIsRejectedBeforeWriting() {
+        val body = NetworkUtils.StreamingResponseBody(4) {}
+        body.write(ByteBuffer.wrap(byteArrayOf(1, 2, 3, 4)))
+
+        val error = org.junit.Assert.assertThrows(IOException::class.java) {
+            body.write(ByteBuffer.wrap(byteArrayOf(5)))
+        }
+
+        assertTrue(error.message.orEmpty().contains("4 byte limit"))
+        body.cancel()
+    }
+
+    @Test
+    fun closingTheConsumerSourceCancelsTheProducer() {
+        val cancelled = AtomicBoolean(false)
+        lateinit var body: NetworkUtils.StreamingResponseBody
+        body = NetworkUtils.StreamingResponseBody(1024) {
+            cancelled.set(true)
+            body.cancel()
+        }
+
+        body.source.close()
+
+        assertTrue(cancelled.get())
+    }
+
+    @Test
+    fun upstreamFailureAfterHeadersWakesTheConsumerWithAnError() {
+        val body = NetworkUtils.StreamingResponseBody(1024) {}
+        body.cancel()
+
+        org.junit.Assert.assertThrows(IOException::class.java) {
+            body.source.read(Buffer(), 1)
+        }
+    }
+
+    @Test
+    fun aSlowConsumerBackpressuresTheProducerAndCancellationUnblocksIt() = runBlocking {
+        val started = CompletableDeferred<Unit>()
+        val cancelled = AtomicBoolean(false)
+        lateinit var body: NetworkUtils.StreamingResponseBody
+        body = NetworkUtils.StreamingResponseBody(1024 * 1024) {
+            cancelled.set(true)
+            body.cancel()
+        }
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+        val writer = scope.launch {
+            started.complete(Unit)
+            body.write(ByteBuffer.wrap(ByteArray(512 * 1024)))
+        }
+
+        withTimeout(1_000) { started.await() }
+        delay(50)
+        assertFalse(writer.isCompleted)
+
+        body.source.close()
+        withTimeout(1_000) { writer.join() }
+        assertTrue(cancelled.get())
+        scope.cancel()
+    }
+
+    @Test
+    fun cronetCallbackStreamsChunksAndCancelsWhenConsumerCloses() = runBlocking {
+        val harness = startCronetResponse()
+        harness.callback.onReadCompleted(harness.request, harness.info, callbackBuffer("cronet"))
+        harness.callback.onSucceeded(harness.request, harness.info)
+        assertEquals("cronet", readAll(harness.response.body))
+
+        val closed = startCronetResponse()
+        closed.response.body.close()
+        closed.callback.onCanceled(closed.request, closed.info)
+        assertTrue(closed.request.cancelled)
+    }
+
+    @Test
+    fun cronetCallbackPropagatesFailureTimeoutAndStreamOverflow() = runBlocking {
+        val failed = startCronetResponse()
+        failed.callback.onFailed(failed.request, failed.info, TestCronetException("network failure"))
+        org.junit.Assert.assertThrows(IOException::class.java) { failed.response.body.read(Buffer(), 1) }
+
+        val timedOut = startCronetResponse()
+        timedOut.timeout.timeout()
+        assertTrue(timedOut.request.cancelled)
+        org.junit.Assert.assertThrows(IOException::class.java) { timedOut.response.body.read(Buffer(), 1) }
+
+        val overflow = startCronetResponse(maxBodyBytes = 4)
+        overflow.callback.onReadCompleted(overflow.request, overflow.info, callbackBuffer("12345"))
+        assertTrue(overflow.request.cancelled)
+        org.junit.Assert.assertThrows(IOException::class.java) { overflow.response.body.read(Buffer(), 1) }
+        Unit
+    }
+
+    private suspend fun startCronetResponse(
+        headers: Map<String, List<String>> = emptyMap(),
+        maxBodyBytes: Int = 64 * 1024 * 1024,
+    ): CronetHarness {
+        lateinit var callback: NetworkUtils.StreamingCronetCallback
+        lateinit var request: FakeCronetRequest
+        lateinit var info: FakeCronetResponseInfo
+        lateinit var timeout: NetworkUtils.CronetStreamingTimeout
+        val response = kotlinx.coroutines.suspendCancellableCoroutine<NetworkUtils.CronetStreamingResponse> { continuation ->
+            timeout = NetworkUtils.CronetStreamingTimeout(60_000L)
+            request = FakeCronetRequest()
+            info = FakeCronetResponseInfo(headers)
+            callback = NetworkUtils.StreamingCronetCallback(continuation, timeout, maxBodyBytes)
+            timeout.start(request)
+            callback.onResponseStarted(request, info)
+        }
+        return CronetHarness(callback, request, info, timeout, response)
+    }
+
+    private fun readAll(source: okio.BufferedSource): String {
+        val output = Buffer()
+        while (source.read(output, 4) != -1L) { }
+        return output.readUtf8()
+    }
+
+    private fun callbackBuffer(value: String): ByteBuffer = ByteBuffer.allocate(value.length).apply {
+        put(value.toByteArray())
+    }
+
+    private data class CronetHarness(
+        val callback: NetworkUtils.StreamingCronetCallback,
+        val request: FakeCronetRequest,
+        val info: FakeCronetResponseInfo,
+        val timeout: NetworkUtils.CronetStreamingTimeout,
+        val response: NetworkUtils.CronetStreamingResponse,
+    )
+
+    private class FakeCronetRequest : org.chromium.net.UrlRequest() {
+        var cancelled = false
+
+        override fun cancel() { cancelled = true }
+        override fun followRedirect() = Unit
+        override fun read(byteBuffer: ByteBuffer) = Unit
+        override fun start() = Unit
+        override fun isDone(): Boolean = cancelled
+        override fun getStatus(listener: org.chromium.net.UrlRequest.StatusListener) = Unit
+    }
+
+    private class FakeCronetResponseInfo(
+        private val headers: Map<String, List<String>>,
+    ) : org.chromium.net.UrlResponseInfo() {
+        override fun getUrl(): String = "https://example.test/image"
+        override fun getUrlChain(): List<String> = listOf("https://example.test/image")
+        override fun getHttpStatusCode(): Int = 200
+        override fun getHttpStatusText(): String = "OK"
+        override fun getAllHeadersAsList(): List<Map.Entry<String, String>> = headers.flatMap { (name, values) ->
+            values.map { value -> AbstractMap.SimpleImmutableEntry(name, value) }
+        }
+        override fun getAllHeaders(): Map<String, List<String>> = headers
+        override fun wasCached(): Boolean = false
+        override fun getNegotiatedProtocol(): String = "h2"
+        override fun getProxyServer(): String = ""
+        override fun getReceivedByteCount(): Long = 0L
+    }
+
+    private class TestCronetException(message: String) : CronetException(message, null)
+}


### PR DESCRIPTION
## Summary

Reduce repeated work and retained memory during long chats and feed browsing.

- Apply known chat append and head-eviction changes directly to RecyclerView.
- Bound personal 7TV sets and back off failed set loads for 60 seconds.
- Evict process-local feed snapshots when durable feed entries are removed.
- Stream Cronet and HttpEngine image responses through a bounded pipe.
- Drop overloaded caption buffers before copying PCM data.
- Make fresh-install stream previews Wi-Fi-only while preserving saved choices.

## Checks

- `:app:compileDebugKotlin`
- `:app:testDebugUnitTest --tests com.github.andreyasadchy.xtra.repository.preload.StreamPreviewPolicyTest --tests com.github.andreyasadchy.xtra.ui.chat.v2.ChatCatalogRepositoryTest`
- `:app:assembleDebug`
- Installed and launched the debug APK on `xtra-api35` without a crash.