### PR TITLE
Rework player controls visibility

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/ControllerVisibilityState.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/ControllerVisibilityState.kt
@@ -1,0 +1,49 @@
+package com.github.andreyasadchy.xtra.ui.player
+
+internal class ControllerVisibilityState(
+    initiallyAutoHideEnabled: Boolean = true,
+) {
+    var targetVisible = false
+        private set
+
+    private var autoHideEnabled = initiallyAutoHideEnabled
+    private var scrubbing = false
+
+    fun setAutoHideEnabled(enabled: Boolean) {
+        autoHideEnabled = enabled
+    }
+
+    fun toggle(hideOnTouch: Boolean): Boolean {
+        targetVisible = if (hideOnTouch) !targetVisible else true
+        return targetVisible
+    }
+
+    fun show() {
+        targetVisible = true
+    }
+
+    fun hide() {
+        targetVisible = false
+    }
+
+    fun onScrubStart() {
+        scrubbing = true
+    }
+
+    fun onScrubStop() {
+        scrubbing = false
+    }
+
+    fun shouldScheduleHide(
+        hideOnTouch: Boolean,
+        interactionLocked: Boolean,
+        progressPressed: Boolean,
+        rootVisible: Boolean,
+    ): Boolean = targetVisible &&
+        autoHideEnabled &&
+        !scrubbing &&
+        hideOnTouch &&
+        !interactionLocked &&
+        !progressPressed &&
+        rootVisible
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/ExoPlayerFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/ExoPlayerFragment.kt
@@ -168,7 +168,7 @@ class ExoPlayerFragment : PlayerFragment(), ClipEditorDialogFragment.Host, Playb
                 updateProgress()
                 controllerAutoHide = !requireContext().isTelevision() && !showPlayButton
                 if (useController) {
-                    showController(show = playbackService?.type != BasePlaybackService.STREAM && playbackState == Player.STATE_ENDED)
+                    showController(show = (playbackService?.type != BasePlaybackService.STREAM && playbackState == Player.STATE_ENDED) || showPlayButton)
                 }
                 if (playbackState == Player.STATE_READY && playbackService?.type == BasePlaybackService.VIDEO) {
                     refreshClipAvailability()
@@ -194,7 +194,7 @@ class ExoPlayerFragment : PlayerFragment(), ClipEditorDialogFragment.Host, Playb
                 updateProgress()
                 controllerAutoHide = !requireContext().isTelevision() && !showPlayButton
                 if (useController) {
-                    showController(show = playbackService?.type != BasePlaybackService.STREAM && playbackService?.player?.playbackState == Player.STATE_ENDED)
+                    showController(show = (playbackService?.type != BasePlaybackService.STREAM && playbackService?.player?.playbackState == Player.STATE_ENDED) || showPlayButton)
                 }
             }
 

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/Media3Fragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/Media3Fragment.kt
@@ -220,8 +220,8 @@ class Media3Fragment : Media3PlayerFragment(), PlaybackVideoInfoHost {
                     setPipActions(!showPlayButton)
                     updateProgress()
                     controllerAutoHide = !requireContext().isTelevision() && !showPlayButton
-                    if (videoType != STREAM && useController) {
-                        showController()
+                    if (useController) {
+                        showController(show = videoType != STREAM || showPlayButton)
                     }
                 }
 
@@ -231,8 +231,8 @@ class Media3Fragment : Media3PlayerFragment(), PlaybackVideoInfoHost {
                     setPipActions(!showPlayButton)
                     updateProgress()
                     controllerAutoHide = !requireContext().isTelevision() && !showPlayButton
-                    if (videoType != STREAM && useController) {
-                        showController()
+                    if (useController) {
+                        showController(show = videoType != STREAM || showPlayButton)
                     }
                 }
 

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/Media3PlayerFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/Media3PlayerFragment.kt
@@ -154,11 +154,17 @@ abstract class Media3PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFr
     private var isAnimating = false
     private var moveAnimation: ViewPropertyAnimator? = null
     protected var useController = true
+    private val controllerVisibility = ControllerVisibilityState()
     protected var controllerAutoHide = true
+        set(value) {
+            field = value
+            controllerVisibility.setAutoHideEnabled(value)
+        }
     private var controllerHideOnTouch = true
     private val controllerHideAction = Runnable { if (view != null) hideController() }
     private var controllerIsAnimating = false
     private var controllerAnimation: ViewPropertyAnimator? = null
+    private var controllerAnimationGeneration = 0L
     private var backgroundColor: Int? = null
     private var backgroundVisible = false
     private var pipPlaying = false
@@ -569,17 +575,7 @@ abstract class Media3PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFr
                 object : GestureDetector.SimpleOnGestureListener() {
                     override fun onSingleTapUp(e: MotionEvent): Boolean {
                         return if (!doubleTap || isPortrait) {
-                            val visible = playerControls.root.isVisible
-                            if (visible) {
-                                if (controllerHideOnTouch) {
-                                    hideController()
-                                }
-                            } else {
-                                showController()
-                            }
-                            if (!visible) {
-                                updateProgress()
-                            }
+                            toggleController()
                             true
                         } else {
                             false
@@ -588,17 +584,7 @@ abstract class Media3PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFr
 
                     override fun onSingleTapConfirmed(e: MotionEvent): Boolean {
                         return if (doubleTap && !isPortrait) {
-                            val visible = playerControls.root.isVisible
-                            if (visible) {
-                                if (controllerHideOnTouch) {
-                                    hideController()
-                                }
-                            } else {
-                                showController()
-                            }
-                            if (!visible) {
-                                updateProgress()
-                            }
+                            toggleController()
                             true
                         } else {
                             false
@@ -627,6 +613,9 @@ abstract class Media3PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFr
                 if (isMaximized) {
                     if (playerControls.root.isVisible) {
                         controlTouchActive = playerControls.root.dispatchTouchEvent(event)
+                        if (!controlTouchActive) {
+                            controllerTapDetector.onTouchEvent(event)
+                        }
                     } else {
                         controllerTapDetector.onTouchEvent(event)
                     }
@@ -663,11 +652,9 @@ abstract class Media3PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFr
                         if (slidingLayout.translationY in touchSlopRange) {
                             if (playerControls.root.isVisible) {
                                 playerControls.root.dispatchTouchEvent(event)
+                                controllerTapDetector.onTouchEvent(event)
                             } else {
                                 controllerTapDetector.onTouchEvent(event)
-                                if (isTap && (!doubleTap || isPortrait)) {
-                                    showController()
-                                }
                             }
                         }
                         val minimizeThreshold = slidingLayout.height / 5
@@ -923,6 +910,8 @@ abstract class Media3PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFr
                 progressBar.addListener(
                     object : TimeBar.OnScrubListener {
                         override fun onScrubStart(timeBar: TimeBar, position: Long) {
+                            controllerVisibility.onScrubStart()
+                            binding.playerControls.root.removeCallbacks(controllerHideAction)
                             if (isLiveRewindAvailable()) {
                                 liveRewindScrubPositionMs = position
                                 showLiveRewindPreview(position)
@@ -950,6 +939,7 @@ abstract class Media3PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFr
                         }
 
                         override fun onScrubStop(timeBar: TimeBar, position: Long, canceled: Boolean) {
+                            controllerVisibility.onScrubStop()
                             if (isLiveRewindAvailable()) {
                                 liveRewindScrubPositionMs = null
                                 hideLiveRewindPreview()
@@ -958,15 +948,13 @@ abstract class Media3PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFr
                                 } else {
                                     updateLiveRewindProgress()
                                 }
+                                scheduleControllerHideAfterScrub()
                                 return
                             }
                             if (!canceled) {
                                 seek(position)
-                            } else {
-                                if (controllerAutoHide && controllerHideOnTouch) {
-                                    binding.playerControls.root.postDelayed(controllerHideAction, 3000)
-                                }
                             }
+                            scheduleControllerHideAfterScrub()
                         }
                     }
                 )
@@ -2373,7 +2361,7 @@ abstract class Media3PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFr
                 }
             } else {
                 controllerHideOnTouch = false
-                showController(true)
+                showController(force = true)
                 updateProgress()
                 requireView().keepScreenOn = true
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S &&
@@ -2406,81 +2394,132 @@ abstract class Media3PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFr
         binding.playerErrorRetry.setOnClickListener(null)
     }
 
-    protected fun showController(force: Boolean = false) {
-        if (!controllerIsAnimating) {
-            if (!binding.playerControls.root.isVisible) {
-                binding.playerControls.root.removeCallbacks(controllerHideAction)
-                controllerAnimation = binding.playerControls.root.animate().apply {
-                    alpha(1f)
-                    setDuration(250L)
-                    setListener(
-                        object : AnimatorListenerAdapter() {
-                            override fun onAnimationStart(animation: Animator) {
-                                controllerIsAnimating = true
-                                if (view != null) {
-                                    binding.playerControls.root.visibility = View.VISIBLE
-                                }
-                            }
-
-                            override fun onAnimationEnd(animation: Animator) {
-                                controllerIsAnimating = false
-                                setListener(null)
-                                if (view != null && controllerAutoHide && controllerHideOnTouch && !binding.playerControls.progressBar.isPressed) {
-                                    binding.playerControls.root.postDelayed(controllerHideAction, 3000)
-                                }
-                            }
-                        }
-                    )
-                    start()
-                }
-            } else {
-                binding.playerControls.root.removeCallbacks(controllerHideAction)
-                if (controllerAutoHide && controllerHideOnTouch && !binding.playerControls.progressBar.isPressed) {
-                    binding.playerControls.root.postDelayed(controllerHideAction, 3000)
-                }
-            }
+    private fun toggleController() {
+        if (requireContext().isTelevision() || !controllerHideOnTouch) {
+            controllerVisibility.show()
+            showController(force = true)
+            updateProgress()
+        } else if (controllerVisibility.toggle(hideOnTouch = true)) {
+            showController()
+            updateProgress()
         } else {
-            if (force) {
-                controllerAnimation?.cancel()
-                binding.playerControls.root.removeCallbacks(controllerHideAction)
-                binding.playerControls.root.alpha = 1f
-                binding.playerControls.root.visibility = View.VISIBLE
-                if (controllerAutoHide && controllerHideOnTouch && !binding.playerControls.progressBar.isPressed) {
-                    binding.playerControls.root.postDelayed(controllerHideAction, 3000)
-                }
+            hideController()
+        }
+    }
+
+    private fun scheduleControllerHide() {
+        binding.playerControls.root.removeCallbacks(controllerHideAction)
+        if (controllerVisibility.shouldScheduleHide(
+                hideOnTouch = controllerHideOnTouch,
+                interactionLocked = false,
+                progressPressed = binding.playerControls.progressBar.isPressed,
+                rootVisible = binding.playerControls.root.isVisible,
+            )
+        ) {
+            binding.playerControls.root.postDelayed(controllerHideAction, CONTROLLER_AUTO_HIDE_DELAY_MS)
+        }
+    }
+
+    private fun scheduleControllerHideAfterScrub() {
+        binding.playerControls.root.post {
+            if (view != null) {
+                scheduleControllerHide()
             }
+        }
+    }
+
+    private fun cancelControllerAnimation() {
+        controllerAnimationGeneration++
+        controllerAnimation?.setListener(null)
+        controllerAnimation?.cancel()
+        controllerAnimation = null
+        controllerIsAnimating = false
+    }
+
+    protected fun showController(show: Boolean = true, force: Boolean = false) {
+        if (!useController) return
+
+        if (!show) {
+            scheduleControllerHide()
+            return
+        }
+        controllerVisibility.show()
+        binding.playerControls.root.removeCallbacks(controllerHideAction)
+        cancelControllerAnimation()
+        if (force) {
+            binding.playerControls.root.alpha = 1f
+            binding.playerControls.root.visibility = View.VISIBLE
+            scheduleControllerHide()
+            return
+        }
+        if (binding.playerControls.root.isVisible) {
+            binding.playerControls.root.alpha = 1f
+            scheduleControllerHide()
+            return
+        }
+
+        val animationGeneration = controllerAnimationGeneration
+        binding.playerControls.root.alpha = 0f
+        binding.playerControls.root.visibility = View.VISIBLE
+        controllerIsAnimating = true
+        controllerAnimation = binding.playerControls.root.animate().apply {
+            alpha(1f)
+            setDuration(CONTROLLER_ANIMATION_DURATION_MS)
+            setListener(
+                object : AnimatorListenerAdapter() {
+                    override fun onAnimationEnd(animation: Animator) {
+                        if (animationGeneration != controllerAnimationGeneration) return
+                        controllerIsAnimating = false
+                        controllerAnimation = null
+                        setListener(null)
+                        if (view != null) {
+                            scheduleControllerHide()
+                        }
+                    }
+                }
+            )
+            start()
         }
     }
 
     private fun hideController(force: Boolean = false) {
         if (requireContext().isTelevision() && !force) return
-        if (!controllerIsAnimating && binding.playerControls.root.isVisible) {
-            controllerAnimation = binding.playerControls.root.animate().apply {
-                alpha(0f)
-                setDuration(250L)
-                setListener(
-                    object : AnimatorListenerAdapter() {
-                        override fun onAnimationStart(animation: Animator) {
-                            controllerIsAnimating = true
-                        }
 
-                        override fun onAnimationEnd(animation: Animator) {
-                            controllerIsAnimating = false
-                            setListener(null)
-                            if (view != null) {
-                                binding.playerControls.root.visibility = View.GONE
-                            }
-                        }
-                    }
-                )
-                start()
-            }
-        } else {
+        binding.playerControls.root.removeCallbacks(controllerHideAction)
+        controllerVisibility.hide()
+        cancelControllerAnimation()
+        if (!binding.playerControls.root.isVisible) {
             if (force) {
-                controllerAnimation?.cancel()
                 binding.playerControls.root.alpha = 0f
                 binding.playerControls.root.visibility = View.GONE
             }
+            return
+        }
+        if (force) {
+            binding.playerControls.root.alpha = 0f
+            binding.playerControls.root.visibility = View.GONE
+            return
+        }
+
+        val animationGeneration = controllerAnimationGeneration
+        controllerIsAnimating = true
+        controllerAnimation = binding.playerControls.root.animate().apply {
+            alpha(0f)
+            setDuration(CONTROLLER_ANIMATION_DURATION_MS)
+            setListener(
+                object : AnimatorListenerAdapter() {
+                    override fun onAnimationEnd(animation: Animator) {
+                        if (animationGeneration != controllerAnimationGeneration) return
+                        controllerIsAnimating = false
+                        controllerAnimation = null
+                        setListener(null)
+                        if (view != null) {
+                            binding.playerControls.root.visibility = View.GONE
+                        }
+                    }
+                }
+            )
+            start()
         }
     }
 
@@ -3377,9 +3416,7 @@ abstract class Media3PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFr
                     hideChatLayout()
                 }
                 useController = false
-                controllerAnimation?.cancel()
-                binding.playerControls.root.alpha = 0f
-                binding.playerControls.root.visibility = View.GONE
+                hideController(force = true)
                 // player dialog
                 (childFragmentManager.findFragmentByTag("closeOnPip") as? BottomSheetDialogFragment)?.dismiss()
                 // player chat message dialog
@@ -3396,7 +3433,11 @@ abstract class Media3PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFr
 
     override fun onStop() {
         super.onStop()
-        binding.playerControls.root.removeCallbacks(controllerHideAction)
+        _binding?.let {
+            controllerVisibility.onScrubStop()
+            it.playerControls.root.removeCallbacks(controllerHideAction)
+            hideController(force = true)
+        }
     }
 
     protected fun savePosition() {
@@ -3516,7 +3557,7 @@ abstract class Media3PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFr
             }
             useController = true
             if (!controllerHideOnTouch) {
-                showController(true)
+                showController(force = true)
                 updateProgress()
             }
             if (isPortrait) {
@@ -3770,6 +3811,8 @@ abstract class Media3PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFr
     }
 
     companion object {
+        private const val CONTROLLER_ANIMATION_DURATION_MS = 250L
+        private const val CONTROLLER_AUTO_HIDE_DELAY_MS = 3_000L
         protected const val AUTO_QUALITY = "auto"
         protected const val SOURCE_QUALITY = "source"
         protected const val AUDIO_ONLY_QUALITY = "audio_only"

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/MediaPlayerFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/MediaPlayerFragment.kt
@@ -300,7 +300,7 @@ class MediaPlayerFragment : PlayerFragment() {
             setPipActions(isPlaying)
             controllerAutoHide = !requireContext().isTelevision() && isPlaying
             if (useController) {
-                showController(show = playbackService?.type != BasePlaybackService.STREAM && ended)
+                showController(show = !isPlaying || (playbackService?.type != BasePlaybackService.STREAM && ended))
             }
             updateProgress()
             if (isAdded && view != null) {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/PlayerFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/PlayerFragment.kt
@@ -154,13 +154,19 @@ abstract class PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFragment
     private var isAnimating = false
     private var moveAnimation: ViewPropertyAnimator? = null
     protected var useController = true
+    private val controllerVisibility = ControllerVisibilityState()
     protected var controllerAutoHide = true
+        set(value) {
+            field = value
+            controllerVisibility.setAutoHideEnabled(value)
+        }
     private var controllerHideOnTouch = true
     private var isInteractionLocked = false
     private var interactionLockBackCallback: OnBackPressedCallback? = null
     private val controllerHideAction = Runnable { if (view != null) hideController() }
     private var controllerIsAnimating = false
     private var controllerAnimation: ViewPropertyAnimator? = null
+    private var controllerAnimationGeneration = 0L
     private var backgroundColor: Int? = null
     private var backgroundVisible = false
     private var pipPlaying = false
@@ -672,17 +678,7 @@ abstract class PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFragment
                 object : GestureDetector.SimpleOnGestureListener() {
                     override fun onSingleTapUp(e: MotionEvent): Boolean {
                         return if (!doubleTap || isPortrait) {
-                            val visible = playerControls.root.isVisible
-                            if (visible) {
-                                if (controllerHideOnTouch) {
-                                    hideController()
-                                }
-                            } else {
-                                showController()
-                            }
-                            if (!visible) {
-                                updateProgress()
-                            }
+                            toggleController()
                             true
                         } else {
                             false
@@ -691,17 +687,7 @@ abstract class PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFragment
 
                     override fun onSingleTapConfirmed(e: MotionEvent): Boolean {
                         return if (doubleTap && !isPortrait) {
-                            val visible = playerControls.root.isVisible
-                            if (visible) {
-                                if (controllerHideOnTouch) {
-                                    hideController()
-                                }
-                            } else {
-                                showController()
-                            }
-                            if (!visible) {
-                                updateProgress()
-                            }
+                            toggleController()
                             true
                         } else {
                             false
@@ -730,6 +716,9 @@ abstract class PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFragment
                 if (isMaximized) {
                     if (playerControls.root.isVisible) {
                         controlTouchActive = playerControls.root.dispatchTouchEvent(event)
+                        if (!controlTouchActive) {
+                            controllerTapDetector.onTouchEvent(event)
+                        }
                     } else {
                         controllerTapDetector.onTouchEvent(event)
                     }
@@ -766,11 +755,9 @@ abstract class PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFragment
                         if (slidingLayout.translationY in touchSlopRange) {
                             if (playerControls.root.isVisible) {
                                 playerControls.root.dispatchTouchEvent(event)
+                                controllerTapDetector.onTouchEvent(event)
                             } else {
                                 controllerTapDetector.onTouchEvent(event)
-                                if (isTap && (!doubleTap || isPortrait)) {
-                                    showController()
-                                }
                             }
                         }
                         val minimizeThreshold = slidingLayout.height / 5
@@ -1073,6 +1060,8 @@ abstract class PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFragment
                 progressBar.addListener(
                     object : TimeBar.OnScrubListener {
                         override fun onScrubStart(timeBar: TimeBar, position: Long) {
+                            controllerVisibility.onScrubStart()
+                            binding.playerControls.root.removeCallbacks(controllerHideAction)
                             if (isLiveRewindAvailable()) {
                                 liveRewindScrubPositionMs = position
                                 showLiveRewindPreview(position)
@@ -1100,6 +1089,7 @@ abstract class PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFragment
                         }
 
                         override fun onScrubStop(timeBar: TimeBar, position: Long, canceled: Boolean) {
+                            controllerVisibility.onScrubStop()
                             if (isLiveRewindAvailable()) {
                                 liveRewindScrubPositionMs = null
                                 hideLiveRewindPreview()
@@ -1108,15 +1098,13 @@ abstract class PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFragment
                                 } else {
                                     updateLiveRewindProgress()
                                 }
+                                scheduleControllerHideAfterScrub()
                                 return
                             }
                             if (!canceled) {
                                 seek(position)
-                            } else {
-                                if (controllerAutoHide && controllerHideOnTouch) {
-                                    binding.playerControls.root.postDelayed(controllerHideAction, 3000)
-                                }
                             }
+                            scheduleControllerHideAfterScrub()
                         }
                     }
                 )
@@ -3046,83 +3034,132 @@ abstract class PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFragment
         }
     }
 
-    protected fun showController(show: Boolean = true, force: Boolean = false) {
-        if (!controllerIsAnimating) {
-            if (!binding.playerControls.root.isVisible) {
-                binding.playerControls.root.removeCallbacks(controllerHideAction)
-                if (show) {
-                    controllerAnimation = binding.playerControls.root.animate().apply {
-                        alpha(1f)
-                        setDuration(250L)
-                        setListener(
-                            object : AnimatorListenerAdapter() {
-                                override fun onAnimationStart(animation: Animator) {
-                                    controllerIsAnimating = true
-                                    if (view != null) {
-                                        binding.playerControls.root.visibility = View.VISIBLE
-                                    }
-                                }
+    private fun toggleController() {
+        if (requireContext().isTelevision() || !controllerHideOnTouch || isInteractionLocked) {
+            controllerVisibility.show()
+            showController(force = true)
+            updateProgress()
+        } else if (controllerVisibility.toggle(hideOnTouch = true)) {
+            showController()
+            updateProgress()
+        } else {
+            hideController()
+        }
+    }
 
-                                override fun onAnimationEnd(animation: Animator) {
-                                    controllerIsAnimating = false
-                                    setListener(null)
-                                    if (view != null && controllerAutoHide && controllerHideOnTouch && !binding.playerControls.progressBar.isPressed) {
-                                        binding.playerControls.root.postDelayed(controllerHideAction, 3000)
-                                    }
-                                }
-                            }
-                        )
-                        start()
+    private fun scheduleControllerHide() {
+        binding.playerControls.root.removeCallbacks(controllerHideAction)
+        if (controllerVisibility.shouldScheduleHide(
+                hideOnTouch = controllerHideOnTouch,
+                interactionLocked = isInteractionLocked,
+                progressPressed = binding.playerControls.progressBar.isPressed,
+                rootVisible = binding.playerControls.root.isVisible,
+            )
+        ) {
+            binding.playerControls.root.postDelayed(controllerHideAction, CONTROLLER_AUTO_HIDE_DELAY_MS)
+        }
+    }
+
+    private fun scheduleControllerHideAfterScrub() {
+        binding.playerControls.root.post {
+            if (view != null) {
+                scheduleControllerHide()
+            }
+        }
+    }
+
+    private fun cancelControllerAnimation() {
+        controllerAnimationGeneration++
+        controllerAnimation?.setListener(null)
+        controllerAnimation?.cancel()
+        controllerAnimation = null
+        controllerIsAnimating = false
+    }
+
+    protected fun showController(show: Boolean = true, force: Boolean = false) {
+        if (!useController) return
+
+        if (!show) {
+            scheduleControllerHide()
+            return
+        }
+        controllerVisibility.show()
+        binding.playerControls.root.removeCallbacks(controllerHideAction)
+        cancelControllerAnimation()
+        if (force) {
+            binding.playerControls.root.alpha = 1f
+            binding.playerControls.root.visibility = View.VISIBLE
+            scheduleControllerHide()
+            return
+        }
+        if (binding.playerControls.root.isVisible) {
+            binding.playerControls.root.alpha = 1f
+            scheduleControllerHide()
+            return
+        }
+
+        val animationGeneration = controllerAnimationGeneration
+        binding.playerControls.root.alpha = 0f
+        binding.playerControls.root.visibility = View.VISIBLE
+        controllerIsAnimating = true
+        controllerAnimation = binding.playerControls.root.animate().apply {
+            alpha(1f)
+            setDuration(CONTROLLER_ANIMATION_DURATION_MS)
+            setListener(
+                object : AnimatorListenerAdapter() {
+                    override fun onAnimationEnd(animation: Animator) {
+                        if (animationGeneration != controllerAnimationGeneration) return
+                        controllerIsAnimating = false
+                        controllerAnimation = null
+                        setListener(null)
+                        if (view != null) {
+                            scheduleControllerHide()
+                        }
                     }
                 }
-            } else {
-                binding.playerControls.root.removeCallbacks(controllerHideAction)
-                if (controllerAutoHide && controllerHideOnTouch && !binding.playerControls.progressBar.isPressed) {
-                    binding.playerControls.root.postDelayed(controllerHideAction, 3000)
-                }
-            }
-        } else {
-            if (force) {
-                controllerAnimation?.cancel()
-                binding.playerControls.root.removeCallbacks(controllerHideAction)
-                binding.playerControls.root.alpha = 1f
-                binding.playerControls.root.visibility = View.VISIBLE
-                if (controllerAutoHide && controllerHideOnTouch && !binding.playerControls.progressBar.isPressed) {
-                    binding.playerControls.root.postDelayed(controllerHideAction, 3000)
-                }
-            }
+            )
+            start()
         }
     }
 
     private fun hideController(force: Boolean = false) {
         if (requireContext().isTelevision() && !force) return
-        if (!controllerIsAnimating && binding.playerControls.root.isVisible) {
-            controllerAnimation = binding.playerControls.root.animate().apply {
-                alpha(0f)
-                setDuration(250L)
-                setListener(
-                    object : AnimatorListenerAdapter() {
-                        override fun onAnimationStart(animation: Animator) {
-                            controllerIsAnimating = true
-                        }
 
-                        override fun onAnimationEnd(animation: Animator) {
-                            controllerIsAnimating = false
-                            setListener(null)
-                            if (view != null) {
-                                binding.playerControls.root.visibility = View.GONE
-                            }
-                        }
-                    }
-                )
-                start()
-            }
-        } else {
+        binding.playerControls.root.removeCallbacks(controllerHideAction)
+        controllerVisibility.hide()
+        cancelControllerAnimation()
+        if (!binding.playerControls.root.isVisible) {
             if (force) {
-                controllerAnimation?.cancel()
                 binding.playerControls.root.alpha = 0f
                 binding.playerControls.root.visibility = View.GONE
             }
+            return
+        }
+        if (force) {
+            binding.playerControls.root.alpha = 0f
+            binding.playerControls.root.visibility = View.GONE
+            return
+        }
+
+        val animationGeneration = controllerAnimationGeneration
+        controllerIsAnimating = true
+        controllerAnimation = binding.playerControls.root.animate().apply {
+            alpha(0f)
+            setDuration(CONTROLLER_ANIMATION_DURATION_MS)
+            setListener(
+                object : AnimatorListenerAdapter() {
+                    override fun onAnimationEnd(animation: Animator) {
+                        if (animationGeneration != controllerAnimationGeneration) return
+                        controllerIsAnimating = false
+                        controllerAnimation = null
+                        setListener(null)
+                        if (view != null) {
+                            binding.playerControls.root.visibility = View.GONE
+                        }
+                    }
+                }
+            )
+            start()
         }
     }
 
@@ -3358,9 +3395,7 @@ abstract class PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFragment
                     hideChatLayout()
                 }
                 useController = false
-                controllerAnimation?.cancel()
-                binding.playerControls.root.alpha = 0f
-                binding.playerControls.root.visibility = View.GONE
+                hideController(force = true)
                 updateInteractionLockBackCallback()
                 // player dialog
                 (childFragmentManager.findFragmentByTag("closeOnPip") as? BottomSheetDialogFragment)?.dismiss()
@@ -3386,7 +3421,11 @@ abstract class PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFragment
 
     override fun onStop() {
         super.onStop()
-        binding.playerControls.root.removeCallbacks(controllerHideAction)
+        _binding?.let {
+            controllerVisibility.onScrubStop()
+            it.playerControls.root.removeCallbacks(controllerHideAction)
+            hideController(force = true)
+        }
     }
 
     override fun onSaveInstanceState(outState: Bundle) {
@@ -3692,6 +3731,8 @@ abstract class PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFragment
     }
 
     companion object {
+        private const val CONTROLLER_ANIMATION_DURATION_MS = 250L
+        private const val CONTROLLER_AUTO_HIDE_DELAY_MS = 3_000L
         private const val REQUEST_CODE_QUALITY = 0
         private const val REQUEST_CODE_SPEED = 1
         private const val REQUEST_CODE_AUDIO_ONLY = 2

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/player/ControllerVisibilityStateTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/player/ControllerVisibilityStateTest.kt
@@ -1,0 +1,70 @@
+package com.github.andreyasadchy.xtra.ui.player
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ControllerVisibilityStateTest {
+
+    @Test
+    fun rapidTapsToggleAgainstTargetVisibility() {
+        val state = ControllerVisibilityState()
+
+        assertTrue(state.toggle(hideOnTouch = true))
+        assertFalse(state.toggle(hideOnTouch = true))
+        assertTrue(state.toggle(hideOnTouch = true))
+    }
+
+    @Test
+    fun pausedPlaybackDoesNotScheduleAutoHide() {
+        val state = ControllerVisibilityState()
+        state.show()
+        state.setAutoHideEnabled(false)
+
+        assertFalse(state.shouldScheduleHide(
+            hideOnTouch = true,
+            interactionLocked = false,
+            progressPressed = false,
+            rootVisible = true,
+        ))
+    }
+
+    @Test
+    fun scrubCancelsTimerAndSuccessfulStopRestoresItWhenPlaying() {
+        val state = ControllerVisibilityState()
+        state.show()
+
+        state.onScrubStart()
+        assertFalse(state.shouldScheduleHide(
+            hideOnTouch = true,
+            interactionLocked = false,
+            progressPressed = false,
+            rootVisible = true,
+        ))
+
+        state.onScrubStop()
+        assertTrue(state.shouldScheduleHide(
+            hideOnTouch = true,
+            interactionLocked = false,
+            progressPressed = false,
+            rootVisible = true,
+        ))
+    }
+
+    @Test
+    fun scrubStopKeepsPausedControlsVisibleWithoutTimer() {
+        val state = ControllerVisibilityState()
+        state.show()
+        state.setAutoHideEnabled(false)
+        state.onScrubStart()
+        state.onScrubStop()
+
+        assertFalse(state.shouldScheduleHide(
+            hideOnTouch = true,
+            interactionLocked = false,
+            progressPressed = false,
+            rootVisible = true,
+        ))
+        assertTrue(state.targetVisible)
+    }
+}


### PR DESCRIPTION
Make player controls behave like YouTube: tap to show or hide, auto-hide during playback, keep controls available when playback stops, and hide them when leaving the player.