### PR TITLE
Remove refresh button from emote picker

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatFragment.kt
@@ -2095,11 +2095,6 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
         adapter?.refreshChatHighlightSettings()
         if (useChatV2) {
             chatV2Renderer?.refreshStyle(resolveChatRenderStyle(requireContext()))
-            if (parentFragment is MultiviewFragment) {
-                chatV2SessionSlot.current()?.active?.catalog?.refresh(force = false)
-            } else {
-                (requireContext().applicationContext as XtraApp).xtraModule.chatSessionManager.active.value?.catalog?.refresh(force = false)
-            }
         }
         if (useChatV2 && chatV2RendererVisible) chatV2Renderer?.setVisible(true)
         val args = requireArguments()

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/EmotesFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/EmotesFragment.kt
@@ -74,10 +74,6 @@ class EmotesFragment : Fragment() {
         val expectedChannelId = chatFragment?.arguments?.getString(ChatFragment.KEY_CHANNEL_ID)
         val expectedChannelLogin = chatFragment?.arguments?.getString(ChatFragment.KEY_CHANNEL_LOGIN)
         val usesV2 = chatFragment?.isUsingChatV2 == true
-        binding.refreshEmotes.isVisible = usesV2
-        binding.refreshEmotes.setOnClickListener {
-            chatFragment?.reloadEmotes()
-        }
         binding.emptyState.setOnClickListener {
             (thirdPartyPickerState as? ChatViewModel.ThirdPartyPickerState.Error)?.retry?.invoke()
         }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/session/ChatSessionManager.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/session/ChatSessionManager.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.NonCancellable
+import java.util.LinkedHashMap
 
 data class LiveChatSessionSpec(
     val channelId: String,
@@ -40,6 +41,37 @@ data class ActiveChatSession(
     val rewardCatalog: Flow<ChatRewardCatalog> = flowOf(ChatRewardCatalog()),
 )
 
+/** Limits invisible provider refreshes when a viewer rapidly reopens the same channel. */
+class ChatCatalogRefreshGate(
+    private val cooldownMs: Long = DEFAULT_COOLDOWN_MS,
+    private val nowMs: () -> Long = System::currentTimeMillis,
+) {
+    private val lastRefreshByChannel = LinkedHashMap<String, Long>(16, 0.75f, true)
+
+    init {
+        require(cooldownMs > 0L)
+    }
+
+    @Synchronized
+    fun shouldForceRefresh(channelId: String): Boolean {
+        val now = nowMs()
+        val lastRefresh = lastRefreshByChannel[channelId]
+        if (lastRefresh != null && now >= lastRefresh && now - lastRefresh < cooldownMs) {
+            return false
+        }
+        lastRefreshByChannel[channelId] = now
+        while (lastRefreshByChannel.size > MAX_TRACKED_CHANNELS) {
+            lastRefreshByChannel.remove(lastRefreshByChannel.entries.first().key)
+        }
+        return true
+    }
+
+    private companion object {
+        const val DEFAULT_COOLDOWN_MS = 10 * 60 * 1000L
+        const val MAX_TRACKED_CHANNELS = 128
+    }
+}
+
 /** Creates independent live sessions. The player and Multiview use separate handles. */
 class ChatSessionFactory(
     private val parentScope: CoroutineScope,
@@ -49,6 +81,7 @@ class ChatSessionFactory(
     private val initialSettings: suspend (LiveChatSessionSpec) -> ChatEvent.SettingsUpdated? = { null },
     private val rewardCatalogFactory: (LiveChatSessionSpec, CoroutineScope) -> Flow<ChatRewardCatalog> = { _, _ -> flowOf(ChatRewardCatalog()) },
     private val maxTimelineSize: Int = 600,
+    private val automaticCatalogRefreshGate: ChatCatalogRefreshGate = ChatCatalogRefreshGate(),
 ) {
     private var generation = 0L
 
@@ -85,6 +118,7 @@ class ChatSessionFactory(
             startRewardCatalog = { rewardScope -> rewardCatalogFactory(spec, rewardScope) },
             initialSettings = { initialSettings(spec) },
             rewardCatalogState = rewardCatalog,
+            automaticCatalogRefreshGate = automaticCatalogRefreshGate,
         )
     }
 }
@@ -96,6 +130,7 @@ class ChatSessionHandle internal constructor(
     private val startRewardCatalog: (CoroutineScope) -> Flow<ChatRewardCatalog>,
     private val initialSettings: suspend () -> ChatEvent.SettingsUpdated?,
     private val rewardCatalogState: MutableStateFlow<ChatRewardCatalog>,
+    private val automaticCatalogRefreshGate: ChatCatalogRefreshGate,
 ) {
     private val lifecycleMutex = Mutex()
     private var started = false
@@ -107,7 +142,7 @@ class ChatSessionHandle internal constructor(
             if (closed || started) return@withLock
             active.session.start(active.key)
             started = true
-            active.catalog.refresh(force = false)
+            active.catalog.refresh(force = automaticCatalogRefreshGate.shouldForceRefresh(active.spec.channelId))
             startupWork = scope.launch {
                 // Transport, catalog, history, settings, and reward metadata are independent.
                 launch { reconcileRecent() }
@@ -179,6 +214,7 @@ class ChatSessionManager(
     private val initialSettings: suspend (LiveChatSessionSpec) -> ChatEvent.SettingsUpdated? = { null },
     private val rewardCatalogFactory: (LiveChatSessionSpec, CoroutineScope) -> Flow<ChatRewardCatalog> = { _, _ -> flowOf(ChatRewardCatalog()) },
     private val maxTimelineSize: Int = 600,
+    private val automaticCatalogRefreshGate: ChatCatalogRefreshGate = ChatCatalogRefreshGate(),
 ) {
     private val managerJob = SupervisorJob(parentScope.coroutineContext[Job])
     private val scope = CoroutineScope(parentScope.coroutineContext + managerJob)
@@ -195,6 +231,7 @@ class ChatSessionManager(
         initialSettings = initialSettings,
         rewardCatalogFactory = rewardCatalogFactory,
         maxTimelineSize = maxTimelineSize,
+        automaticCatalogRefreshGate = automaticCatalogRefreshGate,
     )
 
     /** Multiview entry point. It does not touch [_active]. */
@@ -225,7 +262,7 @@ class ChatSessionManager(
         session.start(key)
         val active = ActiveChatSession(spec, key, session, catalog, rewardCatalogFactory(spec, scope))
         _active.value = active
-        catalog.refresh(force = false)
+        catalog.refresh(force = automaticCatalogRefreshGate.shouldForceRefresh(spec.channelId))
         // Reconcile startup/reconstruction history independently of transport startup. Live
         // events can arrive while this request is in flight; ChatEventProcessor serializes the
         // atomic merge with those events and rejects the work if this generation is no longer

--- a/app/src/main/res/drawable/baseline_refresh_black_24.xml
+++ b/app/src/main/res/drawable/baseline_refresh_black_24.xml
@@ -1,9 +1,0 @@
-<vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="24dp"
-    android:height="24dp"
-    android:viewportWidth="24"
-    android:viewportHeight="24">
-    <path
-        android:fillColor="#FF000000"
-        android:pathData="M17.65,6.35C16.2,4.9 14.21,4 12,4c-4.42,0 -7.99,3.58 -7.99,8s3.57,8 7.99,8c3.73,0 6.84,-2.55 7.73,-6h-2.08c-0.82,2.33 -3.04,4 -5.65,4 -3.31,0 -6,-2.69 -6,-6s2.69,-6 6,-6c1.66,0 3.14,0.69 4.22,1.78L13,11h7V4l-2.35,2.35z" />
-</vector>

--- a/app/src/main/res/layout/fragment_emotes.xml
+++ b/app/src/main/res/layout/fragment_emotes.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
@@ -27,18 +26,6 @@
         android:paddingEnd="12dp"
         android:text="@string/reorder_favorite_emotes"
         android:visibility="gone" />
-
-    <ImageButton
-        android:id="@+id/refreshEmotes"
-        android:layout_width="48dp"
-        android:layout_height="48dp"
-        android:layout_gravity="top|end"
-        android:background="?android:selectableItemBackgroundBorderless"
-        android:contentDescription="@string/refresh"
-        android:padding="12dp"
-        android:src="@drawable/baseline_refresh_black_24"
-        android:visibility="visible"
-        app:tint="@android:color/white" />
 
     <TextView
         android:id="@+id/emptyState"

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatSessionManagerIntegrationTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatSessionManagerIntegrationTest.kt
@@ -13,6 +13,7 @@ import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatMessageKind
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatModerationDisplayMode
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatSessionKey
 import com.github.andreyasadchy.xtra.ui.chat.v2.domain.ChatUser
+import com.github.andreyasadchy.xtra.ui.chat.v2.session.ChatCatalogRefreshGate
 import com.github.andreyasadchy.xtra.ui.chat.v2.session.ChatSessionManager
 import com.github.andreyasadchy.xtra.ui.chat.v2.session.ChatSessionFactory
 import com.github.andreyasadchy.xtra.ui.chat.v2.session.ChatTimelineDelta
@@ -42,6 +43,49 @@ import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.atomic.AtomicInteger
 
 class ChatSessionManagerIntegrationTest {
+    @Test
+    fun newChatSessionRefreshesCatalogOnlyAfterTheChannelCooldown() = runBlocking {
+        val parent = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val refreshModes = CopyOnWriteArrayList<Boolean>()
+        val source = object : ChatCatalogSource {
+            override suspend fun load(): ChatCatalogLoadResult = EMPTY_CATALOG_SOURCE.load()
+
+            override suspend fun load(force: Boolean): ChatCatalogLoadResult {
+                refreshModes += force
+                return EMPTY_CATALOG_SOURCE.load()
+            }
+        }
+        var now = 0L
+        val manager = ChatSessionManager(
+            parentScope = parent,
+            transportFactory = { FakeTransport() },
+            catalogFactory = { _, scope -> ChatCatalogRepository(scope, source) },
+            automaticCatalogRefreshGate = ChatCatalogRefreshGate(
+                cooldownMs = 1_000L,
+                nowMs = { now },
+            ),
+        )
+        val spec = LiveChatSessionSpec("channel-id", "channel-login")
+
+        manager.start(spec)
+        withTimeout(1_000) { while (refreshModes.size < 1) delay(1) }
+        assertEquals(listOf(true), refreshModes.toList())
+
+        manager.stop()
+        manager.start(spec)
+        withTimeout(1_000) { while (refreshModes.size < 2) delay(1) }
+        assertEquals(listOf(true, false), refreshModes.toList())
+
+        now = 1_000L
+        manager.stop()
+        manager.start(spec)
+        withTimeout(1_000) { while (refreshModes.size < 3) delay(1) }
+        assertEquals(listOf(true, false, true), refreshModes.toList())
+
+        manager.close()
+        parent.cancel()
+    }
+
     @Test
     fun initialHistoryReconcilesLiveMessagesWithoutDuplicates() = runBlocking {
         val parent = CoroutineScope(SupervisorJob() + Dispatchers.Default)

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/session/ChatCatalogRefreshGateTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/session/ChatCatalogRefreshGateTest.kt
@@ -1,0 +1,22 @@
+package com.github.andreyasadchy.xtra.ui.chat.v2.session
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ChatCatalogRefreshGateTest {
+    @Test
+    fun throttlesEachChannelIndependently() {
+        var now = 0L
+        val gate = ChatCatalogRefreshGate(cooldownMs = 1_000L, nowMs = { now })
+
+        assertTrue(gate.shouldForceRefresh("channel-a"))
+        assertFalse(gate.shouldForceRefresh("channel-a"))
+        assertTrue(gate.shouldForceRefresh("channel-b"))
+
+        now = 999L
+        assertFalse(gate.shouldForceRefresh("channel-b"))
+        now = 1_000L
+        assertTrue(gate.shouldForceRefresh("channel-a"))
+    }
+}


### PR DESCRIPTION
The emote picker no longer shows a refresh button. Cached emotes remain available when a stream opens, then the chat session silently refreshes providers in the background when that channel's automatic refresh cooldown has elapsed. Rapid reopenings and unrelated stream resumes do not force another refresh, while the existing player settings reload command stays available.

Validated with the debug compile, focused session refresh tests, and the emote picker layout test on an API 35 emulator.