### PR TITLE
Enable previews for all visible streams

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/preload/StreamPreloadCoordinator.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/preload/StreamPreloadCoordinator.kt
@@ -81,6 +81,7 @@ class StreamPreloadCoordinator(
         elapsedRealtimeMs = elapsedRealtimeMs,
         canStart = ::canPreload,
         isEligible = ::isEligible,
+        isPreviewEligible = { streamKey -> isEligible(streamKey, forPreview = true) },
         onResolved = ::onResolverSuccess,
         onFailed = { key, error -> debug("failed:${error::class.simpleName}", key.channelLogin) },
     )
@@ -225,7 +226,7 @@ class StreamPreloadCoordinator(
         // Preview is a reader, not the owner of the URL. Fullscreen playback must
         // still be able to consume this exact signed URL for Media3 handoff.
         urlOwnership.forPreview(login, config.fingerprint)?.let { return it }
-        resolver.join(login, config.fingerprint)?.let { return it }
+        resolver.join(login, config.fingerprint, forPreview = true)?.let { return it }
         if (!canResolvePreview()) return null
         val key = currentCandidates().firstOrNull { it.channelLogin.equals(login, true) }
             ?.streamKey
@@ -312,7 +313,7 @@ class StreamPreloadCoordinator(
             }
             return null
         }
