### PR TITLE
Add configurable fast-chat batching

### DIFF
--- a/.github/scripts/check-resources.py
+++ b/.github/scripts/check-resources.py
@@ -173,6 +173,11 @@ INTENTIONAL_FALLBACK_RESOURCES = {
     "chat_moderation_preview_username",
     "chat_moderation_preview_message",
     "chat_moderation_preview_new_message",
+    # Fast-chat batching settings use the default English wording until their
+    # translations are reviewed by native speakers.
+    "settings_chat_batch_interval",
+    "settings_chat_batch_interval_summary",
+    "settings_chat_batch_interval_off",
     # Chat event rows ship with the default English wording until their
     # translations are reviewed by native speakers. Android intentionally
     # falls back to values/ for these presentation labels.

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/session/ChatSession.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/session/ChatSession.kt
@@ -5,8 +5,10 @@ import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatEvent
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatCommunityGift
 import com.github.andreyasadchy.xtra.ui.chat.v2.transport.ChatTransport
 import com.github.andreyasadchy.xtra.ui.chat.v2.catalog.ChatDecorationUpdate
+import com.github.andreyasadchy.xtra.util.DEFAULT_CHAT_UI_BATCH_INTERVAL_MS
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.CoroutineStart
@@ -100,11 +102,15 @@ class ChatSession(
 
     suspend fun snapshot(): List<com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessage> = timeline.snapshot()
 
-    fun attachUi() = ChatUiBatcher(
+    fun attachUi(
+        batchIntervalMsFlow: StateFlow<Long>? = null,
+    ) = ChatUiBatcher(
         versions = timeline.versions,
         snapshot = timeline::versionedSnapshot,
         versionOf = VersionedTimelineSnapshot::version,
         snapshotAfter = timeline::versionedSnapshotAfter,
+        batchIntervalMs = DEFAULT_CHAT_UI_BATCH_INTERVAL_MS,
+        batchIntervalMsFlow = batchIntervalMsFlow,
     ).flow()
 
     suspend fun reconcile(key: ChatSessionKey, recent: List<com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessage>) = processor.reconcile(key, recent)

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/session/ChatUiBatcher.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/session/ChatUiBatcher.kt
@@ -1,19 +1,24 @@
 package com.github.andreyasadchy.xtra.ui.chat.v2.session
 
+import com.github.andreyasadchy.xtra.util.DEFAULT_CHAT_UI_BATCH_INTERVAL_MS
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
 
-/** Coalesces timeline publications to at most one UI publication per frame. */
+/** Coalesces timeline publications over the configured UI update interval. */
 class ChatUiBatcher<T>(
     private val versions: Flow<Long>,
     private val snapshot: suspend () -> T,
     private val versionOf: (T) -> Long,
-    private val frameMs: Long = 16L,
+    private val batchIntervalMs: Long = DEFAULT_CHAT_UI_BATCH_INTERVAL_MS,
+    private val batchIntervalMsFlow: StateFlow<Long>? = null,
     private val snapshotAfter: (suspend (Long) -> T)? = null,
 ) {
     /** Cold and collection-owned. No collector means no version collection or snapshot work. */
@@ -31,7 +36,12 @@ class ChatUiBatcher<T>(
             try {
                 for (dirtyVersion in dirty) {
                     if (dirtyVersion <= materializedVersion) continue
-                    delay(frameMs)
+                    if (batchIntervalMsFlow == null) {
+                        val waitMs = batchIntervalMs.coerceAtLeast(0L)
+                        if (waitMs > 0L) delay(waitMs)
+                    } else {
+                        awaitBatchInterval(batchIntervalMsFlow)
+                    }
                     val current = snapshotAfter?.invoke(materializedVersion) ?: snapshot()
                     materializedVersion = versionOf(current)
                     emit(current)
@@ -40,6 +50,20 @@ class ChatUiBatcher<T>(
                 versionJob.cancel()
                 dirty.close()
             }
+        }
+    }
+
+    private suspend fun awaitBatchInterval(intervals: StateFlow<Long>) {
+        var intervalMs = intervals.value.coerceAtLeast(0L)
+        val startedAtNanos = System.nanoTime()
+        while (true) {
+            val elapsedMs = ((System.nanoTime() - startedAtNanos) / 1_000_000L).coerceAtLeast(0L)
+            val remainingMs = intervalMs - elapsedMs
+            if (remainingMs <= 0L) return
+
+            intervalMs = withTimeoutOrNull(remainingMs) {
+                intervals.first { it.coerceAtLeast(0L) != intervalMs }
+            }?.coerceAtLeast(0L) ?: return
         }
     }
 }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatV2RendererController.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatV2RendererController.kt
@@ -29,6 +29,7 @@ import com.github.andreyasadchy.xtra.ui.chat.v2.session.ChatTimelineDelta
 import com.github.andreyasadchy.xtra.ui.chat.ChatRenderStyle
 import com.github.andreyasadchy.xtra.ui.chat.ChatProfilePopoutGesture
 import com.github.andreyasadchy.xtra.ui.chat.resolveChatHighlightSettings
+import com.github.andreyasadchy.xtra.util.ChatBatchingPreferences
 import com.github.andreyasadchy.xtra.util.ChatRenderDiagnostics
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -649,7 +650,9 @@ class ChatV2RendererController(
 
     private fun ActiveChatSession.presentationFlow() =
         combine(
-            session.attachUi(),
+            session.attachUi(
+                batchIntervalMsFlow = ChatBatchingPreferences.intervalMs(recyclerView.context),
+            ),
             catalog.state,
             rewardCatalog,
             rewardCatalogSettled,

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/multiview/chat/CombinedChatViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/multiview/chat/CombinedChatViewModel.kt
@@ -14,6 +14,7 @@ import com.github.andreyasadchy.xtra.ui.chat.v2.session.ActiveChatSession
 import com.github.andreyasadchy.xtra.ui.chat.v2.session.ChatSessionHandle
 import com.github.andreyasadchy.xtra.ui.chat.v2.session.ChatTimelineDelta
 import com.github.andreyasadchy.xtra.ui.chat.v2.session.LiveChatSessionSpec
+import com.github.andreyasadchy.xtra.util.ChatBatchingPreferences
 import com.github.andreyasadchy.xtra.util.C
 import com.github.andreyasadchy.xtra.util.prefs
 import kotlinx.coroutines.CoroutineScope
@@ -130,7 +131,9 @@ class CombinedChatViewModel(
         session.jobs += ownerScope.launch {
             // Keeping one collector per handle means a second Multiview channel cannot stop or
             // overwrite the first one. Append publications are applied to the channel index.
-            session.handle.active.session.attachUi().collect { snapshot ->
+            session.handle.active.session.attachUi(
+                batchIntervalMsFlow = ChatBatchingPreferences.intervalMs(applicationContext),
+            ).collect { snapshot ->
                 val delta = snapshot.delta as? ChatTimelineDelta.Append
                 if (delta != null &&
                     snapshot.version > session.timelineVersion &&

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/settings/SettingsActivity.kt
@@ -127,7 +127,9 @@ import com.github.andreyasadchy.xtra.util.updater.UpdateTimeFormatter
 import com.github.andreyasadchy.xtra.util.updater.UpdateVersionDisplay
 import com.github.andreyasadchy.xtra.util.applyTheme
 import com.github.andreyasadchy.xtra.util.chatBadgeSizeOrDefault
+import com.github.andreyasadchy.xtra.util.DEFAULT_CHAT_UI_BATCH_INTERVAL_MS
 import com.github.andreyasadchy.xtra.util.getAlertDialogBuilder
+import com.github.andreyasadchy.xtra.util.parseChatUiBatchIntervalMs
 import com.github.andreyasadchy.xtra.ui.chat.parseChatHighlightColor
 import com.github.andreyasadchy.xtra.ui.player.captions.formatCaptionTextOffset
 import com.github.andreyasadchy.xtra.ui.player.captions.MoonshineModelState
@@ -1426,6 +1428,32 @@ class SettingsActivity : AppCompatActivity() {
         private fun configureChatSizePreferences() {
             appendCustomListValue(findPreference(C.CHAT_TEXT_SIZE), "sp")
             appendCustomListValue(findPreference(C.CHAT_EMOTE_SIZE), "dp")
+            findPreference<EditTextPreference>(C.CHAT_UI_BATCH_INTERVAL_MS)?.apply {
+                if (text == null) {
+                    text = DEFAULT_CHAT_UI_BATCH_INTERVAL_MS.toString()
+                }
+                fun updateSummary(value: String?) {
+                    val interval = parseChatUiBatchIntervalMs(value)
+                    summary = if (interval == 0L) {
+                        getString(R.string.settings_chat_batch_interval_off)
+                    } else {
+                        getString(R.string.settings_chat_batch_interval_summary, interval)
+                    }
+                }
+                updateSummary(text)
+                setOnBindEditTextListener {
+                    it.inputType = InputType.TYPE_CLASS_NUMBER
+                    it.selectAll()
+                }
+                setOnPreferenceChangeListener { _, value ->
+                    val valid = value.toString().trim().toLongOrNull()?.let { it >= 0L } == true
+                    if (valid) {
+                        updateSummary(value.toString())
+                        (requireActivity() as? SettingsActivity)?.setResult()
+                    }
+                    valid
+                }
+            }
             val chatAppearanceChangeListener = Preference.OnPreferenceChangeListener { _, _ ->
                 (requireActivity() as? SettingsActivity)?.setResult()
                 true

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/C.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/C.kt
@@ -284,6 +284,7 @@ object C {
     const val STREAM_PREVIEW_DELAY = "stream_preview_delay"
     const val ANIMATED_EMOTES = "animatedGifEmotes"
     const val CHAT_SIZE_MODIFIER = "chat_size_modifier"
+    const val CHAT_UI_BATCH_INTERVAL_MS = "chat_ui_batch_interval_ms"
     const val CHAT_TEXT_SIZE = "chat_text_size"
     const val CHAT_EMOTE_SIZE = "chat_emote_size"
     const val CHAT_BADGE_SIZE = "chat_badge_size"

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/ChatBatching.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/ChatBatching.kt
@@ -1,0 +1,42 @@
+package com.github.andreyasadchy.xtra.util
+
+import android.content.Context
+import android.content.SharedPreferences
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+const val DEFAULT_CHAT_UI_BATCH_INTERVAL_MS = 200L
+
+fun parseChatUiBatchIntervalMs(value: String?): Long =
+    value?.trim()?.toLongOrNull()?.takeIf { it >= 0L } ?: DEFAULT_CHAT_UI_BATCH_INTERVAL_MS
+
+internal object ChatBatchingPreferences : SharedPreferences.OnSharedPreferenceChangeListener {
+    private val lock = Any()
+    private val _batchIntervalMs = MutableStateFlow(DEFAULT_CHAT_UI_BATCH_INTERVAL_MS)
+    private val batchIntervalMs = _batchIntervalMs.asStateFlow()
+    @Volatile
+    private var preferences: SharedPreferences? = null
+
+    fun intervalMs(context: Context): StateFlow<Long> {
+        synchronized(lock) {
+            if (preferences == null) {
+                val currentPreferences = context.applicationContext.prefs()
+                preferences = currentPreferences
+                _batchIntervalMs.value = read(currentPreferences)
+                currentPreferences.registerOnSharedPreferenceChangeListener(this)
+            }
+        }
+        return batchIntervalMs
+    }
+
+    override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences?, key: String?) {
+        if (key != C.CHAT_UI_BATCH_INTERVAL_MS) return
+        val currentPreferences = preferences ?: return
+        _batchIntervalMs.value = read(currentPreferences)
+    }
+
+    private fun read(preferences: SharedPreferences): Long = parseChatUiBatchIntervalMs(
+        preferences.getString(C.CHAT_UI_BATCH_INTERVAL_MS, null),
+    )
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -495,6 +495,9 @@
     <string name="settings_7tv_appearance">7TV appearance</string>
     <string name="settings_chat_size">Chat size</string>
     <string name="settings_chat_size_summary">Scale the overall chat interface.</string>
+    <string name="settings_chat_batch_interval">Fast chat update interval (ms)</string>
+    <string name="settings_chat_batch_interval_summary">%1$d ms between chat UI updates</string>
+    <string name="settings_chat_batch_interval_off">0 ms, no batching delay</string>
     <string name="settings_translate_summary">Translate chat messages on-device using Google ML Kit. Language models can be downloaded for offline use.</string>
     <string name="settings_chat_recent">Load recent messages</string>
     <string name="settings_chat_recent_summary">Show messages sent shortly before you opened the stream.</string>

--- a/app/src/main/res/xml/chat_appearance_preferences.xml
+++ b/app/src/main/res/xml/chat_appearance_preferences.xml
@@ -1,5 +1,6 @@
 <androidx.preference.PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android" xmlns:app="http://schemas.android.com/apk/res-auto">
     <SeekBarPreference android:defaultValue="100" android:key="chat_size_modifier" android:max="200" android:summary="@string/settings_chat_size_summary" android:title="@string/settings_chat_size" app:iconSpaceReserved="false" app:min="50" app:showSeekBarValue="true" />
+    <EditTextPreference android:inputType="number" android:key="chat_ui_batch_interval_ms" android:title="@string/settings_chat_batch_interval" app:iconSpaceReserved="false" />
     <ListPreference android:defaultValue="14" android:entries="@array/chatTextSizeEntries" android:entryValues="@array/chatTextSizeValues" android:key="chat_text_size" android:summary="%s" android:title="@string/text_size" app:iconSpaceReserved="false" />
     <ListPreference android:defaultValue="29.5" android:entries="@array/chatEmoteSizeEntries" android:entryValues="@array/chatEmoteSizeValues" android:key="chat_emote_size" android:summary="%s" android:title="@string/chat_emote_size" app:iconSpaceReserved="false" />
     <EditTextPreference android:defaultValue="18.5" android:inputType="numberDecimal" android:key="chat_badge_size" android:title="@string/chat_badge_size" app:iconSpaceReserved="false" app:useSimpleSummaryProvider="true" />

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatUiBatcherTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatUiBatcherTest.kt
@@ -1,6 +1,8 @@
 package com.github.andreyasadchy.xtra.ui.chat.v2
 
 import com.github.andreyasadchy.xtra.ui.chat.v2.session.ChatUiBatcher
+import com.github.andreyasadchy.xtra.util.DEFAULT_CHAT_UI_BATCH_INTERVAL_MS
+import com.github.andreyasadchy.xtra.util.parseChatUiBatchIntervalMs
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.take
@@ -19,7 +21,7 @@ class ChatUiBatcherTest {
     fun attachmentGetsOneImmediateSnapshotAndCoalescesBurst() = runBlocking {
         val version = MutableStateFlow(0L)
         val copies = AtomicInteger()
-        val snapshots = ChatUiBatcher(version, { copies.incrementAndGet() }, { it.toLong() }, frameMs = 20).flow()
+        val snapshots = ChatUiBatcher(version, { copies.incrementAndGet() }, { it.toLong() }, batchIntervalMs = 20).flow()
         val values = mutableListOf<Int>()
         val collector = launch { snapshots.take(2).toList(values) }
         withTimeout(1_000) { while (copies.get() < 1) delay(1) }
@@ -32,7 +34,7 @@ class ChatUiBatcherTest {
     fun cancellingCollectorStopsAllFutureSnapshotWork() = runBlocking {
         val version = MutableStateFlow(0L)
         val copies = AtomicInteger()
-        val snapshots = ChatUiBatcher(version, { copies.incrementAndGet() }, { it.toLong() }, frameMs = 20).flow()
+        val snapshots = ChatUiBatcher(version, { copies.incrementAndGet() }, { it.toLong() }, batchIntervalMs = 20).flow()
         snapshots.take(1).collect { }
         repeat(100) { version.value++ }
         delay(50)
@@ -54,7 +56,7 @@ class ChatUiBatcherTest {
                 Versioned(currentVersion)
             },
             Versioned::version,
-            frameMs = 10,
+            batchIntervalMs = 10,
         ).flow()
         val values = mutableListOf<Versioned>()
         val collector = launch { snapshots.take(2).toList(values) }
@@ -67,5 +69,59 @@ class ChatUiBatcherTest {
         gate.complete(Unit)
         collector.join()
         assertEquals(listOf(0L, 2L), values.map { it.version })
+    }
+
+    @Test
+    fun zeroIntervalPublishesWithoutAnArtificialWait() = runBlocking {
+        val version = MutableStateFlow(0L)
+        var currentVersion = 0L
+        val values = mutableListOf<Long>()
+        val snapshots = ChatUiBatcher(
+            version,
+            { currentVersion },
+            { it },
+            batchIntervalMs = 0,
+        ).flow()
+        val collector = launch { snapshots.take(2).toList(values) }
+        withTimeout(1_000) { while (values.isEmpty()) delay(1) }
+        currentVersion = 1
+        version.value = 1
+        withTimeout(1_000) { collector.join() }
+
+        assertEquals(listOf(0L, 1L), values)
+    }
+
+    @Test
+    fun changingIntervalReleasesAnActiveWait() = runBlocking {
+        val version = MutableStateFlow(0L)
+        val interval = MutableStateFlow(5_000L)
+        var currentVersion = 0L
+        val values = mutableListOf<Long>()
+        val snapshots = ChatUiBatcher(
+            version,
+            { currentVersion },
+            { it },
+            batchIntervalMsFlow = interval,
+        ).flow()
+        val collector = launch { snapshots.take(2).toList(values) }
+        withTimeout(1_000) { while (values.isEmpty()) delay(1) }
+
+        currentVersion = 1
+        version.value = 1
+        delay(100)
+        assertEquals(listOf(0L), values)
+
+        interval.value = 0L
+        withTimeout(1_000) { collector.join() }
+
+        assertEquals(listOf(0L, 1L), values)
+    }
+
+    @Test
+    fun batchIntervalParsingAllowsOffAndArbitraryNonnegativeValues() {
+        assertEquals(DEFAULT_CHAT_UI_BATCH_INTERVAL_MS, parseChatUiBatchIntervalMs(null))
+        assertEquals(0L, parseChatUiBatchIntervalMs("0"))
+        assertEquals(Long.MAX_VALUE, parseChatUiBatchIntervalMs(Long.MAX_VALUE.toString()))
+        assertEquals(DEFAULT_CHAT_UI_BATCH_INTERVAL_MS, parseChatUiBatchIntervalMs("-1"))
     }
 }


### PR DESCRIPTION
Fast chats can now coalesce UI updates instead of publishing every burst immediately. The interval defaults to 200 ms, accepts 0 for immediate updates, and can be set to any nonnegative millisecond value in Chat > Appearance.