### PR TITLE
Preserve quality across live rewind switches

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/BasePlaybackService.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/BasePlaybackService.kt
@@ -53,6 +53,7 @@ abstract class BasePlaybackService : LifecycleService() {
     var quality: VideoQuality? = null
     var previousQuality: VideoQuality? = null
     var restoreQuality = false
+    private val pendingSourceSwitchQuality = SourceSwitchQualityState()
     var playlistUrl: String? = null
     var restorePlaylist = false
     var useCustomProxy = false
@@ -321,7 +322,18 @@ abstract class BasePlaybackService : LifecycleService() {
         val connectivityManager = getSystemService(CONNECTIVITY_SERVICE) as ConnectivityManager
         val networkCapabilities = connectivityManager.getNetworkCapabilities(connectivityManager.activeNetwork)
         val cellular = networkCapabilities?.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR) == true
-        quality = resolveDefaultQualityForNetwork(cellular)
+        quality = pendingSourceSwitchQuality.consume()?.let { name ->
+            qualities?.firstOrNull { it.name.equals(name, ignoreCase = true) }
+                ?: findQuality(name)
+        } ?: resolveDefaultQualityForNetwork(cellular)
+    }
+
+    protected fun rememberQualityForSourceSwitch() {
+        pendingSourceSwitchQuality.capture(quality?.name)
+    }
+
+    protected fun clearRememberedSourceSwitchQuality() {
+        pendingSourceSwitchQuality.clear()
     }
 
     fun resolveDefaultQualityForNetwork(cellular: Boolean): VideoQuality? {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/ExoPlayerService.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/ExoPlayerService.kt
@@ -1457,6 +1457,7 @@ class ExoPlayerService : BasePlaybackService() {
         val oldUpdateQualities = updateQualities
         val oldLiveClipSourceMediaId = liveClipSourceMediaId
         val wasPlaying = player.playWhenReady
+        rememberQualityForSourceSwitch()
         beginLiveRewindTransition()
         cancelLiveClipPreparation()
         adAvoidanceJob?.cancel()
@@ -1481,6 +1482,7 @@ class ExoPlayerService : BasePlaybackService() {
                 val loaded = !playlistUrl.isNullOrBlank()
                 videoId = oldVideoId
                 if (!loaded) {
+                    clearRememberedSourceSwitchQuality()
                     playlistUrl = oldPlaylistUrl
                     hlsClipDataSourceFactory = oldHlsClipDataSourceFactory
                     qualities = oldQualities
@@ -1509,8 +1511,11 @@ class ExoPlayerService : BasePlaybackService() {
                 }
                 loaded
             } catch (e: CancellationException) {
+                // The opposite-direction transition can immediately hand this
+                // selection off. The service clears it when playback is destroyed.
                 throw e
             } catch (e: Exception) {
+                clearRememberedSourceSwitchQuality()
                 videoId = oldVideoId
                 playlistUrl = oldPlaylistUrl
                 hlsClipDataSourceFactory = oldHlsClipDataSourceFactory
@@ -1556,6 +1561,7 @@ class ExoPlayerService : BasePlaybackService() {
         val oldHidden = hidden
         val oldUpdateQualities = updateQualities
         val oldLiveClipSourceMediaId = liveClipSourceMediaId
+        rememberQualityForSourceSwitch()
         beginLiveRewindTransition()
         cancelLiveClipPreparation()
         playlistUrl = null
@@ -1574,6 +1580,7 @@ class ExoPlayerService : BasePlaybackService() {
             if (success) {
                 clearLiveRewindState()
             } else {
+                clearRememberedSourceSwitchQuality()
                 playlistUrl = oldPlaylistUrl
                 hlsClipDataSourceFactory = oldHlsClipDataSourceFactory
                 qualities = oldQualities
@@ -2951,6 +2958,7 @@ class ExoPlayerService : BasePlaybackService() {
     }
 
     override fun onDestroy() {
+        clearRememberedSourceSwitchQuality()
         releaseViewingStats()
         clearLiveClipState()
         streamRecoveryJob?.cancel()

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/Media3Fragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/Media3Fragment.kt
@@ -93,6 +93,7 @@ class Media3Fragment : Media3PlayerFragment(), PlaybackVideoInfoHost {
     private var qualityRequestInFlight = false
     private var qualityRequestGeneration = 0
     private val pendingQualityCallbacks = mutableListOf<() -> Unit>()
+    private val pendingSourceSwitchQuality = SourceSwitchQualityState()
     private var nativeCues: List<Cue> = emptyList()
     private var shownLiveCaptionError: String? = null
     private var renderedPositionSecond = Long.MIN_VALUE
@@ -765,6 +766,7 @@ class Media3Fragment : Media3PlayerFragment(), PlaybackVideoInfoHost {
         adAvoidanceJob = null
         primaryStreamRestoreJob?.cancel()
         primaryStreamRestoreJob = null
+        pendingSourceSwitchQuality.capture(viewModel.quality?.name)
         viewModel.usingAlternateStream = false
         viewModel.resetAdController()
         viewModel.playingAds = false
@@ -928,6 +930,10 @@ class Media3Fragment : Media3PlayerFragment(), PlaybackVideoInfoHost {
         } catch (_: Exception) {
             null
         } ?: return false
+        val oldQualities = viewModel.qualities
+        val oldQuality = viewModel.quality
+        val oldUpdateQualities = viewModel.updateQualities
+        pendingSourceSwitchQuality.capture(viewModel.quality?.name)
         adAvoidanceJob?.cancel()
         adAvoidanceJob = null
         primaryStreamRestoreJob?.cancel()
@@ -950,14 +956,31 @@ class Media3Fragment : Media3PlayerFragment(), PlaybackVideoInfoHost {
             ),
             Bundle.EMPTY,
         )
-        return withContext(Dispatchers.IO) {
-            runCatching { result.get().resultCode == SessionResult.RESULT_SUCCESS }.getOrDefault(false)
+        val success = try {
+            withContext(Dispatchers.IO) {
+                result.get().resultCode == SessionResult.RESULT_SUCCESS
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (_: Exception) {
+            false
         }
+        if (!success) {
+            restoreQualityAfterSourceSwitchFailure(
+                qualities = oldQualities,
+                quality = oldQuality,
+                updateQualities = oldUpdateQualities,
+            )
+        }
+        return success
     }
 
     override suspend fun returnToLivePlayback(): Boolean {
         val controller = player ?: return false
         val wasPlaying = controller.playWhenReady
+        val oldQualities = viewModel.qualities
+        val oldQuality = viewModel.quality
+        val oldUpdateQualities = viewModel.updateQualities
         val login = requireArguments().getString(KEY_CHANNEL_LOGIN) ?: return false
         val proxyUrl = requireContext().prefs().getString(C.PLAYER_PROXY_URL, "")
         val url = if (viewModel.useCustomProxy && !proxyUrl.isNullOrBlank()) {
@@ -969,10 +992,43 @@ class Media3Fragment : Media3PlayerFragment(), PlaybackVideoInfoHost {
                 null
             }
         } ?: return false
-        val result = startStreamInternal(url, wasPlaying) ?: return false
-        return withContext(Dispatchers.IO) {
-            runCatching { result.get().resultCode == SessionResult.RESULT_SUCCESS }.getOrDefault(false)
+        val result = startStreamInternal(url, wasPlaying) ?: run {
+            restoreQualityAfterSourceSwitchFailure(
+                qualities = oldQualities,
+                quality = oldQuality,
+                updateQualities = oldUpdateQualities,
+            )
+            return false
         }
+        val success = try {
+            withContext(Dispatchers.IO) {
+                result.get().resultCode == SessionResult.RESULT_SUCCESS
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (_: Exception) {
+            false
+        }
+        if (!success) {
+            restoreQualityAfterSourceSwitchFailure(
+                qualities = oldQualities,
+                quality = oldQuality,
+                updateQualities = oldUpdateQualities,
+            )
+        }
+        return success
+    }
+
+    private fun restoreQualityAfterSourceSwitchFailure(
+        qualities: List<VideoQuality>?,
+        quality: VideoQuality?,
+        updateQualities: Boolean,
+    ) {
+        viewModel.qualities = qualities
+        viewModel.quality = quality
+        viewModel.updateQualities = updateQualities
+        pendingSourceSwitchQuality.clear()
+        setQualityText()
     }
 
     override suspend fun getLiveRewindVodId(): String? {
@@ -1565,8 +1621,16 @@ class Media3Fragment : Media3PlayerFragment(), PlaybackVideoInfoHost {
                         }
                     viewModel.updateQualities = false
                     setDefaultQuality()
+                    val pendingQualityName = pendingSourceSwitchQuality.consume()
+                    val restoredQuality = pendingQualityName?.let { name ->
+                        viewModel.qualities?.firstOrNull {
+                            it.name.equals(name, ignoreCase = true)
+                        } ?: findQuality(name)
+                    }
                     changePlayerMode()
-                    if (viewModel.quality?.name == AUDIO_ONLY_QUALITY) {
+                    if (restoredQuality != null) {
+                        changeQuality(restoredQuality, persistSavedQuality = false)
+                    } else if (viewModel.quality?.name == AUDIO_ONLY_QUALITY) {
                         changeQuality(viewModel.quality, persistSavedQuality = false)
                     }
                     setQualityText()
@@ -1683,6 +1747,7 @@ class Media3Fragment : Media3PlayerFragment(), PlaybackVideoInfoHost {
     }
 
     override fun onDestroyView() {
+        pendingSourceSwitchQuality.clear()
         qualityRequestGeneration++
         qualityRequestInFlight = false
         nativeCues = emptyList()

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/Media3PlayerFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/Media3PlayerFragment.kt
@@ -2332,7 +2332,7 @@ abstract class Media3PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFr
         setQualityText()
     }
 
-    private fun findQuality(targetQualityString: String?): VideoQuality? {
+    protected fun findQuality(targetQualityString: String?): VideoQuality? {
         val targetQuality = targetQualityString?.split("p")
         return targetQuality?.getOrNull(0)?.takeWhile { it.isDigit() }?.toIntOrNull()?.let { targetResolution ->
             val targetFps = targetQuality.getOrNull(1)?.takeWhile { it.isDigit() }?.toIntOrNull() ?: 30

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/SourceSwitchQualityState.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/SourceSwitchQualityState.kt
@@ -1,0 +1,24 @@
+package com.github.andreyasadchy.xtra.ui.player
+
+/**
+ * Keeps a quality selection while a player source is being replaced.
+ *
+ * A reverse transition can begin after the first transition has already
+ * cleared the live quality object. In that case a null capture must not erase
+ * the selection that the reverse transition needs to restore.
+ */
+internal class SourceSwitchQualityState {
+    private var pendingName: String? = null
+
+    fun capture(currentName: String?) {
+        if (currentName != null) {
+            pendingName = currentName
+        }
+    }
+
+    fun consume(): String? = pendingName.also { pendingName = null }
+
+    fun clear() {
+        pendingName = null
+    }
+}

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/player/SourceSwitchQualityStateTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/player/SourceSwitchQualityStateTest.kt
@@ -1,0 +1,61 @@
+package com.github.andreyasadchy.xtra.ui.player
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class SourceSwitchQualityStateTest {
+
+    @Test
+    fun reverseTransitionKeepsSelectionWhenClearedSourceHasNoQuality() {
+        val state = SourceSwitchQualityState()
+
+        state.capture("1080p60")
+        state.capture(null)
+
+        assertEquals("1080p60", state.consume())
+        assertNull(state.consume())
+    }
+
+    @Test
+    fun newerExplicitSelectionReplacesOlderPendingSelection() {
+        val state = SourceSwitchQualityState()
+
+        state.capture("1080p60")
+        state.capture("720p60")
+
+        assertEquals("720p60", state.consume())
+    }
+
+    @Test
+    fun cancellationCleanupDoesNotLeakSelection() {
+        val state = SourceSwitchQualityState()
+
+        state.capture("1080p60")
+        state.clear()
+
+        assertNull(state.consume())
+    }
+
+    @Test
+    fun failedTransitionCanRestoreTheCapturedSelectionBeforeClearingIt() {
+        val state = SourceSwitchQualityState()
+
+        state.capture("1080p60")
+        val selectionForRollback = state.consume()
+
+        assertEquals("1080p60", selectionForRollback)
+        assertNull(state.consume())
+    }
+
+    @Test
+    fun autoAndAudioOnlySelectionsArePreservedLikeNamedQualities() {
+        val state = SourceSwitchQualityState()
+
+        state.capture("auto")
+        assertEquals("auto", state.consume())
+
+        state.capture("audio_only")
+        assertEquals("audio_only", state.consume())
+    }
+}


### PR DESCRIPTION
Keep the selected stream quality when switching between live playback and stream replay. Rebind the selection to the new manifest so the quality control does not fall back to Auto.