-        return resolver.preload(channelLogin, streamKey, config.fingerprint) {
+        return resolver.preload(channelLogin, streamKey, config.fingerprint, forPreview = forPreview) {
             debug("url_start", channelLogin)
             playerRepository.loadStreamPlaylistUrl(
                 context = context,
@@ -441,8 +442,12 @@ class StreamPreloadCoordinator(
 
     private fun isEligible(streamKey: String, forPreview: Boolean): Boolean {
         if (!(if (forPreview) canResolvePreview() else canPreload()) || viewports.values.any { it.scrolling }) return false
-        val rankedKeys = StreamPreloadPolicy.rank(currentCandidates())
-            .take(StreamPreloadPolicy.MAX_URL_CANDIDATES)
+        // Speculative preloading is intentionally bounded, but visible previews are not.
+        // Every selected preview gets a shared resolver flight; the resolver semaphore still
+        // limits network work while allowing the remaining visible cards to queue behind it.
+        val rankedCandidates = StreamPreloadPolicy.rank(currentCandidates())
+            .let { if (forPreview) it else it.take(StreamPreloadPolicy.MAX_URL_CANDIDATES) }
+        val rankedKeys = rankedCandidates
             .map { it.streamKey.ifBlank { it.channelLogin.trim().lowercase() } }
         return streamKey in rankedKeys
     }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/preload/StreamPreloadResolver.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/preload/StreamPreloadResolver.kt
@@ -23,6 +23,7 @@ internal class StreamPreloadResolver(
     private val elapsedRealtimeMs: () -> Long,
     private val canStart: () -> Boolean,
     private val isEligible: (String) -> Boolean,
+    private val isPreviewEligible: (String) -> Boolean = isEligible,
     private val onResolved: (StreamPreloadFlightKey, String) -> Unit = { _, _ -> },
     private val onFailed: (StreamPreloadFlightKey, Throwable) -> Unit = { _, _ -> },
 ) {
@@ -34,23 +35,25 @@ internal class StreamPreloadResolver(
         channelLogin: String,
         streamKey: String,
         configurationFingerprint: String,
+        forPreview: Boolean = false,
         resolve: suspend () -> String?,
     ): String? {
         val key = key(channelLogin, configurationFingerprint)
-        if (!canStart() || !isEligible(streamKey) || isCoolingDown(key)) return null
-        val flight = flights[key] ?: synchronized(flights) {
-            flights[key] ?: createFlight(key, streamKey, resolve).also { flights[key] = it }
-        }
-        flight.owners.incrementAndGet()
+        val eligible = if (forPreview) isPreviewEligible(streamKey) else isEligible(streamKey)
+        if (!canStart() || !eligible || isCoolingDown(key)) return null
+        val flight = acquireOrCreateFlight(key, forPreview, resolve)
         flight.deferred.start()
-        return awaitOwned(flight)
+        return awaitOwned(flight, forPreview)
     }
 
-    suspend fun join(channelLogin: String, configurationFingerprint: String): String? {
-        val flight = flights[key(channelLogin, configurationFingerprint)] ?: return null
-        flight.owners.incrementAndGet()
+    suspend fun join(
+        channelLogin: String,
+        configurationFingerprint: String,
+        forPreview: Boolean = false,
+    ): String? {
+        val flight = acquireExistingFlight(key(channelLogin, configurationFingerprint), forPreview) ?: return null
         flight.deferred.start()
-        return awaitOwned(flight)
+        return awaitOwned(flight, forPreview)
     }
 
     fun promoteForPlayback(channelLogin: String, configurationFingerprint: String): Boolean {
@@ -77,7 +80,7 @@ internal class StreamPreloadResolver(
             if (flight.pendingPlaybackOwners.get() == 0 && flight.playbackConsumers.get() == 0) {
                 flight.promotedForPlayback = false
             }
-            releaseOwner(flight)
+            releaseOwner(flight, previewOwner = false)
         }
     }
 
@@ -86,13 +89,19 @@ internal class StreamPreloadResolver(
         activeLogins: Set<String>,
         keepLogins: Set<String> = emptySet(),
     ) {
-        flights.entries
-            .filter { (key, flight) ->
-                key.configurationFingerprint != configurationFingerprint ||
-                    (!flight.promotedForPlayback &&
-                        (key.channelLogin !in activeLogins && key.channelLogin !in keepLogins))
+        flights.entries.forEach { (key, flight) ->
+            val configurationObsolete = key.configurationFingerprint != configurationFingerprint
+            val loginObsolete = !flight.promotedForPlayback &&
+                key.channelLogin !in activeLogins &&
+                key.channelLogin !in keepLogins
+            if (configurationObsolete || loginObsolete) {
+                cancel(
+                    key = key,
+                    flight = flight,
+                    preservePreviewOwners = !configurationObsolete,
+                )
             }
-            .forEach { (key, flight) -> cancel(key, flight) }
+        }
         failureUntil.keys.toList()
             .filter { it.configurationFingerprint != configurationFingerprint }
             .forEach(failureUntil::remove)
@@ -122,13 +131,16 @@ internal class StreamPreloadResolver(
 
     private fun createFlight(
         key: StreamPreloadFlightKey,
-        streamKey: String,
         resolve: suspend () -> String?,
     ): Flight {
         lateinit var flight: Flight
         val deferred = scope.async(start = CoroutineStart.LAZY) {
             semaphore.withPermit {
-                if (!flight.promotedForPlayback && (!canStart() || !isEligible(streamKey))) return@withPermit null
+                // Eligibility is checked before a flight is created. Once another owner joins
+                // the same flight, its ownership must not inherit the creator's preload-only
+                // top-N rule. Obsolete speculative flights are cancelled by reconciliation;
+                // preview-owned flights are retained there.
+                if (!flight.promotedForPlayback && !canStart()) return@withPermit null
                 val url = try {
                     resolve()
                 } catch (error: CancellationException) {
@@ -147,19 +159,60 @@ internal class StreamPreloadResolver(
         return flight
     }
 
-    private suspend fun awaitOwned(flight: Flight): String? {
-        try {
-            return flight.deferred.await()
-        } finally {
-            releaseOwner(flight)
+    private fun acquireOrCreateFlight(
+        key: StreamPreloadFlightKey,
+        previewOwner: Boolean,
+        resolve: suspend () -> String?,
+    ): Flight {
+        while (true) {
+            val flight = synchronized(flights) {
+                flights[key] ?: createFlight(key, resolve).also { flights[key] = it }
+            }
+            var acquired = false
+            synchronized(flight.ownershipLock) {
+                if (flights[key] === flight) {
+                    flight.owners.incrementAndGet()
+                    if (previewOwner) flight.previewOwners.incrementAndGet()
+                    acquired = true
+                }
+            }
+            if (acquired) return flight
         }
     }
 
-    private fun releaseOwner(flight: Flight) {
-        if (flight.owners.decrementAndGet() == 0 &&
-            !flight.promotedForPlayback &&
-            !flight.deferred.isCompleted
-        ) cancel(flight.key, flight)
+    private fun acquireExistingFlight(
+        key: StreamPreloadFlightKey,
+        previewOwner: Boolean,
+    ): Flight? {
+        val flight = flights[key] ?: return null
+        synchronized(flight.ownershipLock) {
+            if (flights[key] !== flight) return null
+            flight.owners.incrementAndGet()
+            if (previewOwner) flight.previewOwners.incrementAndGet()
+            return flight
+        }
+    }
+
+    private suspend fun awaitOwned(flight: Flight, previewOwner: Boolean): String? {
+        try {
+            return flight.deferred.await()
+        } finally {
+            releaseOwner(flight, previewOwner)
+        }
+    }
+
+    private fun releaseOwner(flight: Flight, previewOwner: Boolean) {
+        synchronized(flight.ownershipLock) {
+            if (previewOwner) flight.previewOwners.decrementAndGet()
+            if (flight.owners.decrementAndGet() == 0 &&
+                !flight.promotedForPlayback &&
+                !flight.deferred.isCompleted
+            ) {
+                // Keep removal under the same lock as the last decrement. A preview cannot
+                // acquire this flight between the ownership decision and cancellation.
+                if (flights.remove(flight.key, flight)) flight.deferred.cancel()
+            }
+        }
     }
 
     private fun consumePendingPlaybackOwner(flight: Flight): Boolean {
@@ -170,8 +223,15 @@ internal class StreamPreloadResolver(
         }
     }
 
-    private fun cancel(key: StreamPreloadFlightKey, flight: Flight) {
-        if (flights.remove(key, flight)) flight.deferred.cancel()
+    private fun cancel(
+        key: StreamPreloadFlightKey,
+        flight: Flight,
+        preservePreviewOwners: Boolean = false,
+    ) {
+        synchronized(flight.ownershipLock) {
+            if (preservePreviewOwners && flight.previewOwners.get() > 0) return
+            if (flights.remove(key, flight)) flight.deferred.cancel()
+        }
     }
 
     private fun isCoolingDown(key: StreamPreloadFlightKey): Boolean {
@@ -188,7 +248,9 @@ internal class StreamPreloadResolver(
         val key: StreamPreloadFlightKey,
         val deferred: Deferred<String?>,
     ) {
+        val ownershipLock = Any()
         val owners = AtomicInteger()
+        val previewOwners = AtomicInteger()
         val pendingPlaybackOwners = AtomicInteger()
         val playbackConsumers = AtomicInteger()
 

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/preload/StreamPreviewPolicy.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/preload/StreamPreviewPolicy.kt
@@ -63,7 +63,7 @@ object StreamPreviewPolicy {
     }
 
     fun allowsMultiplePreviews(context: Context): Boolean =
-        context.prefs().getBoolean(C.STREAM_PREVIEW_MULTIPLE, false)
+        context.prefs().getBoolean(C.STREAM_PREVIEW_MULTIPLE, true)
 
     fun quality(context: Context): StreamPreviewQuality =
         StreamPreviewQuality.fromPreference(context.prefs().getString(C.STREAM_PREVIEW_QUALITY, StreamPreviewQuality.P360.preferenceValue))

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/preload/StreamPreviewSelection.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/preload/StreamPreviewSelection.kt
@@ -7,9 +7,8 @@ data class StreamPreviewSelectionCandidate(
     val order: Int,
 )
 
-/** Deterministic, bounded selection for muted in-feed previews. */
+/** Deterministic selection for the currently eligible muted in-feed previews. */
 object StreamPreviewSelectionPolicy {
-    const val MAX_ACTIVE_PREVIEWS = 2
     const val START_VISIBLE_FRACTION = 0.33f
     const val STOP_VISIBLE_FRACTION = 0.12f
     const val ACTIVE_VISIBILITY_BIAS = 0.08f

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/StreamPreviewCoordinator.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/StreamPreviewCoordinator.kt
@@ -387,7 +387,7 @@ class StreamPreviewCoordinator(
                 )
             },
             activeIdentities = activeIdentities,
-            maxActivePreviews = maxActivePreviews(),
+            maxActivePreviews = maxActivePreviews(candidates),
         )
         val selectedSet = selected.toSet()
         val bestCandidates = bestCandidatesByIdentity(candidates)
@@ -399,7 +399,7 @@ class StreamPreviewCoordinator(
             handoffIdentity = handoffLogin,
         ).forEach(::releasePreview)
 
-        val maxActive = maxActivePreviews()
+        val maxActive = maxActivePreviews(candidates)
         if (activePreviews.size > maxActive) {
             activePreviews.keys.toList()
                 .filter { it !in selectedSet && it != handoffLogin }
@@ -662,9 +662,12 @@ class StreamPreviewCoordinator(
         viewports.values.flatMap { it.candidates }
             .mapNotNull { candidate -> candidate.takeIf { it.previewIdentity != null } }
 
-    private fun maxActivePreviews(): Int =
+    private fun maxActivePreviews(candidates: Collection<StreamPreviewCandidate> = currentCandidates()): Int =
         if (StreamPreviewPolicy.allowsMultiplePreviews(context)) {
-            StreamPreviewSelectionPolicy.MAX_ACTIVE_PREVIEWS
+            candidates
+                .mapNotNullTo(mutableSetOf(), StreamPreviewCandidate::previewIdentity)
+                .size
+                .coerceAtLeast(1)
         } else {
             1
         }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/StreamUptimeTicker.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/StreamUptimeTicker.kt
@@ -40,8 +40,8 @@ internal class VisibleStreamUptimeTicker(
                         (holder as? StreamUptimeViewHolder)?.updateUptime(nowMs)
                     }
 
-                    // Uptime is informational; avoid invalidating every live card every
-                    // second while retaining a predictable, wall-clock-aligned refresh.
+                    // Uptime is a live counter. Refresh once per wall-clock second so it
+                    // does not appear frozen while avoiding a separate job per card.
                     val afterUpdateMs = System.currentTimeMillis()
                     val delayMs = UPTIME_UPDATE_INTERVAL_MS - (afterUpdateMs % UPTIME_UPDATE_INTERVAL_MS)
                     delay(delayMs.coerceIn(1L, UPTIME_UPDATE_INTERVAL_MS))
@@ -56,7 +56,7 @@ internal class VisibleStreamUptimeTicker(
     }
 
     private companion object {
-        const val UPTIME_UPDATE_INTERVAL_MS = 30_000L
+        const val UPTIME_UPDATE_INTERVAL_MS = 1_000L
     }
 }
 

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/overview/ShelfCardSizing.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/overview/ShelfCardSizing.kt
@@ -24,10 +24,11 @@ internal object ShelfCardSizing {
         val availableWidth = (measuredWidth - shelf.paddingLeft - shelf.paddingRight).coerceAtLeast(1)
         val density = shelf.resources.displayMetrics.density
         val widthDp = availableWidth / density
+        val shelfItemGap = (8 * density).toInt()
         val cardWidthDp = when {
             widthDp < 600f -> (availableWidth / 1.45f / density).coerceIn(220f, 280f)
             widthDp < 840f -> (availableWidth / 2.6f / density).coerceIn(200f, 300f)
-            else -> (availableWidth / 4.0f / density).coerceIn(220f, 320f)
+            else -> ((availableWidth - shelfItemGap * 4) / 4.0f / density).coerceIn(220f, 320f)
         }
         return (cardWidthDp * density).toInt()
     }

--- a/app/src/main/res/layout/fragment_streams_list_item.xml
+++ b/app/src/main/res/layout/fragment_streams_list_item.xml
@@ -74,6 +74,8 @@
                 android:paddingTop="2dp"
                 android:paddingEnd="4dp"
                 android:paddingBottom="2dp"
+                android:maxLines="1"
+                android:singleLine="true"
                 android:visibility="gone"
                 app:layout_constraintEnd_toEndOf="@id/thumbnail"
                 app:layout_constraintTop_toTopOf="@id/thumbnail"

--- a/app/src/main/res/layout/fragment_streams_list_item_compact.xml
+++ b/app/src/main/res/layout/fragment_streams_list_item_compact.xml
@@ -77,6 +77,8 @@
                 android:paddingTop="1dp"
                 android:paddingEnd="3dp"
                 android:paddingBottom="1dp"
+                android:maxLines="1"
+                android:singleLine="true"
                 android:visibility="gone"
                 app:layout_constraintEnd_toEndOf="@id/thumbnail"
                 app:layout_constraintTop_toTopOf="@id/thumbnail"

--- a/app/src/main/res/layout/item_featured_stream_shelf.xml
+++ b/app/src/main/res/layout/item_featured_stream_shelf.xml
@@ -77,6 +77,8 @@
                 android:paddingTop="3dp"
                 android:paddingEnd="6dp"
                 android:paddingBottom="3dp"
+                android:maxLines="1"
+                android:singleLine="true"
                 android:visibility="gone"
                 tools:text="1:23:45"
                 tools:visibility="visible" />

--- a/app/src/main/res/layout/item_stream_shelf.xml
+++ b/app/src/main/res/layout/item_stream_shelf.xml
@@ -71,6 +71,8 @@
             android:paddingTop="2dp"
             android:paddingEnd="4dp"
             android:paddingBottom="2dp"
+            android:maxLines="1"
+            android:singleLine="true"
             android:visibility="gone"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="parent"

--- a/app/src/main/res/values-ar/preview_fallback_strings.xml
+++ b/app/src/main/res/values-ar/preview_fallback_strings.xml
@@ -2,7 +2,7 @@
     <string name="settings_feed_previews">Feed previews</string>
     <string name="settings_in_feed_previews">In-feed live previews</string>
     <string name="settings_multiple_previews">Multiple in-feed previews</string>
-    <string name="settings_multiple_previews_summary">Play up to two visible stream previews at once</string>
+    <string name="settings_multiple_previews_summary">Play all eligible visible stream previews at once</string>
     <string name="settings_preview_quality">Preview quality</string>
     <string name="settings_preview_delay">Preview start delay</string>
     <string name="preview_quality_360">360p</string>

--- a/app/src/main/res/values-cs/preview_fallback_strings.xml
+++ b/app/src/main/res/values-cs/preview_fallback_strings.xml
@@ -2,7 +2,7 @@
     <string name="settings_feed_previews">Feed previews</string>
     <string name="settings_in_feed_previews">In-feed live previews</string>
     <string name="settings_multiple_previews">Multiple in-feed previews</string>
-    <string name="settings_multiple_previews_summary">Play up to two visible stream previews at once</string>
+    <string name="settings_multiple_previews_summary">Play all eligible visible stream previews at once</string>
     <string name="settings_preview_quality">Preview quality</string>
     <string name="settings_preview_delay">Preview start delay</string>
     <string name="preview_quality_360">360p</string>

--- a/app/src/main/res/values-de/preview_fallback_strings.xml
+++ b/app/src/main/res/values-de/preview_fallback_strings.xml
@@ -2,7 +2,7 @@
     <string name="settings_feed_previews">Feed previews</string>
     <string name="settings_in_feed_previews">In-feed live previews</string>
     <string name="settings_multiple_previews">Multiple in-feed previews</string>
-    <string name="settings_multiple_previews_summary">Play up to two visible stream previews at once</string>
+    <string name="settings_multiple_previews_summary">Play all eligible visible stream previews at once</string>
     <string name="settings_preview_quality">Preview quality</string>
     <string name="settings_preview_delay">Preview start delay</string>
     <string name="preview_quality_360">360p</string>

--- a/app/src/main/res/values-es/preview_fallback_strings.xml
+++ b/app/src/main/res/values-es/preview_fallback_strings.xml
@@ -2,7 +2,7 @@
     <string name="settings_feed_previews">Feed previews</string>
     <string name="settings_in_feed_previews">In-feed live previews</string>
     <string name="settings_multiple_previews">Multiple in-feed previews</string>
-    <string name="settings_multiple_previews_summary">Play up to two visible stream previews at once</string>
+    <string name="settings_multiple_previews_summary">Play all eligible visible stream previews at once</string>
     <string name="settings_preview_quality">Preview quality</string>
     <string name="settings_preview_delay">Preview start delay</string>
     <string name="preview_quality_360">360p</string>

--- a/app/src/main/res/values-fr/preview_fallback_strings.xml
+++ b/app/src/main/res/values-fr/preview_fallback_strings.xml
@@ -2,7 +2,7 @@
     <string name="settings_feed_previews">Feed previews</string>
     <string name="settings_in_feed_previews">In-feed live previews</string>
     <string name="settings_multiple_previews">Multiple in-feed previews</string>
-    <string name="settings_multiple_previews_summary">Play up to two visible stream previews at once</string>
+    <string name="settings_multiple_previews_summary">Play all eligible visible stream previews at once</string>
     <string name="settings_preview_quality">Preview quality</string>
     <string name="settings_preview_delay">Preview start delay</string>
     <string name="preview_quality_360">360p</string>

--- a/app/src/main/res/values-gl/preview_fallback_strings.xml
+++ b/app/src/main/res/values-gl/preview_fallback_strings.xml
@@ -2,7 +2,7 @@
     <string name="settings_feed_previews">Feed previews</string>
     <string name="settings_in_feed_previews">In-feed live previews</string>
     <string name="settings_multiple_previews">Multiple in-feed previews</string>
-    <string name="settings_multiple_previews_summary">Play up to two visible stream previews at once</string>
+    <string name="settings_multiple_previews_summary">Play all eligible visible stream previews at once</string>
     <string name="settings_preview_quality">Preview quality</string>
     <string name="settings_preview_delay">Preview start delay</string>
     <string name="preview_quality_360">360p</string>

--- a/app/src/main/res/values-in/preview_fallback_strings.xml
+++ b/app/src/main/res/values-in/preview_fallback_strings.xml
@@ -2,7 +2,7 @@
     <string name="settings_feed_previews">Feed previews</string>
     <string name="settings_in_feed_previews">In-feed live previews</string>
     <string name="settings_multiple_previews">Multiple in-feed previews</string>
-    <string name="settings_multiple_previews_summary">Play up to two visible stream previews at once</string>
+    <string name="settings_multiple_previews_summary">Play all eligible visible stream previews at once</string>
     <string name="settings_preview_quality">Preview quality</string>
     <string name="settings_preview_delay">Preview start delay</string>
     <string name="preview_quality_360">360p</string>

--- a/app/src/main/res/values-it/preview_fallback_strings.xml
+++ b/app/src/main/res/values-it/preview_fallback_strings.xml
@@ -2,7 +2,7 @@
     <string name="settings_feed_previews">Feed previews</string>
     <string name="settings_in_feed_previews">In-feed live previews</string>
     <string name="settings_multiple_previews">Multiple in-feed previews</string>
-    <string name="settings_multiple_previews_summary">Play up to two visible stream previews at once</string>
+    <string name="settings_multiple_previews_summary">Play all eligible visible stream previews at once</string>
     <string name="settings_preview_quality">Preview quality</string>
     <string name="settings_preview_delay">Preview start delay</string>
     <string name="preview_quality_360">360p</string>

--- a/app/src/main/res/values-ja/preview_fallback_strings.xml
+++ b/app/src/main/res/values-ja/preview_fallback_strings.xml
@@ -2,7 +2,7 @@
     <string name="settings_feed_previews">Feed previews</string>
     <string name="settings_in_feed_previews">In-feed live previews</string>
     <string name="settings_multiple_previews">Multiple in-feed previews</string>
-    <string name="settings_multiple_previews_summary">Play up to two visible stream previews at once</string>
+    <string name="settings_multiple_previews_summary">Play all eligible visible stream previews at once</string>
     <string name="settings_preview_quality">Preview quality</string>
     <string name="settings_preview_delay">Preview start delay</string>
     <string name="preview_quality_360">360p</string>

--- a/app/src/main/res/values-pl/preview_fallback_strings.xml
+++ b/app/src/main/res/values-pl/preview_fallback_strings.xml
@@ -2,7 +2,7 @@
     <string name="settings_feed_previews">Feed previews</string>
     <string name="settings_in_feed_previews">In-feed live previews</string>
     <string name="settings_multiple_previews">Multiple in-feed previews</string>
-    <string name="settings_multiple_previews_summary">Play up to two visible stream previews at once</string>
+    <string name="settings_multiple_previews_summary">Play all eligible visible stream previews at once</string>
     <string name="settings_preview_quality">Preview quality</string>
     <string name="settings_preview_delay">Preview start delay</string>
     <string name="preview_quality_360">360p</string>

--- a/app/src/main/res/values-pt-rBR/preview_fallback_strings.xml
+++ b/app/src/main/res/values-pt-rBR/preview_fallback_strings.xml
@@ -2,7 +2,7 @@
     <string name="settings_feed_previews">Feed previews</string>
     <string name="settings_in_feed_previews">In-feed live previews</string>
     <string name="settings_multiple_previews">Multiple in-feed previews</string>
-    <string name="settings_multiple_previews_summary">Play up to two visible stream previews at once</string>
+    <string name="settings_multiple_previews_summary">Play all eligible visible stream previews at once</string>
     <string name="settings_preview_quality">Preview quality</string>
     <string name="settings_preview_delay">Preview start delay</string>
     <string name="preview_quality_360">360p</string>

--- a/app/src/main/res/values-ru/preview_fallback_strings.xml
+++ b/app/src/main/res/values-ru/preview_fallback_strings.xml
@@ -2,7 +2,7 @@
     <string name="settings_feed_previews">Feed previews</string>
     <string name="settings_in_feed_previews">In-feed live previews</string>
     <string name="settings_multiple_previews">Multiple in-feed previews</string>
-    <string name="settings_multiple_previews_summary">Play up to two visible stream previews at once</string>
+    <string name="settings_multiple_previews_summary">Play all eligible visible stream previews at once</string>
     <string name="settings_preview_quality">Preview quality</string>
     <string name="settings_preview_delay">Preview start delay</string>
     <string name="preview_quality_360">360p</string>

--- a/app/src/main/res/values-sk/preview_fallback_strings.xml
+++ b/app/src/main/res/values-sk/preview_fallback_strings.xml
@@ -2,7 +2,7 @@
     <string name="settings_feed_previews">Feed previews</string>
     <string name="settings_in_feed_previews">In-feed live previews</string>
     <string name="settings_multiple_previews">Multiple in-feed previews</string>
-    <string name="settings_multiple_previews_summary">Play up to two visible stream previews at once</string>
+    <string name="settings_multiple_previews_summary">Play all eligible visible stream previews at once</string>
     <string name="settings_preview_quality">Preview quality</string>
     <string name="settings_preview_delay">Preview start delay</string>
     <string name="preview_quality_360">360p</string>

--- a/app/src/main/res/values-tr/preview_fallback_strings.xml
+++ b/app/src/main/res/values-tr/preview_fallback_strings.xml
@@ -2,7 +2,7 @@
     <string name="settings_feed_previews">Feed previews</string>
     <string name="settings_in_feed_previews">In-feed live previews</string>
     <string name="settings_multiple_previews">Multiple in-feed previews</string>
-    <string name="settings_multiple_previews_summary">Play up to two visible stream previews at once</string>
+    <string name="settings_multiple_previews_summary">Play all eligible visible stream previews at once</string>
     <string name="settings_preview_quality">Preview quality</string>
     <string name="settings_preview_delay">Preview start delay</string>
     <string name="preview_quality_360">360p</string>

--- a/app/src/main/res/values-zh-rCN/preview_fallback_strings.xml
+++ b/app/src/main/res/values-zh-rCN/preview_fallback_strings.xml
@@ -2,7 +2,7 @@
     <string name="settings_feed_previews">Feed previews</string>
     <string name="settings_in_feed_previews">In-feed live previews</string>
     <string name="settings_multiple_previews">Multiple in-feed previews</string>
-    <string name="settings_multiple_previews_summary">Play up to two visible stream previews at once</string>
+    <string name="settings_multiple_previews_summary">Play all eligible visible stream previews at once</string>
     <string name="settings_preview_quality">Preview quality</string>
     <string name="settings_preview_delay">Preview start delay</string>
     <string name="preview_quality_360">360p</string>

--- a/app/src/main/res/values-zh-rTW/preview_fallback_strings.xml
+++ b/app/src/main/res/values-zh-rTW/preview_fallback_strings.xml
@@ -2,7 +2,7 @@
     <string name="settings_feed_previews">Feed previews</string>
     <string name="settings_in_feed_previews">In-feed live previews</string>
     <string name="settings_multiple_previews">Multiple in-feed previews</string>
-    <string name="settings_multiple_previews_summary">Play up to two visible stream previews at once</string>
+    <string name="settings_multiple_previews_summary">Play all eligible visible stream previews at once</string>
     <string name="settings_preview_quality">Preview quality</string>
     <string name="settings_preview_delay">Preview start delay</string>
     <string name="preview_quality_360">360p</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -559,7 +559,7 @@
     <string name="settings_feed_previews">Feed previews</string>
     <string name="settings_in_feed_previews">In-feed live previews</string>
     <string name="settings_multiple_previews">Multiple in-feed previews</string>
-    <string name="settings_multiple_previews_summary">Play up to two visible stream previews at once</string>
+    <string name="settings_multiple_previews_summary">Play all eligible visible stream previews at once</string>
     <string name="settings_preview_quality">Preview quality</string>
     <string name="settings_preview_delay">Preview start delay</string>
     <string name="preview_quality_360">360p</string>

--- a/app/src/main/res/xml/ui_preferences.xml
+++ b/app/src/main/res/xml/ui_preferences.xml
@@ -2,7 +2,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
     <PreferenceCategory android:title="@string/settings_feed_previews" app:iconSpaceReserved="false" />
     <ListPreference android:defaultValue="wifi" android:entries="@array/streamPreviewEntries" android:entryValues="@array/streamPreviewValues" android:key="stream_preview_mode" android:summary="%s" android:title="@string/settings_in_feed_previews" app:iconSpaceReserved="false" />
-    <SwitchPreferenceCompat android:defaultValue="false" android:key="stream_preview_multiple" android:summary="@string/settings_multiple_previews_summary" android:title="@string/settings_multiple_previews" app:iconSpaceReserved="false" />
+    <SwitchPreferenceCompat android:defaultValue="true" android:key="stream_preview_multiple" android:summary="@string/settings_multiple_previews_summary" android:title="@string/settings_multiple_previews" app:iconSpaceReserved="false" />
     <ListPreference android:defaultValue="360" android:entries="@array/previewQualityEntries" android:entryValues="@array/previewQualityValues" android:key="stream_preview_quality" android:summary="%s" android:title="@string/settings_preview_quality" app:iconSpaceReserved="false" />
     <ListPreference android:defaultValue="fast" android:entries="@array/previewDelayEntries" android:entryValues="@array/previewDelayValues" android:key="stream_preview_delay" android:summary="%s" android:title="@string/settings_preview_delay" app:iconSpaceReserved="false" />
     <PreferenceCategory android:title="@string/settings_browsing_streams_videos" app:iconSpaceReserved="false" />

--- a/app/src/test/java/com/github/andreyasadchy/xtra/repository/preload/StreamPreloadResolverTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/repository/preload/StreamPreloadResolverTest.kt
@@ -18,6 +18,77 @@ import org.junit.Test
 class StreamPreloadResolverTest {
 
     @Test
+    fun previewJoinsAndPromotesAnExistingSpeculativeFlight() = runBlocking {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val blockerStarted = CompletableDeferred<Unit>()
+        val blockerRelease = CompletableDeferred<Unit>()
+        val resolveCalls = AtomicInteger()
+        var speculativeEligible = true
+        val resolver = StreamPreloadResolver(
+            scope = scope,
+            maxConcurrency = 1,
+            elapsedRealtimeMs = { 0L },
+            canStart = { true },
+            isEligible = { speculativeEligible },
+            isPreviewEligible = { true },
+        )
+
+        val blocker = scope.async(start = CoroutineStart.UNDISPATCHED) {
+            resolver.preload("blocker", "blocker", "config") {
+                blockerStarted.complete(Unit)
+                blockerRelease.await()
+                "blocker-url"
+            }
+        }
+        blockerStarted.await()
+
+        val speculative = scope.async(start = CoroutineStart.UNDISPATCHED) {
+            resolver.preload("channel", "channel", "config") {
+                resolveCalls.incrementAndGet()
+                "preview-url"
+            }
+        }
+        assertTrue(resolver.hasFlight("channel", "config"))
+
+        speculativeEligible = false
+        val preview = scope.async(start = CoroutineStart.UNDISPATCHED) {
+            resolver.join("channel", "config", forPreview = true)
+        }
+        // Drop the speculative owner after the preview has promoted the same flight. The
+        // preview owner must keep the single resolve alive.
+        speculative.cancel()
+        assertTrue(runCatching { speculative.await() }.isFailure)
+        resolver.cancelObsolete("config", activeLogins = setOf("blocker"))
+        assertTrue(resolver.hasFlight("channel", "config"))
+
+        blockerRelease.complete(Unit)
+
+        assertEquals("preview-url", preview.await())
+        assertEquals("blocker-url", blocker.await())
+        assertEquals(1, resolveCalls.get())
+        scope.cancel()
+    }
+
+    @Test
+    fun previewFlightsUsePreviewEligibilityInsteadOfPreloadLimit() = runBlocking {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val resolver = StreamPreloadResolver(
+            scope = scope,
+            elapsedRealtimeMs = { 0L },
+            canStart = { true },
+            isEligible = { false },
+            isPreviewEligible = { it == "visible-preview" },
+        )
+
+        assertNull(resolver.preload("preload", "visible-preview", "config") { "url" })
+        assertEquals(
+            "url",
+            resolver.preload("preview", "visible-preview", "config", forPreview = true) { "url" },
+        )
+        scope.cancel()
+    }
+
+    @Test
     fun playbackJoinsAnInFlightResolveWithoutStartingAnotherRequest() = runBlocking {
         val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
         val started = CompletableDeferred<Unit>()

--- a/app/src/test/java/com/github/andreyasadchy/xtra/repository/preload/StreamPreviewSelectionPolicyTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/repository/preload/StreamPreviewSelectionPolicyTest.kt
@@ -76,6 +76,22 @@ class StreamPreviewSelectionPolicyTest {
     }
 
     @Test
+    fun allEligibleCardsCanBeSelectedForTheVisiblePreviewPool() {
+        val selected = StreamPreviewSelectionPolicy.select(
+            candidates = listOf(
+                StreamPreviewSelectionCandidate("first", 0.90f, 0.5f, 0),
+                StreamPreviewSelectionCandidate("second", 0.80f, 0.5f, 1),
+                StreamPreviewSelectionCandidate("third", 0.70f, 0.5f, 2),
+                StreamPreviewSelectionCandidate("fourth", 0.60f, 0.5f, 3),
+            ),
+            activeIdentities = emptySet(),
+            maxActivePreviews = 4,
+        )
+
+        assertEquals(listOf("first", "second", "third", "fourth"), selected)
+    }
+
+    @Test
     fun defaultSelectionUsesOnePreviewSlot() {
         val selected = StreamPreviewSelectionPolicy.select(
             candidates = listOf(


### PR DESCRIPTION
Feed previews now default to multi-view and can resolve every eligible visible stream while keeping speculative preloads bounded. Stream uptime labels update every second, stay single-line, and fit the shelf without clipping.