### PR TITLE
Keep live notifications working without EventSub

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/main/LiveNotificationPolicy.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/main/LiveNotificationPolicy.kt
@@ -20,9 +20,14 @@ internal fun liveNotificationCoverageState(
     activeEventSubChannelCount: Int,
     eventSubConnected: Boolean,
     eventSubSuspended: Boolean,
+    monitoredChannelCount: Int = desiredChannelCount,
 ): LiveNotificationCoverageState {
-    if (desiredChannelCount <= 0) return LiveNotificationCoverageState.NO_CHANNELS
-    if (eventSubConnected && !eventSubSuspended && activeEventSubChannelCount >= desiredChannelCount) {
+    if (monitoredChannelCount <= 0) return LiveNotificationCoverageState.NO_CHANNELS
+    if (desiredChannelCount > 0 &&
+        eventSubConnected &&
+        !eventSubSuspended &&
+        activeEventSubChannelCount >= desiredChannelCount
+    ) {
         return LiveNotificationCoverageState.COMPLETE
     }
     return if (eventSubConnected && !eventSubSuspended) {
@@ -37,12 +42,14 @@ internal fun reconcileIntervalMs(
     activeEventSubChannelCount: Int,
     eventSubConnected: Boolean,
     eventSubSuspended: Boolean,
+    monitoredChannelCount: Int = desiredChannelCount,
 ): Long {
     return when (liveNotificationCoverageState(
         desiredChannelCount,
         activeEventSubChannelCount,
         eventSubConnected,
         eventSubSuspended,
+        monitoredChannelCount,
     )) {
         LiveNotificationCoverageState.NO_CHANNELS -> NO_CHANNELS_RECONCILE_INTERVAL_MS
         LiveNotificationCoverageState.COMPLETE -> FULL_EVENTSUB_RECONCILE_INTERVAL_MS

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/main/LiveNotificationRunner.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/main/LiveNotificationRunner.kt
@@ -259,13 +259,20 @@ class LiveNotificationRunner(
                     } else {
                         coverage.copy(connected = false, suspended = true)
                     }
-                    nextDelayMs.set(nextReconciliationDelay(coverage, helixMinimumDelayMs))
+                    nextDelayMs.set(
+                        nextReconciliationDelay(
+                            coverage = coverage,
+                            monitoredChannelCount = it.channelCount,
+                            helixMinimumDelayMs = helixMinimumDelayMs,
+                        )
+                    )
                     if (BuildConfig.PERF_DIAGNOSTICS) {
                         val coverageState = liveNotificationCoverageState(
                             desiredChannelCount = coverage.desiredChannelCount,
                             activeEventSubChannelCount = coverage.activeSubscriptionCount,
                             eventSubConnected = coverage.connected,
                             eventSubSuspended = coverage.suspended,
+                            monitoredChannelCount = it.channelCount,
                         )
                         Log.i(
                             TAG,
@@ -324,6 +331,7 @@ class LiveNotificationRunner(
 
     private fun nextReconciliationDelay(
         coverage: LiveEventSubCoverage,
+        monitoredChannelCount: Int,
         helixMinimumDelayMs: Long?,
     ): Long {
         val coverageState = liveNotificationCoverageState(
@@ -331,6 +339,7 @@ class LiveNotificationRunner(
             activeEventSubChannelCount = coverage.activeSubscriptionCount,
             eventSubConnected = coverage.connected,
             eventSubSuspended = coverage.suspended,
+            monitoredChannelCount = monitoredChannelCount,
         )
         val coverageDelayMs = if (coverageState == LiveNotificationCoverageState.NO_CHANNELS) {
             monitor.nextNotificationUserSyncDelayMs()
@@ -340,6 +349,7 @@ class LiveNotificationRunner(
                 activeEventSubChannelCount = coverage.activeSubscriptionCount,
                 eventSubConnected = coverage.connected,
                 eventSubSuspended = coverage.suspended,
+                monitoredChannelCount = monitoredChannelCount,
             )
         }
         return applyHelixMinimumDelay(coverageDelayMs, helixMinimumDelayMs)

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/main/LiveNotificationPolicyTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/main/LiveNotificationPolicyTest.kt
@@ -51,6 +51,16 @@ class LiveNotificationPolicyTest {
             NO_CHANNELS_RECONCILE_INTERVAL_MS,
             reconcileIntervalMs(0, 0, eventSubConnected = false, eventSubSuspended = false),
         )
+        assertEquals(
+            PARTIAL_EVENTSUB_RECONCILE_INTERVAL_MS,
+            reconcileIntervalMs(
+                desiredChannelCount = 0,
+                activeEventSubChannelCount = 0,
+                eventSubConnected = false,
+                eventSubSuspended = false,
+                monitoredChannelCount = 12,
+            ),
+        )
     }
 
     @Test
@@ -141,6 +151,16 @@ class LiveNotificationPolicyTest {
         assertEquals(
             LiveNotificationCoverageState.NO_CHANNELS,
             liveNotificationCoverageState(0, 0, eventSubConnected = false, eventSubSuspended = false),
+        )
+        assertEquals(
+            LiveNotificationCoverageState.DISCONNECTED,
+            liveNotificationCoverageState(
+                desiredChannelCount = 0,
+                activeEventSubChannelCount = 0,
+                eventSubConnected = false,
+                eventSubSuspended = false,
+                monitoredChannelCount = 12,
+            ),
         )
         assertEquals(
             LiveNotificationCoverageState.PARTIAL,


### PR DESCRIPTION
Keep checking followed channels when the real-time connection is unavailable, so alerts arrive without reopening Xtra.