### PR TITLE
Fix JVM test hang

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -118,7 +118,8 @@ jobs:
           '{versionName: $version_name, versionCode: $version_code, buildNumber: $build_number}' \
           > xtra-release-metadata.json
     - name: Run JVM tests
-      run: ./gradlew testDebugUnitTest
+      timeout-minutes: 12
+      run: ./gradlew testDebugUnitTest --console=plain
 
     - name: Check resource localization hygiene
       run: python3 .github/scripts/check-resources.py

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -196,6 +196,12 @@ tasks.register<PrintVersionInfoTask>("printVersionInfo") {
     versionCode.set(printVersionCode)
 }
 
+tasks.withType<org.gradle.api.tasks.testing.Test>().configureEach {
+    testLogging {
+        events("started", "failed", "skipped")
+    }
+}
+
 dependencies {
     testImplementation("junit:junit:4.13.2")
     testImplementation("org.json:json:20240303")

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatSessionManagerIntegrationTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatSessionManagerIntegrationTest.kt
@@ -576,22 +576,17 @@ class ChatSessionManagerIntegrationTest {
         private val deliveryGate: MessageDeliveryGate? = null,
     ) : ChatTransport {
         private val feeds = ConcurrentHashMap<ChatSessionKey, MutableSharedFlow<ChatEvent>>()
-        private val active = AtomicInteger()
-        val activeCollectors: Int get() = active.get()
+        val activeCollectors: Int
+            get() = feeds.values.sumOf { it.subscriptionCount.value }
         val requested = CopyOnWriteArrayList<ChatSessionKey>()
 
         override fun events(session: ChatSessionKey): Flow<ChatEvent> = flow {
             requested += session
-            active.incrementAndGet()
-            try {
-                feeds.computeIfAbsent(session) { MutableSharedFlow(extraBufferCapacity = 1_024) }
-                    .collect {
-                        emit(it)
-                        deliveryGate?.after(it)
-                    }
-            } finally {
-                active.decrementAndGet()
-            }
+            feeds.computeIfAbsent(session) { MutableSharedFlow(extraBufferCapacity = 1_024) }
+                .collect {
+                    emit(it)
+                    deliveryGate?.after(it)
+                }
         }
 
         suspend fun send(key: ChatSessionKey, message: ChatMessage) = send(key, ChatEvent.Message(message))


### PR DESCRIPTION
Fixes the chat test transport readiness race, logs started tests, and limits the JVM test step to 12 minutes.