### PR TITLE
Keep VOD chat replay moving

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatReplayManager.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatReplayManager.kt
@@ -1,5 +1,6 @@
 package com.github.andreyasadchy.xtra.ui.chat
 
+import android.util.Log
 import com.github.andreyasadchy.xtra.model.chat.Badge
 import com.github.andreyasadchy.xtra.model.chat.ChatMessage
 import com.github.andreyasadchy.xtra.model.chat.TwitchEmote
@@ -8,17 +9,31 @@ import com.github.andreyasadchy.xtra.model.gql.video.nextCursor
 import com.github.andreyasadchy.xtra.repository.GraphQLRepository
 import com.github.andreyasadchy.xtra.util.C
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import kotlin.math.max
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Instant
 
-class ChatReplayManager(
+internal data class ChatReplayPage(
+    val messages: List<VideoChatMessage>,
+    val hasNextPage: Boolean,
+    val nextCursor: String?,
+    val boundaryOffsetSeconds: Int? = null,
+)
+
+internal interface ChatReplayPageLoader {
+    suspend fun loadGraphQl(request: ChatReplayPageRequest): ChatReplayPage
+    suspend fun loadLegacy(request: ChatReplayPageRequest): ChatReplayPage
+}
+
+class ChatReplayManager internal constructor(
     private val networkLibrary: String?,
     private val gqlHeaders: Map<String, String>,
     private val graphQLRepository: GraphQLRepository,
@@ -30,16 +45,22 @@ class ChatReplayManager(
     private var getCurrentSpeed: () -> Float?,
     private val coroutineScope: CoroutineScope,
     private val listener: Listener,
+    private val pageLoaderOverride: ChatReplayPageLoader? = null,
 ) {
-    private var cursor: String? = null
+    private val pagination = ChatReplayPagination()
     private val list = mutableListOf<VideoChatMessage>()
     private var started = false
     private var isLoading = false
     private var loadJob: Job? = null
     private var messageJob: Job? = null
+    private var loadGeneration = 0L
     private var lastCheckedPosition = 0L
     private var playbackSpeed: Float? = null
     var isActive = true
+
+    private companion object {
+        const val TAG = "ChatReplayManager"
+    }
 
     fun start() {
         if (!started) {
@@ -47,6 +68,7 @@ class ChatReplayManager(
             val currentPosition = getCurrentPosition() ?: 0
             lastCheckedPosition = currentPosition
             playbackSpeed = getCurrentSpeed()
+            pagination.reset()
             list.clear()
             coroutineScope.launch {
                 listener.clearMessages()
@@ -56,138 +78,243 @@ class ChatReplayManager(
     }
 
     fun stop() {
+        loadGeneration++
         loadJob?.cancel()
         messageJob?.cancel()
+        isLoading = false
         isActive = false
     }
 
     private fun load(position: Long? = null) {
+        val generation = ++loadGeneration
         isLoading = true
-        loadJob = coroutineScope.launch(Dispatchers.IO) {
+        loadJob = coroutineScope.launch {
             try {
-                val response = if (position != null) {
-                    graphQLRepository.loadQueryVideoComments(networkLibrary, gqlHeaders, videoId, offset = position.div(1000).toInt())
-                } else {
-                    graphQLRepository.loadQueryVideoComments(networkLibrary, gqlHeaders, videoId, cursor = cursor)
-                }
-                val comments = response.data!!.video!!.comments!!
-                val messages = comments.edges!!.mapNotNull { comment ->
-                    comment?.node.let { item ->
-                        item?.message?.let { message ->
-                            val chatMessage = StringBuilder()
-                            val emotes = message.fragments?.mapNotNull { fragment ->
-                                fragment?.text?.let { text ->
-                                    fragment.emote?.emoteID?.let { id ->
-                                        TwitchEmote(
-                                            id = id,
-                                            begin = chatMessage.codePointCount(0, chatMessage.length),
-                                            end = chatMessage.codePointCount(0, chatMessage.length) + text.lastIndex
-                                        )
-                                    }.also { chatMessage.append(text) }
-                                }
-                            }
-                            val badges = message.userBadges?.mapNotNull { badge ->
-                                badge?.setID?.let { setId ->
-                                    badge.version?.let { version ->
-                                        Badge(
-                                            setId = setId,
-                                            version = version,
-                                        )
-                                    }
-                                }
-                            }
-                            VideoChatMessage(
-                                id = item.id,
-                                offsetSeconds = item.contentOffsetSeconds,
-                                createdAt = item.createdAt?.toString(),
-                                userId = item.commenter?.id,
-                                userLogin = item.commenter?.login,
-                                userName = item.commenter?.displayName,
-                                message = chatMessage.toString(),
-                                color = message.userColor,
-                                emotes = emotes,
-                                badges = badges,
-                                fullMsg = null
-                            )
-                        }
+                val offsetSeconds = position?.div(1000)?.toInt()
+                val request = pagination.request(offsetSeconds)
+                val loadedPage = try {
+                    ChatReplayPageWithRequest(
+                        request = request,
+                        page = withContext(Dispatchers.IO) {
+                            pageLoaderOverride?.loadGraphQl(request) ?: loadGraphQlPage(request)
+                        },
+                    )
+                } catch (error: CancellationException) {
+                    throw error
+                } catch (error: Exception) {
+                    if (generation != loadGeneration || !this@ChatReplayManager.isActive) return@launch
+                    if (request is ChatReplayPageRequest.Cursor) {
+                        pagination.onCursorFailure()
                     }
+                    val fallbackRequest = pagination.request(offsetSeconds)
+                    ChatReplayPageWithRequest(
+                        request = fallbackRequest,
+                        page = withContext(Dispatchers.IO) {
+                            pageLoaderOverride?.loadLegacy(fallbackRequest)
+                                ?: loadLegacyPage(fallbackRequest)
+                        },
+                    )
                 }
+
+                if (generation != loadGeneration || !this@ChatReplayManager.isActive) return@launch
                 messageJob?.cancel()
-                list.addAll(messages)
-                val edges = comments.edges.orEmpty()
-                cursor = if (comments.pageInfo?.hasNextPage != false) {
-                    edges.asReversed().firstNotNullOfOrNull { edge -> edge?.cursor?.takeIf(String::isNotBlank) }
-                } else null
+                appendPage(loadedPage.request, loadedPage.page)
                 isLoading = false
                 startJob()
-            } catch (e: Exception) {
-                try {
-                    val response = if (position != null) {
-                        graphQLRepository.loadVideoMessages(networkLibrary, gqlHeaders, videoId, offset = position.div(1000).toInt())
-                    } else {
-                        graphQLRepository.loadVideoMessages(networkLibrary, gqlHeaders, videoId, cursor = cursor)
-                    }
-                    val comments = response.data?.video?.comments ?: run {
-                        isLoading = false
-                        return@launch
-                    }
-                    val messages = comments.edges.orEmpty().mapNotNull { comment ->
-                        comment?.node?.let { item ->
-                            item.message?.let { message ->
-                                val chatMessage = StringBuilder()
-                                val emotes = message.fragments?.mapNotNull { fragment ->
-                                    fragment.text?.let { text ->
-                                        fragment.emote?.emoteID?.let { id ->
-                                            TwitchEmote(
-                                                id = id,
-                                                begin = chatMessage.codePointCount(0, chatMessage.length),
-                                                end = chatMessage.codePointCount(0, chatMessage.length) + text.lastIndex
-                                            )
-                                        }.also { chatMessage.append(text) }
-                                    }
-                                }
-                                val badges = message.userBadges?.mapNotNull { badge ->
-                                    badge.setID?.let { setId ->
-                                        badge.version?.let { version ->
-                                            Badge(
-                                                setId = setId,
-                                                version = version,
-                                            )
-                                        }
-                                    }
-                                }
-                                VideoChatMessage(
-                                    id = item.id,
-                                    offsetSeconds = item.contentOffsetSeconds,
-                                    createdAt = item.createdAt,
-                                    userId = item.commenter?.id,
-                                    userLogin = item.commenter?.login,
-                                    userName = item.commenter?.displayName,
-                                    message = chatMessage.toString(),
-                                    color = message.userColor,
-                                    emotes = emotes,
-                                    badges = badges,
-                                    fullMsg = json.encodeToString(item)
-                                )
-                            }
-                        }
-                    }
-                    messageJob?.cancel()
-                    list.addAll(messages)
-                    cursor = if (comments.pageInfo?.hasNextPage != false) comments.nextCursor else null
+            } catch (error: CancellationException) {
+                throw error
+            } catch (_: Exception) {
+                // A failed page will be retried by the next playback-triggered load.
+            } finally {
+                if (generation == loadGeneration) {
                     isLoading = false
-                    startJob()
-                } catch (e: Exception) {
-
                 }
             }
         }
     }
 
+    private data class ChatReplayPageWithRequest(
+        val request: ChatReplayPageRequest,
+        val page: ChatReplayPage,
+    )
+
+    private suspend fun loadGraphQlPage(request: ChatReplayPageRequest): ChatReplayPage {
+        val response = when (request) {
+            ChatReplayPageRequest.Initial -> graphQLRepository.loadQueryVideoComments(
+                networkLibrary,
+                gqlHeaders,
+                videoId,
+            )
+            is ChatReplayPageRequest.Offset -> graphQLRepository.loadQueryVideoComments(
+                networkLibrary,
+                gqlHeaders,
+                videoId,
+                offset = request.seconds,
+            )
+            is ChatReplayPageRequest.Cursor -> graphQLRepository.loadQueryVideoComments(
+                networkLibrary,
+                gqlHeaders,
+                videoId,
+                cursor = request.value,
+            )
+        }
+        val comments = response.data!!.video!!.comments!!
+        val edges = comments.edges.orEmpty()
+        return ChatReplayPage(
+            messages = edges.mapNotNull { comment ->
+                comment?.node.let { item ->
+                    item?.message?.let { message ->
+                        val chatMessage = StringBuilder()
+                        val emotes = message.fragments?.mapNotNull { fragment ->
+                            fragment?.text?.let { text ->
+                                fragment.emote?.emoteID?.let { id ->
+                                    TwitchEmote(
+                                        id = id,
+                                        begin = chatMessage.codePointCount(0, chatMessage.length),
+                                        end = chatMessage.codePointCount(0, chatMessage.length) + text.lastIndex
+                                    )
+                                }.also { chatMessage.append(text) }
+                            }
+                        }
+                        val badges = message.userBadges?.mapNotNull { badge ->
+                            badge?.setID?.let { setId ->
+                                badge.version?.let { version ->
+                                    Badge(
+                                        setId = setId,
+                                        version = version,
+                                    )
+                                }
+                            }
+                        }
+                        VideoChatMessage(
+                            id = item.id,
+                            offsetSeconds = item.contentOffsetSeconds,
+                            createdAt = item.createdAt?.toString(),
+                            userId = item.commenter?.id,
+                            userLogin = item.commenter?.login,
+                            userName = item.commenter?.displayName,
+                            message = chatMessage.toString(),
+                            color = message.userColor,
+                            emotes = emotes,
+                            badges = badges,
+                            fullMsg = null,
+                        )
+                    }
+                }
+            },
+            hasNextPage = comments.pageInfo?.hasNextPage == true,
+            nextCursor = edges.asReversed().firstNotNullOfOrNull { edge ->
+                edge?.cursor?.takeIf(String::isNotBlank)
+            },
+            boundaryOffsetSeconds = edges.asReversed().firstNotNullOfOrNull { edge ->
+                edge?.node?.contentOffsetSeconds
+            },
+        )
+    }
+
+    private suspend fun loadLegacyPage(request: ChatReplayPageRequest): ChatReplayPage {
+        val response = when (request) {
+            ChatReplayPageRequest.Initial -> graphQLRepository.loadVideoMessages(
+                networkLibrary,
+                gqlHeaders,
+                videoId,
+            )
+            is ChatReplayPageRequest.Offset -> graphQLRepository.loadVideoMessages(
+                networkLibrary,
+                gqlHeaders,
+                videoId,
+                offset = request.seconds,
+            )
+            is ChatReplayPageRequest.Cursor -> graphQLRepository.loadVideoMessages(
+                networkLibrary,
+                gqlHeaders,
+                videoId,
+                cursor = request.value,
+            )
+        }
+        val comments = response.data?.video?.comments ?: return ChatReplayPage(emptyList(), false, null)
+        val edges = comments.edges.orEmpty()
+        return ChatReplayPage(
+            messages = edges.mapNotNull { comment ->
+                comment?.node?.let { item ->
+                    item.message?.let { message ->
+                        val chatMessage = StringBuilder()
+                        val emotes = message.fragments?.mapNotNull { fragment ->
+                            fragment.text?.let { text ->
+                                fragment.emote?.emoteID?.let { id ->
+                                    TwitchEmote(
+                                        id = id,
+                                        begin = chatMessage.codePointCount(0, chatMessage.length),
+                                        end = chatMessage.codePointCount(0, chatMessage.length) + text.lastIndex
+                                    )
+                                }.also { chatMessage.append(text) }
+                            }
+                        }
+                        val badges = message.userBadges?.mapNotNull { badge ->
+                            badge.setID?.let { setId ->
+                                badge.version?.let { version ->
+                                    Badge(
+                                        setId = setId,
+                                        version = version,
+                                    )
+                                }
+                            }
+                        }
+                        VideoChatMessage(
+                            id = item.id,
+                            offsetSeconds = item.contentOffsetSeconds,
+                            createdAt = item.createdAt,
+                            userId = item.commenter?.id,
+                            userLogin = item.commenter?.login,
+                            userName = item.commenter?.displayName,
+                            message = chatMessage.toString(),
+                            color = message.userColor,
+                            emotes = emotes,
+                            badges = badges,
+                            fullMsg = json.encodeToString(item),
+                        )
+                    }
+                }
+            },
+            hasNextPage = comments.pageInfo?.hasNextPage == true,
+            nextCursor = comments.nextCursor,
+            boundaryOffsetSeconds = edges.asReversed().firstNotNullOfOrNull { edge ->
+                edge?.node?.contentOffsetSeconds
+            },
+        )
+    }
+
+    private fun appendPage(request: ChatReplayPageRequest, page: ChatReplayPage) {
+        list.addAll(
+            pagination.acceptPage(
+                request = request,
+                messages = page.messages,
+                hasNextPage = page.hasNextPage,
+                nextCursor = page.nextCursor,
+                messageId = VideoChatMessage::id,
+                contentOffsetSeconds = VideoChatMessage::offsetSeconds,
+                pageBoundaryOffsetSeconds = page.boundaryOffsetSeconds,
+                onForcedBoundaryEscape = { fromSeconds, toSeconds ->
+                    Log.w(
+                        TAG,
+                        "Replay offset boundary made no progress at $fromSeconds; " +
+                            "escaping to $toSeconds",
+                    )
+                },
+            )
+        )
+    }
+
     private fun startJob() {
         messageJob = coroutineScope.launch {
             while (isActive) {
-                val message = list.firstOrNull() ?: break
+                val message = list.firstOrNull()
+                if (message == null) {
+                    if (!isLoading && pagination.hasMorePages) {
+                        load()
+                    }
+                    break
+                }
                 val messageOffset = if (createdAt != null && !message.createdAt.isNullOrBlank()) {
                     Instant.parseOrNull(message.createdAt)?.toEpochMilliseconds()?.takeIf { ms -> ms > 0 }?.minus(createdAt)
                 } else {
@@ -222,7 +349,7 @@ class ChatReplayManager(
                             fullMsg = message.fullMsg
                         )
                     )
-                    if (list.size <= 25 && !cursor.isNullOrBlank() && !isLoading) {
+                    if (list.size <= 25 && pagination.hasMorePages && !isLoading) {
                         load()
                     }
                 } else {
@@ -241,6 +368,7 @@ class ChatReplayManager(
                 loadJob?.cancel()
                 messageJob?.cancel()
                 list.clear()
+                pagination.resetWindow()
                 coroutineScope.launch {
                     listener.clearMessages()
                 }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatReplayPagination.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatReplayPagination.kt
@@ -1,0 +1,147 @@
+package com.github.andreyasadchy.xtra.ui.chat
+
+internal sealed interface ChatReplayPageRequest {
+    data object Initial : ChatReplayPageRequest
+
+    data class Offset(val seconds: Int) : ChatReplayPageRequest
+
+    data class Cursor(val value: String) : ChatReplayPageRequest
+}
+
+/** Keeps replay pagination safe when a cursor becomes unusable mid-session. */
+internal class ChatReplayPagination {
+    private var previousPageMessageIds = emptySet<String>()
+    private var forcedBoundaryEscapeFromSeconds: Int? = null
+
+    var offsetPagination = false
+        private set
+
+    var cursor: String? = null
+        private set
+
+    var nextOffsetSeconds: Int? = null
+        private set
+
+    val hasMorePages: Boolean
+        get() = !cursor.isNullOrBlank() || nextOffsetSeconds != null
+
+    fun reset() {
+        offsetPagination = false
+        resetWindow()
+    }
+
+    /** Clears the current page window while retaining a known-safe pagination mode. */
+    fun resetWindow() {
+        cursor = null
+        nextOffsetSeconds = null
+        previousPageMessageIds = emptySet()
+        forcedBoundaryEscapeFromSeconds = null
+    }
+
+    fun request(positionOffsetSeconds: Int?): ChatReplayPageRequest {
+        return when {
+            positionOffsetSeconds != null -> ChatReplayPageRequest.Offset(positionOffsetSeconds)
+            offsetPagination && nextOffsetSeconds != null -> ChatReplayPageRequest.Offset(nextOffsetSeconds!!)
+            !cursor.isNullOrBlank() -> ChatReplayPageRequest.Cursor(cursor!!)
+            nextOffsetSeconds != null -> ChatReplayPageRequest.Offset(nextOffsetSeconds!!)
+            else -> ChatReplayPageRequest.Initial
+        }
+    }
+
+    fun onCursorFailure() {
+        offsetPagination = true
+        cursor = null
+    }
+
+    fun <T> acceptPage(
+        request: ChatReplayPageRequest,
+        messages: List<T>,
+        hasNextPage: Boolean,
+        nextCursor: String?,
+        messageId: (T) -> String?,
+        contentOffsetSeconds: (T) -> Int?,
+        pageBoundaryOffsetSeconds: Int? = null,
+        onForcedBoundaryEscape: (fromSeconds: Int, toSeconds: Int) -> Unit = { _, _ -> },
+    ): List<T> {
+        val pageIds = messages.mapNotNullTo(mutableSetOf(), messageId)
+        val newMessages = messages.filter { message ->
+            messageId(message) == null || messageId(message) !in previousPageMessageIds
+        }
+        val boundarySeconds = pageBoundaryOffsetSeconds
+            ?: messages.asReversed().firstNotNullOfOrNull(contentOffsetSeconds)
+        previousPageMessageIds = pageIds
+
+        if (!hasNextPage) {
+            cursor = null
+            nextOffsetSeconds = null
+            forcedBoundaryEscapeFromSeconds = null
+            return newMessages
+        }
+
+        val normalizedNextCursor = nextCursor?.takeIf(String::isNotBlank)
+        when (request) {
+            is ChatReplayPageRequest.Cursor -> {
+                if (normalizedNextCursor != null && normalizedNextCursor != request.value) {
+                    cursor = normalizedNextCursor
+                    nextOffsetSeconds = boundarySeconds
+                    forcedBoundaryEscapeFromSeconds = null
+                } else {
+                    // The cursor stopped making token progress. Keep the known
+                    // boundary and permanently use inclusive offset pagination.
+                    offsetPagination = true
+                    cursor = null
+                    nextOffsetSeconds = boundarySeconds
+                    forcedBoundaryEscapeFromSeconds = null
+                }
+            }
+
+            is ChatReplayPageRequest.Offset -> {
+                if (!offsetPagination && normalizedNextCursor != null) {
+                    // The initial position is represented as an offset, but the
+                    // first page can still establish cursor pagination.
+                    cursor = normalizedNextCursor
+                    nextOffsetSeconds = boundarySeconds
+                    forcedBoundaryEscapeFromSeconds = null
+                } else {
+                    cursor = null
+                    if (newMessages.isNotEmpty() && boundarySeconds != null) {
+                    // Keep the boundary second. The offset API is inclusive, and
+                    // overlap is removed using the previous page IDs.
+                        nextOffsetSeconds = boundarySeconds
+                        forcedBoundaryEscapeFromSeconds = null
+                    } else if (boundarySeconds != null && boundarySeconds > request.seconds) {
+                        nextOffsetSeconds = boundarySeconds
+                        forcedBoundaryEscapeFromSeconds = null
+                    } else if (boundarySeconds != null && forcedBoundaryEscapeFromSeconds != request.seconds - 1) {
+                        // A repeated inclusive boundary cannot make offset progress.
+                        // Escape it exactly once; a second repeated boundary terminates
+                        // instead of spinning forever.
+                        val escapedSeconds = if (request.seconds < Int.MAX_VALUE) {
+                            request.seconds + 1
+                        } else {
+                            null
+                        }
+                        if (escapedSeconds != null) {
+                            forcedBoundaryEscapeFromSeconds = request.seconds
+                            nextOffsetSeconds = escapedSeconds
+                            onForcedBoundaryEscape(request.seconds, escapedSeconds)
+                        } else {
+                            nextOffsetSeconds = null
+                            forcedBoundaryEscapeFromSeconds = null
+                        }
+                    } else {
+                        nextOffsetSeconds = null
+                        forcedBoundaryEscapeFromSeconds = null
+                    }
+                }
+            }
+
+            ChatReplayPageRequest.Initial -> {
+                cursor = normalizedNextCursor
+                nextOffsetSeconds = boundarySeconds
+                forcedBoundaryEscapeFromSeconds = null
+            }
+        }
+        return newMessages
+    }
+}

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/ChatReplayManagerTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/ChatReplayManagerTest.kt
@@ -1,0 +1,150 @@
+package com.github.andreyasadchy.xtra.ui.chat
+
+import android.net.http.HttpEngine
+import com.github.andreyasadchy.xtra.model.chat.ChatMessage
+import com.github.andreyasadchy.xtra.model.chat.VideoChatMessage
+import com.github.andreyasadchy.xtra.repository.GraphQLRepository
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
+import kotlinx.serialization.json.Json
+import okhttp3.OkHttpClient
+import org.chromium.net.CronetEngine
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+
+class ChatReplayManagerTest {
+    @Test
+    fun stalePageReleasedAfterSeekCannotModifyCurrentReplay() = runBlocking {
+        val ownerExecutor = Executors.newSingleThreadExecutor()
+        val ownerDispatcher = ownerExecutor.asCoroutineDispatcher()
+        val scope = CoroutineScope(SupervisorJob() + ownerDispatcher)
+        val oldStarted = CompletableDeferred<Unit>()
+        val releaseOld = CompletableDeferred<Unit>()
+        val oldReturned = CompletableDeferred<Unit>()
+        val newDelivered = CompletableDeferred<Unit>()
+        val loader = BlockingPageLoader(oldStarted, releaseOld, oldReturned)
+        val deliveredIds = CopyOnWriteArrayList<String>()
+        val repositoryExecutor = Executors.newSingleThreadExecutor()
+        var currentPosition = 0L
+
+        val manager = ChatReplayManager(
+            networkLibrary = null,
+            gqlHeaders = emptyMap(),
+            graphQLRepository = emptyGraphQlRepository(repositoryExecutor),
+            json = Json.Default,
+            videoId = "video",
+            createdAt = null,
+            startTime = 0,
+            getCurrentPosition = { currentPosition },
+            getCurrentSpeed = { 1f },
+            coroutineScope = scope,
+            listener = object : ChatReplayManager.Listener {
+                override suspend fun onChatMessage(message: ChatMessage) {
+                    deliveredIds += message.id
+                    if (message.id == "new") {
+                        newDelivered.complete(Unit)
+                    }
+                }
+            },
+            pageLoaderOverride = loader,
+        )
+
+        try {
+            withContext(ownerDispatcher) {
+                manager.start()
+            }
+            withTimeout(1_000) { oldStarted.await() }
+
+            currentPosition = 30_000L
+            withContext(ownerDispatcher) {
+                manager.updatePosition(30_000L)
+            }
+            withTimeout(1_000) { newDelivered.await() }
+
+            releaseOld.complete(Unit)
+            withTimeout(1_000) { oldReturned.await() }
+            delay(100)
+
+            assertEquals(
+                listOf(
+                    ChatReplayPageRequest.Offset(0),
+                    ChatReplayPageRequest.Offset(30),
+                ),
+                loader.requests.toList(),
+            )
+            assertEquals(listOf("new"), deliveredIds.toList())
+        } finally {
+            withContext(ownerDispatcher) {
+                manager.stop()
+            }
+            scope.cancel()
+            ownerDispatcher.close()
+            ownerExecutor.shutdownNow()
+            repositoryExecutor.shutdownNow()
+            repositoryExecutor.awaitTermination(1, TimeUnit.SECONDS)
+        }
+    }
+
+    private class BlockingPageLoader(
+        private val oldStarted: CompletableDeferred<Unit>,
+        private val releaseOld: CompletableDeferred<Unit>,
+        private val oldReturned: CompletableDeferred<Unit>,
+    ) : ChatReplayPageLoader {
+        val requests = CopyOnWriteArrayList<ChatReplayPageRequest>()
+
+        override suspend fun loadGraphQl(request: ChatReplayPageRequest): ChatReplayPage {
+            requests += request
+            if (request == ChatReplayPageRequest.Offset(0)) {
+                oldStarted.complete(Unit)
+                withContext(NonCancellable) {
+                    releaseOld.await()
+                }
+                oldReturned.complete(Unit)
+                return page("old", 0)
+            }
+            return page("new", 30)
+        }
+
+        override suspend fun loadLegacy(request: ChatReplayPageRequest): ChatReplayPage =
+            error("legacy fallback was not expected")
+
+        private fun page(id: String, offsetSeconds: Int) = ChatReplayPage(
+            messages = listOf(
+                VideoChatMessage(
+                    id = id,
+                    offsetSeconds = offsetSeconds,
+                    createdAt = null,
+                    userId = null,
+                    userLogin = null,
+                    userName = null,
+                    message = id,
+                    color = null,
+                    emotes = null,
+                    badges = null,
+                    fullMsg = null,
+                ),
+            ),
+            hasNextPage = false,
+            nextCursor = null,
+        )
+    }
+
+    private fun emptyGraphQlRepository(executor: java.util.concurrent.ExecutorService) = GraphQLRepository(
+        httpEngine = lazyOf<HttpEngine?>(null),
+        cronetEngine = lazyOf<CronetEngine?>(null),
+        cronetExecutor = lazyOf(executor),
+        okHttpClient = lazyOf(OkHttpClient()),
+        json = Json.Default,
+    )
+}

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/ChatReplayPaginationTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/ChatReplayPaginationTest.kt
@@ -1,0 +1,211 @@
+package com.github.andreyasadchy.xtra.ui.chat
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ChatReplayPaginationTest {
+    private data class Message(val id: String, val offsetSeconds: Int)
+
+    @Test
+    fun cursorFailureSticksToOffsetPagination() {
+        val pagination = ChatReplayPagination()
+        val firstPage = listOf(Message("a", 10), Message("b", 10))
+
+        pagination.acceptPage(
+            request = ChatReplayPageRequest.Offset(10),
+            messages = firstPage,
+            hasNextPage = true,
+            nextCursor = "cursor-2",
+            messageId = Message::id,
+            contentOffsetSeconds = Message::offsetSeconds,
+        )
+        assertEquals(ChatReplayPageRequest.Cursor("cursor-2"), pagination.request(null))
+
+        pagination.onCursorFailure()
+
+        assertTrue(pagination.offsetPagination)
+        assertEquals(ChatReplayPageRequest.Offset(10), pagination.request(null))
+
+        pagination.acceptPage(
+            request = ChatReplayPageRequest.Offset(10),
+            messages = listOf(Message("b", 10), Message("c", 10)),
+            hasNextPage = true,
+            nextCursor = "cursor-3",
+            messageId = Message::id,
+            contentOffsetSeconds = Message::offsetSeconds,
+        )
+        assertEquals(ChatReplayPageRequest.Offset(10), pagination.request(null))
+        assertTrue(pagination.hasMorePages)
+    }
+
+    @Test
+    fun sameSecondBoundaryRetainsOverlapAndUsesInclusiveOffset() {
+        val pagination = ChatReplayPagination()
+        val firstPage = listOf(Message("a", 20), Message("b", 20))
+        val secondPage = listOf(Message("b", 20), Message("c", 20))
+
+        assertEquals(
+            firstPage,
+            pagination.acceptPage(
+                request = ChatReplayPageRequest.Offset(20),
+                messages = firstPage,
+                hasNextPage = true,
+                nextCursor = "cursor-2",
+                messageId = Message::id,
+                contentOffsetSeconds = Message::offsetSeconds,
+            ),
+        )
+        pagination.onCursorFailure()
+        assertEquals(ChatReplayPageRequest.Offset(20), pagination.request(null))
+        assertEquals(
+            listOf(Message("c", 20)),
+            pagination.acceptPage(
+                request = ChatReplayPageRequest.Offset(20),
+                messages = secondPage,
+                hasNextPage = false,
+                nextCursor = null,
+                messageId = Message::id,
+                contentOffsetSeconds = Message::offsetSeconds,
+            ),
+        )
+        assertFalse(pagination.hasMorePages)
+    }
+
+    @Test
+    fun overlappingCursorPageWithAdvancingCursorContinues() {
+        val pagination = ChatReplayPagination()
+        val page = listOf(Message("a", 30), Message("b", 30))
+
+        pagination.acceptPage(
+            request = ChatReplayPageRequest.Offset(30),
+            messages = page,
+            hasNextPage = true,
+            nextCursor = "cursor-2",
+            messageId = Message::id,
+            contentOffsetSeconds = Message::offsetSeconds,
+        )
+        assertEquals(
+            emptyList<Message>(),
+            pagination.acceptPage(
+                request = ChatReplayPageRequest.Cursor("cursor-2"),
+                messages = listOf(Message("b", 30)),
+                hasNextPage = true,
+                nextCursor = "cursor-3",
+                messageId = Message::id,
+                contentOffsetSeconds = Message::offsetSeconds,
+            ),
+        )
+        assertTrue(pagination.hasMorePages)
+        assertEquals(ChatReplayPageRequest.Cursor("cursor-3"), pagination.request(null))
+    }
+
+    @Test
+    fun unchangedCursorFallsBackToInclusiveOffsetPagination() {
+        val pagination = ChatReplayPagination()
+        val page = listOf(Message("a", 30), Message("b", 30))
+
+        pagination.acceptPage(
+            request = ChatReplayPageRequest.Offset(30),
+            messages = page,
+            hasNextPage = true,
+            nextCursor = "cursor-2",
+            messageId = Message::id,
+            contentOffsetSeconds = Message::offsetSeconds,
+        )
+        assertEquals(ChatReplayPageRequest.Cursor("cursor-2"), pagination.request(null))
+
+        assertEquals(
+            emptyList<Message>(),
+            pagination.acceptPage(
+                request = ChatReplayPageRequest.Cursor("cursor-2"),
+                messages = page,
+                hasNextPage = true,
+                nextCursor = "cursor-2",
+                messageId = Message::id,
+                contentOffsetSeconds = Message::offsetSeconds,
+            ),
+        )
+        assertTrue(pagination.offsetPagination)
+        assertTrue(pagination.hasMorePages)
+        assertEquals(ChatReplayPageRequest.Offset(30), pagination.request(null))
+    }
+
+    @Test
+    fun repeatedOffsetBoundaryEscapesOnceAndContinuesWhenNewMessagesAppear() {
+        val pagination = ChatReplayPagination()
+        val page = listOf(Message("a", 30), Message("b", 30))
+        val escapedOffsets = mutableListOf<Pair<Int, Int>>()
+
+        pagination.acceptPage(
+            request = ChatReplayPageRequest.Offset(30),
+            messages = page,
+            hasNextPage = true,
+            nextCursor = "cursor-2",
+            messageId = Message::id,
+            contentOffsetSeconds = Message::offsetSeconds,
+        )
+        pagination.onCursorFailure()
+
+        pagination.acceptPage(
+            request = ChatReplayPageRequest.Offset(30),
+            messages = page,
+            hasNextPage = true,
+            nextCursor = null,
+            messageId = Message::id,
+            contentOffsetSeconds = Message::offsetSeconds,
+            onForcedBoundaryEscape = { from, to -> escapedOffsets += from to to },
+        )
+        assertEquals(listOf(30 to 31), escapedOffsets)
+        assertEquals(ChatReplayPageRequest.Offset(31), pagination.request(null))
+
+        assertEquals(
+            listOf(Message("c", 31)),
+            pagination.acceptPage(
+                request = ChatReplayPageRequest.Offset(31),
+                messages = listOf(Message("b", 30), Message("c", 31)),
+                hasNextPage = true,
+                nextCursor = null,
+                messageId = Message::id,
+                contentOffsetSeconds = Message::offsetSeconds,
+            ),
+        )
+        assertTrue(pagination.hasMorePages)
+    }
+
+    @Test
+    fun repeatedOffsetBoundaryStopsAfterTheControlledEscape() {
+        val pagination = ChatReplayPagination()
+        val page = listOf(Message("a", 30), Message("b", 30))
+
+        pagination.acceptPage(
+            request = ChatReplayPageRequest.Offset(30),
+            messages = page,
+            hasNextPage = true,
+            nextCursor = null,
+            messageId = Message::id,
+            contentOffsetSeconds = Message::offsetSeconds,
+        )
+        pagination.onCursorFailure()
+        pagination.acceptPage(
+            request = ChatReplayPageRequest.Offset(30),
+            messages = page,
+            hasNextPage = true,
+            nextCursor = null,
+            messageId = Message::id,
+            contentOffsetSeconds = Message::offsetSeconds,
+        )
+        assertEquals(ChatReplayPageRequest.Offset(31), pagination.request(null))
+
+        pagination.acceptPage(
+            request = ChatReplayPageRequest.Offset(31),
+            messages = page,
+            hasNextPage = true,
+            nextCursor = null,
+            messageId = Message::id,
+            contentOffsetSeconds = Message::offsetSeconds,
+        )
+        assertFalse(pagination.hasMorePages)
+    }
+}


### PR DESCRIPTION
Fixes VOD chat stopping after its first comment page. If Twitch rejects cursor pagination, replay continues from the next offset and removes overlapping comments.