### PR TITLE
Reduce chat redraw work and pause hidden animations

### DIFF
--- a/app/src/androidTest/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatMessageTextViewTest.kt
+++ b/app/src/androidTest/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatMessageTextViewTest.kt
@@ -1138,6 +1138,92 @@ class ChatMessageTextViewTest {
     }
 
     @Test
+    fun parentVisibilityPausesAndResumesAnimatedEmotes() {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+        lateinit var animated: RecordingAnimatedDrawable
+        val repository = ChatAssetRepository(scope, ChatAssetLoader {
+            ChatImageHandle { RecordingAnimatedDrawable().also { animated = it } }
+        })
+        val attached = attachView(repository)
+        try {
+            runOnMain {
+                attached.view.bind(row(ChatAssetSpec(ChatAssetKey("visibility-animation"), 20, 20, 28)))
+            }
+            awaitPreDraw(attached.view)
+            runOnMain {
+                assertTrue(animated.isRunning)
+                val parent = attached.view.parent as View
+                parent.visibility = View.GONE
+                assertTrue(!animated.isRunning)
+                assertEquals(null, animated.callback)
+                parent.visibility = View.VISIBLE
+                assertTrue(animated.isRunning)
+                attached.view.setRenderingActive(false)
+                parent.visibility = View.GONE
+                parent.visibility = View.VISIBLE
+                assertTrue(!animated.isRunning)
+                attached.view.setRenderingActive(true)
+                assertTrue(animated.isRunning)
+            }
+        } finally {
+            attached.close()
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun repeatedEmotesDoNotChangeDrawableBoundsEveryFrame() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+        lateinit var animated: RecordingAnimatedDrawable
+        val repository = ChatAssetRepository(scope, ChatAssetLoader {
+            ChatImageHandle { RecordingAnimatedDrawable().also { animated = it } }
+        })
+        val view = TestTextView(context, repository)
+        val spec = ChatAssetSpec(ChatAssetKey("repeated-animation"), 20, 20, 28)
+        try {
+            runOnMain {
+                view.bind(emoteSpamRow(ChatMessageId("repeated"), listOf(spec, spec, spec)))
+                val text = view.text as Spanned
+                val spans = text.getSpans(0, text.length, ReplacementSpan::class.java)
+                val bitmap = Bitmap.createBitmap(200, 60, Bitmap.Config.ARGB_8888)
+                val canvas = Canvas(bitmap)
+                repeat(10) {
+                    spans.forEachIndexed { index, span ->
+                        span.draw(canvas, text, 0, text.length, index * 40f, 0, 28, 40, Paint())
+                    }
+                }
+                assertEquals(1, animated.boundsChangeCount)
+                view.recycle()
+                bitmap.recycle()
+            }
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun accessibilityClickUsesTheCurrentMessage() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+        val repository = ChatAssetRepository(scope, ChatAssetLoader { null })
+        try {
+            runOnMain {
+                val view = TestTextView(context, repository)
+                var clicked: ChatMessageId? = null
+                view.setMessageClickCallback { clicked = it }
+                view.bind(textRow("hello", ChatMessageId("first")))
+                view.bind(textRow("hello again", ChatMessageId("second")))
+                assertTrue(view.performAccessibilityAction(android.view.accessibility.AccessibilityNodeInfo.ACTION_CLICK, null))
+                assertEquals(ChatMessageId("second"), clicked)
+                view.recycle()
+            }
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    @Test
     fun animatedDrawableIsVerifiedAndFollowsAttachDetachLifecycle() {
         val context = InstrumentationRegistry.getInstrumentation().targetContext
         val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
@@ -1746,7 +1832,10 @@ class ChatMessageTextViewTest {
         repository: ChatAssetRepository,
         clipPreviews: ChatClipPreviewRepository? = null,
     ) : ChatMessageTextView(context, repository, clipPreviews) {
-        fun attachedForTest() = onAttachedToWindow()
+        fun attachedForTest() {
+            onAttachedToWindow()
+            onVisibilityAggregated(true)
+        }
         fun detachedForTest() = onDetachedFromWindow()
         fun verifyForTest(drawable: Drawable) = verifyDrawable(drawable)
     }
@@ -1754,6 +1843,9 @@ class ChatMessageTextViewTest {
     private class RecordingAnimatedDrawable : Drawable(), Animatable {
         var startCount = 0
         var stopCount = 0
+        var boundsChangeCount = 0
+
+        override fun onBoundsChange(bounds: android.graphics.Rect) { boundsChangeCount++ }
 
         override fun draw(canvas: Canvas) = Unit
         override fun setAlpha(alpha: Int) = Unit

--- a/app/src/androidTest/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatMessageTextViewTest.kt
+++ b/app/src/androidTest/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatMessageTextViewTest.kt
@@ -1,6 +1,7 @@
 package com.github.andreyasadchy.xtra.ui.chat.v2
 
 import android.content.Context
+import android.content.ContextWrapper
 import android.content.ComponentName
 import android.content.Intent
 import android.app.Activity
@@ -1210,15 +1211,97 @@ class ChatMessageTextViewTest {
         try {
             runOnMain {
                 val view = TestTextView(context, repository)
-                var clicked: ChatMessageId? = null
-                view.setMessageClickCallback { clicked = it }
+                val clicked = mutableListOf<ChatMessageId>()
+                view.setMessageClickCallback { clicked += it }
                 view.bind(textRow("hello", ChatMessageId("first")))
                 view.bind(textRow("hello again", ChatMessageId("second")))
                 assertTrue(view.performAccessibilityAction(android.view.accessibility.AccessibilityNodeInfo.ACTION_CLICK, null))
-                assertEquals(ChatMessageId("second"), clicked)
+                assertEquals(listOf(ChatMessageId("second")), clicked)
                 view.recycle()
             }
         } finally {
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun plainRowTapOpensTheProfileExactlyOnce() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+        val repository = ChatAssetRepository(scope, ChatAssetLoader { null })
+        val view = TestTextView(context, repository)
+        var clicks = 0
+        try {
+            runOnMain {
+                view.setMessageClickCallback { clicks++ }
+                view.layoutParams = ViewGroup.LayoutParams(600, 200)
+                view.bind(textRow("plain row", ChatMessageId("plain")))
+                layoutForTouch(view)
+                dispatchTap(view, 12f, 12f)
+            }
+            assertEquals(1, clicks)
+        } finally {
+            runOnMain { view.recycle() }
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun urlTapInvokesOnlyTheUrlSpan() {
+        val recordingContext = RecordingContext(InstrumentationRegistry.getInstrumentation().targetContext)
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+        val repository = ChatAssetRepository(scope, ChatAssetLoader { null })
+        val view = TestTextView(recordingContext, repository)
+        var profileClicks = 0
+        try {
+            runOnMain {
+                view.setMessageClickCallback { profileClicks++ }
+                view.layoutParams = ViewGroup.LayoutParams(600, 200)
+                view.bind(textRow("https://example.com/watch?v=42"))
+                layoutForTouch(view)
+                val spanned = view.text as Spanned
+                val url = spanned.getSpans(0, spanned.length, URLSpan::class.java).single()
+                dispatchTapOnSpan(view, url)
+            }
+            assertEquals(0, profileClicks)
+            assertEquals("https://example.com/watch?v=42", recordingContext.startedIntent?.data?.toString())
+        } finally {
+            runOnMain { view.recycle() }
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun emoteTapInvokesOnlyTheEmoteSpan() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+        val repository = ChatAssetRepository(scope, ChatAssetLoader { null })
+        val view = TestTextView(context, repository)
+        val interaction = ChatEmoteInteraction(
+            id = "tap-emote",
+            name = "Tap",
+            url = "https://cdn.example.test/tap.webp",
+            animated = false,
+            provider = ChatAssetProvider.BTTV,
+            scope = ChatEmoteScope.CHANNEL,
+        )
+        var profileClicks = 0
+        var emoteClicks = 0
+        try {
+            runOnMain {
+                view.setMessageClickCallback { profileClicks++ }
+                view.setInteractionCallbacks(null, { emoteClicks++ })
+                view.layoutParams = ViewGroup.LayoutParams(600, 200)
+                view.bind(row(ChatAssetSpec(ChatAssetKey("tap-emote"), 16, 16, 24), interaction = interaction))
+                layoutForTouch(view)
+                val spanned = view.text as Spanned
+                val emote = spanned.getSpans(0, spanned.length, ClickableSpan::class.java).single()
+                dispatchTapOnSpan(view, emote)
+            }
+            assertEquals(0, profileClicks)
+            assertEquals(1, emoteClicks)
+        } finally {
+            runOnMain { view.recycle() }
             scope.cancel()
         }
     }
@@ -1789,6 +1872,32 @@ class ChatMessageTextViewTest {
     private fun runOnMain(block: () -> Unit) =
         InstrumentationRegistry.getInstrumentation().runOnMainSync(block)
 
+    private fun layoutForTouch(view: View) {
+        view.measure(
+            View.MeasureSpec.makeMeasureSpec(600, View.MeasureSpec.EXACTLY),
+            View.MeasureSpec.makeMeasureSpec(200, View.MeasureSpec.AT_MOST),
+        )
+        view.layout(0, 0, 600, view.measuredHeight)
+    }
+
+    private fun dispatchTap(view: View, x: Float, y: Float) {
+        val downTime = android.os.SystemClock.uptimeMillis()
+        check(view.dispatchTouchEvent(MotionEvent.obtain(downTime, downTime, MotionEvent.ACTION_DOWN, x, y, 0)))
+        check(view.dispatchTouchEvent(MotionEvent.obtain(downTime, downTime + 20, MotionEvent.ACTION_UP, x, y, 0)))
+    }
+
+    private fun dispatchTapOnSpan(view: ChatMessageTextView, span: ClickableSpan) {
+        val spanned = view.text as Spanned
+        val textLayout = checkNotNull(view.layout)
+        val start = spanned.getSpanStart(span)
+        val end = spanned.getSpanEnd(span)
+        val line = textLayout.getLineForOffset(start)
+        val x = view.totalPaddingLeft +
+            (textLayout.getPrimaryHorizontal(start) + textLayout.getPrimaryHorizontal(end)) / 2f
+        val y = view.totalPaddingTop + (textLayout.getLineTop(line) + textLayout.getLineBottom(line)) / 2f
+        dispatchTap(view, x, y)
+    }
+
     private fun awaitPreDraw(view: View) {
         val drawn = CountDownLatch(1)
         runOnMain {
@@ -1838,6 +1947,14 @@ class ChatMessageTextViewTest {
         }
         fun detachedForTest() = onDetachedFromWindow()
         fun verifyForTest(drawable: Drawable) = verifyDrawable(drawable)
+    }
+
+    private class RecordingContext(base: Context) : ContextWrapper(base) {
+        var startedIntent: Intent? = null
+
+        override fun startActivity(intent: Intent) {
+            startedIntent = intent
+        }
     }
 
     private class RecordingAnimatedDrawable : Drawable(), Animatable {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatAdapter.kt
@@ -383,7 +383,10 @@ class ChatAdapter(
     private var visibleRenderQueue = Channel<RenderRequest>(VISIBLE_RENDER_QUEUE_CAPACITY)
     private var prewarmRenderQueue = Channel<RenderRequest>(PREWARM_QUEUE_CAPACITY)
     /** One signal represents one queued request; this keeps both workers fed during bursts. */
-    private var renderSignal = Channel<Unit>(Channel.UNLIMITED)
+    // Keep the wake-up queue bounded with the work queues. A signal is paired with every
+    // queued request, so this cannot lose work, while a burst of distinct emotes/messages
+    // cannot grow an unbounded list of Unit objects behind the two workers.
+    private var renderSignal = Channel<Unit>(VISIBLE_RENDER_QUEUE_CAPACITY + PREWARM_QUEUE_CAPACITY)
     private var renderWorkers = emptyList<Job>()
     private val imagePrefetchTracker = ChatAdapterUtils.ChatImagePrefetchTracker()
     private val mainHandler = Handler(Looper.getMainLooper())
@@ -412,7 +415,10 @@ class ChatAdapter(
         revision = 0,
         indexes = initialCatalogIndexes,
         translateAllMessages = false,
-        highlightSettings = resolveChatHighlightSettings(fragment.requireContext()),
+        // Direct/combined holders can be created before their Fragment is attached. Use the
+        // defaults until a real Fragment context is available and the settings are refreshed.
+        highlightSettings = fragment.context?.let(::resolveChatHighlightSettings)
+            ?: ChatHighlightSettings(),
     )
     @Volatile
     private var pendingConfiguration: ChatRenderConfiguration? = null
@@ -438,7 +444,7 @@ class ChatAdapter(
         }
 
     fun refreshChatHighlightSettings() {
-        val next = resolveChatHighlightSettings(fragment.requireContext())
+        val next = fragment.context?.let(::resolveChatHighlightSettings) ?: return
         val base = pendingConfiguration ?: activeConfiguration
         if (next == base.highlightSettings) return
         scheduleConfigurationSwitch(
@@ -1443,7 +1449,7 @@ class ChatAdapter(
             renderScope = newRenderScope()
             visibleRenderQueue = Channel(VISIBLE_RENDER_QUEUE_CAPACITY)
             prewarmRenderQueue = Channel(PREWARM_QUEUE_CAPACITY)
-            renderSignal = Channel(Channel.UNLIMITED)
+            renderSignal = Channel(VISIBLE_RENDER_QUEUE_CAPACITY + PREWARM_QUEUE_CAPACITY)
         }
         renderWorkers = startRenderWorkers()
     }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatFragment.kt
@@ -2676,19 +2676,45 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
             if (compact) 40f else 48f,
             resources.displayMetrics,
         ).toInt()
+        // This method is called from a layout-change listener. Reassigning identical params
+        // here schedules another layout pass and can create a permanent invalidation loop.
         listOf(binding.chatIdentity, binding.clear, binding.emotes, binding.send).forEach { control ->
-            control.updateLayoutParams<LinearLayout.LayoutParams> {
-                width = controlSize
-                height = ViewGroup.LayoutParams.MATCH_PARENT
+            val params = control.layoutParams as? LinearLayout.LayoutParams
+            if (params != null) {
+                var paramsChanged = false
+                if (params.width != controlSize) {
+                    params.width = controlSize
+                    paramsChanged = true
+                }
+                if (params.height != ViewGroup.LayoutParams.MATCH_PARENT) {
+                    params.height = ViewGroup.LayoutParams.MATCH_PARENT
+                    paramsChanged = true
+                }
+                if (paramsChanged) control.layoutParams = params
             }
-            control.minimumWidth = controlSize
+            if (control.minimumWidth != controlSize) control.minimumWidth = controlSize
         }
-        binding.channelPointsText.isVisible = binding.channelPoints.isVisible && !compact
-        binding.channelPoints.updateLayoutParams<LinearLayout.LayoutParams> {
-            width = if (compact) controlSize else ViewGroup.LayoutParams.WRAP_CONTENT
-            height = ViewGroup.LayoutParams.MATCH_PARENT
+        val channelPointsTextVisible = binding.channelPoints.isVisible && !compact
+        if (binding.channelPointsText.isVisible != channelPointsTextVisible) {
+            binding.channelPointsText.isVisible = channelPointsTextVisible
         }
-        binding.channelPoints.minimumWidth = controlSize
+        val channelPointsWidth = if (compact) controlSize else ViewGroup.LayoutParams.WRAP_CONTENT
+        val channelPointsParams = binding.channelPoints.layoutParams as? LinearLayout.LayoutParams
+        if (channelPointsParams != null) {
+            var paramsChanged = false
+            if (channelPointsParams.width != channelPointsWidth) {
+                channelPointsParams.width = channelPointsWidth
+                paramsChanged = true
+            }
+            if (channelPointsParams.height != ViewGroup.LayoutParams.MATCH_PARENT) {
+                channelPointsParams.height = ViewGroup.LayoutParams.MATCH_PARENT
+                paramsChanged = true
+            }
+            if (paramsChanged) binding.channelPoints.layoutParams = channelPointsParams
+        }
+        if (binding.channelPoints.minimumWidth != controlSize) {
+            binding.channelPoints.minimumWidth = controlSize
+        }
     }
 
     private fun setupEmotePickerSizing() {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/catalog/ChatCatalogRepository.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/catalog/ChatCatalogRepository.kt
@@ -8,6 +8,8 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
 import java.util.LinkedHashMap
 
 sealed interface ScopeUpdate<out T> {
@@ -117,6 +119,7 @@ class ChatCatalogRepository(
     private val personalEmoteSetLoader: (suspend (String) -> Map<String, ChatCatalogEmote>)? = null,
     private val cacheFreshnessMs: Long = 60 * 60 * 1000L,
     private val personalEmoteFailureTtlMs: Long = 60_000L,
+    maxConcurrentPersonalEmoteLoads: Int = 4,
 ) {
     private enum class Provider { TWITCH, SEVEN_TV, BTTV, FFZ, BADGES, CHEERMOTES }
 
@@ -142,6 +145,7 @@ class ChatCatalogRepository(
     private var cacheCatalogConfigFingerprint: String? = null
     private var cacheBadgeConfigFingerprint: String? = null
     private val personalEmoteSetJobs = mutableMapOf<String, Job>()
+    private val personalEmoteLoadPermits = Semaphore(maxConcurrentPersonalEmoteLoads.coerceAtLeast(1))
     private val loadedPersonalEmoteSets = mutableSetOf<String>()
     private val failedPersonalEmoteSets = LinkedHashMap<String, Long>(16, 0.75f, true)
     private var networkProvidersObserved = emptySet<Provider>()
@@ -312,7 +316,7 @@ class ChatCatalogRepository(
         if (failedPersonalEmoteSets[setId] != null) return
         personalEmoteSetJobs[setId] = scope.launch {
             val emotes = try {
-                loader(setId)
+                personalEmoteLoadPermits.withPermit { loader(setId) }
             } catch (e: CancellationException) {
                 throw e
             } catch (_: Throwable) {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/catalog/ChatCatalogSnapshot.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/catalog/ChatCatalogSnapshot.kt
@@ -49,7 +49,7 @@ data class ScopedEmoteCatalog(
 
     /** Builds the merged projection once for consumers such as the picker. */
     fun effectiveValues(): Collection<ChatCatalogEmote> =
-        (legacyCombined + global + personalProjection + channel).values
+        effectiveProjection.values
 
     fun viewerPersonalValues(): Collection<ChatCatalogEmote> =
         viewerPersonalSetIds.asSequence().flatMap { personal[it].orEmpty().values.asSequence() }.toList()

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/presentation/ChatPresentationCatalog.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/presentation/ChatPresentationCatalog.kt
@@ -1,0 +1,54 @@
+package com.github.andreyasadchy.xtra.ui.chat.v2.presentation
+
+import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatCatalogSnapshot
+import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatDecorationSnapshot
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatRewardCatalog
+
+/** Collection-owned projection of immutable metadata. Message arrivals do not copy catalog maps. */
+internal class ChatPresentationCatalog {
+    private var source: ChatCatalogSnapshot? = null
+    private var rewards: ChatRewardCatalog? = null
+    private var decorations: ChatDecorationSnapshot? = null
+    private var resolved: ChatCatalogSnapshot? = null
+
+    fun resolve(
+        catalog: ChatCatalogSnapshot,
+        rewardCatalog: ChatRewardCatalog,
+        decorationCatalog: ChatDecorationSnapshot,
+    ): ChatCatalogSnapshot {
+        val previous = resolved
+        if (previous != null && source === catalog && rewards === rewardCatalog && decorations === decorationCatalog) {
+            return previous
+        }
+        val next = catalog.copy(
+            channelPointRewards = rewardCatalog.byId,
+            automaticChannelPointRewards = rewardCatalog.automaticByType,
+            channelPointRewardsRevision = if (rewards === rewardCatalog && previous != null) {
+                previous.channelPointRewardsRevision
+            } else rewardCatalog.hashCode(),
+            // Live v2 data wins over the legacy fallback. Unchanged maps remain shared
+            // even when an unrelated provider publishes a new catalog revision.
+            userDecorations = if (previous != null && source?.userDecorations === catalog.userDecorations &&
+                decorations?.users === decorationCatalog.users
+            ) previous.userDecorations else merge(decorationCatalog.users, catalog.userDecorations),
+            namePaints = if (previous != null && source?.namePaints === catalog.namePaints &&
+                decorations?.paints === decorationCatalog.paints
+            ) previous.namePaints else merge(decorationCatalog.paints, catalog.namePaints),
+            sevenTvBadges = if (previous != null && source?.sevenTvBadges === catalog.sevenTvBadges &&
+                decorations?.badges === decorationCatalog.badges
+            ) previous.sevenTvBadges else merge(decorationCatalog.badges, catalog.sevenTvBadges),
+        )
+        source = catalog
+        rewards = rewardCatalog
+        decorations = decorationCatalog
+        resolved = next
+        return next
+    }
+
+    private fun <K, V> merge(fallback: Map<K, V>, current: Map<K, V>): Map<K, V> = when {
+        fallback.isEmpty() -> current
+        current.isEmpty() -> fallback
+        fallback === current -> current
+        else -> fallback + current
+    }
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/transport/TwitchChatTransport.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/transport/TwitchChatTransport.kt
@@ -31,6 +31,8 @@ import kotlinx.coroutines.flow.buffer
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
@@ -159,8 +161,10 @@ class TwitchChatTransport(
         val sevenTv = attachSevenTv(this) { event -> send(event) }
         val hermes = attachHermesRewards(this) { event -> send(event) }
         val connectionJob = socket.connect(this)
-        awaitClose {
-            flowScope.launch {
+        try {
+            awaitClose()
+        } finally {
+            withContext(NonCancellable) {
                 socket.disconnect(connectionJob)
                 sevenTv?.let { (stv, job) -> stv.disconnect(job) }
                 hermes?.let { (hermesSocket, job) -> hermesSocket.disconnect(job) }
@@ -249,8 +253,10 @@ class TwitchChatTransport(
         val sevenTv = attachSevenTv(this) { event -> send(event) }
         val hermes = attachHermesRewards(this) { event -> send(event) }
         val connectionJob = socket.connect(this)
-        awaitClose {
-            flowScope.launch {
+        try {
+            awaitClose()
+        } finally {
+            withContext(NonCancellable) {
                 socket.disconnect(connectionJob)
                 sevenTv?.let { (stv, job) -> stv.disconnect(job) }
                 hermes?.let { (hermesSocket, job) -> hermesSocket.disconnect(job) }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatMessageTextView.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatMessageTextView.kt
@@ -130,6 +130,8 @@ open class ChatMessageTextView private constructor(
     private var longPressConsumed = false
     private var touchDownX = 0f
     private var touchDownY = 0f
+    /** True while TextView is dispatching a pointer gesture that belongs to a span. */
+    private var touchStartedOnClickableSpan = false
     private var longPressRunnable: Runnable? = null
     private val mainHandler = Handler(Looper.getMainLooper())
     private var onMessageLongClick: ((ChatMessageId) -> Unit)? = null
@@ -879,6 +881,9 @@ open class ChatMessageTextView private constructor(
 
     override fun performClick(): Boolean {
         val handled = super.performClick()
+        // LinkMovementMethod can reach performClick while it is finishing a pointer
+        // gesture.  A span owns that gesture; never turn it into a row/profile click.
+        if (touchStartedOnClickableSpan) return handled
         val id = boundMessageId ?: return handled
         val callback = onMessageClick ?: return handled
         callback(id)
@@ -908,6 +913,7 @@ open class ChatMessageTextView private constructor(
             MotionEvent.ACTION_DOWN -> {
                 longPressConsumed = false
                 touchMoved = false
+                touchStartedOnClickableSpan = hasClickableSpanAt(event)
                 touchDownX = event.x
                 touchDownY = event.y
                 longPressRunnable?.let(mainHandler::removeCallbacks)
@@ -931,16 +937,21 @@ open class ChatMessageTextView private constructor(
 
             MotionEvent.ACTION_CANCEL -> {
                 touchMoved = true
+                touchStartedOnClickableSpan = false
                 longPressRunnable?.let(mainHandler::removeCallbacks)
                 longPressRunnable = null
             }
 
             MotionEvent.ACTION_UP -> {
+                // The layout can be unavailable at DOWN (for example during a rebound),
+                // so check UP as well before TextView gets a chance to call performClick.
+                touchStartedOnClickableSpan = touchStartedOnClickableSpan || hasClickableSpanAt(event)
                 hasClipPreviewAt(event)?.let { url ->
                     if (!touchMoved && !longPressConsumed) {
                         openClipUrl(url)
                         longPressRunnable?.let(mainHandler::removeCallbacks)
                         longPressRunnable = null
+                        touchStartedOnClickableSpan = false
                         return true
                     }
                 }
@@ -949,30 +960,32 @@ open class ChatMessageTextView private constructor(
                     onMessageClick != null &&
                     !touchMoved &&
                     !longPressConsumed &&
-                    !hasClickableSpanAt(event)
+                    !touchStartedOnClickableSpan
                 longPressRunnable?.let(mainHandler::removeCallbacks)
                 longPressRunnable = null
                 if (longPressConsumed) {
                     longPressConsumed = false
+                    touchStartedOnClickableSpan = false
                     return true
                 }
                 if (shouldOpenProfile) {
                     performClick()
+                    touchStartedOnClickableSpan = false
                     return true
                 }
             }
         }
         if (event.actionMasked == MotionEvent.ACTION_UP && longPressConsumed) {
             longPressConsumed = false
+            touchStartedOnClickableSpan = false
             return true
         }
         val handled = super.onTouchEvent(event)
-        return if (event.actionMasked == MotionEvent.ACTION_UP && longPressConsumed) {
+        if (event.actionMasked == MotionEvent.ACTION_UP) {
             longPressConsumed = false
-            true
-        } else {
-            handled
+            touchStartedOnClickableSpan = false
         }
+        return handled
     }
 
     private fun appendStyled(output: SpannableStringBuilder, value: String, color: Int?, bold: Boolean = false) {
@@ -1201,6 +1214,7 @@ open class ChatMessageTextView private constructor(
         text = null
         boundMessageId = null
         boundRow = null
+        touchStartedOnClickableSpan = false
         alpha = 1f
     }
 

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatMessageTextView.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatMessageTextView.kt
@@ -124,6 +124,7 @@ open class ChatMessageTextView private constructor(
     private var renderingActive = true
     private var animateGifs = true
     private var windowAttached = false
+    private var aggregatedVisible = false
     private var animatedAssetKeys = emptySet<ChatAssetKey>()
     private var boundMessageId: ChatMessageId? = null
     private var longPressConsumed = false
@@ -684,6 +685,7 @@ open class ChatMessageTextView private constructor(
     }
 
     private fun ensureClipDrawCache() {
+        if (boundRow?.clipPreviews.isNullOrEmpty()) return
         val width = width
         val timeBucket = System.currentTimeMillis() / DateUtils.MINUTE_IN_MILLIS
         if (width <= 0 || (clipDrawCacheWidth == width && clipDrawCacheTimeBucket == timeBucket)) return
@@ -740,7 +742,7 @@ open class ChatMessageTextView private constructor(
     private fun scheduleClipRelativeTimeRefresh() {
         clipRelativeTimeRefresh?.let(mainHandler::removeCallbacks)
         clipRelativeTimeRefresh = null
-        if (!windowAttached || clipDrawCards.none { it.hasRelativeTime }) return
+        if (!windowAttached || !renderingActive || !aggregatedVisible || clipDrawCards.none { it.hasRelativeTime }) return
         val now = System.currentTimeMillis()
         val delayMs = (DateUtils.MINUTE_IN_MILLIS - (now % DateUtils.MINUTE_IN_MILLIS) + 50L)
         clipRelativeTimeRefresh = Runnable {
@@ -770,9 +772,12 @@ open class ChatMessageTextView private constructor(
         val thumbRight = thumbLeft + 72 * density
         val thumbBottom = top + height - 6 * density
         card.thumbnailSpec?.let { spec ->
-            if (!isDirectAssetFailureLatched(spec.key)) drawableFor(spec.key, spec)?.let { drawable ->
-                drawable.setBounds(thumbLeft.toInt(), thumbTop.toInt(), thumbRight.toInt(), thumbBottom.toInt())
+            if (!isDirectAssetFailureLatched(spec.key)) drawableFor(spec.key)?.let { drawable ->
+                drawable.setBounds(0, 0, thumbRight.toInt() - thumbLeft.toInt(), thumbBottom.toInt() - thumbTop.toInt())
+                val saveCount = canvas.save()
+                canvas.translate(thumbLeft.toInt().toFloat(), thumbTop.toInt().toFloat())
                 drawable.draw(canvas)
+                canvas.restoreToCount(saveCount)
             }
         }
 
@@ -872,6 +877,14 @@ open class ChatMessageTextView private constructor(
         }
     }
 
+    override fun performClick(): Boolean {
+        val handled = super.performClick()
+        val id = boundMessageId ?: return handled
+        val callback = onMessageClick ?: return handled
+        callback(id)
+        return true
+    }
+
     /**
      * TextView's normal long-click is intentionally the row action. In particular,
      * it must win over LinkMovementMethod when the pointer goes down on an emote.
@@ -944,7 +957,7 @@ open class ChatMessageTextView private constructor(
                     return true
                 }
                 if (shouldOpenProfile) {
-                    onMessageClick?.invoke(messageId)
+                    performClick()
                     return true
                 }
             }
@@ -1109,7 +1122,7 @@ open class ChatMessageTextView private constructor(
                 spec,
                 fallback,
                 layerSpecs,
-                { layerSpec -> drawableFor(layerSpec.key, layerSpec) },
+                { layerSpec -> drawableFor(layerSpec.key) },
                 { assetRenderState(compositionKey, layerSpecs) },
                 fallbackMode,
             ),
@@ -1137,7 +1150,7 @@ open class ChatMessageTextView private constructor(
         }
     }
 
-    private fun drawableFor(key: ChatAssetKey, spec: ChatAssetSpec): Drawable? {
+    private fun drawableFor(key: ChatAssetKey): Drawable? {
         val handle = (assets.peek(key) as? ChatAssetState.Ready)?.image ?: return null
         val drawable = if (drawableHandles[key] !== handle) {
             drawables.remove(key)?.also { it.stopIfNeeded(); it.callback = null }
@@ -1152,7 +1165,6 @@ open class ChatMessageTextView private constructor(
         } else {
             drawables[key] ?: return null
         }
-        drawable.setBounds(0, 0, spec.computedWidth, spec.targetHeight)
         updateAnimationState(key, drawable)
         return drawable
     }
@@ -1224,9 +1236,9 @@ open class ChatMessageTextView private constructor(
     }
 
     private fun updateAnimationState(key: ChatAssetKey, drawable: Drawable) {
-        drawable.callback = if (renderingActive && windowAttached) this else null
+        drawable.callback = if (renderingActive && windowAttached && aggregatedVisible) this else null
         val animatable = drawable as? Animatable ?: return
-        val shouldRun = animateGifs && renderingActive && windowAttached && key in animatedAssetKeys
+        val shouldRun = animateGifs && renderingActive && windowAttached && aggregatedVisible && key in animatedAssetKeys
         if (shouldRun) {
             if (!animatable.isRunning) {
                 animatable.start()
@@ -1254,7 +1266,11 @@ open class ChatMessageTextView private constructor(
                 maybeApplyStagedRow()
             }
             if (isAttachedToWindow) updateDrawableAnimations()
+            invalidateClipDrawCache()
+            invalidate()
         } else {
+            clipRelativeTimeRefresh?.let(mainHandler::removeCallbacks)
+            clipRelativeTimeRefresh = null
             assetObservers.keys.toList().forEach(::removeAssetObserver)
             stagedAssetObservers.keys.toList().forEach(::removeStagedAssetObserver)
             clipMetadataObservers.keys.toList().forEach(::removeClipMetadataObserver)
@@ -1263,8 +1279,24 @@ open class ChatMessageTextView private constructor(
         }
     }
 
+    override fun onVisibilityAggregated(isVisible: Boolean) {
+        super.onVisibilityAggregated(isVisible)
+        aggregatedVisible = isVisible
+        updateDrawableAnimations()
+        if (isVisible) {
+            invalidateClipDrawCache()
+            invalidate()
+        } else {
+            clipRelativeTimeRefresh?.let(mainHandler::removeCallbacks)
+            clipRelativeTimeRefresh = null
+            longPressRunnable?.let(mainHandler::removeCallbacks)
+            longPressRunnable = null
+        }
+    }
+
     override fun onDetachedFromWindow() {
         windowAttached = false
+        aggregatedVisible = false
         clipRelativeTimeRefresh?.let(mainHandler::removeCallbacks)
         clipRelativeTimeRefresh = null
         // Detach only unregisters callbacks. Keep the bind generation so a staged row can survive
@@ -1423,6 +1455,7 @@ private class ChatNamePaintSpan(
 ) : CharacterStyle() {
     private var imageHandle: Any? = null
     private var imageShader: Shader? = null
+    private val gradientShader: Shader? by lazy(LazyThreadSafetyMode.NONE, ::createGradientShader)
 
     override fun updateDrawState(textPaint: TextPaint) {
         textPaint.clearShadowLayer()
@@ -1448,40 +1481,42 @@ private class ChatNamePaintSpan(
                 return
             }
         }
-        textPaint.shader = when {
-            paintSpec.colors.size >= 2 -> {
-                val shader = if (paintSpec.type == "RADIAL_GRADIENT") {
-                    android.graphics.RadialGradient(
-                        140f,
-                        14f,
-                        140f,
-                        paintSpec.colors.toIntArray(),
-                        paintSpec.colorPositions.takeIf { it.size == paintSpec.colors.size }?.toFloatArray(),
-                        if (paintSpec.repeat) Shader.TileMode.REPEAT else Shader.TileMode.CLAMP,
-                    )
-                } else {
-                    LinearGradient(
-                        0f,
-                        0f,
-                        280f,
-                        0f,
-                        paintSpec.colors.toIntArray(),
-                        paintSpec.colorPositions.takeIf { it.size == paintSpec.colors.size }?.toFloatArray(),
-                        if (paintSpec.repeat) Shader.TileMode.REPEAT else Shader.TileMode.CLAMP,
-                    ).also { value ->
-                        paintSpec.angle?.let { angle ->
-                            value.setLocalMatrix(android.graphics.Matrix().apply {
-                                setRotate((angle - 90).toFloat(), 140f, 14f)
-                            })
-                        }
-                    }
-                }
-                shader
-            }
-            else -> null
-        }
+        textPaint.shader = gradientShader
         if (paintSpec.colors.size == 1) textPaint.color = paintSpec.colors.single()
         applyShadow(textPaint)
+    }
+
+    private fun createGradientShader(): Shader? = when {
+        paintSpec.colors.size >= 2 -> {
+            val shader = if (paintSpec.type == "RADIAL_GRADIENT") {
+                android.graphics.RadialGradient(
+                    140f,
+                    14f,
+                    140f,
+                    paintSpec.colors.toIntArray(),
+                    paintSpec.colorPositions.takeIf { it.size == paintSpec.colors.size }?.toFloatArray(),
+                    if (paintSpec.repeat) Shader.TileMode.REPEAT else Shader.TileMode.CLAMP,
+                )
+            } else {
+                LinearGradient(
+                    0f,
+                    0f,
+                    280f,
+                    0f,
+                    paintSpec.colors.toIntArray(),
+                    paintSpec.colorPositions.takeIf { it.size == paintSpec.colors.size }?.toFloatArray(),
+                    if (paintSpec.repeat) Shader.TileMode.REPEAT else Shader.TileMode.CLAMP,
+                ).also { value ->
+                    paintSpec.angle?.let { angle ->
+                        value.setLocalMatrix(android.graphics.Matrix().apply {
+                            setRotate((angle - 90).toFloat(), 140f, 14f)
+                        })
+                    }
+                }
+            }
+            shader
+        }
+        else -> null
     }
 
     private fun applyShadow(textPaint: TextPaint) {
@@ -1548,8 +1583,13 @@ private class ChatAssetSpan(
             val height = layerSpec.targetHeight
             val left = (centerX - width / 2f).roundToInt()
             val layerTop = (centerY - height / 2f).roundToInt()
-            drawable.setBounds(left, layerTop, left + width, layerTop + height)
+            // Repeated emotes share a drawable within the row. Move the canvas instead
+            // of invalidating its bounds at every occurrence on every animation frame.
+            drawable.setBounds(0, 0, width, height)
+            val saveCount = canvas.save()
+            canvas.translate(left.toFloat(), layerTop.toFloat())
             drawable.draw(canvas)
+            canvas.restoreToCount(saveCount)
         }
     }
 

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatTimelineAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatTimelineAdapter.kt
@@ -18,6 +18,7 @@ class ChatTimelineAdapter(
     private val onMessageClick: ((ChatMessageId) -> Unit)? = null,
 ) : RecyclerView.Adapter<ChatTimelineAdapter.Holder>() {
     private val rows = ArrayList<ChatRowUiModel>()
+    var renderingActive = true
 
     val currentList: List<ChatRowUiModel>
         get() = rows
@@ -34,12 +35,13 @@ class ChatTimelineAdapter(
         },
     )
     override fun onBindViewHolder(holder: Holder, position: Int) {
+        holder.view.setRenderingActive(renderingActive)
         holder.view.setMessageTextSizeSp(textSizeSp)
         holder.view.setAnimateGifs(animateGifs)
         holder.bind(rows[position])
     }
 
-    /** Replaces the complete snapshot for reconciliation and presentation-wide changes. */
+    /** Replaces the complete snapshot for reconciliation and presentation-wide updates. */
     fun replaceAll(newRows: List<ChatRowUiModel>, commitCallback: (() -> Unit)? = null) {
         val nextRows = newRows.toList()
         rows.clear()
@@ -110,13 +112,20 @@ class ChatTimelineAdapter(
     }
 
     fun setMessageTextSizeSp(value: Float) {
+        if (textSizeSp == value) return
         textSizeSp = value
         if (itemCount > 0) notifyItemRangeChanged(0, itemCount)
     }
     fun setAnimateGifs(value: Boolean) {
+        if (animateGifs == value) return
         animateGifs = value
         if (itemCount > 0) notifyItemRangeChanged(0, itemCount)
     }
+    override fun onViewAttachedToWindow(holder: Holder) {
+        super.onViewAttachedToWindow(holder)
+        holder.view.setRenderingActive(renderingActive)
+    }
+
     override fun onViewRecycled(holder: Holder) { holder.view.recycle(); super.onViewRecycled(holder) }
 
     class Holder(val view: ChatMessageTextView) : RecyclerView.ViewHolder(view) {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatV2RendererController.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatV2RendererController.kt
@@ -41,6 +41,9 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.emitAll
+import com.github.andreyasadchy.xtra.ui.chat.v2.presentation.ChatPresentationCatalog
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -145,6 +148,7 @@ class ChatV2RendererController(
     private val latestMessages = ArrayDeque<ChatMessage>()
     private val latestRows = ArrayList<ChatRowUiModel>()
     private var latestPublication: PresentationPublication? = null
+    private var committedPublication: PresentationPublication? = null
     private val reuseIndex = ChatPresentationReuseIndex()
     private val presentationSnapshot = ChatPresentationSnapshot()
     private val rendererVisible = MutableStateFlow(true)
@@ -170,24 +174,29 @@ class ChatV2RendererController(
         lifecycleOwner = owner
         collectionJob = owner.lifecycleScope.launch {
             owner.repeatOnLifecycle(Lifecycle.State.STARTED) {
-                rendererVisible
-                    .flatMapLatest { visible ->
-                        if (!visible) {
-                            emptyFlow()
-                        } else {
-                            activeSessions.flatMapLatest { active ->
-                                if (active == null ||
-                                    active.spec.channelId != expectedChannelId ||
-                                    !active.spec.channelLogin.equals(expectedChannelLogin, ignoreCase = true)
-                                ) {
-                                    emptyFlow()
-                                } else {
-                                    active.presentationFlow()
+                updateRenderingActive(rendererVisible.value)
+                try {
+                    rendererVisible
+                        .flatMapLatest { visible ->
+                            if (!visible) {
+                                emptyFlow()
+                            } else {
+                                activeSessions.flatMapLatest { active ->
+                                    if (active == null ||
+                                        active.spec.channelId != expectedChannelId ||
+                                        !active.spec.channelLogin.equals(expectedChannelLogin, ignoreCase = true)
+                                    ) {
+                                        emptyFlow()
+                                    } else {
+                                        active.presentationFlow()
+                                    }
                                 }
                             }
                         }
-                    }
-                    .collect { publication -> publish(publication) }
+                        .collect { publication -> publish(publication) }
+                } finally {
+                    updateRenderingActive(false)
+                }
             }
         }
     }
@@ -196,8 +205,13 @@ class ChatV2RendererController(
     fun setVisible(visible: Boolean) {
         if (rendererVisible.value == visible) return
         rendererVisible.value = visible
+        updateRenderingActive(visible && lifecycleOwner?.lifecycle?.currentState?.isAtLeast(Lifecycle.State.STARTED) == true)
+    }
+
+    private fun updateRenderingActive(active: Boolean) {
+        adapter.renderingActive = active
         for (index in 0 until recyclerView.childCount) {
-            (recyclerView.getChildAt(index) as? ChatMessageTextView)?.setRenderingActive(visible)
+            (recyclerView.getChildAt(index) as? ChatMessageTextView)?.setRenderingActive(active)
         }
     }
 
@@ -215,6 +229,7 @@ class ChatV2RendererController(
         adapter.dispose()
         latestMessages.clear()
         latestRows.clear()
+        committedPublication = null
         previousIds.clear()
         hasPreviousIds = false
         previousTailId = null
@@ -296,6 +311,19 @@ class ChatV2RendererController(
 
     private suspend fun publish(publication: PresentationPublication) {
         if (!rendererVisible.value) return
+        val committed = committedPublication
+        if (styleRefreshJob?.isActive != true && committed != null && committed.key == publication.key &&
+            committed.timelineVersion == publication.timelineVersion &&
+            committed.forceRefreshRevision == publication.forceRefreshRevision &&
+            committed.metadataSettlement == publication.metadataSettlement &&
+            publication.metadataSettlement.let { it.structuralSettled && it.badgesSettled && it.rewardsSettled }
+        ) {
+            // Settled rows deliberately freeze their metadata. A new 7TV entitlement
+            // affects future messages, so it must not rescan the entire visible history.
+            latestPublication = publication
+            committedPublication = publication
+            return
+        }
         val previousPublication = latestPublication
         val previousRows = latestRows
         val previousMessageCount = latestMessages.size
@@ -413,6 +441,7 @@ class ChatV2RendererController(
                 latestMessages.addAll(requireNotNull(currentMessages))
             }
             previousTailId = latestMessages.lastOrNull()?.id
+            committedPublication = preparedPublication
             ChatRenderDiagnostics.recordPublication(
                 messageCount = latestMessages.size,
                 changed = compiled.result.messagesChanged,
@@ -648,8 +677,9 @@ class ChatV2RendererController(
             highlightSettings = highlightSettings,
         )
 
-    private fun ActiveChatSession.presentationFlow() =
-        combine(
+    private fun ActiveChatSession.presentationFlow() = flow {
+        val presentationCatalog = ChatPresentationCatalog()
+        emitAll(combine(
             session.attachUi(
                 batchIntervalMsFlow = ChatBatchingPreferences.intervalMs(recyclerView.context),
             ),
@@ -679,19 +709,11 @@ class ChatV2RendererController(
                         rewardsSettled = rewardsSettled,
                     ),
                     forceRefreshRevision = catalogState.forceRefreshRevision,
-                    catalogState.snapshot.copy(
-                        channelPointRewards = rewards.byId,
-                        automaticChannelPointRewards = rewards.automaticByType,
-                        channelPointRewardsRevision = rewards.hashCode(),
-                        // The v2 catalog owns live 7TV updates. Keep the legacy snapshot as a
-                        // compatibility fallback without allowing it to erase newer v2 data.
-                        userDecorations = decorations.users + catalogState.snapshot.userDecorations,
-                        namePaints = decorations.paints + catalogState.snapshot.namePaints,
-                        sevenTvBadges = decorations.badges + catalogState.snapshot.sevenTvBadges,
-                    ),
+                    presentationCatalog.resolve(catalogState.snapshot, rewards, decorations),
                 )
             }
-        }.filter { it != null }.map { it!! }
+        }.filter { it != null }.map { it!! })
+    }
 
     private data class PresentationPublication(
         val key: com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatSessionKey,

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/captions/LiveCaptionOverlayView.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/captions/LiveCaptionOverlayView.kt
@@ -197,6 +197,11 @@ class LiveCaptionOverlayView @JvmOverloads constructor(
         applySavedPosition()
     }
 
+    override fun onLayout(changed: Boolean, left: Int, top: Int, right: Int, bottom: Int) {
+        super.onLayout(changed, left, top, right, bottom)
+        if (changed) applySavedPosition()
+    }
+
     override fun onDetachedFromWindow() {
         preferences.unregisterOnSharedPreferenceChangeListener(preferenceListener)
         cancelLineAnimations()
@@ -295,7 +300,10 @@ class LiveCaptionOverlayView @JvmOverloads constructor(
     private fun applySavedPosition() {
         val parent = parent as? android.view.ViewGroup ?: return
         if (width == 0 || height == 0 || parent.width == 0 || parent.height == 0) {
-            post { applySavedPosition() }
+            // The overlay starts GONE and can be measured before its parent has a
+            // size. Retrying with post() here creates an unbounded main-thread loop
+            // until captions become visible. onSizeChanged/onLayout call this again
+            // once both dimensions are available.
             return
         }
         if (!preferences.contains(C.PLAYER_LIVE_CAPTION_POSITION_CENTER_X) ||

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/captions/PcmPresentationDelayBuffer.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/captions/PcmPresentationDelayBuffer.kt
@@ -64,18 +64,20 @@ internal class PcmPresentationDelayBuffer(capacityBytes: Int) {
     }
 
     private fun append(input: ByteBuffer) {
-        require(input.remaining() <= bytes.size - size)
-        while (input.hasRemaining()) {
-            bytes[(readIndex + size) % bytes.size] = input.get()
-            size++
-        }
+        val count = input.remaining()
+        require(count <= bytes.size - size)
+        val writeIndex = (readIndex + size) % bytes.size
+        val firstCount = minOf(count, bytes.size - writeIndex)
+        input.get(bytes, writeIndex, firstCount)
+        if (count > firstCount) input.get(bytes, 0, count - firstCount)
+        size += count
     }
 
     private fun read(output: ByteBuffer, count: Int) {
-        repeat(count) {
-            output.put(bytes[readIndex])
-            readIndex = (readIndex + 1) % bytes.size
-            size--
-        }
+        val firstCount = minOf(count, bytes.size - readIndex)
+        output.put(bytes, readIndex, firstCount)
+        if (count > firstCount) output.put(bytes, 0, count - firstCount)
+        readIndex = (readIndex + count) % bytes.size
+        size -= count
     }
 }


### PR DESCRIPTION
Busy chat repeatedly changed emote drawing bounds and rebuilt username gradients. Reuse those values, stop hidden chat animations and timers, and avoid rebinding rows when settings have not changed.

This also bounds burst render wakeups, reuses catalog projections instead of copying metadata maps for every chat publication, limits concurrent personal-emote loads, and makes transport teardown synchronous and cancellation-safe. The composer now changes layout parameters only when their actual values change, removing a self-triggering requestLayout loop. Direct adapter holders can be created before a Fragment is attached.

Chat profile clicks now work through accessibility actions without stealing URL or emote ClickableSpan taps. Caption audio buffering uses bulk copies instead of copying each byte individually.

The active-playback CPU profile found a larger architectural issue: `LiveCaptionOverlayView` posted an immediate `applySavedPosition()` retry while it was zero-sized. A 100 Hz Perfetto profile with a 720p stream and visible chat measured 1,896 main-thread samples in 20 seconds before the fix, including about 918 samples in that retry stack. After the fix, the matched profile measured 10 main-thread samples; a scheduler-inclusive run measured 104.8 ms of main-thread CPU across about 19.4 seconds, with 19.13 seconds sleeping. Position restoration now retries through `onSizeChanged()` and changed `onLayout()` instead of posting an unbounded loop.

Validation: `:app:assembleDebug` passes after the caption fix. The xtra-api35 AVD profile used 0-10 seconds idle playback and 10-20 seconds with four chat swipes. The earlier rendering capture recorded 1,296 improper-layout warnings before the composer fix and 0 after it; janky frames improved from 3.80% to 2.82% and frame p90 from 18 ms to 14 ms. PSS stayed within capture variance. These are debug-build emulator measurements; physical-device battery and thermal savings still need measurement.
A paired active-chat A/B on the same 9.5K-viewer channel showed the remaining rendering target: animated emotes enabled used 11.56 s of `RenderThread` CPU and 996 ms of `AnimatedImageThread` CPU in 20 seconds; the existing animated-emotes-off setting used 406 ms of `RenderThread` CPU. A 30 Hz callback-cap prototype was measured and reverted because it did not materially lower that cost. The next animation optimization should limit the number of active animated drawables or move their rendering off the full chat surface.