### PR TITLE
Fix live chat snapshot contract tests

### DIFF
--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatSessionManagerIntegrationTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatSessionManagerIntegrationTest.kt
@@ -10,26 +10,32 @@ import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatEvent
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessage
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessageId
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessageKind
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatModerationDisplayMode
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatSessionKey
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatUser
 import com.github.andreyasadchy.xtra.ui.chat.v2.session.ChatSessionManager
 import com.github.andreyasadchy.xtra.ui.chat.v2.session.ChatSessionFactory
+import com.github.andreyasadchy.xtra.ui.chat.v2.session.ChatTimelineDelta
 import com.github.andreyasadchy.xtra.ui.chat.v2.session.LiveChatSessionSpec
 import com.github.andreyasadchy.xtra.ui.chat.v2.transport.ChatTransport
+import com.github.andreyasadchy.xtra.ui.chat.v2.session.VersionedTimelineSnapshot
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CopyOnWriteArrayList
@@ -155,12 +161,235 @@ class ChatSessionManagerIntegrationTest {
         withTimeout(1_000) { while (transport.activeCollectors != 1) delay(1) }
         repeat(500) { transport.send(active.key, message(it)) }
 
-        val snapshot = withTimeout(2_000) {
-            active.session.attachUi().first { it.messages.lastOrNull()?.id?.value == "499" }
+        val canonical = withTimeout(2_000) {
+            var result: List<ChatMessage>? = null
+            while (result == null) {
+                val current = active.session.snapshot()
+                if (current.lastOrNull()?.id?.value == "499") result = current
+                else delay(1)
+            }
+            checkNotNull(result)
         }
-        assertEquals((0 until 500).map(Int::toString), snapshot.messages.map { it.id.value })
+        assertEquals((0 until 500).map(Int::toString), canonical.map { it.id.value })
+
+        // There is deliberately no UI collector while the transport fills the canonical tail.
+        assertEquals(1, transport.activeCollectors)
+        val publication = withTimeout(2_000) { active.session.attachUi().first() }
+        assertEquals(null, publication.delta)
+        assertEquals((0 until 500).map(Int::toString), publication.messages.map { it.id.value })
+
+        manager.close()
+        withTimeout(1_000) { while (transport.activeCollectors != 0) delay(1) }
+        parent.cancel()
+    }
+
+    @Test
+    fun uiCollectorReconstructsBacklogFromAppendDeltas() = runBlocking {
+        val parent = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val gate = MessageDeliveryGate(blockAfterMessages = 1)
+        val transport = FakeTransport(gate)
+        val manager = ChatSessionManager(
+            parentScope = parent,
+            transportFactory = { transport },
+            catalogFactory = { _, scope -> ChatCatalogRepository(scope, EMPTY_CATALOG_SOURCE) },
+            maxTimelineSize = 600,
+        )
+        val active = manager.start(LiveChatSessionSpec("channel-id", "channel-login"))
+        withTimeout(1_000) { while (transport.activeCollectors != 1) delay(1) }
+
+        val sender = launch {
+            repeat(500) { transport.send(active.key, message(it)) }
+        }
+        withTimeout(1_000) { gate.blocked.await() }
+        withTimeout(1_000) { sender.join() }
+
+        val local = ArrayDeque<ChatMessage>()
+        val initial = CompletableDeferred<VersionedTimelineSnapshot>()
+        val complete = CompletableDeferred<Unit>()
+        val appendPublications = AtomicInteger()
+        val collector = launch {
+            active.session.attachUi().collect { publication ->
+                when (val delta = publication.delta) {
+                    null -> {
+                        local.clear()
+                        local.addAll(publication.messages)
+                        initial.complete(publication)
+                    }
+                    ChatTimelineDelta.Full -> {
+                        local.clear()
+                        local.addAll(publication.messages)
+                    }
+                    is ChatTimelineDelta.Append -> {
+                        assertTrue(publication.messages.isEmpty())
+                        repeat(delta.evictedCount) { local.removeFirst() }
+                        local.addAll(delta.messages)
+                        assertEquals(delta.resultingSize, local.size)
+                        appendPublications.incrementAndGet()
+                    }
+                }
+                if (local.map { it.id.value } == (0 until 500).map(Int::toString)) {
+                    complete.complete(Unit)
+                }
+            }
+        }
+
+        val initialPublication = withTimeout(2_000) { initial.await() }
+        assertEquals(null, initialPublication.delta)
+        gate.release.complete(Unit)
+        withTimeout(5_000) { complete.await() }
+
+        assertEquals((0 until 500).map(Int::toString), local.map { it.id.value })
+        assertTrue(appendPublications.get() > 0)
+
+        collector.cancelAndJoin()
+        manager.close()
+        withTimeout(1_000) { while (transport.activeCollectors != 0) delay(1) }
+        parent.cancel()
+    }
+
+    @Test
+    fun uiCollectorAppliesHeadEvictionWhileCatchingUp() = runBlocking {
+        val parent = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val transport = FakeTransport()
+        val manager = ChatSessionManager(
+            parentScope = parent,
+            transportFactory = { transport },
+            catalogFactory = { _, scope -> ChatCatalogRepository(scope, EMPTY_CATALOG_SOURCE) },
+            maxTimelineSize = 3,
+        )
+        val active = manager.start(LiveChatSessionSpec("channel-id", "channel-login"))
+        withTimeout(1_000) { while (transport.activeCollectors != 1) delay(1) }
+        repeat(3) { transport.send(active.key, message(it)) }
+        awaitLast(active.session, "2")
+
+        val local = ArrayDeque<ChatMessage>()
+        val initial = CompletableDeferred<Unit>()
+        val complete = CompletableDeferred<Unit>()
+        var evicted = 0
+        val collector = launch {
+            active.session.attachUi().collect { publication ->
+                when (val delta = publication.delta) {
+                    null -> {
+                        local.clear()
+                        local.addAll(publication.messages)
+                        initial.complete(Unit)
+                    }
+                    ChatTimelineDelta.Full -> {
+                        local.clear()
+                        local.addAll(publication.messages)
+                    }
+                    is ChatTimelineDelta.Append -> {
+                        assertTrue(publication.messages.isEmpty())
+                        repeat(delta.evictedCount) { local.removeFirst() }
+                        local.addAll(delta.messages)
+                        evicted += delta.evictedCount
+                        assertEquals(delta.resultingSize, local.size)
+                    }
+                }
+                if (local.map { it.id.value } == listOf("3", "4", "5")) complete.complete(Unit)
+            }
+        }
+        withTimeout(2_000) { initial.await() }
+        (3..5).forEach { transport.send(active.key, message(it)) }
+        withTimeout(2_000) { complete.await() }
+
+        assertEquals(listOf("3", "4", "5"), local.map { it.id.value })
+        assertEquals(3, evicted)
+
+        collector.cancelAndJoin()
+        manager.close()
+        withTimeout(1_000) { while (transport.activeCollectors != 0) delay(1) }
+        parent.cancel()
+    }
+
+    @Test
+    fun reattachingUiGetsCanonicalTailAfterDetachedMessages() = runBlocking {
+        val parent = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val transport = FakeTransport()
+        val manager = ChatSessionManager(
+            parentScope = parent,
+            transportFactory = { transport },
+            catalogFactory = { _, scope -> ChatCatalogRepository(scope, EMPTY_CATALOG_SOURCE) },
+            maxTimelineSize = 5,
+        )
+        val active = manager.start(LiveChatSessionSpec("channel-id", "channel-login"))
+        withTimeout(1_000) { while (transport.activeCollectors != 1) delay(1) }
+
+        val first = withTimeout(2_000) { active.session.attachUi().first() }
+        assertEquals(null, first.delta)
+        repeat(8) { transport.send(active.key, message(it)) }
+        val canonical = awaitLast(active.session, "7")
+        assertEquals(listOf("3", "4", "5", "6", "7"), canonical.map { it.id.value })
         assertEquals(1, transport.activeCollectors)
 
+        val reattached = withTimeout(2_000) { active.session.attachUi().first() }
+        assertEquals(null, reattached.delta)
+        assertEquals(canonical.map { it.id.value }, reattached.messages.map { it.id.value })
+
+        manager.close()
+        withTimeout(1_000) { while (transport.activeCollectors != 0) delay(1) }
+        parent.cancel()
+    }
+
+    @Test
+    fun moderationFullPublicationReplacesLocalWindowAfterAppendDeltas() = runBlocking {
+        val parent = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val transport = FakeTransport()
+        val manager = ChatSessionManager(
+            parentScope = parent,
+            transportFactory = { transport },
+            catalogFactory = { _, scope -> ChatCatalogRepository(scope, EMPTY_CATALOG_SOURCE) },
+        )
+        val active = manager.start(LiveChatSessionSpec("channel-id", "channel-login"))
+        withTimeout(1_000) { while (transport.activeCollectors != 1) delay(1) }
+
+        val local = ArrayDeque<ChatMessage>()
+        val initial = CompletableDeferred<Unit>()
+        val appended = CompletableDeferred<Unit>()
+        val full = CompletableDeferred<VersionedTimelineSnapshot>()
+        val collector = launch {
+            active.session.attachUi().collect { publication ->
+                when (val delta = publication.delta) {
+                    null -> {
+                        local.clear()
+                        local.addAll(publication.messages)
+                        initial.complete(Unit)
+                    }
+                    ChatTimelineDelta.Full -> {
+                        local.clear()
+                        local.addAll(publication.messages)
+                        full.complete(publication)
+                    }
+                    is ChatTimelineDelta.Append -> {
+                        assertTrue(publication.messages.isEmpty())
+                        repeat(delta.evictedCount) { local.removeFirst() }
+                        local.addAll(delta.messages)
+                        assertEquals(delta.resultingSize, local.size)
+                        if (local.map { it.id.value } == (0 until 5).map(Int::toString)) {
+                            appended.complete(Unit)
+                        }
+                    }
+                }
+            }
+        }
+        withTimeout(2_000) { initial.await() }
+        repeat(5) { transport.send(active.key, message(it)) }
+        withTimeout(2_000) { appended.await() }
+
+        transport.send(
+            active.key,
+            ChatEvent.Delete(
+                messageId = ChatMessageId("2"),
+                eventId = "delete-2",
+                receivedAtMs = 10_000L,
+                displayMode = ChatModerationDisplayMode.HIDE,
+            ),
+        )
+        val fullPublication = withTimeout(2_000) { full.await() }
+        assertEquals(listOf("0", "1", "3", "4"), fullPublication.messages.map { it.id.value })
+        assertEquals(listOf("0", "1", "3", "4"), local.map { it.id.value })
+
+        collector.cancelAndJoin()
         manager.close()
         withTimeout(1_000) { while (transport.activeCollectors != 0) delay(1) }
         parent.cancel()
@@ -328,7 +557,24 @@ class ChatSessionManagerIntegrationTest {
         kind = ChatMessageKind.CHAT,
     )
 
-    private class FakeTransport : ChatTransport {
+    private class MessageDeliveryGate(private val blockAfterMessages: Int) {
+        val blocked = CompletableDeferred<Unit>()
+        val release = CompletableDeferred<Unit>()
+        private var deliveredMessages = 0
+
+        suspend fun after(event: ChatEvent) {
+            if (event !is ChatEvent.Message) return
+            deliveredMessages++
+            if (deliveredMessages == blockAfterMessages) {
+                blocked.complete(Unit)
+                release.await()
+            }
+        }
+    }
+
+    private class FakeTransport(
+        private val deliveryGate: MessageDeliveryGate? = null,
+    ) : ChatTransport {
         private val feeds = ConcurrentHashMap<ChatSessionKey, MutableSharedFlow<ChatEvent>>()
         private val active = AtomicInteger()
         val activeCollectors: Int get() = active.get()
@@ -339,15 +585,20 @@ class ChatSessionManagerIntegrationTest {
             active.incrementAndGet()
             try {
                 feeds.computeIfAbsent(session) { MutableSharedFlow(extraBufferCapacity = 1_024) }
-                    .collect { emit(it) }
+                    .collect {
+                        emit(it)
+                        deliveryGate?.after(it)
+                    }
             } finally {
                 active.decrementAndGet()
             }
         }
 
-        suspend fun send(key: ChatSessionKey, message: ChatMessage) {
+        suspend fun send(key: ChatSessionKey, message: ChatMessage) = send(key, ChatEvent.Message(message))
+
+        suspend fun send(key: ChatSessionKey, event: ChatEvent) {
             feeds.computeIfAbsent(key) { MutableSharedFlow(extraBufferCapacity = 1_024) }
-                .emit(ChatEvent.Message(message))
+                .emit(event)
         }
 
         suspend fun sendDisconnect(key: ChatSessionKey) {


### PR DESCRIPTION
Fix integration tests for append-only chat publications. Cover backlog catch-up, eviction, reattach, and moderation resets.