### PR TITLE
Fix player lifecycle and navigation layout issues

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/channel/ChannelPagerFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/channel/ChannelPagerFragment.kt
@@ -110,7 +110,7 @@ class ChannelPagerFragment : BaseNetworkFragment(), Scrollable, FragmentHost {
         with(binding) {
             val activity = requireActivity() as MainActivity
             if (resources.configuration.orientation == Configuration.ORIENTATION_LANDSCAPE) {
-                appBar.setExpanded(false, false)
+                appBar.setExpanded(true, false)
             }
             if (viewModel.stream.value == null) {
                 watchLive.setOnClickListener {
@@ -780,7 +780,7 @@ class ChannelPagerFragment : BaseNetworkFragment(), Scrollable, FragmentHost {
     override fun onConfigurationChanged(newConfig: Configuration) {
         super.onConfigurationChanged(newConfig)
         if (newConfig.orientation == Configuration.ORIENTATION_LANDSCAPE) {
-            binding.appBar.setExpanded(false, false)
+            binding.appBar.setExpanded(true, false)
         }
     }
 

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/main/MainActivity.kt
@@ -1335,6 +1335,7 @@ class MainActivity : AppCompatActivity() {
 
     fun closePlayer() {
         onPlayerReturnedToBrowsing(playerStillOpen = false)
+        updateMiniPlayerExclusion(null)
         supportFragmentManager.findFragmentById(R.id.playerContainer)?.let { player ->
             supportFragmentManager.beginTransaction()
                 .setTransition(FragmentTransaction.TRANSIT_FRAGMENT_FADE)
@@ -1360,9 +1361,46 @@ class MainActivity : AppCompatActivity() {
     }
 
     fun onPlayerEnteredPlayback(isLive: Boolean = true, channelLogin: String? = null) {
+        updateMiniPlayerExclusion(null)
         viewModel.isPlayerOpened = true
         (application as XtraApp).xtraModule.streamFeedRefreshCoordinator.playbackEntered(isLive)
         (application as XtraApp).xtraModule.streamPreviewCoordinator.onFullscreenPlaybackStarted(channelLogin)
+    }
+
+    fun updateMiniPlayerExclusion(playerView: View?) {
+        if (isTv) return
+        binding.navHostFragment.post {
+            if (playerView == null || !playerView.isShown || playerView.width <= 0 || playerView.height <= 0) {
+                binding.navHostFragment.updateLayoutParams<ViewGroup.MarginLayoutParams> { bottomMargin = 0 }
+                return@post
+            }
+            val navigationBounds = Rect()
+            val playerBounds = Rect()
+            if (!playerView.getGlobalVisibleRect(playerBounds)) {
+                binding.navHostFragment.updateLayoutParams<ViewGroup.MarginLayoutParams> { bottomMargin = 0 }
+                return@post
+            }
+            val navigationTop = if (binding.navBarContainer.getGlobalVisibleRect(navigationBounds)) {
+                navigationBounds.top
+            } else {
+                val hostBounds = Rect()
+                if (!binding.navHostFragment.getGlobalVisibleRect(hostBounds)) {
+                    binding.navHostFragment.updateLayoutParams<ViewGroup.MarginLayoutParams> { bottomMargin = 0 }
+                    return@post
+                }
+                hostBounds.bottom +
+                    ((binding.navHostFragment.layoutParams as? ViewGroup.MarginLayoutParams)?.bottomMargin ?: 0)
+            }
+            val gap = (16 * resources.displayMetrics.density).toInt()
+            val bottomExclusion = calculateMiniPlayerBottomExclusion(
+                navigationTop = navigationTop,
+                playerTop = playerBounds.top,
+                gap = gap,
+            )
+            binding.navHostFragment.updateLayoutParams<ViewGroup.MarginLayoutParams> {
+                bottomMargin = bottomExclusion
+            }
+        }
     }
 
     fun onPlayerChangedPlayback(isLive: Boolean) {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/main/MiniPlayerExclusion.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/main/MiniPlayerExclusion.kt
@@ -1,0 +1,7 @@
+package com.github.andreyasadchy.xtra.ui.main
+
+internal fun calculateMiniPlayerBottomExclusion(
+    navigationTop: Int,
+    playerTop: Int,
+    gap: Int,
+): Int = (navigationTop - playerTop + gap).coerceAtLeast(0)

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/Media3PlayerFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/Media3PlayerFragment.kt
@@ -34,6 +34,7 @@ import android.view.View
 import android.view.ViewConfiguration
 import android.view.ViewGroup
 import android.view.ViewPropertyAnimator
+import android.view.ViewTreeObserver
 import android.view.inputmethod.InputMethodManager
 import android.widget.Button
 import android.widget.FrameLayout
@@ -138,6 +139,7 @@ abstract class Media3PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFr
     var isMaximized = true
     private var isChatOpen = true
     private var isKeyboardShown = false
+    private var keyboardLayoutListener: ViewTreeObserver.OnGlobalLayoutListener? = null
     private var resizeMode = 0
     private var chatWidthLandscape = 0
 
@@ -562,6 +564,7 @@ abstract class Media3PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFr
             resizeMode = requireContext().prefs().getInt(C.ASPECT_RATIO_LANDSCAPE, AspectRatioFrameLayout.RESIZE_MODE_FIT)
             aspectRatioFrameLayout.setAspectRatio(16f / 9f)
             initLayout()
+            (activity as? MainActivity)?.updateMiniPlayerExclusion(if (isMaximized) null else slidingLayout)
             changePlayerMode()
             val viewConfiguration = ViewConfiguration.get(requireContext())
             val touchSlop = viewConfiguration.scaledTouchSlop
@@ -733,8 +736,18 @@ abstract class Media3PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFr
                                             newX?.let { translationX(it) }
                                             newY?.let { translationY(it) }
                                             setDuration(250L)
+                                            setListener(
+                                                object : AnimatorListenerAdapter() {
+                                                    override fun onAnimationEnd(animation: Animator) {
+                                                        setListener(null)
+                                                        (activity as? MainActivity)?.updateMiniPlayerExclusion(slidingLayout)
+                                                    }
+                                                }
+                                            )
                                             start()
                                         }
+                                    } else {
+                                        (activity as? MainActivity)?.updateMiniPlayerExclusion(slidingLayout)
                                     }
                                 } else {
                                     val windowInsets = ViewCompat.getRootWindowInsets(requireView())
@@ -749,6 +762,14 @@ abstract class Media3PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFr
                                         translationX(0f - scaledXDiff - ((insets?.left ?: 0) * slidingLayout.scaleX) + newX)
                                         translationY(0f - scaledYDiff - ((insets?.top ?: 0) * slidingLayout.scaleY) + newY)
                                         setDuration(250L)
+                                        setListener(
+                                            object : AnimatorListenerAdapter() {
+                                                override fun onAnimationEnd(animation: Animator) {
+                                                    setListener(null)
+                                                    (activity as? MainActivity)?.updateMiniPlayerExclusion(slidingLayout)
+                                                }
+                                            }
+                                        )
                                         start()
                                     }
                                 }
@@ -1081,21 +1102,24 @@ abstract class Media3PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFr
                                 toggleChatBar()
                             }
                         }
-                        slidingLayout.viewTreeObserver.addOnGlobalLayoutListener {
-                            if (slidingLayout.isKeyboardShown) {
+                        keyboardLayoutListener?.let(slidingLayout.viewTreeObserver::removeOnGlobalLayoutListener)
+                        keyboardLayoutListener = ViewTreeObserver.OnGlobalLayoutListener {
+                            val currentBinding = _binding ?: return@OnGlobalLayoutListener
+                            val currentContext = context ?: return@OnGlobalLayoutListener
+                            if (currentBinding.slidingLayout.isKeyboardShown) {
                                 if (!isKeyboardShown) {
                                     isKeyboardShown = true
-                                    if (!isPortrait && !requireContext().isTelevision()) {
-                                        chatLayout.updateLayoutParams { width = (slidingLayout.width / 1.8f).toInt() }
+                                    if (!isPortrait && !currentContext.isTelevision()) {
+                                        currentBinding.chatLayout.updateLayoutParams { width = (currentBinding.slidingLayout.width / 1.8f).toInt() }
                                         showStatusBar()
                                     }
                                 }
                             } else {
                                 if (isKeyboardShown) {
                                     isKeyboardShown = false
-                                    chatLayout.clearFocus()
-                                    if (!isPortrait && !requireContext().isTelevision()) {
-                                        chatLayout.updateLayoutParams { width = effectiveLandscapeChatWidth() }
+                                    currentBinding.chatLayout.clearFocus()
+                                    if (!isPortrait && !currentContext.isTelevision()) {
+                                        currentBinding.chatLayout.updateLayoutParams { width = effectiveLandscapeChatWidth() }
                                         if (isMaximized) {
                                             hideStatusBar()
                                         }
@@ -1103,6 +1127,7 @@ abstract class Media3PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFr
                                 }
                             }
                         }
+                        slidingLayout.viewTreeObserver.addOnGlobalLayoutListener(keyboardLayoutListener)
                     }
                     viewLifecycleOwner.lifecycleScope.launch {
                         repeatOnLifecycle(Lifecycle.State.STARTED) {
@@ -3387,6 +3412,7 @@ abstract class Media3PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFr
                 (requireContext().getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager).hideSoftInputFromWindow(chatLayout.windowToken, 0)
                 chatLayout.clearFocus()
                 initLayout()
+                (activity as? MainActivity)?.updateMiniPlayerExclusion(if (isMaximized) null else slidingLayout)
                 refreshPlayerControls()
                 PlayerControlLayout.applyToPlayer(requireContext(), binding)
                 hideTvSecondaryActions()
@@ -3518,6 +3544,7 @@ abstract class Media3PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFr
                                 isAnimating = false
                                 setListener(null)
                                 activePointerId = -1
+                                (activity as? MainActivity)?.updateMiniPlayerExclusion(slidingLayout)
                             }
                         }
                     )
@@ -3547,6 +3574,7 @@ abstract class Media3PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFr
     fun maximize() {
         with(binding) {
             isMaximized = true
+            (activity as? MainActivity)?.updateMiniPlayerExclusion(null)
             dismissPlayer.visibility = View.GONE
             dismissPlayer.scaleX = 1f
             dismissPlayer.scaleY = 1f
@@ -3783,6 +3811,11 @@ abstract class Media3PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFr
     }
 
     override fun onDestroyView() {
+        _binding?.let { binding ->
+            keyboardLayoutListener?.let(binding.slidingLayout.viewTreeObserver::removeOnGlobalLayoutListener)
+        }
+        keyboardLayoutListener = null
+        (activity as? MainActivity)?.updateMiniPlayerExclusion(null)
         _binding?.playerControls?.root?.let { root ->
             pendingTvFocusRequest?.let(root::removeCallbacks)
             root.removeCallbacks(controllerHideAction)

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/PlayerFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/PlayerFragment.kt
@@ -32,6 +32,7 @@ import android.view.View
 import android.view.ViewConfiguration
 import android.view.ViewGroup
 import android.view.ViewPropertyAnimator
+import android.view.ViewTreeObserver
 import android.view.inputmethod.InputMethodManager
 import android.widget.Button
 import android.widget.FrameLayout
@@ -137,6 +138,7 @@ abstract class PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFragment
     protected var isMaximized = true
     private var isChatOpen = true
     private var isKeyboardShown = false
+    private var keyboardLayoutListener: ViewTreeObserver.OnGlobalLayoutListener? = null
     private var resizeMode = 0
     private var chatWidthLandscape = 0
 
@@ -661,6 +663,7 @@ abstract class PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFragment
             resizeMode = requireContext().prefs().getInt(C.ASPECT_RATIO_LANDSCAPE, AspectRatioFrameLayout.RESIZE_MODE_FIT)
             aspectRatioFrameLayout.setAspectRatio(16f / 9f)
             initLayout()
+            (activity as? MainActivity)?.updateMiniPlayerExclusion(if (isMaximized) null else slidingLayout)
             changePlayerMode()
             setupLiveCaptionOverlay()
             val viewConfiguration = ViewConfiguration.get(requireContext())
@@ -836,8 +839,18 @@ abstract class PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFragment
                                             newX?.let { translationX(it) }
                                             newY?.let { translationY(it) }
                                             setDuration(250L)
+                                            setListener(
+                                                object : AnimatorListenerAdapter() {
+                                                    override fun onAnimationEnd(animation: Animator) {
+                                                        setListener(null)
+                                                        (activity as? MainActivity)?.updateMiniPlayerExclusion(slidingLayout)
+                                                    }
+                                                }
+                                            )
                                             start()
                                         }
+                                    } else {
+                                        (activity as? MainActivity)?.updateMiniPlayerExclusion(slidingLayout)
                                     }
                                 } else {
                                     val windowInsets = ViewCompat.getRootWindowInsets(requireView())
@@ -852,6 +865,14 @@ abstract class PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFragment
                                         translationX(0f - scaledXDiff - ((insets?.left ?: 0) * slidingLayout.scaleX) + newX)
                                         translationY(0f - scaledYDiff - ((insets?.top ?: 0) * slidingLayout.scaleY) + newY)
                                         setDuration(250L)
+                                        setListener(
+                                            object : AnimatorListenerAdapter() {
+                                                override fun onAnimationEnd(animation: Animator) {
+                                                    setListener(null)
+                                                    (activity as? MainActivity)?.updateMiniPlayerExclusion(slidingLayout)
+                                                }
+                                            }
+                                        )
                                         start()
                                     }
                                 }
@@ -1760,21 +1781,24 @@ abstract class PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFragment
                                 toggleChatBar()
                             }
                         }
-                        slidingLayout.viewTreeObserver.addOnGlobalLayoutListener {
-                            if (slidingLayout.isKeyboardShown) {
+                        keyboardLayoutListener?.let(slidingLayout.viewTreeObserver::removeOnGlobalLayoutListener)
+                        keyboardLayoutListener = ViewTreeObserver.OnGlobalLayoutListener {
+                            val currentBinding = _binding ?: return@OnGlobalLayoutListener
+                            val currentContext = context ?: return@OnGlobalLayoutListener
+                            if (currentBinding.slidingLayout.isKeyboardShown) {
                                 if (!isKeyboardShown) {
                                     isKeyboardShown = true
-                                    if (!isPortrait && !requireContext().isTelevision()) {
-                                        chatLayout.updateLayoutParams { width = (slidingLayout.width / 1.8f).toInt() }
+                                    if (!isPortrait && !currentContext.isTelevision()) {
+                                        currentBinding.chatLayout.updateLayoutParams { width = (currentBinding.slidingLayout.width / 1.8f).toInt() }
                                         showStatusBar()
                                     }
                                 }
                             } else {
                                 if (isKeyboardShown) {
                                     isKeyboardShown = false
-                                    chatLayout.clearFocus()
-                                    if (!isPortrait && !requireContext().isTelevision()) {
-                                        chatLayout.updateLayoutParams { width = effectiveLandscapeChatWidth() }
+                                    currentBinding.chatLayout.clearFocus()
+                                    if (!isPortrait && !currentContext.isTelevision()) {
+                                        currentBinding.chatLayout.updateLayoutParams { width = effectiveLandscapeChatWidth() }
                                         if (isMaximized) {
                                             hideStatusBar()
                                         }
@@ -1782,6 +1806,7 @@ abstract class PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFragment
                                 }
                             }
                         }
+                        slidingLayout.viewTreeObserver.addOnGlobalLayoutListener(keyboardLayoutListener)
                     }
                     viewLifecycleOwner.lifecycleScope.launch {
                         viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
@@ -3365,6 +3390,7 @@ abstract class PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFragment
                 (requireContext().getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager).hideSoftInputFromWindow(chatLayout.windowToken, 0)
                 chatLayout.clearFocus()
                 initLayout()
+                (activity as? MainActivity)?.updateMiniPlayerExclusion(if (isMaximized) null else slidingLayout)
                 refreshPlayerControls()
                 applyControlLayout()
                 if (isInteractionLocked) {
@@ -3494,6 +3520,7 @@ abstract class PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFragment
                                 isAnimating = false
                                 setListener(null)
                                 activePointerId = -1
+                                (activity as? MainActivity)?.updateMiniPlayerExclusion(slidingLayout)
                             }
                         }
                     )
@@ -3523,6 +3550,7 @@ abstract class PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFragment
     fun maximize() {
         with(binding) {
             isMaximized = true
+            (activity as? MainActivity)?.updateMiniPlayerExclusion(null)
             dismissPlayer.visibility = View.GONE
             dismissPlayer.scaleX = 1f
             dismissPlayer.scaleY = 1f
@@ -3704,6 +3732,11 @@ abstract class PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFragment
     }
 
     override fun onDestroyView() {
+        _binding?.let { binding ->
+            keyboardLayoutListener?.let(binding.slidingLayout.viewTreeObserver::removeOnGlobalLayoutListener)
+        }
+        keyboardLayoutListener = null
+        (activity as? MainActivity)?.updateMiniPlayerExclusion(null)
         _binding?.playerControls?.root?.let { root ->
             pendingTvFocusRequest?.let(root::removeCallbacks)
         }

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/main/MiniPlayerExclusionTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/main/MiniPlayerExclusionTest.kt
@@ -1,0 +1,31 @@
+package com.github.andreyasadchy.xtra.ui.main
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class MiniPlayerExclusionTest {
+    @Test
+    fun repeatedCalculationIsIdempotent() {
+        val first = calculateMiniPlayerBottomExclusion(navigationTop = 1000, playerTop = 760, gap = 16)
+
+        assertEquals(first, calculateMiniPlayerBottomExclusion(navigationTop = 1000, playerTop = 760, gap = 16))
+    }
+
+    @Test
+    fun existingHostMarginDoesNotChangeTheStableAnchorResult() {
+        val expected = 256
+
+        assertEquals(expected, calculateMiniPlayerBottomExclusion(navigationTop = 1000, playerTop = 760, gap = 16))
+    }
+
+    @Test
+    fun movedPlayerChangesTheExclusionFromItsNewTop() {
+        assertEquals(356, calculateMiniPlayerBottomExclusion(navigationTop = 1000, playerTop = 660, gap = 16))
+        assertEquals(156, calculateMiniPlayerBottomExclusion(navigationTop = 1000, playerTop = 860, gap = 16))
+    }
+
+    @Test
+    fun playerBelowTheNavigationBarNeedsNoExclusion() {
+        assertEquals(0, calculateMiniPlayerBottomExclusion(navigationTop = 1000, playerTop = 1100, gap = 16))
+    }
+}


### PR DESCRIPTION
Fixes the player crash seen during display resize and keeps the minimized player from covering browsing controls. Also keeps channel identity and navigation controls visible in landscape.