### PR TITLE
Fix chat gaps during fast message bursts

### DIFF
--- a/app/src/androidTest/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatMessageTextViewTest.kt
+++ b/app/src/androidTest/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatMessageTextViewTest.kt
@@ -222,7 +222,7 @@ class ChatMessageTextViewTest {
     }
 
     @Test
-    fun pendingAssetKeepsFinalGeometryAndRowIsNotExposed() = runBlocking {
+    fun pendingAssetKeepsFinalGeometryAndRowRemainsVisible() = runBlocking {
         val context = InstrumentationRegistry.getInstrumentation().targetContext
         val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
         val asset = CompletableDeferred<ChatImageHandle?>()
@@ -237,7 +237,8 @@ class ChatMessageTextViewTest {
                 val spanned = view.text as Spanned
                 val usernameColor = spanned.getSpans(0, 5, ForegroundColorSpan::class.java).single().foregroundColor
                 assertNotEquals(Color.WHITE, usernameColor)
-                assertEquals(0f, view.alpha)
+                assertEquals(1f, view.alpha)
+                assertTrue(view.text.toString().contains("login"))
                 span = spanned.getSpans(0, spanned.length, ReplacementSpan::class.java).single()
                 val metrics = Paint.FontMetricsInt()
                 assertEquals(spec.compositionWidth, span.getSize(Paint(), spanned, 0, 1, metrics))
@@ -255,6 +256,33 @@ class ChatMessageTextViewTest {
                 assertEquals(1f, view.alpha)
                 assertEquals(spec.compositionWidth, span.getSize(Paint(), spanned, 0, 1, metrics))
                 assertTrue(containsColor(draw(span, spanned, metrics), Color.RED))
+            }
+        } finally {
+            attached.close()
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun pendingAssetsNeverHideRecycledRows() = runBlocking {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val release = CompletableDeferred<ChatImageHandle?>()
+        val repository = ChatAssetRepository(scope, ChatAssetLoader { release.await() })
+        val attached = attachView(repository)
+        val view = attached.view
+        try {
+            repeat(100) { index ->
+                runOnMain {
+                    view.bind(
+                        row(
+                            ChatAssetSpec(ChatAssetKey("pending-$index"), 20, 20, 28),
+                            username = "login",
+                        ),
+                    )
+                    assertEquals(1f, view.alpha)
+                    assertTrue(view.text.toString().contains("login"))
+                    view.recycle()
+                }
             }
         } finally {
             attached.close()
@@ -556,7 +584,7 @@ class ChatMessageTextViewTest {
     }
 
     @Test
-    fun failedEmoteUsesTextOnlyAfterFailure() = runBlocking {
+    fun failedEmoteUsesTextOnlyAfterFailureWithoutHidingRow() = runBlocking {
         val context = InstrumentationRegistry.getInstrumentation().targetContext
         val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
         val releaseFailure = CompletableDeferred<Unit>()
@@ -573,7 +601,7 @@ class ChatMessageTextViewTest {
                 view.bind(row(spec, fallback = "OMEGALUL"))
                 val spanned = view.text as Spanned
                 span = spanned.getSpans(0, spanned.length, ReplacementSpan::class.java).single()
-                assertEquals(0f, view.alpha)
+                assertEquals(1f, view.alpha)
                 assertFalse(hasVisiblePixels(draw(span, spanned, Paint.FontMetricsInt())))
             }
 
@@ -593,7 +621,7 @@ class ChatMessageTextViewTest {
     }
 
     @Test
-    fun rowRevealsOnlyAfterAllInitialAssetsSettle() = runBlocking {
+    fun rowRemainsVisibleWhileInitialAssetsSettle() = runBlocking {
         val context = InstrumentationRegistry.getInstrumentation().targetContext
         val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
         val first = CompletableDeferred<ChatImageHandle?>()
@@ -629,13 +657,13 @@ class ChatMessageTextViewTest {
         try {
             runOnMain {
                 view.bind(row)
-                assertEquals(0f, view.alpha)
+                assertEquals(1f, view.alpha)
             }
 
             first.complete(ChatImageHandle { SolidDrawable(Color.RED) })
             awaitSettled(repository, listOf(firstSpec.key))
             awaitPreDraw(view)
-            runOnMain { assertEquals(0f, view.alpha) }
+            runOnMain { assertEquals(1f, view.alpha) }
 
             second.complete(null)
             awaitPresentationTerminal(repository, listOf(secondSpec.key))
@@ -648,7 +676,7 @@ class ChatMessageTextViewTest {
     }
 
     @Test
-    fun retryableFailureKeepsInitialRowHiddenUntilRecovery() = runBlocking {
+    fun retryableFailureKeepsRowVisibleUntilRecovery() = runBlocking {
         val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
         val firstFailed = CompletableDeferred<Unit>()
         val secondStarted = CompletableDeferred<Unit>()
@@ -680,7 +708,7 @@ class ChatMessageTextViewTest {
             runOnMain {
                 val spanned = view.text as Spanned
                 val span = spanned.getSpans(0, spanned.length, ReplacementSpan::class.java).single()
-                assertEquals(0f, view.alpha)
+                assertEquals(1f, view.alpha)
                 assertFalse(hasVisiblePixels(draw(span, spanned, Paint.FontMetricsInt())))
             }
 
@@ -689,7 +717,7 @@ class ChatMessageTextViewTest {
             runOnMain {
                 val spanned = view.text as Spanned
                 val span = spanned.getSpans(0, spanned.length, ReplacementSpan::class.java).single()
-                assertEquals(0f, view.alpha)
+                assertEquals(1f, view.alpha)
                 assertFalse(hasVisiblePixels(draw(span, spanned, Paint.FontMetricsInt())))
             }
 
@@ -786,7 +814,7 @@ class ChatMessageTextViewTest {
     }
 
     @Test
-    fun recycledRowGetsANewInitialGate() = runBlocking {
+    fun recycledRowRemainsVisibleWithPendingAssets() = runBlocking {
         val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
         val first = CompletableDeferred<ChatImageHandle?>()
         val second = CompletableDeferred<ChatImageHandle?>()
@@ -800,10 +828,10 @@ class ChatMessageTextViewTest {
             val secondSpec = ChatAssetSpec(ChatAssetKey("second-row"), 20, 20, 28)
             runOnMain {
                 view.bind(row(firstSpec))
-                assertEquals(0f, view.alpha)
+                assertEquals(1f, view.alpha)
                 view.recycle()
                 view.bind(row(secondSpec))
-                assertEquals(0f, view.alpha)
+                assertEquals(1f, view.alpha)
             }
             second.complete(ChatImageHandle { SolidDrawable(Color.RED) })
             withTimeout(2_000) {
@@ -818,7 +846,7 @@ class ChatMessageTextViewTest {
     }
 
     @Test
-    fun clipRowReservesGeometryAndWaitsForMetadataAndThumbnail() = runBlocking {
+    fun clipRowReservesGeometryWhileMetadataAndThumbnailLoad() = runBlocking {
         val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
         val releaseMetadata = CompletableDeferred<ChatClipPreview?>()
         val releaseThumbnail = CompletableDeferred<ChatImageHandle?>()
@@ -842,7 +870,7 @@ class ChatMessageTextViewTest {
         try {
             runOnMain {
                 view.bind(row)
-                assertEquals(0f, view.alpha)
+                assertEquals(1f, view.alpha)
             }
             awaitPreDraw(view)
             val reservedHeight = view.measuredHeight
@@ -860,7 +888,7 @@ class ChatMessageTextViewTest {
             }
             awaitPreDraw(view)
             runOnMain {
-                assertEquals(0f, view.alpha)
+                assertEquals(1f, view.alpha)
                 assertEquals(reservedHeight, view.measuredHeight)
             }
             releaseThumbnail.complete(ChatImageHandle { SolidDrawable(Color.RED) })
@@ -1202,7 +1230,7 @@ class ChatMessageTextViewTest {
 
         runOnMain {
             holder = adapter.onCreateViewHolder(FrameLayout(context), 0)
-            adapter.submitList(listOf(row)) { submitted.countDown() }
+            adapter.replaceAll(listOf(row)) { submitted.countDown() }
         }
         assertTrue(submitted.await(1, TimeUnit.SECONDS))
 
@@ -1393,7 +1421,7 @@ class ChatMessageTextViewTest {
         val firstCommitted = CountDownLatch(1)
         runOnMain {
             holder = adapter.onCreateViewHolder(FrameLayout(context), 0)
-            adapter.submitList(listOf(textRow("first", ChatMessageId("first")))) { firstCommitted.countDown() }
+            adapter.replaceAll(listOf(textRow("first", ChatMessageId("first")))) { firstCommitted.countDown() }
         }
         assertTrue(firstCommitted.await(1, TimeUnit.SECONDS))
         runOnMain {
@@ -1402,7 +1430,7 @@ class ChatMessageTextViewTest {
         }
         val committed = CountDownLatch(1)
         runOnMain {
-            adapter.submitList(listOf(textRow("second", ChatMessageId("second")))) { committed.countDown() }
+            adapter.replaceAll(listOf(textRow("second", ChatMessageId("second")))) { committed.countDown() }
         }
         assertTrue(committed.await(1, TimeUnit.SECONDS))
         runOnMain {
@@ -1484,9 +1512,9 @@ class ChatMessageTextViewTest {
         val first = ChatAssetSpec(ChatAssetKey("first"), 16, 16, 24)
         val second = ChatAssetSpec(ChatAssetKey("second"), 16, 16, 24)
         runOnMain {
-            view.bind(row(first))
+            view.bind(row(first, id = ChatMessageId("first-row")))
             assertEquals(1, repository.observerCount(first.key))
-            view.bind(row(second))
+            view.bind(row(second, id = ChatMessageId("second-row")))
             assertEquals(0, repository.observerCount(first.key))
             assertEquals(1, repository.observerCount(second.key))
         }
@@ -1518,8 +1546,9 @@ class ChatMessageTextViewTest {
         interaction: ChatEmoteInteraction? = null,
         fallback: String = ":asset:",
         animated: Boolean = true,
+        id: ChatMessageId = ChatMessageId("row"),
     ) = ChatRowUiModel(
-        id = ChatMessageId("row"), channelId = "channel", timestampText = null,
+        id = id, channelId = "channel", timestampText = null,
         pieces = buildList {
             username?.let { add(ChatPiece.Username(it, 0xffff8a80.toInt())) }
             add(ChatPiece.Emote(spec, fallback, animated = animated, interaction = interaction))

--- a/app/src/androidTest/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatTimelineAdapterTest.kt
+++ b/app/src/androidTest/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatTimelineAdapterTest.kt
@@ -8,7 +8,6 @@ import com.github.andreyasadchy.xtra.ui.chat.v2.assets.ChatAssetRepository
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessageId
 import com.github.andreyasadchy.xtra.ui.chat.v2.presentation.ChatPiece
 import com.github.andreyasadchy.xtra.ui.chat.v2.presentation.ChatRowUiModel
-import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -31,7 +30,7 @@ class ChatTimelineAdapterTest {
         val adapter = adapter(scope)
         try {
             submitAndWait(adapter, listOf(row("a"), row("b"), row("c")))
-            val observer = RecordingObserver()
+            val observer = RecordingObserver(adapter)
             onMain { adapter.registerAdapterDataObserver(observer) }
 
             var applied = false
@@ -81,7 +80,7 @@ class ChatTimelineAdapterTest {
     }
 
     @Test
-    fun reconciliationFallbackReplacesRowsByStableId() {
+    fun replaceAllReplacesRowsForReconciliation() {
         val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
         val adapter = adapter(scope)
         try {
@@ -94,21 +93,72 @@ class ChatTimelineAdapterTest {
     }
 
     @Test
-    fun staleFallbackDiffCannotOverwriteNewerSubmission() {
+    fun replaceAllCommitsBeforeAHighVolumeDeltaBurst() {
         val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
-        val dispatcher = ManualDispatcher()
-        val adapter = adapter(scope, dispatcher)
+        val adapter = adapter(scope)
         try {
-            val oldRows = (0 until 600).map { row("old-$it") }
-            val newRows = listOf(row("new"))
-            val committed = CountDownLatch(1)
-            onMain { adapter.submitList(oldRows) }
-            onMain { adapter.submitList(newRows) { committed.countDown() } }
+            onMain { adapter.replaceAll((0 until 600).map { row("initial-$it") }) }
+            repeat(100) { index ->
+                var applied = false
+                onMain {
+                    applied = adapter.appendDelta(
+                        appendedRows = listOf(row("tail-$index")),
+                        evictedHeadCount = 1,
+                        expectedSize = 600,
+                    )
+                }
+                assertTrue(applied)
+            }
+            assertEquals(600, adapter.itemCount)
+            assertEquals("tail-99", adapter.currentList.last().id.value)
+        } finally {
+            dispose(adapter, scope)
+        }
+    }
 
-            dispatcher.runNext()
-            dispatcher.runNext()
-            assertTrue(committed.await(1, TimeUnit.SECONDS))
-            assertEquals(newRows, adapter.currentList)
+    @Test
+    fun rejectedDeltaLeavesRowsUntouchedAndTheNextDeltaApplies() {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val adapter = adapter(scope)
+        try {
+            onMain { adapter.replaceAll(listOf(row("a"), row("b"), row("c"))) }
+            var applied = true
+            onMain {
+                applied = adapter.appendDelta(
+                    appendedRows = listOf(row("d")),
+                    evictedHeadCount = 1,
+                    expectedSize = 99,
+                )
+            }
+            assertFalse(applied)
+            assertEquals(listOf("a", "b", "c"), adapter.currentList.map { it.id.value })
+
+            onMain {
+                applied = adapter.appendDelta(
+                    appendedRows = listOf(row("d")),
+                    evictedHeadCount = 1,
+                    expectedSize = 3,
+                )
+            }
+            assertTrue(applied)
+            assertEquals(listOf("b", "c", "d"), adapter.currentList.map { it.id.value })
+        } finally {
+            dispose(adapter, scope)
+        }
+    }
+
+    @Test
+    fun rangeNotificationsSeeTheMatchingIntermediateSnapshots() {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val adapter = adapter(scope)
+        try {
+            onMain { adapter.replaceAll(listOf(row("a"), row("b"), row("c"))) }
+            val observer = RecordingObserver(adapter)
+            onMain { adapter.registerAdapterDataObserver(observer) }
+
+            onMain { adapter.appendDelta(listOf(row("d")), evictedHeadCount = 1, expectedSize = 3) }
+
+            assertEquals(listOf("b,c", "b,c,d"), observer.snapshots.toList())
         } finally {
             dispose(adapter, scope)
         }
@@ -133,19 +183,15 @@ class ChatTimelineAdapterTest {
         assertEquals(FollowMode.USER_SCROLLED_UP, controller.state.followMode)
     }
 
-    private fun adapter(
-        scope: CoroutineScope,
-        diffDispatcher: CoroutineDispatcher = Dispatchers.Default,
-    ) = ChatTimelineAdapter(
+    private fun adapter(scope: CoroutineScope) = ChatTimelineAdapter(
         assets = ChatAssetRepository(scope, ChatAssetLoader { null }),
         textSizeSp = 14f,
         animateGifs = false,
-        diffDispatcher = diffDispatcher,
     )
 
     private fun submitAndWait(adapter: ChatTimelineAdapter, rows: List<ChatRowUiModel>) {
         val committed = CountDownLatch(1)
-        onMain { adapter.submitList(rows) { committed.countDown() } }
+        onMain { adapter.replaceAll(rows) { committed.countDown() } }
         assertTrue(committed.await(1, TimeUnit.SECONDS))
     }
 
@@ -170,28 +216,18 @@ class ChatTimelineAdapterTest {
         isAction = false,
     )
 
-    private class RecordingObserver : RecyclerView.AdapterDataObserver() {
+    private class RecordingObserver(private val adapter: ChatTimelineAdapter) : RecyclerView.AdapterDataObserver() {
         val events = ConcurrentLinkedQueue<String>()
+        val snapshots = ConcurrentLinkedQueue<String>()
 
         override fun onItemRangeRemoved(positionStart: Int, itemCount: Int) {
             events += "remove:$positionStart:$itemCount"
+            snapshots += adapter.currentList.joinToString(",") { it.id.value }
         }
 
         override fun onItemRangeInserted(positionStart: Int, itemCount: Int) {
             events += "insert:$positionStart:$itemCount"
-        }
-    }
-
-    private class ManualDispatcher : CoroutineDispatcher() {
-        private val queue = ConcurrentLinkedQueue<Runnable>()
-
-        override fun dispatch(context: kotlin.coroutines.CoroutineContext, block: Runnable) {
-            queue += block
-        }
-
-        fun runNext() {
-            val task = checkNotNull(queue.poll()) { "No queued diff" }
-            task.run()
+            snapshots += adapter.currentList.joinToString(",") { it.id.value }
         }
     }
 }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatMessageTextView.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatMessageTextView.kt
@@ -40,7 +40,6 @@ import android.widget.TextView
 import android.util.TypedValue
 import android.util.AttributeSet
 import androidx.core.content.ContextCompat
-import androidx.core.view.doOnPreDraw
 import androidx.appcompat.widget.AppCompatTextView
 import com.github.andreyasadchy.xtra.R
 import com.github.andreyasadchy.xtra.XtraApp
@@ -142,8 +141,6 @@ open class ChatMessageTextView private constructor(
     private var touchMoved = false
     private var clipPreviewSlugs = emptySet<String>()
     private var clipPreviewAssetKeys = emptySet<ChatAssetKey>()
-    private var awaitingInitialAssetFrame = false
-    private var revealOnPreDrawPosted = false
     private var stagedRow: ChatRowUiModel? = null
     private var stagedBindGeneration = 0L
     private var stagedAssetKeys = emptySet<ChatAssetKey>()
@@ -220,7 +217,6 @@ open class ChatMessageTextView private constructor(
 
     private fun shouldStageRow(row: ChatRowUiModel): Boolean =
         boundMessageId == row.id &&
-            !awaitingInitialAssetFrame &&
             hasPendingAssets(row.assetKeys())
 
     private fun stageRow(row: ChatRowUiModel) {
@@ -269,14 +265,12 @@ open class ChatMessageTextView private constructor(
 
     private fun bindRow(row: ChatRowUiModel) {
         invalidateClipDrawCache()
-        val sameRevealedMessage = boundMessageId == row.id && !awaitingInitialAssetFrame
-        if (!sameRevealedMessage) {
-            awaitingInitialAssetFrame = true
-            alpha = 0f
+        if (boundMessageId != row.id) {
             latchedFailedCompositionKeys.clear()
             latchedFailedDirectKeys.clear()
             latchedFailedClipMetadataSlugs.clear()
         }
+        alpha = 1f
         boundRow = row
         boundMessageId = row.id
         longPressConsumed = false
@@ -472,50 +466,6 @@ open class ChatMessageTextView private constructor(
         if (row.isAction) output.setSpan(StyleSpan(android.graphics.Typeface.ITALIC), 0, output.length, 0)
         contentDescription = row.accessibilityText
         text = output
-        maybeRevealInitialAssetFrame()
-    }
-
-    private fun maybeRevealInitialAssetFrame() {
-        if (!awaitingInitialAssetFrame) return
-
-        latchFailedClipMetadata()
-
-        if (hasPendingAssets(keys + clipPreviewAssetKeys)) return
-        if (clipPreviewSlugs.any { slug ->
-                when (clipPreviews?.peekState(slug)) {
-                    ChatClipPreviewState.Missing,
-                    ChatClipPreviewState.Loading -> true
-                    is ChatClipPreviewState.Ready,
-                    null -> false
-                }
-            }
-        ) return
-
-        if (!isAttachedToWindow || revealOnPreDrawPosted) return
-        revealOnPreDrawPosted = true
-        doOnPreDraw {
-            revealOnPreDrawPosted = false
-            revealInitialAssetFrameIfReady()
-        }
-    }
-
-    private fun revealInitialAssetFrameIfReady() {
-        if (!awaitingInitialAssetFrame) return
-        latchFailedClipMetadata()
-        if (hasPendingAssets(keys + clipPreviewAssetKeys) || clipPreviewSlugs.any { slug ->
-                when (clipPreviews?.peekState(slug)) {
-                    ChatClipPreviewState.Missing,
-                    ChatClipPreviewState.Loading -> true
-                    is ChatClipPreviewState.Ready,
-                    null -> false
-                }
-            }
-        ) return
-
-        latchTerminalAssetFailures()
-
-        awaitingInitialAssetFrame = false
-        alpha = 1f
     }
 
     private fun hasPendingAssets(assetKeys: Set<ChatAssetKey>): Boolean = assetKeys.any { key ->
@@ -586,7 +536,6 @@ open class ChatMessageTextView private constructor(
             ChatRenderDiagnostics.recordDrawOnlyInvalidation()
         }
         postInvalidateOnAnimation()
-        maybeRevealInitialAssetFrame()
     }
 
     private fun observeAsset(key: ChatAssetKey) {
@@ -1240,8 +1189,6 @@ open class ChatMessageTextView private constructor(
         text = null
         boundMessageId = null
         boundRow = null
-        awaitingInitialAssetFrame = false
-        revealOnPreDrawPosted = false
         alpha = 1f
     }
 
@@ -1305,7 +1252,6 @@ open class ChatMessageTextView private constructor(
             if (isAttachedToWindow) {
                 refreshClipPreviewAssets()
                 maybeApplyStagedRow()
-                maybeRevealInitialAssetFrame()
             }
             if (isAttachedToWindow) updateDrawableAnimations()
         } else {
@@ -1344,7 +1290,6 @@ open class ChatMessageTextView private constructor(
             clipPreviewAssetKeys.forEach(::observeClipThumbnail)
             refreshClipPreviewAssets()
             maybeApplyStagedRow()
-            maybeRevealInitialAssetFrame()
             updateDrawableAnimations()
         }
     }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatTimelineAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatTimelineAdapter.kt
@@ -1,20 +1,12 @@
 package com.github.andreyasadchy.xtra.ui.chat.v2.ui
 
 import android.view.ViewGroup
-import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
 import com.github.andreyasadchy.xtra.ui.chat.v2.assets.ChatAssetRepository
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatEmoteInteraction
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatGifInteraction
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessageId
 import com.github.andreyasadchy.xtra.ui.chat.v2.presentation.ChatRowUiModel
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancel
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
 class ChatTimelineAdapter(
     private val assets: ChatAssetRepository,
@@ -24,11 +16,8 @@ class ChatTimelineAdapter(
     private val onEmoteClick: ((ChatEmoteInteraction) -> Unit)? = null,
     private val onGifClick: ((ChatGifInteraction) -> Unit)? = null,
     private val onMessageClick: ((ChatMessageId) -> Unit)? = null,
-    private val diffDispatcher: CoroutineDispatcher = Dispatchers.Default,
 ) : RecyclerView.Adapter<ChatTimelineAdapter.Holder>() {
     private val rows = ArrayList<ChatRowUiModel>()
-    private val diffScope = CoroutineScope(SupervisorJob() + diffDispatcher)
-    private var submitGeneration = 0L
 
     val currentList: List<ChatRowUiModel>
         get() = rows
@@ -50,33 +39,13 @@ class ChatTimelineAdapter(
         holder.bind(rows[position])
     }
 
-    /**
-     * Correctness fallback for reconciliation, session changes, and presentation-wide updates.
-     * The common live append path uses [append] and never reaches DiffUtil.
-     */
-    fun submitList(newRows: List<ChatRowUiModel>, commitCallback: (() -> Unit)? = null) {
-        val oldRows = rows.toList()
+    /** Replaces the complete snapshot for reconciliation and presentation-wide changes. */
+    fun replaceAll(newRows: List<ChatRowUiModel>, commitCallback: (() -> Unit)? = null) {
         val nextRows = newRows.toList()
-        val generation = ++submitGeneration
-        diffScope.launch {
-            val diff = DiffUtil.calculateDiff(object : DiffUtil.Callback() {
-                override fun getOldListSize(): Int = oldRows.size
-                override fun getNewListSize(): Int = nextRows.size
-
-                override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean =
-                    oldRows[oldItemPosition].id == nextRows[newItemPosition].id
-
-                override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean =
-                    oldRows[oldItemPosition] == nextRows[newItemPosition]
-            })
-            withContext(Dispatchers.Main.immediate) {
-                if (generation != submitGeneration) return@withContext
-                rows.clear()
-                rows.addAll(nextRows)
-                diff.dispatchUpdatesTo(this@ChatTimelineAdapter)
-                commitCallback?.invoke()
-            }
-        }
+        rows.clear()
+        rows.addAll(nextRows)
+        notifyDataSetChanged()
+        commitCallback?.invoke()
     }
 
     /**
@@ -88,7 +57,6 @@ class ChatTimelineAdapter(
         evictedHeadCount: Int,
         appendedCount: Int,
     ): Boolean {
-        ++submitGeneration
         if (evictedHeadCount < 0 || appendedCount < 0 || appendedCount > newRows.size) return false
         val retainedCount = newRows.size - appendedCount
         if (rows.size != retainedCount + evictedHeadCount || evictedHeadCount > rows.size) return false
@@ -96,12 +64,15 @@ class ChatTimelineAdapter(
             if (rows[index + evictedHeadCount] != newRows[index]) return false
         }
 
-        rows.subList(0, evictedHeadCount).clear()
-        if (appendedCount > 0) {
-            rows.addAll(newRows.subList(retainedCount, newRows.size))
+        if (evictedHeadCount > 0) {
+            rows.subList(0, evictedHeadCount).clear()
+            notifyItemRangeRemoved(0, evictedHeadCount)
         }
-        if (evictedHeadCount > 0) notifyItemRangeRemoved(0, evictedHeadCount)
-        if (appendedCount > 0) notifyItemRangeInserted(retainedCount, appendedCount)
+        if (appendedCount > 0) {
+            val insertionPosition = rows.size
+            rows.addAll(newRows.subList(retainedCount, newRows.size))
+            notifyItemRangeInserted(insertionPosition, appendedCount)
+        }
         return true
     }
 
@@ -111,21 +82,23 @@ class ChatTimelineAdapter(
         evictedHeadCount: Int,
         expectedSize: Int,
     ): Boolean {
-        ++submitGeneration
         if (evictedHeadCount < 0 || evictedHeadCount > rows.size) return false
         if (rows.size - evictedHeadCount + appendedRows.size != expectedSize) return false
 
-        val retainedCount = rows.size - evictedHeadCount
-        rows.subList(0, evictedHeadCount).clear()
-        rows.addAll(appendedRows)
-        if (evictedHeadCount > 0) notifyItemRangeRemoved(0, evictedHeadCount)
-        if (appendedRows.isNotEmpty()) notifyItemRangeInserted(retainedCount, appendedRows.size)
+        if (evictedHeadCount > 0) {
+            rows.subList(0, evictedHeadCount).clear()
+            notifyItemRangeRemoved(0, evictedHeadCount)
+        }
+        if (appendedRows.isNotEmpty()) {
+            val insertionPosition = rows.size
+            rows.addAll(appendedRows)
+            notifyItemRangeInserted(insertionPosition, appendedRows.size)
+        }
         return true
     }
 
     /** Clears the adapter synchronously when its RecyclerView is being detached. */
     fun clear() {
-        ++submitGeneration
         if (rows.isEmpty()) return
         val oldSize = rows.size
         rows.clear()
@@ -133,7 +106,6 @@ class ChatTimelineAdapter(
     }
 
     fun dispose() {
-        diffScope.cancel()
         clear()
     }
 

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatV2RendererController.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatV2RendererController.kt
@@ -282,7 +282,7 @@ class ChatV2RendererController(
                 )
                 if (uiChanged) {
                     onPublicationChanged(currentMessages, rows)
-                    adapter.submitList(rows)
+                    adapter.replaceAll(rows)
                 }
             }
         }
@@ -444,7 +444,7 @@ class ChatV2RendererController(
                     viewport.onSnapshotCommitted(previousAnchor, latestRows, appendedCount)
                     onStateChanged(viewport.state)
                 } else {
-                    adapter.submitList(latestRows) {
+                    adapter.replaceAll(latestRows) {
                         viewport.onSnapshotCommitted(previousAnchor, latestRows, appendedCount)
                         onStateChanged(viewport.state)
                     }


### PR DESCRIPTION
Keep chat rows visible while assets load and apply full adapter corrections synchronously so fast deltas cannot starve reconciliation.