### PR TITLE
Optimize live chat append rendering

### DIFF
--- a/app/src/androidTest/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatTimelineAdapterTest.kt
+++ b/app/src/androidTest/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatTimelineAdapterTest.kt
@@ -46,6 +46,23 @@ class ChatTimelineAdapterTest {
     }
 
     @Test
+    fun deltaAppendDoesNotValidateRetainedRows() {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val adapter = adapter(scope)
+        try {
+            submitAndWait(adapter, listOf(row("a"), row("b"), row("c")))
+
+            var applied = false
+            onMain { applied = adapter.appendDelta(listOf(row("d")), evictedHeadCount = 1, expectedSize = 3) }
+
+            assertTrue(applied)
+            assertEquals(listOf("b", "c", "d"), adapter.currentList.map { it.id.value })
+        } finally {
+            dispose(adapter, scope)
+        }
+    }
+
+    @Test
     fun retainedRowMutationRejectsDirectAppendAndUsesFallback() {
         val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
         val adapter = adapter(scope)

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/presentation/ChatPresentationSnapshot.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/presentation/ChatPresentationSnapshot.kt
@@ -83,24 +83,49 @@ internal class ChatPresentationSnapshot {
         }
         val settlement = ChatMetadataSettlement(structuralSettled, badgesSettled, rewardsSettled)
         return messages.map { message ->
-            val frozen = catalogsByMessage[message.id]
-            if (frozen == null) {
-                val created = FrozenCatalog.from(
-                    catalog = catalog,
-                    captureBadges = captureBadges,
-                    settlement = settlement,
-                )
-                catalogsByMessage[message.id] = created
-                created.toCatalog(catalog)
-            } else {
-                frozen.update(
-                    catalog = catalog,
-                    captureBadges = captureBadges,
-                    settlement = settlement,
-                    forceUpgrade = forceUpgrade,
-                )
-                frozen.toCatalog(catalog)
+            catalogForMessage(message, catalog, captureBadges, settlement, forceUpgrade)
+        }
+    }
+
+    /** Applies a known tail append without walking the retained message window. */
+    @Synchronized
+    fun catalogsForAppend(
+        key: ChatSessionKey,
+        appendedMessages: List<ChatMessage>,
+        evictedCount: Int,
+        newMessageCount: Int,
+        catalog: ChatCatalogSnapshot,
+        captureBadges: Boolean = true,
+        structuralSettled: Boolean = true,
+        badgesSettled: Boolean = true,
+        rewardsSettled: Boolean = true,
+    ): List<ChatCatalogSnapshot>? {
+        if (sessionKey != key || evictedCount < 0 || evictedCount > orderedMessageIds.size) return null
+        val appendedStart = newMessageCount - appendedMessages.size
+        val alreadyApplied = orderedMessageIds.size == newMessageCount &&
+            appendedStart >= 0 &&
+            appendedMessages.indices.all { index ->
+                orderedMessageIds[appendedStart + index] == appendedMessages[index].id
             }
+        if (alreadyApplied) {
+            val settlement = ChatMetadataSettlement(structuralSettled, badgesSettled, rewardsSettled)
+            return appendedMessages.map { message ->
+                catalogForMessage(message, catalog, captureBadges, settlement, forceUpgrade = false)
+            }
+        }
+        repeat(evictedCount) {
+            val evicted = orderedMessageIds.removeFirst()
+            activeMessageIds.remove(evicted)
+            catalogsByMessage.remove(evicted)
+        }
+        val settlement = ChatMetadataSettlement(structuralSettled, badgesSettled, rewardsSettled)
+        appendedMessages.forEach { message ->
+            activeMessageIds += message.id
+            orderedMessageIds += message.id
+        }
+        ChatRenderDiagnostics.recordCatalogIndexUpdate(incremental = true)
+        return appendedMessages.map { message ->
+            catalogForMessage(message, catalog, captureBadges, settlement, forceUpgrade = false)
         }
     }
 
@@ -110,6 +135,32 @@ internal class ChatPresentationSnapshot {
         catalogsByMessage.clear()
         activeMessageIds.clear()
         orderedMessageIds.clear()
+    }
+
+    private fun catalogForMessage(
+        message: ChatMessage,
+        catalog: ChatCatalogSnapshot,
+        captureBadges: Boolean,
+        settlement: ChatMetadataSettlement,
+        forceUpgrade: Boolean,
+    ): ChatCatalogSnapshot {
+        val frozen = catalogsByMessage[message.id]
+        if (frozen == null) {
+            val created = FrozenCatalog.from(
+                catalog = catalog,
+                captureBadges = captureBadges,
+                settlement = settlement,
+            )
+            catalogsByMessage[message.id] = created
+            return created.toCatalog(catalog)
+        }
+        frozen.update(
+            catalog = catalog,
+            captureBadges = captureBadges,
+            settlement = settlement,
+            forceUpgrade = forceUpgrade,
+        )
+        return frozen.toCatalog(catalog)
     }
 
     private class FrozenCatalog(

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/session/ChatSession.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/session/ChatSession.kt
@@ -100,7 +100,12 @@ class ChatSession(
 
     suspend fun snapshot(): List<com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessage> = timeline.snapshot()
 
-    fun attachUi() = ChatUiBatcher(timeline.versions, timeline::versionedSnapshot, VersionedTimelineSnapshot::version).flow()
+    fun attachUi() = ChatUiBatcher(
+        versions = timeline.versions,
+        snapshot = timeline::versionedSnapshot,
+        versionOf = VersionedTimelineSnapshot::version,
+        snapshotAfter = timeline::versionedSnapshotAfter,
+    ).flow()
 
     suspend fun reconcile(key: ChatSessionKey, recent: List<com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessage>) = processor.reconcile(key, recent)
 

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/session/ChatTimelineStore.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/session/ChatTimelineStore.kt
@@ -6,6 +6,7 @@ import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessageId
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatModeration
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatModerationDisplayMode
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatUserClearReason
+import com.github.andreyasadchy.xtra.util.ChatRenderDiagnostics
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.flow.Flow
@@ -33,11 +34,33 @@ sealed interface TimelineOperation {
     data class Clear(val atMs: Long) : TimelineOperation
     data class Replace(val items: List<ChatMessage>) : TimelineOperation
     class RequestSnapshot(val result: CompletableDeferred<List<ChatMessage>>) : TimelineOperation
-    class RequestVersionedSnapshot(val result: CompletableDeferred<VersionedTimelineSnapshot>) : TimelineOperation
+    class RequestVersionedSnapshot(
+        val result: CompletableDeferred<VersionedTimelineSnapshot>,
+        val afterVersion: Long? = null,
+    ) : TimelineOperation
     data class Reconcile(val recent: List<ChatMessage>) : TimelineOperation
 }
 
-data class VersionedTimelineSnapshot(val version: Long, val messages: List<ChatMessage>)
+sealed interface ChatTimelineDelta {
+    /** The messages list is the tail to append, not a replacement for the current window. */
+    data class Append(
+        val messages: List<ChatMessage>,
+        val evictedCount: Int,
+        val resultingSize: Int,
+    ) : ChatTimelineDelta
+
+    data object Full : ChatTimelineDelta
+}
+
+/**
+ * For an append delta, [messages] is intentionally empty. Consumers keep their own window and
+ * use the delta; initial snapshots and full reconciliations contain the complete window.
+ */
+data class VersionedTimelineSnapshot(
+    val version: Long,
+    val messages: List<ChatMessage>,
+    val delta: ChatTimelineDelta? = null,
+)
 
 /** The only mutable owner of the live message tail. Asset work is deliberately absent here. */
 class ChatTimelineStore(
@@ -56,21 +79,60 @@ class ChatTimelineStore(
             // processor's generation boundary and resets them before a new channel is accepted.
             val deletedMessages = LinkedHashMap<ChatMessageId, ChatModerationDisplayMode>(MODERATION_TOMBSTONE_LIMIT)
             val clearedUsers = ArrayDeque<UserModeration>(MODERATION_TOMBSTONE_LIMIT)
+            val changes = ArrayDeque<TimelineChange>(TIMELINE_CHANGE_HISTORY_LIMIT)
             var globallyClearedAt: Long? = null
+            var version = 0L
             for (operation in operations) {
                 when (operation) {
                     is TimelineOperation.RequestSnapshot -> {
-                        operation.result.complete(items.toList())
+                        val snapshot = items.toList()
+                        ChatRenderDiagnostics.recordTimelineSnapshot(items.size, snapshot.size)
+                        operation.result.complete(snapshot)
                         continue
                     }
                     is TimelineOperation.RequestVersionedSnapshot -> {
-                        operation.result.complete(VersionedTimelineSnapshot(_version.value, items.toList()))
+                        val delta = operation.afterVersion?.let {
+                            deltaSince(it, version, items.size, changes)
+                        }
+                        val messages = if (delta is ChatTimelineDelta.Append) {
+                            ChatRenderDiagnostics.recordTimelineSnapshot(0, 0)
+                            emptyList()
+                        } else {
+                            val snapshot = items.toList()
+                            ChatRenderDiagnostics.recordTimelineSnapshot(items.size, snapshot.size)
+                            snapshot
+                        }
+                        operation.result.complete(
+                            VersionedTimelineSnapshot(
+                                version = version,
+                                messages = messages,
+                                delta = delta,
+                            ),
+                        )
                         continue
                     }
-                    is TimelineOperation.Append -> operation.items.forEach { item ->
-                        if (isSuppressed(item, deletedMessages, clearedUsers, globallyClearedAt)) continue
-                        if (isDuplicateReward(item, items)) continue
-                        if (ids.add(item.id)) items.addLast(decorate(item, deletedMessages, clearedUsers))
+                    is TimelineOperation.Append -> {
+                        val appended = ArrayList<ChatMessage>(operation.items.size)
+                        operation.items.forEach { item ->
+                            if (isSuppressed(item, deletedMessages, clearedUsers, globallyClearedAt)) return@forEach
+                            if (isDuplicateReward(item, items)) return@forEach
+                            if (ids.add(item.id)) {
+                                val decorated = decorate(item, deletedMessages, clearedUsers)
+                                items.addLast(decorated)
+                                appended += decorated
+                            }
+                        }
+                        val evicted = trimToSize(items, ids)
+                        version++
+                        recordChange(
+                            changes,
+                            TimelineChange(
+                                version,
+                                ChatTimelineDelta.Append(appended, evicted, items.size),
+                            ),
+                        )
+                        _version.value = version
+                        continue
                     }
                     is TimelineOperation.Prepend -> operation.items.asReversed().forEach { item ->
                         if (isSuppressed(item, deletedMessages, clearedUsers, globallyClearedAt)) continue
@@ -165,8 +227,60 @@ class ChatTimelineStore(
                     }
                 }
                 while (items.size > maxSize) items.removeFirst().also { ids.remove(it.id) }
-                _version.value++
+                version++
+                recordChange(changes, TimelineChange(version, ChatTimelineDelta.Full))
+                _version.value = version
             }
+        }
+    }
+
+    private fun trimToSize(
+        items: ArrayDeque<ChatMessage>,
+        ids: HashSet<ChatMessageId>,
+    ): Int {
+        var evicted = 0
+        while (items.size > maxSize) {
+            items.removeFirst().also { ids.remove(it.id) }
+            evicted++
+        }
+        return evicted
+    }
+
+    private fun recordChange(changes: ArrayDeque<TimelineChange>, change: TimelineChange) {
+        changes.addLast(change)
+        while (changes.size > TIMELINE_CHANGE_HISTORY_LIMIT) changes.removeFirst()
+    }
+
+    private fun deltaSince(
+        afterVersion: Long,
+        currentVersion: Long,
+        currentSize: Int,
+        changes: ArrayDeque<TimelineChange>,
+    ): ChatTimelineDelta {
+        if (afterVersion == currentVersion) return ChatTimelineDelta.Append(emptyList(), 0, currentSize)
+        if (afterVersion > currentVersion) return ChatTimelineDelta.Full
+        val required = currentVersion - afterVersion
+        if (required > changes.size) return ChatTimelineDelta.Full
+
+        var expectedVersion = afterVersion + 1
+        var evictedCount = 0
+        val appended = ArrayList<ChatMessage>()
+        changes.forEach { change ->
+            if (change.version < expectedVersion) return@forEach
+            if (change.version != expectedVersion) return ChatTimelineDelta.Full
+            when (val delta = change.delta) {
+                ChatTimelineDelta.Full -> return ChatTimelineDelta.Full
+                is ChatTimelineDelta.Append -> {
+                    appended.addAll(delta.messages)
+                    evictedCount += delta.evictedCount
+                }
+            }
+            expectedVersion++
+        }
+        return if (expectedVersion == currentVersion + 1) {
+            ChatTimelineDelta.Append(appended, evictedCount, currentSize)
+        } else {
+            ChatTimelineDelta.Full
         }
     }
 
@@ -251,7 +365,15 @@ class ChatTimelineStore(
     private companion object {
         const val MODERATION_TOMBSTONE_LIMIT = 4096
         const val REWARD_DUPLICATE_WINDOW_MS = 3_000L
+        // At the measured 11.7 messages/sec this covers roughly 90 seconds while retaining at
+        // most 1,024 append records. Collectors outside that window safely request a full tail.
+        const val TIMELINE_CHANGE_HISTORY_LIMIT = 1024
     }
+
+    private data class TimelineChange(
+        val version: Long,
+        val delta: ChatTimelineDelta,
+    )
 
     suspend fun apply(operation: TimelineOperation) = operations.send(operation)
 
@@ -264,6 +386,12 @@ class ChatTimelineStore(
     suspend fun versionedSnapshot(): VersionedTimelineSnapshot {
         val result = CompletableDeferred<VersionedTimelineSnapshot>()
         operations.send(TimelineOperation.RequestVersionedSnapshot(result))
+        return result.await()
+    }
+
+    suspend fun versionedSnapshotAfter(afterVersion: Long): VersionedTimelineSnapshot {
+        val result = CompletableDeferred<VersionedTimelineSnapshot>()
+        operations.send(TimelineOperation.RequestVersionedSnapshot(result, afterVersion))
         return result.await()
     }
 

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/session/ChatUiBatcher.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/session/ChatUiBatcher.kt
@@ -8,12 +8,13 @@ import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.launch
 
-/** Coalesces complete truth snapshots to at most one UI publication per frame. */
+/** Coalesces timeline publications to at most one UI publication per frame. */
 class ChatUiBatcher<T>(
     private val versions: Flow<Long>,
     private val snapshot: suspend () -> T,
     private val versionOf: (T) -> Long,
     private val frameMs: Long = 16L,
+    private val snapshotAfter: (suspend (Long) -> T)? = null,
 ) {
     /** Cold and collection-owned. No collector means no version collection or snapshot work. */
     fun flow(): Flow<T> = flow {
@@ -31,7 +32,7 @@ class ChatUiBatcher<T>(
                 for (dirtyVersion in dirty) {
                     if (dirtyVersion <= materializedVersion) continue
                     delay(frameMs)
-                    val current = snapshot()
+                    val current = snapshotAfter?.invoke(materializedVersion) ?: snapshot()
                     materializedVersion = versionOf(current)
                     emit(current)
                 }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatPresentationReuse.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatPresentationReuse.kt
@@ -11,6 +11,9 @@ internal class ChatPresentationReuseIndex {
     private val rowsById = HashMap<ChatMessageId, ChatRowUiModel>()
     private val orderedIds = ArrayDeque<ChatMessageId>()
 
+    val size: Int
+        get() = orderedIds.size
+
     fun rowFor(message: ChatMessage): ChatRowUiModel? =
         rowsById[message.id]?.takeIf { messagesById[message.id] == message }
 
@@ -59,6 +62,30 @@ internal class ChatPresentationReuseIndex {
         return true
     }
 
+    /** Updates the reuse tables from a timeline delta without visiting retained messages. */
+    fun appendDelta(
+        appendedMessages: List<ChatMessage>,
+        appendedRows: List<ChatRowUiModel>,
+        evictedCount: Int,
+        expectedSize: Int,
+    ): Boolean {
+        if (evictedCount < 0 || evictedCount > orderedIds.size) return false
+        if (appendedMessages.size != appendedRows.size) return false
+        if (orderedIds.size - evictedCount + appendedMessages.size != expectedSize) return false
+        repeat(evictedCount) {
+            val evicted = orderedIds.removeFirst()
+            messagesById.remove(evicted)
+            rowsById.remove(evicted)
+        }
+        appendedMessages.forEachIndexed { index, message ->
+            val row = appendedRows[index]
+            messagesById[message.id] = message
+            rowsById[row.id] = row
+            orderedIds += row.id
+        }
+        return true
+    }
+
     fun clear() {
         messagesById.clear()
         rowsById.clear()
@@ -99,6 +126,8 @@ internal data class ChatRowCompileResult(
     val messagesChanged: Int,
     val rowsCompiled: Int,
     val rowsReused: Int,
+    val rowsVisited: Int,
+    val rowsAllocated: Int,
 )
 
 internal fun compileChatRows(
@@ -121,5 +150,32 @@ internal fun compileChatRows(
             rows += resolve(message, index)
         }
     }
-    return ChatRowCompileResult(rows, changed, compiled, reused)
+    return ChatRowCompileResult(
+        rows = rows,
+        messagesChanged = changed,
+        rowsCompiled = compiled,
+        rowsReused = reused,
+        rowsVisited = messages.size,
+        rowsAllocated = rows.size,
+    )
+}
+
+internal fun compileChatRowAppend(
+    messages: List<ChatMessage>,
+    startIndex: Int,
+    retainedRows: Int,
+    resolve: (ChatMessage, Int) -> ChatRowUiModel,
+): ChatRowCompileResult {
+    val rows = ArrayList<ChatRowUiModel>(messages.size)
+    messages.forEachIndexed { index, message ->
+        rows += resolve(message, startIndex + index)
+    }
+    return ChatRowCompileResult(
+        rows = rows,
+        messagesChanged = messages.size,
+        rowsCompiled = messages.size,
+        rowsReused = retainedRows,
+        rowsVisited = messages.size,
+        rowsAllocated = rows.size,
+    )
 }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatTimelineAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatTimelineAdapter.kt
@@ -105,6 +105,24 @@ class ChatTimelineAdapter(
         return true
     }
 
+    /** Applies a known tail append without validating or traversing the retained rows. */
+    fun appendDelta(
+        appendedRows: List<ChatRowUiModel>,
+        evictedHeadCount: Int,
+        expectedSize: Int,
+    ): Boolean {
+        ++submitGeneration
+        if (evictedHeadCount < 0 || evictedHeadCount > rows.size) return false
+        if (rows.size - evictedHeadCount + appendedRows.size != expectedSize) return false
+
+        val retainedCount = rows.size - evictedHeadCount
+        rows.subList(0, evictedHeadCount).clear()
+        rows.addAll(appendedRows)
+        if (evictedHeadCount > 0) notifyItemRangeRemoved(0, evictedHeadCount)
+        if (appendedRows.isNotEmpty()) notifyItemRangeInserted(retainedCount, appendedRows.size)
+        return true
+    }
+
     /** Clears the adapter synchronously when its RecyclerView is being detached. */
     fun clear() {
         ++submitGeneration

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatV2RendererController.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatV2RendererController.kt
@@ -25,6 +25,7 @@ import com.github.andreyasadchy.xtra.ui.chat.v2.presentation.ChatRowCompiler
 import com.github.andreyasadchy.xtra.ui.chat.v2.presentation.ChatRowUiModel
 import com.github.andreyasadchy.xtra.ui.chat.v2.presentation.ChatPresentationLabels
 import com.github.andreyasadchy.xtra.ui.chat.v2.session.ActiveChatSession
+import com.github.andreyasadchy.xtra.ui.chat.v2.session.ChatTimelineDelta
 import com.github.andreyasadchy.xtra.ui.chat.ChatRenderStyle
 import com.github.andreyasadchy.xtra.ui.chat.ChatProfilePopoutGesture
 import com.github.andreyasadchy.xtra.ui.chat.resolveChatHighlightSettings
@@ -122,12 +123,12 @@ class ChatV2RendererController(
         renderStyle.textSizeSp,
         renderStyle.animateGifs,
         onMessageLongClick = if (profilePopoutGesture.allowsHold) {
-            { id -> latestPublication?.messages?.firstOrNull { it.id == id }?.let(onMessageLongClick) }
+            { id -> latestMessages.firstOrNull { it.id == id }?.let(onMessageLongClick) }
         } else null,
         onEmoteClick = onEmoteClick,
         onGifClick = onGifClick,
         onMessageClick = if (profilePopoutGesture.allowsTap) {
-            { id -> latestPublication?.messages?.firstOrNull { it.id == id }?.let(onMessageLongClick) }
+            { id -> latestMessages.firstOrNull { it.id == id }?.let(onMessageLongClick) }
         } else null,
     )
     private val viewport = ChatViewportController(recyclerView, initialState)
@@ -140,7 +141,8 @@ class ChatV2RendererController(
     private val previousIds = HashSet<ChatMessageId>()
     private var hasPreviousIds = false
     private var previousTailId: ChatMessageId? = null
-    private var latestRows: List<ChatRowUiModel> = emptyList()
+    private val latestMessages = ArrayDeque<ChatMessage>()
+    private val latestRows = ArrayList<ChatRowUiModel>()
     private var latestPublication: PresentationPublication? = null
     private val reuseIndex = ChatPresentationReuseIndex()
     private val presentationSnapshot = ChatPresentationSnapshot()
@@ -159,7 +161,7 @@ class ChatV2RendererController(
     val state: ChatViewportState
         get() = viewport.state
 
-    internal fun currentMessages(): List<ChatMessage> = latestPublication?.messages.orEmpty()
+    internal fun currentMessages(): List<ChatMessage> = latestMessages.toList()
     internal fun currentRows(): List<ChatRowUiModel> = latestRows
 
     fun attach(owner: LifecycleOwner) {
@@ -210,7 +212,8 @@ class ChatV2RendererController(
         }
         recyclerView.adapter = null
         adapter.dispose()
-        latestRows = emptyList()
+        latestMessages.clear()
+        latestRows.clear()
         previousIds.clear()
         hasPreviousIds = false
         previousTailId = null
@@ -246,35 +249,39 @@ class ChatV2RendererController(
     fun setTranslateAllMessages(enabled: Boolean) {
         if (translateAllMessages == enabled) return
         translateAllMessages = enabled
-        if (enabled) latestPublication?.let { requestTranslations(it.messages) }
+        if (enabled) requestTranslations(latestMessages)
     }
 
     /** Recompiles the current snapshot after an external presentation-only update. */
     fun invalidatePresentation() {
         val publication = latestPublication ?: return
         val owner = lifecycleOwner ?: return
+        val currentMessages = latestMessages.toList()
         presentation.invalidate()
         styleRefreshJob?.cancel()
         styleRefreshJob = owner.lifecycleScope.launch {
-            val compiled = compileCurrent(publication)
+            val compiled = compileCurrent(publication, fullMessages = currentMessages)
             val rows = compiled.result.rows
             withContext(Dispatchers.Main.immediate) {
                 if (!rendererVisible.value || latestPublication !== publication) return@withContext
                 val uiChanged = !sameRows(latestRows, rows)
-                latestRows = rows
-                reuseIndex.replace(publication.messages, rows)
+                latestRows.clear()
+                latestRows.addAll(rows)
+                reuseIndex.replace(currentMessages, rows)
                 ChatRenderDiagnostics.recordReuseIndexUpdate(incremental = false)
                 ChatRenderDiagnostics.recordPublication(
-                    messageCount = publication.messages.size,
+                    messageCount = currentMessages.size,
                     changed = compiled.result.messagesChanged,
                     compiled = compiled.result.rowsCompiled,
                     reused = compiled.result.rowsReused,
+                    visited = compiled.result.rowsVisited,
+                    allocated = compiled.result.rowsAllocated,
                     compileNanos = compiled.durationNanos,
                     fullRebuild = compiled.fullRebuild,
                     uiChanged = uiChanged,
                 )
                 if (uiChanged) {
-                    onPublicationChanged(publication.messages, rows)
+                    onPublicationChanged(currentMessages, rows)
                     adapter.submitList(rows)
                 }
             }
@@ -290,88 +297,155 @@ class ChatV2RendererController(
         if (!rendererVisible.value) return
         val previousPublication = latestPublication
         val previousRows = latestRows
+        val previousMessageCount = latestMessages.size
         withContext(Dispatchers.Main.immediate) {
             if (!rendererVisible.value) return@withContext
             latestPublication = publication
         }
         styleRefreshJob?.cancel()
-        val compiled = compileCurrent(publication, previousPublication)
+        var preparedPublication = materializeFullPublicationIfNeeded(
+            publication = publication,
+            previousPublication = previousPublication,
+            previousRows = previousRows,
+            previousMessageCount = previousMessageCount,
+        )
+        var fullMessages = preparedPublication.messages.takeIf {
+            preparedPublication.timelineDelta !is ChatTimelineDelta.Append
+        }
+        var compiled = compileCurrent(
+            publication = preparedPublication,
+            previousPublication = previousPublication,
+            previousRows = previousRows,
+            previousMessageCount = previousMessageCount,
+            fullMessages = fullMessages,
+        )
+        if (fullMessages == null && compiled.appendInfo == null) {
+            preparedPublication = preparedPublication.copy(
+                messages = preparedPublication.fullSnapshot(),
+                timelineDelta = ChatTimelineDelta.Full,
+            )
+            fullMessages = preparedPublication.messages
+            compiled = compileCurrent(
+                publication = preparedPublication,
+                previousPublication = previousPublication,
+                previousRows = previousRows,
+                previousMessageCount = previousMessageCount,
+                fullMessages = fullMessages,
+            )
+        }
         val rows = compiled.result.rows
         if (!rendererVisible.value) return
         withContext(Dispatchers.Main.immediate) {
             if (!rendererVisible.value) return@withContext
             if (latestPublication !== publication) return@withContext
-            if (currentKey != publication.key) {
+            latestPublication = preparedPublication
+            if (currentKey != preparedPublication.key) {
                 if (currentKey != null) viewport.resetForNewSession()
-                currentKey = publication.key
+                currentKey = preparedPublication.key
                 hasPreviousIds = false
                 previousIds.clear()
                 previousTailId = null
                 reuseIndex.clear()
             }
-            latestPublication = publication
-            requestTranslations(publication.messages)
+            val delta = compiled.appendInfo?.let {
+                preparedPublication.timelineDelta as? ChatTimelineDelta.Append
+            }
+            val currentMessages = fullMessages
+            requestTranslations(delta?.messages ?: currentMessages.orEmpty())
             val oldIds = previousIds
             val previousAnchor = if (!hasPreviousIds) null else viewport.captureAnchor(adapter)
             // Reconciliation can insert older messages into the middle/front of the timeline.
             // Only messages newer than the previous tail are live appends.
-            val appendedCount = countNewLiveMessages(
+            val appendInfo = compiled.appendInfo ?: previousPublication
+                ?.takeIf { it.key == preparedPublication.key }
+                ?.let { currentMessages?.let { messages -> findChatAppendInfo(latestMessages, messages) } }
+            val appendedCount = compiled.appendInfo?.appendedCount ?: countNewLiveMessages(
                 oldIds.takeIf { hasPreviousIds },
                 previousTailId,
-                publication.messages,
+                currentMessages.orEmpty(),
             )
-            val appendInfo = previousPublication
-                ?.takeIf { it.key == publication.key }
-                ?.let { findChatAppendInfo(it.messages, publication.messages) }
             if (appendInfo != null && hasPreviousIds) {
                 repeat(appendInfo.evictedCount) {
-                    previousPublication.messages.getOrNull(it)?.id?.let(previousIds::remove)
+                    latestMessages.getOrNull(it)?.id?.let(previousIds::remove)
                 }
-                publication.messages.takeLast(appendInfo.appendedCount).forEach { previousIds += it.id }
+                (delta?.messages ?: currentMessages.orEmpty().takeLast(appendInfo.appendedCount))
+                    .forEach { previousIds += it.id }
             } else {
                 previousIds.clear()
-                publication.messages.forEach { previousIds += it.id }
+                currentMessages.orEmpty().forEach { previousIds += it.id }
             }
             hasPreviousIds = true
-            previousTailId = publication.messages.lastOrNull()?.id
-            latestRows = rows
-            val incrementallyUpdated = appendInfo?.let {
-                reuseIndex.append(
-                    messages = publication.messages,
-                    rows = rows,
-                    appendedCount = it.appendedCount,
-                    evictedCount = it.evictedCount,
+            val incrementallyUpdated = if (delta != null) {
+                reuseIndex.appendDelta(
+                    appendedMessages = delta.messages,
+                    appendedRows = rows,
+                    evictedCount = delta.evictedCount,
+                    expectedSize = delta.resultingSize,
                 )
-            } == true
-            if (!incrementallyUpdated) {
-                reuseIndex.replace(publication.messages, rows)
+            } else {
+                appendInfo?.let {
+                    reuseIndex.append(
+                        messages = requireNotNull(currentMessages),
+                        rows = rows,
+                        appendedCount = it.appendedCount,
+                        evictedCount = it.evictedCount,
+                    )
+                } == true
             }
+            if (!incrementallyUpdated) reuseIndex.replace(requireNotNull(currentMessages), rows)
             ChatRenderDiagnostics.recordReuseIndexUpdate(incrementallyUpdated)
-            val uiChanged = !sameRows(previousRows, rows)
+            val uiChanged: Boolean
+            if (delta != null) {
+                latestRows.subList(0, delta.evictedCount).clear()
+                latestRows.addAll(rows)
+                uiChanged = delta.evictedCount > 0 || rows.isNotEmpty()
+            } else {
+                uiChanged = !sameRows(previousRows, rows)
+                latestRows.clear()
+                latestRows.addAll(rows)
+            }
+            if (delta != null) {
+                repeat(delta.evictedCount) { latestMessages.removeFirst() }
+                latestMessages.addAll(delta.messages)
+            } else {
+                latestMessages.clear()
+                latestMessages.addAll(requireNotNull(currentMessages))
+            }
+            previousTailId = latestMessages.lastOrNull()?.id
             ChatRenderDiagnostics.recordPublication(
-                messageCount = publication.messages.size,
+                messageCount = latestMessages.size,
                 changed = compiled.result.messagesChanged,
                 compiled = compiled.result.rowsCompiled,
                 reused = compiled.result.rowsReused,
+                visited = compiled.result.rowsVisited,
+                allocated = compiled.result.rowsAllocated,
                 compileNanos = compiled.durationNanos,
                 fullRebuild = compiled.fullRebuild,
                 uiChanged = uiChanged,
             )
             if (uiChanged) {
-                onPublicationChanged(publication.messages, rows)
-                val appliedIncrementally = appendInfo?.let {
-                    adapter.append(
-                        newRows = rows,
-                        evictedHeadCount = it.evictedCount,
-                        appendedCount = it.appendedCount,
+                onPublicationChanged(latestMessages, latestRows)
+                val appliedIncrementally = if (delta != null) {
+                    adapter.appendDelta(
+                        appendedRows = rows,
+                        evictedHeadCount = delta.evictedCount,
+                        expectedSize = delta.resultingSize,
                     )
-                } == true
+                } else {
+                    appendInfo?.let {
+                        adapter.append(
+                            newRows = rows,
+                            evictedHeadCount = it.evictedCount,
+                            appendedCount = it.appendedCount,
+                        )
+                    } == true
+                }
                 if (appliedIncrementally) {
-                    viewport.onSnapshotCommitted(previousAnchor, rows, appendedCount)
+                    viewport.onSnapshotCommitted(previousAnchor, latestRows, appendedCount)
                     onStateChanged(viewport.state)
                 } else {
-                    adapter.submitList(rows) {
-                        viewport.onSnapshotCommitted(previousAnchor, rows, appendedCount)
+                    adapter.submitList(latestRows) {
+                        viewport.onSnapshotCommitted(previousAnchor, latestRows, appendedCount)
                         onStateChanged(viewport.state)
                     }
                 }
@@ -379,15 +453,59 @@ class ChatV2RendererController(
         }
     }
 
+    private suspend fun materializeFullPublicationIfNeeded(
+        publication: PresentationPublication,
+        previousPublication: PresentationPublication?,
+        previousRows: List<ChatRowUiModel>,
+        previousMessageCount: Int,
+    ): PresentationPublication {
+        if (publication.timelineDelta !is ChatTimelineDelta.Append ||
+            canApplyTimelineAppend(publication, previousPublication, previousRows, previousMessageCount)
+        ) {
+            return publication
+        }
+        return publication.copy(
+            messages = publication.fullSnapshot(),
+            timelineDelta = ChatTimelineDelta.Full,
+        )
+    }
+
+    private fun canApplyTimelineAppend(
+        publication: PresentationPublication,
+        previousPublication: PresentationPublication?,
+        previousRows: List<ChatRowUiModel>,
+        previousMessageCount: Int,
+    ): Boolean {
+        val delta = publication.timelineDelta as? ChatTimelineDelta.Append ?: return false
+        val forceCatalogUpgrade = previousPublication?.let { previous ->
+            publication.forceRefreshRevision != previous.forceRefreshRevision
+        } == true
+        val metadataSettlementChanged = previousPublication?.metadataSettlement !=
+            publication.metadataSettlement
+        return previousPublication != null &&
+            previousPublication.key == publication.key &&
+            publication.timelineVersion > previousPublication.timelineVersion &&
+            !forceCatalogUpgrade &&
+            !metadataSettlementChanged &&
+            previousRows.size == previousMessageCount &&
+            reuseIndex.size == previousMessageCount &&
+            delta.evictedCount <= previousMessageCount &&
+            delta.resultingSize == previousMessageCount - delta.evictedCount + delta.messages.size
+    }
+
     private data class CompiledRows(
         val result: ChatRowCompileResult,
         val durationNanos: Long,
         val fullRebuild: Boolean,
+        val appendInfo: ChatAppendInfo? = null,
     )
 
     private suspend fun compileCurrent(
         publication: PresentationPublication,
         previousPublication: PresentationPublication? = null,
+        previousRows: List<ChatRowUiModel> = latestRows,
+        previousMessageCount: Int = latestMessages.size,
+        fullMessages: List<ChatMessage>? = publication.messages,
     ): CompiledRows {
         val startedAt = SystemClock.elapsedRealtimeNanos()
         while (true) {
@@ -395,9 +513,6 @@ class ChatV2RendererController(
             val forceCatalogUpgrade = previousPublication?.let { previous ->
                 publication.forceRefreshRevision != previous.forceRefreshRevision
             } == true
-            val appendInfo = previousPublication
-                ?.takeIf { it.key == publication.key && !forceCatalogUpgrade }
-                ?.let { findChatAppendInfo(it.messages, publication.messages) }
             val metadataSettlementChanged = previousPublication?.metadataSettlement !=
                     publication.metadataSettlement
             val reusablePublication = previousPublication?.takeIf {
@@ -405,27 +520,65 @@ class ChatV2RendererController(
                         !metadataSettlementChanged &&
                         it.key == publication.key
             }
-            val catalogs = presentationSnapshot.catalogsFor(
-                publication.key,
-                publication.messages,
-                publication.catalog,
-                captureBadges = renderStyle.showBadges,
-                structuralSettled = publication.metadataSettlement.structuralSettled,
-                badgesSettled = publication.metadataSettlement.badgesSettled,
-                rewardsSettled = publication.metadataSettlement.rewardsSettled,
-                forceUpgrade = forceCatalogUpgrade,
-                appendOnly = reusablePublication != null && appendInfo != null,
-                appendedCount = appendInfo?.appendedCount ?: 0,
-                evictedCount = appendInfo?.evictedCount ?: 0,
-            )
+            val timelineAppend = publication.timelineDelta as? ChatTimelineDelta.Append
+            val appendInfo = timelineAppend
+                ?.takeIf { delta ->
+                    canApplyTimelineAppend(
+                        publication = publication,
+                        previousPublication = previousPublication,
+                        previousRows = previousRows,
+                        previousMessageCount = previousMessageCount,
+                    ) && delta.resultingSize == previousMessageCount - delta.evictedCount + delta.messages.size
+                }
+                ?.let { delta -> ChatAppendInfo(delta.messages.size, delta.evictedCount) }
+            val appendCatalogs = appendInfo?.let {
+                val delta = requireNotNull(timelineAppend)
+                if (delta.messages.isEmpty() && delta.evictedCount == 0) {
+                    emptyList()
+                } else {
+                    presentationSnapshot.catalogsForAppend(
+                        key = publication.key,
+                        appendedMessages = delta.messages,
+                        evictedCount = delta.evictedCount,
+                        newMessageCount = delta.resultingSize,
+                        catalog = publication.catalog,
+                        captureBadges = renderStyle.showBadges,
+                        structuralSettled = publication.metadataSettlement.structuralSettled,
+                        badgesSettled = publication.metadataSettlement.badgesSettled,
+                        rewardsSettled = publication.metadataSettlement.rewardsSettled,
+                    )
+                }
+            }
             val rows = withContext(Dispatchers.Default) {
                 if (BuildConfig.PERF_DIAGNOSTICS) Trace.beginSection("Xtra.ChatV2.compileCurrent")
                 try {
-                    compileChatRows(
-                        messages = publication.messages,
-                        reuseIndex = reuseIndex.takeIf { reusablePublication != null },
-                        resolve = { message, index -> compiler.resolve(message, catalogs[index]) },
-                    )
+                    if (appendInfo != null && appendCatalogs != null) {
+                        val delta = requireNotNull(timelineAppend)
+                        val startIndex = delta.resultingSize - delta.messages.size
+                        compileChatRowAppend(
+                            messages = delta.messages,
+                            startIndex = startIndex,
+                            retainedRows = previousRows.size - delta.evictedCount,
+                            resolve = { message, index -> compiler.resolve(message, appendCatalogs[index - startIndex]) },
+                        )
+                    } else {
+                        val messages = requireNotNull(fullMessages)
+                        val catalogs = presentationSnapshot.catalogsFor(
+                            publication.key,
+                            messages,
+                            publication.catalog,
+                            captureBadges = renderStyle.showBadges,
+                            structuralSettled = publication.metadataSettlement.structuralSettled,
+                            badgesSettled = publication.metadataSettlement.badgesSettled,
+                            rewardsSettled = publication.metadataSettlement.rewardsSettled,
+                            forceUpgrade = forceCatalogUpgrade,
+                        )
+                        compileChatRows(
+                            messages = messages,
+                            reuseIndex = reuseIndex.takeIf { reusablePublication != null },
+                            resolve = { message, index -> compiler.resolve(message, catalogs[index]) },
+                        )
+                    }
                 } finally {
                     if (BuildConfig.PERF_DIAGNOSTICS) Trace.endSection()
                 }
@@ -434,7 +587,8 @@ class ChatV2RendererController(
                 return CompiledRows(
                     result = rows,
                     durationNanos = SystemClock.elapsedRealtimeNanos() - startedAt,
-                    fullRebuild = reusablePublication == null,
+                    fullRebuild = appendInfo == null && reusablePublication == null,
+                    appendInfo = appendInfo?.takeIf { appendCatalogs != null },
                 )
             }
         }
@@ -513,6 +667,9 @@ class ChatV2RendererController(
                 PresentationPublication(
                     key,
                     snapshot.messages,
+                    fullSnapshot = session::snapshot,
+                    timelineVersion = snapshot.version,
+                    timelineDelta = snapshot.delta,
                     metadataSettlement = ChatMetadataSettlement(
                         structuralSettled = catalogState.structuralCatalogSettled,
                         badgesSettled = !renderStyle.showBadges || catalogState.badgesSettled,
@@ -536,6 +693,9 @@ class ChatV2RendererController(
     private data class PresentationPublication(
         val key: com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatSessionKey,
         val messages: List<com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessage>,
+        val fullSnapshot: suspend () -> List<com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessage>,
+        val timelineVersion: Long,
+        val timelineDelta: ChatTimelineDelta?,
         val metadataSettlement: ChatMetadataSettlement,
         val forceRefreshRevision: Long,
         val catalog: com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatCatalogSnapshot,

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/multiview/chat/CombinedChatViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/multiview/chat/CombinedChatViewModel.kt
@@ -12,6 +12,7 @@ import com.github.andreyasadchy.xtra.ui.multiview.CombinedChatPresentationPolicy
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessage
 import com.github.andreyasadchy.xtra.ui.chat.v2.session.ActiveChatSession
 import com.github.andreyasadchy.xtra.ui.chat.v2.session.ChatSessionHandle
+import com.github.andreyasadchy.xtra.ui.chat.v2.session.ChatTimelineDelta
 import com.github.andreyasadchy.xtra.ui.chat.v2.session.LiveChatSessionSpec
 import com.github.andreyasadchy.xtra.util.C
 import com.github.andreyasadchy.xtra.util.prefs
@@ -127,10 +128,24 @@ class CombinedChatViewModel(
 
     private fun observe(session: ChannelSession) {
         session.jobs += ownerScope.launch {
-            // The v2 batcher publishes a complete, ordered snapshot. Keeping one collector per
-            // handle means a second Multiview channel cannot stop or overwrite the first one.
+            // Keeping one collector per handle means a second Multiview channel cannot stop or
+            // overwrite the first one. Append publications are applied to the channel index.
             session.handle.active.session.attachUi().collect { snapshot ->
-                replaceSession(session, snapshot.messages)
+                val delta = snapshot.delta as? ChatTimelineDelta.Append
+                if (delta != null &&
+                    snapshot.version > session.timelineVersion &&
+                    delta.evictedCount <= session.renderedMessages.size &&
+                    delta.resultingSize == session.renderedMessages.size - delta.evictedCount + delta.messages.size
+                ) {
+                    appendSession(session, delta, snapshot.version)
+                } else {
+                    val incoming = if (delta != null && snapshot.messages.isEmpty()) {
+                        session.handle.active.session.snapshot()
+                    } else {
+                        snapshot.messages
+                    }
+                    replaceSession(session, incoming, snapshot.version)
+                }
             }
         }
         session.jobs += ownerScope.launch {
@@ -155,7 +170,37 @@ class CombinedChatViewModel(
         }
     }
 
-    private fun replaceSession(session: ChannelSession, incoming: List<ChatMessage>) {
+    private fun appendSession(
+        session: ChannelSession,
+        delta: ChatTimelineDelta.Append,
+        version: Long,
+    ) {
+        // A removed tile can still have one queued snapshot callback racing with release().
+        // Never let that old channel repopulate the combined timeline after replacement.
+        if (sessions[session.identity] !== session) return
+        synchronized(messages) {
+            if (sessions[session.identity] !== session) return
+            repeat(delta.evictedCount) {
+                val id = session.renderedMessages.keys.firstOrNull() ?: return
+                messages.remove(session.renderedMessages.remove(id))
+            }
+            delta.messages.forEach { message ->
+                val added = CombinedChatMessage(
+                    identity = session.identity,
+                    channelName = displayName(session.stream),
+                    message = message,
+                    sequence = sequence++,
+                )
+                session.renderedMessages[message.id] = added
+                messages.add(added)
+            }
+            session.timelineVersion = version
+            while (messages.size > MAX_MESSAGES) messages.pollFirst()
+        }
+        _updates.tryEmit(Unit)
+    }
+
+    private fun replaceSession(session: ChannelSession, incoming: List<ChatMessage>, version: Long) {
         // A removed tile can still have one queued snapshot callback racing with release().
         // Never let that old channel repopulate the combined timeline after replacement.
         if (sessions[session.identity] !== session) return
@@ -193,6 +238,7 @@ class CombinedChatViewModel(
                 // every subsequent publication.
                 messages.pollFirst()
             }
+            session.timelineVersion = version
         }
         _updates.tryEmit(Unit)
     }
@@ -237,6 +283,7 @@ class CombinedChatViewModel(
         var rewardCatalog: com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatRewardCatalog =
             com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatRewardCatalog()
         val renderedMessages = linkedMapOf<com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessageId, CombinedChatMessage>()
+        var timelineVersion: Long = -1L
 
         fun pause(scope: kotlinx.coroutines.CoroutineScope) {
             if (!networkActive) return
@@ -254,6 +301,7 @@ class CombinedChatViewModel(
             controlJob?.cancel()
             controlJob = null
             renderedMessages.clear()
+            timelineVersion = -1L
             handle.closeAsync()
         }
 

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/ChatRenderDiagnostics.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/ChatRenderDiagnostics.kt
@@ -17,6 +17,10 @@ internal data class ChatRenderDiagnosticsSnapshot(
     val messagesChanged: Long,
     val rowsCompiled: Long,
     val rowsReused: Long,
+    val rowsVisited: Long,
+    val rowsAllocated: Long,
+    val timelineRowsVisited: Long,
+    val timelineRowsAllocated: Long,
     val compileCurrentNanos: Long,
     val fullPresentationRebuilds: Long,
     val incrementalReuseIndexUpdates: Long,
@@ -48,6 +52,8 @@ internal data class ChatRenderDiagnosticsSnapshot(
             "activeAnimations=$activeAnimations publications=$publications " +
             "publicationMessages=$publicationMessages maxPublicationMessages=$maxPublicationMessages " +
             "messagesChanged=$messagesChanged rowsCompiled=$rowsCompiled rowsReused=$rowsReused " +
+            "rowsVisited=$rowsVisited rowsAllocated=$rowsAllocated " +
+            "timelineRowsVisited=$timelineRowsVisited timelineRowsAllocated=$timelineRowsAllocated " +
             "compileCurrentNanos=$compileCurrentNanos fullPresentationRebuilds=$fullPresentationRebuilds " +
             "incrementalReuseIndexUpdates=$incrementalReuseIndexUpdates " +
             "fullReuseIndexRebuilds=$fullReuseIndexRebuilds " +
@@ -78,6 +84,10 @@ internal object ChatRenderDiagnostics {
     private val messagesChanged = AtomicLong()
     private val rowsCompiled = AtomicLong()
     private val rowsReused = AtomicLong()
+    private val rowsVisited = AtomicLong()
+    private val rowsAllocated = AtomicLong()
+    private val timelineRowsVisited = AtomicLong()
+    private val timelineRowsAllocated = AtomicLong()
     private val compileCurrentNanos = AtomicLong()
     private val fullPresentationRebuilds = AtomicLong()
     private val incrementalReuseIndexUpdates = AtomicLong()
@@ -134,6 +144,8 @@ internal object ChatRenderDiagnostics {
         changed: Int,
         compiled: Int,
         reused: Int,
+        visited: Int,
+        allocated: Int,
         compileNanos: Long,
         fullRebuild: Boolean,
         uiChanged: Boolean,
@@ -145,6 +157,8 @@ internal object ChatRenderDiagnostics {
         messagesChanged.addAndGet(changed.toLong())
         rowsCompiled.addAndGet(compiled.toLong())
         rowsReused.addAndGet(reused.toLong())
+        rowsVisited.addAndGet(visited.toLong())
+        rowsAllocated.addAndGet(allocated.toLong())
         compileCurrentNanos.addAndGet(compileNanos)
         if (fullRebuild) fullPresentationRebuilds.incrementAndGet()
         if (!uiChanged) unchangedPublications.incrementAndGet()
@@ -154,6 +168,12 @@ internal object ChatRenderDiagnostics {
         if (!BuildConfig.PERF_DIAGNOSTICS) return
         if (incremental) incrementalReuseIndexUpdates.incrementAndGet()
         else fullReuseIndexRebuilds.incrementAndGet()
+    }
+
+    fun recordTimelineSnapshot(visited: Int, allocated: Int) {
+        if (!BuildConfig.PERF_DIAGNOSTICS) return
+        timelineRowsVisited.addAndGet(visited.toLong())
+        timelineRowsAllocated.addAndGet(allocated.toLong())
     }
 
     fun recordCatalogIndexUpdate(incremental: Boolean) {
@@ -234,6 +254,10 @@ internal object ChatRenderDiagnostics {
         messagesChanged = messagesChanged.getAndSet(0),
         rowsCompiled = rowsCompiled.getAndSet(0),
         rowsReused = rowsReused.getAndSet(0),
+        rowsVisited = rowsVisited.getAndSet(0),
+        rowsAllocated = rowsAllocated.getAndSet(0),
+        timelineRowsVisited = timelineRowsVisited.getAndSet(0),
+        timelineRowsAllocated = timelineRowsAllocated.getAndSet(0),
         compileCurrentNanos = compileCurrentNanos.getAndSet(0),
         fullPresentationRebuilds = fullPresentationRebuilds.getAndSet(0),
         incrementalReuseIndexUpdates = incrementalReuseIndexUpdates.getAndSet(0),

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatPresentationReuseTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatPresentationReuseTest.kt
@@ -9,6 +9,7 @@ import com.github.andreyasadchy.xtra.ui.chat.v2.presentation.ChatRowUiModel
 import com.github.andreyasadchy.xtra.ui.chat.v2.ui.ChatPresentationReuseIndex
 import com.github.andreyasadchy.xtra.ui.chat.v2.ui.ChatAppendInfo
 import com.github.andreyasadchy.xtra.ui.chat.v2.ui.compileChatRows
+import com.github.andreyasadchy.xtra.ui.chat.v2.ui.compileChatRowAppend
 import com.github.andreyasadchy.xtra.ui.chat.v2.ui.findChatAppendInfo
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertSame
@@ -16,6 +17,23 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class ChatPresentationReuseTest {
+    @Test
+    fun appendCompilationVisitsAndAllocatesOnlyTheAppendedRows() {
+        val appended = listOf(message(600), message(601))
+        val result = compileChatRowAppend(
+            messages = appended,
+            startIndex = 600,
+            retainedRows = 600,
+            resolve = { message, _ -> row(message) },
+        )
+
+        assertEquals(2, result.rowsVisited)
+        assertEquals(2, result.rowsAllocated)
+        assertEquals(2, result.rowsCompiled)
+        assertEquals(600, result.rowsReused)
+        assertEquals(appended.map { it.id }, result.rows.map { it.id })
+    }
+
     @Test
     fun normalAppendCompilesOnlyTheChangedRow() {
         val previous = (0 until 600).map(::message)

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatTimelineArchitectureTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatTimelineArchitectureTest.kt
@@ -7,6 +7,7 @@ import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessageKind
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatModerationDisplayMode
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatUserClearReason
 import com.github.andreyasadchy.xtra.ui.chat.v2.session.ChatEventProcessor
+import com.github.andreyasadchy.xtra.ui.chat.v2.session.ChatTimelineDelta
 import com.github.andreyasadchy.xtra.ui.chat.v2.session.ChatTimelineStore
 import com.github.andreyasadchy.xtra.ui.chat.v2.transport.TwitchChatEventParser
 import kotlinx.coroutines.CoroutineScope
@@ -19,9 +20,45 @@ import kotlinx.coroutines.runBlocking
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class ChatTimelineArchitectureTest {
+    @Test
+    fun appendDeltasAreRepeatableForIndependentUiCollectors() = runBlocking {
+        val scope = CoroutineScope(Dispatchers.Default)
+        val store = ChatTimelineStore(scope, maxSize = 2)
+        val baseline = store.versionedSnapshot()
+
+        store.apply(com.github.andreyasadchy.xtra.ui.chat.v2.session.TimelineOperation.Append(listOf(message(1), message(2))))
+        val first = store.versionedSnapshotAfter(baseline.version)
+        val second = store.versionedSnapshotAfter(baseline.version)
+        val firstDelta = first.delta
+        val secondDelta = second.delta
+        assertTrue(firstDelta is ChatTimelineDelta.Append)
+        assertEquals(firstDelta, secondDelta)
+        assertEquals(listOf("1", "2"), (firstDelta as ChatTimelineDelta.Append).messages.map { it.id.value })
+        assertTrue(first.messages.isEmpty())
+        assertEquals(2, firstDelta.resultingSize)
+
+        store.apply(com.github.andreyasadchy.xtra.ui.chat.v2.session.TimelineOperation.Append(listOf(message(3))))
+        val tail = store.versionedSnapshotAfter(first.version)
+        assertEquals(ChatTimelineDelta.Append(listOf(message(3)), 1, 2), tail.delta)
+        assertTrue(tail.messages.isEmpty())
+
+        store.apply(
+            com.github.andreyasadchy.xtra.ui.chat.v2.session.TimelineOperation.Delete(
+                id = ChatMessageId("2"),
+                atMs = 4,
+                displayMode = ChatModerationDisplayMode.HIDE,
+            ),
+        )
+        val full = store.versionedSnapshotAfter(tail.version)
+        assertEquals(ChatTimelineDelta.Full, full.delta)
+        assertEquals(listOf("3"), full.messages.map { it.id.value })
+        scope.cancel()
+    }
+
     @Test
     fun processorKeepsOrderAndDeduplicatesDelivery() = runBlocking {
         val scope = CoroutineScope(Dispatchers.Default)


### PR DESCRIPTION
Live chat append publications now carry only appended messages, evicted count, and resulting size. The v2 renderer and Multiview keep their own message windows and apply those deltas. Initial loads, moderation, history, reconnects, and catalog changes still use a full snapshot. Debug diagnostics now report timeline rows visited and allocated, alongside presentation rows. Batching remains at 16 ms.

Verified with the full JVM test suite, debug and Android-test builds, and the existing adapter test on emulator-5554. The exact indegnasen0706 broadcast was a recorded segment during the run, so no live-v2 workload result is claimed.