### PR TITLE
Prevent viewing stats CI starvation

### DIFF
--- a/app/src/test/java/com/github/andreyasadchy/xtra/util/viewingstats/ViewingStatsRecorderTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/util/viewingstats/ViewingStatsRecorderTest.kt
@@ -193,7 +193,11 @@ class ViewingStatsRecorderTest {
     @Test
     fun semanticIngressHasBoundedPendingWorkWhenPersistenceStalls() = runBlocking {
         val localStore = FakeViewingStatsStore().also { it.writeDelayMs = 8L }
-        val localScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        // Producers deliberately fill the bounded semantic channel. Keep the
+        // recorder worker on the same IO-style dispatcher used in production;
+        // putting blocking producers and the worker on a small Default pool
+        // can starve the worker before it gets a chance to drain the channel.
+        val localScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
         val localRecorder = ViewingStatsRecorder(
             repository = localStore,
             clock = clock,


### PR DESCRIPTION
Keep the bounded-ingress stress test worker on the IO-style dispatcher used in production so blocking producers cannot starve it on small CI runners.