### PR TITLE
Make overview card metadata clickable

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/discover/DiscoverFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/discover/DiscoverFragment.kt
@@ -34,6 +34,7 @@ import com.github.andreyasadchy.xtra.ui.main.MainActivity
 import com.github.andreyasadchy.xtra.ui.login.TwitchWebLoginActivity
 import com.github.andreyasadchy.xtra.ui.search.SearchPagerFragmentDirections
 import com.github.andreyasadchy.xtra.ui.settings.SettingsActivity
+import com.github.andreyasadchy.xtra.ui.top.TopStreamsFragmentDirections
 import com.github.andreyasadchy.xtra.util.C
 import com.github.andreyasadchy.xtra.util.TwitchApiHelper
 import com.github.andreyasadchy.xtra.util.getAlertDialogBuilder
@@ -131,6 +132,11 @@ class DiscoverFragment : BaseNetworkFragment(), Scrollable {
                         gameName = game.name,
                         boxArt = game.boxArt,
                     ),
+                )
+            },
+            onStreamTagClick = { tag ->
+                navController.navigate(
+                    TopStreamsFragmentDirections.actionGlobalTopFragment(tags = arrayOf(tag)),
                 )
             },
             onStreamShelfAttached = { key, recyclerView, streamAtPosition, isFeatured ->

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/overview/FeaturedStreamShelfAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/overview/FeaturedStreamShelfAdapter.kt
@@ -5,6 +5,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.core.view.MarginLayoutParamsCompat
+import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -14,6 +15,7 @@ import com.github.andreyasadchy.xtra.R
 import com.github.andreyasadchy.xtra.XtraApp
 import com.github.andreyasadchy.xtra.databinding.ItemFeaturedStreamShelfBinding
 import com.github.andreyasadchy.xtra.model.ui.Stream
+import com.github.andreyasadchy.xtra.ui.channel.ChannelPagerFragmentDirections
 import com.github.andreyasadchy.xtra.ui.common.loadStreamProfileImage
 import com.github.andreyasadchy.xtra.ui.common.loadStreamThumbnail
 import com.github.andreyasadchy.xtra.ui.common.prepareStreamProfileImage
@@ -35,6 +37,7 @@ import com.github.andreyasadchy.xtra.ui.common.streamContentsSame
 import com.github.andreyasadchy.xtra.ui.common.streamIdentity
 import com.github.andreyasadchy.xtra.ui.common.streamThumbnailOnlyChanged
 import com.github.andreyasadchy.xtra.ui.common.StreamThumbnailChangedPayload
+import com.github.andreyasadchy.xtra.ui.game.GamePagerFragmentDirections
 import com.github.andreyasadchy.xtra.ui.tv.TvFocusHelper
 import com.github.andreyasadchy.xtra.ui.drops.StreamDropsBottomSheet
 import com.github.andreyasadchy.xtra.util.C
@@ -46,6 +49,7 @@ import kotlin.math.max
 class FeaturedStreamShelfAdapter(
     private val fragment: Fragment,
     private val onStreamClick: (Stream) -> Unit,
+    private val onTagClick: (String) -> Unit,
 ) : ListAdapter<Stream, FeaturedStreamShelfAdapter.ViewHolder>(DIFF_CALLBACK) {
 
     private val thumbnailLoadScheduler = StreamThumbnailIdleScheduler()
@@ -217,6 +221,7 @@ class FeaturedStreamShelfAdapter(
         private var boundImageIdentity: String? = null
         private var boundThumbnailKey: String? = null
         private var boundStream: Stream? = null
+        private var boundTags: List<String> = emptyList()
         private var uptimeStartedAtMs: Long? = null
         private var uptimeEnabled = false
         private var lastRenderedUptimeSecond = Long.MIN_VALUE
@@ -226,6 +231,10 @@ class FeaturedStreamShelfAdapter(
 
         init {
             binding.root.setOnClickListener { boundStream?.let(onStreamClick) }
+            binding.avatar.setOnClickListener { boundStream?.let(::openChannel) }
+            binding.channel.setOnClickListener { boundStream?.let(::openChannel) }
+            binding.category.setOnClickListener { boundStream?.let(::openGame) }
+            binding.tagOne.setOnClickListener { boundTags.firstOrNull()?.let(onTagClick) }
             TvFocusHelper.install(binding.root)
         }
 
@@ -249,6 +258,7 @@ class FeaturedStreamShelfAdapter(
             boundImageIdentity = null
             boundThumbnailKey = null
             boundStream = null
+            boundTags = emptyList()
             dropsBadgeBinder.clear()
             clearUptime()
         }
@@ -314,6 +324,7 @@ class FeaturedStreamShelfAdapter(
 
                 val tags = presentation?.tags ?: if (uiPreferences.showTags) stream.tags.orEmpty() else emptyList()
                 val firstTag = tags.firstOrNull()?.trim()?.takeIf(String::isNotEmpty)
+                boundTags = listOfNotNull(firstTag)
                 tagOne.text = firstTag.orEmpty()
                 tagOne.visibility = if (firstTag != null) View.VISIBLE else View.GONE
 
@@ -348,9 +359,33 @@ class FeaturedStreamShelfAdapter(
                 category.text = presentation.gameName.orEmpty()
                 category.visibility = if (category.text.isNullOrBlank()) View.GONE else View.VISIBLE
                 val firstTag = presentation.tags.firstOrNull()?.trim()?.takeIf(String::isNotEmpty)
+                boundTags = listOfNotNull(firstTag)
                 tagOne.text = firstTag.orEmpty()
                 tagOne.visibility = if (firstTag != null) View.VISIBLE else View.GONE
             }
+        }
+
+        private fun openChannel(stream: Stream) {
+            fragment.findNavController().navigate(
+                ChannelPagerFragmentDirections.actionGlobalChannelPagerFragment(
+                    channelId = stream.channelId,
+                    channelLogin = stream.channelLogin,
+                    channelName = stream.channelName,
+                    channelImage = stream.channelImage,
+                    streamId = stream.id,
+                ),
+            )
+        }
+
+        private fun openGame(stream: Stream) {
+            if (stream.gameName.isNullOrBlank()) return
+            fragment.findNavController().navigate(
+                GamePagerFragmentDirections.actionGlobalGamePagerFragment(
+                    gameId = stream.gameId,
+                    gameSlug = stream.gameSlug,
+                    gameName = stream.gameName,
+                ),
+            )
         }
 
         override fun updateUptime(nowMs: Long) {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/overview/FollowingOverviewAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/overview/FollowingOverviewAdapter.kt
@@ -40,6 +40,7 @@ class FollowingOverviewAdapter(
     private val onUpcomingClick: (UpcomingStream) -> Unit,
     private val onSeeAll: (String) -> Unit,
     private val onGameClick: (Game) -> Unit = {},
+    private val onStreamTagClick: (String) -> Unit = {},
     private val onStreamShelfAttached: ((String, RecyclerView, (Int) -> Stream?, Boolean) -> Unit)? = null,
     private val onStreamShelfDetached: ((String) -> Unit)? = null,
     private val onVideoShelfAttached: ((String, RecyclerView, (Int) -> VideoHistory?) -> Unit)? = null,
@@ -84,11 +85,11 @@ class FollowingOverviewAdapter(
         inner class ViewHolder(
         private val binding: ItemFollowingSectionBinding,
     ) : RecyclerView.ViewHolder(binding.root) {
-        private val shelfAdapter = StreamShelfAdapter(fragment, onStreamClick)
-        private val videoShelfAdapter = VideoShelfAdapter(onVideoClick)
-        private val upcomingShelfAdapter = UpcomingStreamShelfAdapter(onUpcomingClick)
+        private val shelfAdapter = StreamShelfAdapter(fragment, onStreamClick, onStreamTagClick)
+        private val videoShelfAdapter = VideoShelfAdapter(fragment, onVideoClick)
+        private val upcomingShelfAdapter = UpcomingStreamShelfAdapter(fragment, onUpcomingClick)
         private val gameShelfAdapter = GameShelfAdapter(onGameClick)
-        private val featuredShelfAdapter = FeaturedStreamShelfAdapter(fragment, onStreamClick)
+        private val featuredShelfAdapter = FeaturedStreamShelfAdapter(fragment, onStreamClick, onStreamTagClick)
         private val skeletonShelfAdapter = ShelfSkeletonAdapter()
         private var shelfType: ShelfType? = null
         private var boundStreamShelfKey: String? = null

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/overview/FollowingOverviewFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/overview/FollowingOverviewFragment.kt
@@ -32,6 +32,7 @@ import com.github.andreyasadchy.xtra.ui.following.FollowMediaFragment
 import com.github.andreyasadchy.xtra.ui.following.FollowPagerFragment
 import com.github.andreyasadchy.xtra.ui.main.MainActivity
 import com.github.andreyasadchy.xtra.ui.overview.OverviewFragment
+import com.github.andreyasadchy.xtra.ui.top.TopStreamsFragmentDirections
 import com.github.andreyasadchy.xtra.util.TwitchApiHelper
 import com.github.andreyasadchy.xtra.ui.following.overview.FollowingOverviewViewModel.Companion.FollowingOverviewViewModelFactory
 import kotlinx.coroutines.flow.collectLatest
@@ -94,6 +95,11 @@ class FollowingOverviewFragment : BaseNetworkFragment(), Scrollable {
                 )
             },
             onSeeAll = ::showAll,
+            onStreamTagClick = { tag ->
+                findNavController().navigate(
+                    TopStreamsFragmentDirections.actionGlobalTopFragment(tags = arrayOf(tag)),
+                )
+            },
             onStreamShelfAttached = { key, recyclerView, streamAtPosition, _ ->
                 streamShelfPreloadControllers.remove(key)?.stop()
                 StreamPreloadViewportController(

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/overview/StreamShelfAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/overview/StreamShelfAdapter.kt
@@ -3,6 +3,7 @@ package com.github.andreyasadchy.xtra.ui.following.overview
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
@@ -10,6 +11,7 @@ import com.github.andreyasadchy.xtra.R
 import com.github.andreyasadchy.xtra.XtraApp
 import com.github.andreyasadchy.xtra.databinding.ItemStreamShelfBinding
 import com.github.andreyasadchy.xtra.model.ui.Stream
+import com.github.andreyasadchy.xtra.ui.channel.ChannelPagerFragmentDirections
 import com.github.andreyasadchy.xtra.ui.common.loadStreamProfileImage
 import com.github.andreyasadchy.xtra.ui.common.loadStreamThumbnail
 import com.github.andreyasadchy.xtra.ui.common.prepareStreamProfileImage
@@ -31,12 +33,14 @@ import com.github.andreyasadchy.xtra.ui.common.streamContentsSame
 import com.github.andreyasadchy.xtra.ui.common.streamIdentity
 import com.github.andreyasadchy.xtra.ui.common.streamThumbnailOnlyChanged
 import com.github.andreyasadchy.xtra.ui.common.StreamThumbnailChangedPayload
+import com.github.andreyasadchy.xtra.ui.game.GamePagerFragmentDirections
 import com.github.andreyasadchy.xtra.ui.tv.TvFocusHelper
 import com.github.andreyasadchy.xtra.ui.drops.StreamDropsBottomSheet
 
 class StreamShelfAdapter(
     private val fragment: androidx.fragment.app.Fragment,
     private val onStreamClick: (Stream) -> Unit,
+    private val onTagClick: (String) -> Unit,
 ) : ListAdapter<Stream, StreamShelfAdapter.ViewHolder>(DIFF_CALLBACK) {
 
     private val thumbnailLoadScheduler = StreamThumbnailIdleScheduler()
@@ -112,6 +116,7 @@ class StreamShelfAdapter(
         private var boundImageIdentity: String? = null
         private var boundThumbnailKey: String? = null
         private var boundStream: Stream? = null
+        private var boundTags: List<String> = emptyList()
         private var uptimeStartedAtMs: Long? = null
         private var uptimeEnabled = false
         private var lastRenderedUptimeSecond = Long.MIN_VALUE
@@ -121,6 +126,12 @@ class StreamShelfAdapter(
 
         init {
             binding.root.setOnClickListener { boundStream?.let(onStreamClick) }
+            binding.avatar.setOnClickListener { boundStream?.let(::openChannel) }
+            binding.channel.setOnClickListener { boundStream?.let(::openChannel) }
+            binding.category.setOnClickListener { boundStream?.let(::openGame) }
+            binding.tagOne.setOnClickListener { boundTags.getOrNull(0)?.let(onTagClick) }
+            binding.tagTwo.setOnClickListener { boundTags.getOrNull(1)?.let(onTagClick) }
+            binding.tagThree.setOnClickListener { boundTags.getOrNull(2)?.let(onTagClick) }
             TvFocusHelper.install(binding.root)
         }
 
@@ -144,6 +155,7 @@ class StreamShelfAdapter(
             boundImageIdentity = null
             boundThumbnailKey = null
             boundStream = null
+            boundTags = emptyList()
             dropsBadgeBinder.clear()
             clearUptime()
         }
@@ -252,6 +264,7 @@ class StreamShelfAdapter(
                 .filter(String::isNotEmpty)
                 .take(3)
                 .toList()
+            boundTags = tagValues
             binding.tagOne.text = tagValues.getOrNull(0).orEmpty()
             binding.tagOne.visibility = if (tagValues.size > 0) View.VISIBLE else View.GONE
             binding.tagTwo.text = tagValues.getOrNull(1).orEmpty()
@@ -259,6 +272,29 @@ class StreamShelfAdapter(
             binding.tagThree.text = tagValues.getOrNull(2).orEmpty()
             binding.tagThree.visibility = if (tagValues.size > 2) View.VISIBLE else View.GONE
             binding.tags.visibility = if (tagValues.isNotEmpty()) View.VISIBLE else View.GONE
+        }
+
+        private fun openChannel(stream: Stream) {
+            fragment.findNavController().navigate(
+                ChannelPagerFragmentDirections.actionGlobalChannelPagerFragment(
+                    channelId = stream.channelId,
+                    channelLogin = stream.channelLogin,
+                    channelName = stream.channelName,
+                    channelImage = stream.channelImage,
+                    streamId = stream.id,
+                ),
+            )
+        }
+
+        private fun openGame(stream: Stream) {
+            if (stream.gameName.isNullOrBlank()) return
+            fragment.findNavController().navigate(
+                GamePagerFragmentDirections.actionGlobalGamePagerFragment(
+                    gameId = stream.gameId,
+                    gameSlug = stream.gameSlug,
+                    gameName = stream.gameName,
+                ),
+            )
         }
 
         private val titleMaxLines: Int

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/overview/UpcomingStreamShelfAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/overview/UpcomingStreamShelfAdapter.kt
@@ -4,6 +4,8 @@ import android.text.format.DateUtils
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
@@ -17,6 +19,7 @@ import coil3.transform.CircleCropTransformation
 import com.github.andreyasadchy.xtra.R
 import com.github.andreyasadchy.xtra.databinding.ItemUpcomingStreamShelfBinding
 import com.github.andreyasadchy.xtra.model.ui.UpcomingStream
+import com.github.andreyasadchy.xtra.ui.channel.ChannelPagerFragmentDirections
 import com.github.andreyasadchy.xtra.ui.common.FeedImageRequestBag
 import com.github.andreyasadchy.xtra.ui.common.FeedImageRequestOwner
 import com.github.andreyasadchy.xtra.ui.common.StreamThumbnailIdleScheduler
@@ -24,8 +27,10 @@ import com.github.andreyasadchy.xtra.ui.common.restoreDecodedMemoryImage
 import com.github.andreyasadchy.xtra.ui.common.thumbnailState
 import com.github.andreyasadchy.xtra.util.TwitchApiHelper
 import com.github.andreyasadchy.xtra.ui.tv.TvFocusHelper
+import com.github.andreyasadchy.xtra.ui.game.GamePagerFragmentDirections
 
 class UpcomingStreamShelfAdapter(
+    private val fragment: Fragment,
     private val onUpcomingClick: (UpcomingStream) -> Unit,
 ) : ListAdapter<UpcomingStream, UpcomingStreamShelfAdapter.ViewHolder>(DIFF_CALLBACK) {
 
@@ -73,6 +78,9 @@ class UpcomingStreamShelfAdapter(
         init {
             TvFocusHelper.install(binding.root)
             binding.root.setOnClickListener { boundItem?.let(onUpcomingClick) }
+            binding.avatar.setOnClickListener { boundItem?.let(::openChannel) }
+            binding.channel.setOnClickListener { boundItem?.let(::openChannel) }
+            binding.category.setOnClickListener { boundItem?.let(::openGame) }
         }
 
         fun beginImageBind(item: UpcomingStream) {
@@ -155,6 +163,26 @@ class UpcomingStreamShelfAdapter(
                 binding.previewImage.setImageDrawable(null)
                 binding.previewImage.tag = null
             }
+        }
+
+        private fun openChannel(item: UpcomingStream) {
+            fragment.findNavController().navigate(
+                ChannelPagerFragmentDirections.actionGlobalChannelPagerFragment(
+                    channelId = item.channelId,
+                    channelLogin = item.channelLogin,
+                    channelName = item.channelName,
+                    channelImage = item.channelImageURL?.let(TwitchApiHelper::getProfileImage),
+                ),
+            )
+        }
+
+        private fun openGame(item: UpcomingStream) {
+            if (item.gameName.isNullOrBlank()) return
+            fragment.findNavController().navigate(
+                GamePagerFragmentDirections.actionGlobalGamePagerFragment(
+                    gameName = item.gameName,
+                ),
+            )
         }
     }
 

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/overview/VideoShelfAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/overview/VideoShelfAdapter.kt
@@ -3,6 +3,8 @@ package com.github.andreyasadchy.xtra.ui.following.overview
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
@@ -17,6 +19,7 @@ import com.github.andreyasadchy.xtra.R
 import com.github.andreyasadchy.xtra.XtraApp
 import com.github.andreyasadchy.xtra.databinding.ItemVideoShelfBinding
 import com.github.andreyasadchy.xtra.model.VideoHistory
+import com.github.andreyasadchy.xtra.ui.channel.ChannelPagerFragmentDirections
 import com.github.andreyasadchy.xtra.ui.common.FeedImageRequestBag
 import com.github.andreyasadchy.xtra.ui.common.FeedImageRequestOwner
 import com.github.andreyasadchy.xtra.ui.common.StreamThumbnailIdleScheduler
@@ -24,9 +27,11 @@ import com.github.andreyasadchy.xtra.ui.common.VideoHistoryCardPresentationCache
 import com.github.andreyasadchy.xtra.ui.common.restoreDecodedMemoryImage
 import com.github.andreyasadchy.xtra.ui.common.thumbnailState
 import com.github.andreyasadchy.xtra.ui.tv.TvFocusHelper
+import com.github.andreyasadchy.xtra.ui.game.GamePagerFragmentDirections
 import com.github.andreyasadchy.xtra.util.TwitchApiHelper
 
 class VideoShelfAdapter(
+    private val fragment: Fragment,
     private val onVideoClick: (VideoHistory) -> Unit,
 ) : ListAdapter<VideoHistory, VideoShelfAdapter.ViewHolder>(DIFF_CALLBACK) {
 
@@ -87,6 +92,9 @@ class VideoShelfAdapter(
 
         init {
             binding.root.setOnClickListener { boundItem?.let(onVideoClick) }
+            binding.avatar.setOnClickListener { boundItem?.let(::openChannel) }
+            binding.channel.setOnClickListener { boundItem?.let(::openChannel) }
+            binding.category.setOnClickListener { boundItem?.let(::openGame) }
             TvFocusHelper.install(binding.root)
         }
 
@@ -191,6 +199,28 @@ class VideoShelfAdapter(
         fun detachPreview() {
             streamPreviewCoordinator.detachSurface(previewSurface)
             boundPreviewIdentity = null
+        }
+
+        private fun openChannel(item: VideoHistory) {
+            fragment.findNavController().navigate(
+                ChannelPagerFragmentDirections.actionGlobalChannelPagerFragment(
+                    channelId = item.channelId,
+                    channelLogin = item.channelLogin,
+                    channelName = item.channelName,
+                    channelImage = item.channelImageURL?.let(TwitchApiHelper::getProfileImage),
+                ),
+            )
+        }
+
+        private fun openGame(item: VideoHistory) {
+            if (item.gameName.isNullOrBlank()) return
+            fragment.findNavController().navigate(
+                GamePagerFragmentDirections.actionGlobalGamePagerFragment(
+                    gameId = item.gameId,
+                    gameSlug = item.gameSlug,
+                    gameName = item.gameName,
+                ),
+            )
         }
     }
 


### PR DESCRIPTION
Make stream avatars and channel names open profiles, categories open category pages, and tags open filtered streams across overview shelves.