### PR TITLE
Bound animated chat rendering

### DIFF
--- a/app/src/androidTest/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatMessageTextViewTest.kt
+++ b/app/src/androidTest/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatMessageTextViewTest.kt
@@ -1330,6 +1330,7 @@ class ChatMessageTextViewTest {
             animated.scheduleSelf({}, 0L)
             view.detachedForTest()
             assertTrue(animated.stopCount > 0)
+            assertEquals(null, animated.callbackAtStop)
             assertEquals(null, animated.callback)
             val starts = animated.startCount
             view.attachedForTest()
@@ -1960,6 +1961,7 @@ class ChatMessageTextViewTest {
     private class RecordingAnimatedDrawable : Drawable(), Animatable {
         var startCount = 0
         var stopCount = 0
+        var callbackAtStop: Drawable.Callback? = null
         var boundsChangeCount = 0
 
         override fun onBoundsChange(bounds: android.graphics.Rect) { boundsChangeCount++ }
@@ -1969,7 +1971,10 @@ class ChatMessageTextViewTest {
         override fun setColorFilter(colorFilter: android.graphics.ColorFilter?) = Unit
         override fun getOpacity(): Int = PixelFormat.TRANSLUCENT
         override fun start() { startCount++ }
-        override fun stop() { stopCount++ }
+        override fun stop() {
+            callbackAtStop = callback
+            stopCount++
+        }
         override fun isRunning(): Boolean = stopCount < startCount
     }
 

--- a/app/src/androidTest/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatTimelineAdapterTest.kt
+++ b/app/src/androidTest/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatTimelineAdapterTest.kt
@@ -6,6 +6,7 @@ import android.graphics.Rect
 import android.graphics.drawable.Animatable
 import android.graphics.drawable.Drawable
 import android.content.ComponentName
+import android.content.Context
 import android.content.Intent
 import android.os.SystemClock
 import android.widget.FrameLayout
@@ -39,6 +40,10 @@ import java.util.concurrent.TimeUnit
 
 @RunWith(AndroidJUnit4::class)
 class ChatTimelineAdapterTest {
+    private class ExtraLayoutLinearLayoutManager(context: Context) : LinearLayoutManager(context) {
+        override fun getExtraLayoutSpace(state: RecyclerView.State): Int = 200
+    }
+
     @Test
     fun appendOnlyNotifiesHeadRemovalAndTailInsertion() {
         val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
@@ -218,7 +223,7 @@ class ChatTimelineAdapterTest {
         lateinit var recyclerView: RecyclerView
         scenario.onActivity { activity ->
             recyclerView = RecyclerView(activity).apply {
-                layoutManager = LinearLayoutManager(activity)
+                layoutManager = ExtraLayoutLinearLayoutManager(activity)
                 adapter = timelineAdapter
             }
             activity.root.addView(recyclerView, FrameLayout.LayoutParams(320, 160))
@@ -240,6 +245,7 @@ class ChatTimelineAdapterTest {
             val attachedClipped = onMainResult {
                 attachedPositions(recyclerView).filterNot(visiblePositions::contains)
             }
+            assertTrue(attachedClipped.isNotEmpty())
             assertTrue(attachedClipped.all { drawables["budget-$it"]?.isRunning != true })
             onMain { timelineAdapter.setAnimationBudget(0) }
             awaitUiIdle()

--- a/app/src/androidTest/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatTimelineAdapterTest.kt
+++ b/app/src/androidTest/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatTimelineAdapterTest.kt
@@ -1,10 +1,24 @@
 package com.github.andreyasadchy.xtra.ui.chat.v2.ui
 
+import android.graphics.Canvas
+import android.graphics.PixelFormat
+import android.graphics.Rect
+import android.graphics.drawable.Animatable
+import android.graphics.drawable.Drawable
+import android.content.ComponentName
+import android.content.Intent
+import android.os.SystemClock
+import android.widget.FrameLayout
+import androidx.test.core.app.ActivityScenario
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import androidx.test.platform.app.InstrumentationRegistry
+import com.github.andreyasadchy.xtra.ui.chat.v2.ChatMessageTextViewTestActivity
 import com.github.andreyasadchy.xtra.ui.chat.v2.assets.ChatAssetLoader
+import com.github.andreyasadchy.xtra.ui.chat.v2.assets.ChatImageHandle
 import com.github.andreyasadchy.xtra.ui.chat.v2.assets.ChatAssetRepository
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatAssetKey
+import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatAssetSpec
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessageId
 import com.github.andreyasadchy.xtra.ui.chat.v2.presentation.ChatPiece
 import com.github.andreyasadchy.xtra.ui.chat.v2.presentation.ChatRowUiModel
@@ -19,6 +33,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
@@ -183,11 +198,172 @@ class ChatTimelineAdapterTest {
         assertEquals(FollowMode.USER_SCROLLED_UP, controller.state.followMode)
     }
 
+    @Test
+    fun animationBudgetUsesNewestViewportVisibleAnimatedRowsOnly() {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+        val drawables = ConcurrentHashMap<String, RecordingAnimatedDrawable>()
+        val repository = ChatAssetRepository(scope, ChatAssetLoader { key ->
+            ChatImageHandle { RecordingAnimatedDrawable().also { drawables[key.value] = it } }
+        })
+        val timelineAdapter = ChatTimelineAdapter(repository, textSizeSp = 14f, animateGifs = true)
+        val rows = (0 until 14).map { index -> animatedRow(index, animated = index % 2 == 0) }
+        val scenario = ActivityScenario.launch<ChatMessageTextViewTestActivity>(
+            Intent().setComponent(
+                ComponentName(
+                    InstrumentationRegistry.getInstrumentation().targetContext,
+                    ChatMessageTextViewTestActivity::class.java,
+                ),
+            ),
+        )
+        lateinit var recyclerView: RecyclerView
+        scenario.onActivity { activity ->
+            recyclerView = RecyclerView(activity).apply {
+                layoutManager = LinearLayoutManager(activity)
+                adapter = timelineAdapter
+            }
+            activity.root.addView(recyclerView, FrameLayout.LayoutParams(320, 160))
+            timelineAdapter.setAnimationBudget(2)
+            timelineAdapter.replaceAll(rows)
+        }
+        try {
+            awaitUiIdle()
+            val visiblePositions = onMainResult { visiblePositions(recyclerView) }
+            assertTrue(visiblePositions.size >= 2)
+            awaitDrawables(drawables, visiblePositions.map { "budget-$it" })
+            val expectedRunning = visiblePositions
+                .filter { it % 2 == 0 }
+                .takeLast(2)
+                .map { "budget-$it" }
+                .toSet()
+            val running = drawables.filterValues { it.isRunning }.keys
+            assertEquals(expectedRunning, running)
+            val attachedClipped = onMainResult {
+                attachedPositions(recyclerView).filterNot(visiblePositions::contains)
+            }
+            assertTrue(attachedClipped.all { drawables["budget-$it"]?.isRunning != true })
+            onMain { timelineAdapter.setAnimationBudget(0) }
+            awaitUiIdle()
+            assertTrue(drawables.values.none { it.isRunning })
+        } finally {
+            scenario.close()
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun animationBudgetReassignsNewestVisibleRowsAfterScroll() {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+        val drawables = ConcurrentHashMap<String, RecordingAnimatedDrawable>()
+        val repository = ChatAssetRepository(scope, ChatAssetLoader { key ->
+            ChatImageHandle { RecordingAnimatedDrawable().also { drawables[key.value] = it } }
+        })
+        val timelineAdapter = ChatTimelineAdapter(repository, textSizeSp = 14f, animateGifs = true)
+        val rows = (0 until 20).map { index -> animatedRow(index) }
+        val scenario = ActivityScenario.launch<ChatMessageTextViewTestActivity>(
+            Intent().setComponent(
+                ComponentName(
+                    InstrumentationRegistry.getInstrumentation().targetContext,
+                    ChatMessageTextViewTestActivity::class.java,
+                ),
+            ),
+        )
+        lateinit var recyclerView: RecyclerView
+        scenario.onActivity { activity ->
+            recyclerView = RecyclerView(activity).apply {
+                layoutManager = LinearLayoutManager(activity)
+                adapter = timelineAdapter
+            }
+            activity.root.addView(recyclerView, FrameLayout.LayoutParams(320, 160))
+            timelineAdapter.setAnimationBudget(2)
+            timelineAdapter.replaceAll(rows)
+        }
+        try {
+            awaitUiIdle()
+            onMain { recyclerView.scrollToPosition(10) }
+            awaitUiIdle()
+            val visiblePositions = onMainResult { visiblePositions(recyclerView) }
+            assertTrue(visiblePositions.isNotEmpty())
+            awaitDrawables(drawables, visiblePositions.map { "budget-$it" })
+            val expectedRunning = visiblePositions.takeLast(2).map { "budget-$it" }.toSet()
+            val running = drawables.filterValues { it.isRunning }.keys
+            assertEquals(expectedRunning, running)
+        } finally {
+            scenario.close()
+            scope.cancel()
+        }
+    }
+
     private fun adapter(scope: CoroutineScope) = ChatTimelineAdapter(
         assets = ChatAssetRepository(scope, ChatAssetLoader { null }),
         textSizeSp = 14f,
         animateGifs = false,
     )
+
+    private fun animatedRow(index: Int, animated: Boolean = true) = ChatRowUiModel(
+        id = ChatMessageId("row-$index"),
+        channelId = "channel",
+        timestampText = null,
+        pieces = listOf(
+            ChatPiece.Text("message-$index "),
+            ChatPiece.Emote(
+                asset = ChatAssetSpec(ChatAssetKey("budget-$index"), 20, 20, 28),
+                fallback = "EMOTE",
+                animated = animated,
+            ),
+        ),
+        background = 0,
+        accessibilityText = "message-$index",
+        reply = null,
+        source = null,
+        isAction = false,
+    )
+
+    private fun visiblePositions(recyclerView: RecyclerView): List<Int> {
+        val layoutManager = checkNotNull(recyclerView.layoutManager)
+        val bounds = Rect()
+        val left = recyclerView.paddingLeft
+        val top = recyclerView.paddingTop
+        val right = recyclerView.width - recyclerView.paddingRight
+        val bottom = recyclerView.height - recyclerView.paddingBottom
+        return (0 until recyclerView.childCount).mapNotNull { index ->
+            val child = recyclerView.getChildAt(index)
+            layoutManager.getDecoratedBoundsWithMargins(child, bounds)
+            if (
+                bounds.left < right && bounds.right > left &&
+                bounds.top < bottom && bounds.bottom > top
+            ) recyclerView.getChildAdapterPosition(child).takeIf { it != RecyclerView.NO_POSITION } else null
+        }.sorted()
+    }
+
+    private fun attachedPositions(recyclerView: RecyclerView): List<Int> =
+        (0 until recyclerView.childCount).mapNotNull { index ->
+            recyclerView.getChildAdapterPosition(recyclerView.getChildAt(index))
+                .takeIf { it != RecyclerView.NO_POSITION }
+        }.sorted()
+
+    private fun awaitDrawables(
+        drawables: Map<String, RecordingAnimatedDrawable>,
+        expectedKeys: Collection<String>,
+    ) {
+        val deadline = SystemClock.uptimeMillis() + 2_000L
+        while (SystemClock.uptimeMillis() < deadline) {
+            awaitUiIdle()
+            if (drawables.keys.containsAll(expectedKeys)) return
+            Thread.sleep(10)
+        }
+        assertTrue(drawables.keys.containsAll(expectedKeys))
+    }
+
+    private fun awaitUiIdle() {
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+        Thread.sleep(40)
+    }
+
+    private fun <T> onMainResult(block: () -> T): T {
+        var result: T? = null
+        onMain { result = block() }
+        return checkNotNull(result)
+    }
 
     private fun submitAndWait(adapter: ChatTimelineAdapter, rows: List<ChatRowUiModel>) {
         val committed = CountDownLatch(1)
@@ -202,6 +378,18 @@ class ChatTimelineAdapterTest {
 
     private fun onMain(block: () -> Unit) {
         InstrumentationRegistry.getInstrumentation().runOnMainSync(block)
+    }
+
+    private class RecordingAnimatedDrawable : Drawable(), Animatable {
+        private var running = false
+
+        override fun draw(canvas: Canvas) = Unit
+        override fun setAlpha(alpha: Int) = Unit
+        override fun setColorFilter(colorFilter: android.graphics.ColorFilter?) = Unit
+        override fun getOpacity(): Int = PixelFormat.TRANSLUCENT
+        override fun start() { running = true }
+        override fun stop() { running = false }
+        override fun isRunning(): Boolean = running
     }
 
     private fun row(id: String, text: String = id) = ChatRowUiModel(

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/assets/ChatAssetRepository.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/assets/ChatAssetRepository.kt
@@ -31,6 +31,8 @@ class ChatAssetRepository(
     private val listeners = HashMap<ChatAssetKey, MutableSet<() -> Unit>>()
     private val retryJobs = HashMap<ChatAssetKey, Job>()
     private val loadJobs = HashMap<ChatAssetKey, Job>()
+    /** Loads that have acquired a permit and are inside the loader. */
+    private val activeLoads = HashSet<ChatAssetKey>()
     private val loadPermits = Semaphore(maxConcurrentLoads.coerceAtLeast(1))
     private val _changes = MutableStateFlow<ChatAssetKey?>(null)
     val changes: StateFlow<ChatAssetKey?> = _changes.asStateFlow()
@@ -57,8 +59,13 @@ class ChatAssetRepository(
             if (listeners[key].isNullOrEmpty()) {
                 listeners.remove(key)
                 retryJobs.remove(key)?.cancel()
-                loadJob = loadJobs.remove(key)
-                if (states[key] is ChatAssetState.Loading) states.remove(key)
+                // RecyclerView can briefly recycle the last row using this asset while a
+                // batched publication is being applied. Keep an already-started request alive
+                // so the next bind can reuse its result; queued work is still canceled promptly.
+                if (key !in activeLoads) {
+                    loadJob = loadJobs.remove(key)
+                    if (states[key] is ChatAssetState.Loading) states.remove(key)
+                }
                 if ((states[key] as? ChatAssetState.Ready)?.image?.holdsDecodedImage() == true) {
                     states.remove(key)
                 }
@@ -97,7 +104,14 @@ class ChatAssetRepository(
                 try {
                     var completedAt: Long
                     val state = try {
-                        val loaded = loadPermits.withPermit { loader.load(key) }
+                        val loaded = loadPermits.withPermit {
+                            synchronized(this@ChatAssetRepository) { activeLoads += key }
+                            try {
+                                loader.load(key)
+                            } finally {
+                                synchronized(this@ChatAssetRepository) { activeLoads -= key }
+                            }
+                        }
                         completedAt = nowMs()
                         loaded?.let(ChatAssetState::Ready)
                             ?: ChatAssetState.Failed(completedAt + retryDelay(attempt), attempt)
@@ -133,11 +147,21 @@ class ChatAssetRepository(
                     }
                     val callbacks = synchronized(this@ChatAssetRepository) {
                         if (loadJobs[key] !== currentJob) null else {
-                            states[key] = state
+                            val observers = listeners[key]?.toList().orEmpty()
+                            if (
+                                observers.isEmpty() &&
+                                (state as? ChatAssetState.Ready)?.image?.holdsDecodedImage() == true
+                            ) {
+                                // Do not retain a non-shareable decoded handle after a transient
+                                // observer disappears while its request is completing.
+                                states.remove(key)
+                            } else {
+                                states[key] = state
+                            }
                             retryJobs.remove(key)
                             trimCacheLocked()
                             updateDiagnosticsLocked()
-                            listeners[key]?.toList().orEmpty()
+                            observers
                         }
                     } ?: return@launch
                     _changes.value = key

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatMessageTextView.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatMessageTextView.kt
@@ -291,7 +291,7 @@ open class ChatMessageTextView private constructor(
         isLongClickable = onMessageLongClick != null
         val oldKeys = keys
         val oldClipPreviewSlugs = clipPreviewSlugs
-        drawables.values.forEach { it.stopIfNeeded(); it.callback = null }
+        drawables.values.forEach(Drawable::disconnectAndStopIfNeeded)
         drawables.clear()
         drawableHandles.clear()
         val newKeys = row.assetKeys()
@@ -1175,7 +1175,7 @@ open class ChatMessageTextView private constructor(
     private fun drawableFor(key: ChatAssetKey): Drawable? {
         val handle = (assets.peek(key) as? ChatAssetState.Ready)?.image ?: return null
         val drawable = if (drawableHandles[key] !== handle) {
-            drawables.remove(key)?.also { it.stopIfNeeded(); it.callback = null }
+            drawables.remove(key)?.also(Drawable::disconnectAndStopIfNeeded)
             drawableHandles[key] = handle
             val created = handle.newDrawable()
             if (created == null) {
@@ -1199,7 +1199,7 @@ open class ChatMessageTextView private constructor(
         stagedAssetObservers.keys.toList().forEach(::removeStagedAssetObserver)
         clipMetadataObservers.keys.toList().forEach(::removeClipMetadataObserver)
         clipThumbnailObservers.keys.toList().forEach(::removeClipThumbnailObserver)
-        drawables.values.forEach { it.stopIfNeeded(); it.callback = null }
+        drawables.values.forEach(Drawable::disconnectAndStopIfNeeded)
         drawables.clear()
         drawableHandles.clear()
         keys = emptySet()
@@ -1259,17 +1259,16 @@ open class ChatMessageTextView private constructor(
     }
 
     private fun updateAnimationState(key: ChatAssetKey, drawable: Drawable) {
-        drawable.callback = if (renderingActive && windowAttached && aggregatedVisible) this else null
         val animatable = drawable as? Animatable ?: return
         val shouldRun = animateGifs && animationBudgetAllowed && renderingActive && windowAttached && aggregatedVisible && key in animatedAssetKeys
         if (shouldRun) {
+            drawable.callback = this
             if (!animatable.isRunning) {
                 animatable.start()
                 ChatRenderDiagnostics.recordAnimationStarted()
             }
-        } else if (animatable.isRunning) {
-            animatable.stop()
-            ChatRenderDiagnostics.recordAnimationStopped()
+        } else {
+            drawable.disconnectAndStopIfNeeded()
         }
     }
 
@@ -1330,7 +1329,7 @@ open class ChatMessageTextView private constructor(
         stagedAssetObservers.keys.toList().forEach(::removeStagedAssetObserver)
         clipMetadataObservers.keys.toList().forEach(::removeClipMetadataObserver)
         clipThumbnailObservers.keys.toList().forEach(::removeClipThumbnailObserver)
-        drawables.values.forEach { it.stopIfNeeded(); it.callback = null }
+        drawables.values.forEach(Drawable::disconnectAndStopIfNeeded)
         super.onDetachedFromWindow()
     }
 
@@ -1354,7 +1353,7 @@ open class ChatMessageTextView private constructor(
 
     override fun invalidateDrawable(drawable: Drawable) {
         if (BuildConfig.PERF_DIAGNOSTICS && drawable is Animatable) {
-            ChatRenderDiagnostics.recordAnimationInvalidation()
+            ChatRenderDiagnostics.recordAnimationInvalidation((drawable as Animatable).isRunning)
         }
         super.invalidateDrawable(drawable)
     }
@@ -1425,7 +1424,8 @@ private fun blendColors(baseColor: Int, overlayColor: Int, overlayAlpha: Int): I
 
 private fun Int?.orZero(): Int = this ?: 0
 
-private fun Drawable.stopIfNeeded() {
+private fun Drawable.disconnectAndStopIfNeeded() {
+    callback = null
     (this as? Animatable)?.let { animatable ->
         if (animatable.isRunning) {
             animatable.stop()

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatMessageTextView.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatMessageTextView.kt
@@ -123,6 +123,7 @@ open class ChatMessageTextView private constructor(
     )
     private var renderingActive = true
     private var animateGifs = true
+    private var animationBudgetAllowed = true
     private var windowAttached = false
     private var aggregatedVisible = false
     private var animatedAssetKeys = emptySet<ChatAssetKey>()
@@ -194,6 +195,14 @@ open class ChatMessageTextView private constructor(
         animateGifs = value
         updateDrawableAnimations()
     }
+
+    fun setAnimationBudgetAllowed(value: Boolean) {
+        if (animationBudgetAllowed == value) return
+        animationBudgetAllowed = value
+        updateDrawableAnimations()
+    }
+
+    fun hasAnimatedAssets(): Boolean = animatedAssetKeys.isNotEmpty()
 
     fun bind(row: ChatRowUiModel) {
         externalBindGeneration++
@@ -1252,7 +1261,7 @@ open class ChatMessageTextView private constructor(
     private fun updateAnimationState(key: ChatAssetKey, drawable: Drawable) {
         drawable.callback = if (renderingActive && windowAttached && aggregatedVisible) this else null
         val animatable = drawable as? Animatable ?: return
-        val shouldRun = animateGifs && renderingActive && windowAttached && aggregatedVisible && key in animatedAssetKeys
+        val shouldRun = animateGifs && animationBudgetAllowed && renderingActive && windowAttached && aggregatedVisible && key in animatedAssetKeys
         if (shouldRun) {
             if (!animatable.isRunning) {
                 animatable.start()

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatTimelineAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatTimelineAdapter.kt
@@ -1,5 +1,6 @@
 package com.github.andreyasadchy.xtra.ui.chat.v2.ui
 
+import android.graphics.Rect
 import android.view.ViewGroup
 import androidx.core.view.children
 import androidx.recyclerview.widget.RecyclerView
@@ -154,26 +155,43 @@ class ChatTimelineAdapter(
         val recyclerView = attachedRecyclerView ?: return
         if (animationBudgetUpdatePosted) return
         animationBudgetUpdatePosted = true
-        recyclerView.post(animationBudgetUpdateRunnable)
+        recyclerView.postOnAnimation(animationBudgetUpdateRunnable)
     }
 
     private fun updateAnimationBudget() {
         val recyclerView = attachedRecyclerView ?: return
-        // Sorting by adapter position keeps animation on the newest messages while older visible
-        // rows retain their current frame, even if RecyclerView changes child order.
-        var slots = animationBudget
-        recyclerView.children
+        val layoutManager = recyclerView.layoutManager ?: return
+        val viewportLeft = recyclerView.paddingLeft
+        val viewportTop = recyclerView.paddingTop
+        val viewportRight = recyclerView.width - recyclerView.paddingRight
+        val viewportBottom = recyclerView.height - recyclerView.paddingBottom
+        val decoratedBounds = Rect()
+        val visibleHolders = recyclerView.children
             .mapNotNull { child ->
                 val holder = recyclerView.getChildViewHolder(child) as? Holder ?: return@mapNotNull null
+                layoutManager.getDecoratedBoundsWithMargins(child, decoratedBounds)
+                val visible = decoratedBounds.left < viewportRight &&
+                    decoratedBounds.right > viewportLeft &&
+                    decoratedBounds.top < viewportBottom &&
+                    decoratedBounds.bottom > viewportTop
+                if (!visible) {
+                    // Attached prefetch children must never keep an animation running.
+                    holder.view.setAnimationBudgetAllowed(false)
+                    return@mapNotNull null
+                }
                 val position = recyclerView.getChildAdapterPosition(child)
                 position.takeIf { it != RecyclerView.NO_POSITION }?.let { it to holder }
             }
             .sortedByDescending { (position, _) -> position }
-            .forEach { (_, holder) ->
-                val allowed = holder.view.hasAnimatedAssets() && slots > 0
-                if (allowed) slots--
-                holder.view.setAnimationBudgetAllowed(allowed)
-            }
+
+        // Sorting by adapter position keeps animation on the newest viewport-visible messages
+        // while older visible rows retain their current frame.
+        var slots = animationBudget
+        visibleHolders.forEach { (_, holder) ->
+            val allowed = holder.view.hasAnimatedAssets() && slots > 0
+            if (allowed) slots--
+            holder.view.setAnimationBudgetAllowed(allowed)
+        }
     }
 
     override fun onAttachedToRecyclerView(recyclerView: RecyclerView) {
@@ -197,7 +215,16 @@ class ChatTimelineAdapter(
         scheduleAnimationBudgetUpdate()
     }
 
-    override fun onViewRecycled(holder: Holder) { holder.view.recycle(); super.onViewRecycled(holder) }
+    override fun onViewDetachedFromWindow(holder: Holder) {
+        super.onViewDetachedFromWindow(holder)
+        scheduleAnimationBudgetUpdate()
+    }
+
+    override fun onViewRecycled(holder: Holder) {
+        holder.view.recycle()
+        holder.view.setAnimationBudgetAllowed(false)
+        super.onViewRecycled(holder)
+    }
 
     class Holder(val view: ChatMessageTextView) : RecyclerView.ViewHolder(view) {
         fun bind(row: ChatRowUiModel) = view.bind(row)

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatTimelineAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatTimelineAdapter.kt
@@ -1,6 +1,7 @@
 package com.github.andreyasadchy.xtra.ui.chat.v2.ui
 
 import android.graphics.Rect
+import android.view.View
 import android.view.ViewGroup
 import androidx.core.view.children
 import androidx.recyclerview.widget.RecyclerView
@@ -28,6 +29,21 @@ class ChatTimelineAdapter(
     }
     private val animationBudgetScrollListener = object : RecyclerView.OnScrollListener() {
         override fun onScrolled(recyclerView: RecyclerView, dx: Int, dy: Int) {
+            scheduleAnimationBudgetUpdate()
+        }
+    }
+    private val animationBudgetLayoutChangeListener = object : View.OnLayoutChangeListener {
+        override fun onLayoutChange(
+            view: View,
+            left: Int,
+            top: Int,
+            right: Int,
+            bottom: Int,
+            oldLeft: Int,
+            oldTop: Int,
+            oldRight: Int,
+            oldBottom: Int,
+        ) {
             scheduleAnimationBudgetUpdate()
         }
     }
@@ -198,11 +214,13 @@ class ChatTimelineAdapter(
         super.onAttachedToRecyclerView(recyclerView)
         attachedRecyclerView = recyclerView
         recyclerView.addOnScrollListener(animationBudgetScrollListener)
+        recyclerView.addOnLayoutChangeListener(animationBudgetLayoutChangeListener)
         scheduleAnimationBudgetUpdate()
     }
 
     override fun onDetachedFromRecyclerView(recyclerView: RecyclerView) {
         recyclerView.removeOnScrollListener(animationBudgetScrollListener)
+        recyclerView.removeOnLayoutChangeListener(animationBudgetLayoutChangeListener)
         recyclerView.removeCallbacks(animationBudgetUpdateRunnable)
         animationBudgetUpdatePosted = false
         if (attachedRecyclerView === recyclerView) attachedRecyclerView = null

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatTimelineAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatTimelineAdapter.kt
@@ -1,6 +1,7 @@
 package com.github.andreyasadchy.xtra.ui.chat.v2.ui
 
 import android.view.ViewGroup
+import androidx.core.view.children
 import androidx.recyclerview.widget.RecyclerView
 import com.github.andreyasadchy.xtra.ui.chat.v2.assets.ChatAssetRepository
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatEmoteInteraction
@@ -17,6 +18,18 @@ class ChatTimelineAdapter(
     private val onGifClick: ((ChatGifInteraction) -> Unit)? = null,
     private val onMessageClick: ((ChatMessageId) -> Unit)? = null,
 ) : RecyclerView.Adapter<ChatTimelineAdapter.Holder>() {
+    private var attachedRecyclerView: RecyclerView? = null
+    private var animationBudget = Int.MAX_VALUE
+    private var animationBudgetUpdatePosted = false
+    private val animationBudgetUpdateRunnable = Runnable {
+        animationBudgetUpdatePosted = false
+        updateAnimationBudget()
+    }
+    private val animationBudgetScrollListener = object : RecyclerView.OnScrollListener() {
+        override fun onScrolled(recyclerView: RecyclerView, dx: Int, dy: Int) {
+            scheduleAnimationBudgetUpdate()
+        }
+    }
     private val rows = ArrayList<ChatRowUiModel>()
     var renderingActive = true
 
@@ -38,7 +51,11 @@ class ChatTimelineAdapter(
         holder.view.setRenderingActive(renderingActive)
         holder.view.setMessageTextSizeSp(textSizeSp)
         holder.view.setAnimateGifs(animateGifs)
+        // A recycled holder may have been inside the budget for its previous row. Keep the new
+        // row stopped until the visible-child pass assigns the current budget.
+        holder.view.setAnimationBudgetAllowed(false)
         holder.bind(rows[position])
+        scheduleAnimationBudgetUpdate()
     }
 
     /** Replaces the complete snapshot for reconciliation and presentation-wide updates. */
@@ -47,6 +64,7 @@ class ChatTimelineAdapter(
         rows.clear()
         rows.addAll(nextRows)
         notifyDataSetChanged()
+        scheduleAnimationBudgetUpdate()
         commitCallback?.invoke()
     }
 
@@ -75,6 +93,7 @@ class ChatTimelineAdapter(
             rows.addAll(newRows.subList(retainedCount, newRows.size))
             notifyItemRangeInserted(insertionPosition, appendedCount)
         }
+        scheduleAnimationBudgetUpdate()
         return true
     }
 
@@ -96,6 +115,7 @@ class ChatTimelineAdapter(
             rows.addAll(appendedRows)
             notifyItemRangeInserted(insertionPosition, appendedRows.size)
         }
+        scheduleAnimationBudgetUpdate()
         return true
     }
 
@@ -105,6 +125,7 @@ class ChatTimelineAdapter(
         val oldSize = rows.size
         rows.clear()
         notifyItemRangeRemoved(0, oldSize)
+        scheduleAnimationBudgetUpdate()
     }
 
     fun dispose() {
@@ -121,9 +142,59 @@ class ChatTimelineAdapter(
         animateGifs = value
         if (itemCount > 0) notifyItemRangeChanged(0, itemCount)
     }
+
+    fun setAnimationBudget(value: Int) {
+        val next = value.coerceAtLeast(0)
+        if (animationBudget == next) return
+        animationBudget = next
+        scheduleAnimationBudgetUpdate()
+    }
+
+    private fun scheduleAnimationBudgetUpdate() {
+        val recyclerView = attachedRecyclerView ?: return
+        if (animationBudgetUpdatePosted) return
+        animationBudgetUpdatePosted = true
+        recyclerView.post(animationBudgetUpdateRunnable)
+    }
+
+    private fun updateAnimationBudget() {
+        val recyclerView = attachedRecyclerView ?: return
+        // Sorting by adapter position keeps animation on the newest messages while older visible
+        // rows retain their current frame, even if RecyclerView changes child order.
+        var slots = animationBudget
+        recyclerView.children
+            .mapNotNull { child ->
+                val holder = recyclerView.getChildViewHolder(child) as? Holder ?: return@mapNotNull null
+                val position = recyclerView.getChildAdapterPosition(child)
+                position.takeIf { it != RecyclerView.NO_POSITION }?.let { it to holder }
+            }
+            .sortedByDescending { (position, _) -> position }
+            .forEach { (_, holder) ->
+                val allowed = holder.view.hasAnimatedAssets() && slots > 0
+                if (allowed) slots--
+                holder.view.setAnimationBudgetAllowed(allowed)
+            }
+    }
+
+    override fun onAttachedToRecyclerView(recyclerView: RecyclerView) {
+        super.onAttachedToRecyclerView(recyclerView)
+        attachedRecyclerView = recyclerView
+        recyclerView.addOnScrollListener(animationBudgetScrollListener)
+        scheduleAnimationBudgetUpdate()
+    }
+
+    override fun onDetachedFromRecyclerView(recyclerView: RecyclerView) {
+        recyclerView.removeOnScrollListener(animationBudgetScrollListener)
+        recyclerView.removeCallbacks(animationBudgetUpdateRunnable)
+        animationBudgetUpdatePosted = false
+        if (attachedRecyclerView === recyclerView) attachedRecyclerView = null
+        super.onDetachedFromRecyclerView(recyclerView)
+    }
+
     override fun onViewAttachedToWindow(holder: Holder) {
         super.onViewAttachedToWindow(holder)
         holder.view.setRenderingActive(renderingActive)
+        scheduleAnimationBudgetUpdate()
     }
 
     override fun onViewRecycled(holder: Holder) { holder.view.recycle(); super.onViewRecycled(holder) }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatV2RendererController.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatV2RendererController.kt
@@ -48,6 +48,9 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 
+// Keep a small animated tail alive while preventing a busy chat from driving every visible row.
+private const val DEFAULT_ANIMATION_BUDGET = 4
+
 internal fun countNewLiveMessages(
     previousIds: Set<ChatMessageId>?,
     previousTailId: ChatMessageId?,
@@ -99,6 +102,7 @@ class ChatV2RendererController(
     private val readableUsernameColors: Boolean = true,
     private val backgroundColor: Int = 0xFF101010.toInt(),
     private val presentationLabels: ChatPresentationLabels = ChatPresentationLabels(),
+    animationBudget: Int = DEFAULT_ANIMATION_BUDGET,
     private val onStateChanged: (ChatViewportState) -> Unit = {},
     private val onMessageLongClick: (ChatMessage) -> Unit = {},
     private val profilePopoutGesture: ChatProfilePopoutGesture = ChatProfilePopoutGesture.HOLD,
@@ -135,6 +139,9 @@ class ChatV2RendererController(
             { id -> latestMessages.firstOrNull { it.id == id }?.let(onMessageLongClick) }
         } else null,
     )
+    init {
+        adapter.setAnimationBudget(animationBudget)
+    }
     private val viewport = ChatViewportController(recyclerView, initialState)
     private var highlightSettings = resolveChatHighlightSettings(recyclerView.context)
     private val presentation = createPresentation(readableUsernameColors, backgroundColor, renderStyle)

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatV2RendererController.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/ui/ChatV2RendererController.kt
@@ -49,7 +49,7 @@ import kotlinx.coroutines.withContext
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 
 // Keep a small animated tail alive while preventing a busy chat from driving every visible row.
-private const val DEFAULT_ANIMATION_BUDGET = 4
+private const val DEFAULT_ANIMATION_BUDGET = 2
 
 internal fun countNewLiveMessages(
     previousIds: Set<ChatMessageId>?,

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/ChatRenderDiagnostics.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/ChatRenderDiagnostics.kt
@@ -8,6 +8,8 @@ internal data class ChatRenderDiagnosticsSnapshot(
     val binds: Long,
     val draws: Long,
     val animationInvalidations: Long,
+    val runningAnimationInvalidations: Long,
+    val stoppedAnimationInvalidations: Long,
     val animationStarts: Long,
     val animationStops: Long,
     val activeAnimations: Int,
@@ -48,6 +50,8 @@ internal data class ChatRenderDiagnosticsSnapshot(
 ) {
     override fun toString(): String =
         "binds=$binds draws=$draws animationInvalidations=$animationInvalidations " +
+            "runningAnimationInvalidations=$runningAnimationInvalidations " +
+            "stoppedAnimationInvalidations=$stoppedAnimationInvalidations " +
             "animationStarts=$animationStarts animationStops=$animationStops " +
             "activeAnimations=$activeAnimations publications=$publications " +
             "publicationMessages=$publicationMessages maxPublicationMessages=$maxPublicationMessages " +
@@ -75,6 +79,8 @@ internal object ChatRenderDiagnostics {
     private val binds = AtomicLong()
     private val draws = AtomicLong()
     private val animationInvalidations = AtomicLong()
+    private val runningAnimationInvalidations = AtomicLong()
+    private val stoppedAnimationInvalidations = AtomicLong()
     private val animationStarts = AtomicLong()
     private val animationStops = AtomicLong()
     private val activeAnimations = AtomicInteger()
@@ -121,8 +127,11 @@ internal object ChatRenderDiagnostics {
         if (BuildConfig.PERF_DIAGNOSTICS) draws.incrementAndGet()
     }
 
-    fun recordAnimationInvalidation() {
-        if (BuildConfig.PERF_DIAGNOSTICS) animationInvalidations.incrementAndGet()
+    fun recordAnimationInvalidation(running: Boolean) {
+        if (!BuildConfig.PERF_DIAGNOSTICS) return
+        animationInvalidations.incrementAndGet()
+        if (running) runningAnimationInvalidations.incrementAndGet()
+        else stoppedAnimationInvalidations.incrementAndGet()
     }
 
     fun recordAnimationStarted() {
@@ -245,6 +254,8 @@ internal object ChatRenderDiagnostics {
         binds = binds.getAndSet(0),
         draws = draws.getAndSet(0),
         animationInvalidations = animationInvalidations.getAndSet(0),
+        runningAnimationInvalidations = runningAnimationInvalidations.getAndSet(0),
+        stoppedAnimationInvalidations = stoppedAnimationInvalidations.getAndSet(0),
         animationStarts = animationStarts.getAndSet(0),
         animationStops = animationStops.getAndSet(0),
         activeAnimations = activeAnimations.get(),

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatAssetRepositoryTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatAssetRepositoryTest.kt
@@ -173,6 +173,41 @@ class ChatAssetRepositoryTest {
     }
 
     @Test
+    fun activeLoadSurvivesObserverChurn() = runBlocking {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        try {
+            val key = ChatAssetKey("active")
+            val started = CompletableDeferred<Unit>()
+            val release = CompletableDeferred<Unit>()
+            var attempts = 0
+            var callbacks = 0
+            val repository = ChatAssetRepository(scope, ChatAssetLoader {
+                attempts++
+                started.complete(Unit)
+                release.await()
+                ChatImageHandle { ColorDrawable(1) }
+            })
+            val firstListener: () -> Unit = {}
+            val secondListener: () -> Unit = { callbacks++ }
+
+            repository.observe(key, firstListener)
+            withTimeout(2_000) { started.await() }
+            repository.removeObserver(key, firstListener)
+            repository.observe(key, secondListener)
+
+            release.complete(Unit)
+            withTimeout(2_000) {
+                while (repository.peek(key) !is ChatAssetState.Ready) delay(1)
+            }
+
+            assertEquals(1, attempts)
+            assertTrue(callbacks > 0)
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    @Test
     fun readyStateCanReloadWhenCoilHasEvictedTheDecodedImage() = runBlocking {
         val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
         try {


### PR DESCRIPTION
Busy chats were creating independent animated drawable work for every visible row. This caps active animation to the newest visible animated rows, while attached but clipped RecyclerView children are always stopped. Older visible rows keep their current frame. Budget updates are coalesced across binds, scrolling, list updates, detach callbacks, and RecyclerView layout changes.

Measured on the xtra-api35 AVD with the same busy animated stream and 20-second Perfetto CPU captures:

| Animated rows | RenderThread CPU | AnimatedImageThread CPU |
| ---: | ---: | ---: |
| 0 | 0.60 s | 0 s |
| 1 | 2.62 s | 0.08 s |
| 2 | 4.69 s | 0.17 s |
| 4 | 5.36 s | 0.67 s |
| 8 | 7.38 s | 0.83 s |
| 16 | 8.11 s | 1.52 s |
| unlimited | 8.25 s | 1.01 s |

The default is now two animated rows: it preserves a visible animated tail while reducing substantially more work than four rows. These are single AVD captures; absolute RenderThread time is emulator-specific and physical-device battery and thermal validation remains follow-up work.

Validation: `:app:assembleDebug`, `git diff --check`, and the targeted `ChatTimelineAdapterTest` instrumentation suite (10 tests) passed on xtra-api35. The suite covers viewport intersection, non-animated rows, budget zero, scroll reassignment, and clipped attached children. The clipped-child test reserves extra layout space and asserts that the clipped case exists before checking that those holders are stopped.