### PR TITLE
Fix Discover thumbnails refreshing in place

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/ThumbnailImageRequest.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/ThumbnailImageRequest.kt
@@ -339,7 +339,8 @@ private fun streamMetadataSame(oldItem: Stream, newItem: Stream): Boolean {
 }
 
 internal fun streamContentsSame(oldItem: Stream, newItem: Stream): Boolean {
-    return streamMetadataSame(oldItem, newItem)
+    return streamMetadataSame(oldItem, newItem) &&
+            oldItem.thumbnailGeneration == newItem.thumbnailGeneration
 }
 
 internal fun streamThumbnailOnlyChanged(oldItem: Stream, newItem: Stream): Boolean {

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/common/ThumbnailImageRequestTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/common/ThumbnailImageRequestTest.kt
@@ -1,5 +1,6 @@
 package com.github.andreyasadchy.xtra.ui.common
 
+import androidx.recyclerview.widget.DiffUtil
 import com.github.andreyasadchy.xtra.model.ui.Stream
 import coil3.decode.DataSource
 import coil3.request.CachePolicy
@@ -7,6 +8,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -158,7 +160,7 @@ class ThumbnailImageRequestTest {
     }
 
     @Test
-    fun refreshGenerationDoesNotMakeIdenticalStreamMetadataChangedForDiffUtil() {
+    fun refreshGenerationIsDiffUtilContentAndProducesThumbnailPayload() {
         val oldItem = Stream(
             id = "broadcast-1",
             channelId = "channel-42",
@@ -174,8 +176,21 @@ class ThumbnailImageRequestTest {
             thumbnailGeneration = 11L,
         )
 
+        val diffCallback = object : DiffUtil.ItemCallback<Stream>() {
+            override fun areItemsTheSame(oldItem: Stream, newItem: Stream): Boolean =
+                oldItem.streamIdentity() == newItem.streamIdentity()
+
+            override fun areContentsTheSame(oldItem: Stream, newItem: Stream): Boolean =
+                streamContentsSame(oldItem, newItem)
+
+            override fun getChangePayload(oldItem: Stream, newItem: Stream): Any? =
+                if (streamThumbnailOnlyChanged(oldItem, newItem)) StreamThumbnailChangedPayload else null
+        }
+
         assertEquals(oldItem.streamIdentity(), newItem.streamIdentity())
-        org.junit.Assert.assertTrue(streamContentsSame(oldItem, newItem))
+        assertTrue(diffCallback.areItemsTheSame(oldItem, newItem))
+        assertFalse(diffCallback.areContentsTheSame(oldItem, newItem))
+        assertSame(StreamThumbnailChangedPayload, diffCallback.getChangePayload(oldItem, newItem))
     }
 
     @Test

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/following/overview/FollowingOverviewContentTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/following/overview/FollowingOverviewContentTest.kt
@@ -2,16 +2,45 @@ package com.github.andreyasadchy.xtra.ui.following.overview
 
 import com.github.andreyasadchy.xtra.model.VideoHistory
 import com.github.andreyasadchy.xtra.model.gql.schedule.StreamScheduleResponse
+import com.github.andreyasadchy.xtra.model.ui.Stream
 import com.github.andreyasadchy.xtra.model.ui.Video
 import com.github.andreyasadchy.xtra.model.ui.UpcomingStream
 import com.github.andreyasadchy.xtra.repository.TwitchApiException
 import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class FollowingOverviewContentTest {
+
+    @Test
+    fun thumbnailGenerationRefreshesAnOtherwiseUnchangedStreamSection() {
+        val oldSection = FollowingOverviewSection(
+            key = "live",
+            titleRes = 0,
+            emptyRes = 0,
+            streams = listOf(
+                Stream(
+                    channelId = "channel-42",
+                    thumbnailURL = "https://cdn.example/preview.jpg",
+                    thumbnailGeneration = 1L,
+                ),
+            ),
+        )
+        val refreshedSection = oldSection.copy(
+            streams = listOf(
+                Stream(
+                    channelId = "channel-42",
+                    thumbnailURL = "https://cdn.example/preview.jpg",
+                    thumbnailGeneration = 2L,
+                ),
+            ),
+        )
+
+        assertFalse(followingOverviewSectionContentsSame(oldSection, refreshedSection))
+    }
 
     @Test
     fun recentFollowedVideosFillAnEmptyContinueWatchingShelf() {


### PR DESCRIPTION
Some Discover cards stayed on the grey placeholder because the outer shelf comparison ignored thumbnail refresh generations. Propagate generation changes so the existing thumbnail payload runs when feed data refreshes, and cover the regression.