### PR TITLE
Improve CI build reliability

### DIFF
--- a/.github/scripts/collect-gradle-diagnostics.sh
+++ b/.github/scripts/collect-gradle-diagnostics.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -u
+
+output_dir="${CI_DIAGNOSTICS_DIR:-ci-diagnostics}"
+gradle_user_home="${GRADLE_USER_HOME:-$HOME/.gradle}"
+mkdir -p "$output_dir"
+
+{
+  echo "# Gradle diagnostics"
+  echo
+  echo "- UTC time: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  echo "- Job: ${GITHUB_JOB:-unknown}"
+  echo "- Run: ${GITHUB_RUN_ID:-unknown}"
+  echo "- Gradle JVM arguments: ${CI_GRADLE_JVM_ARGS:-not set}"
+  echo
+  echo '```text'
+  free -h 2>&1 || true
+  echo
+  df -h 2>&1 || true
+  echo
+  nproc 2>&1 || true
+  echo '```'
+} > "$output_dir/summary.md"
+
+{
+  echo "Gradle version"
+  ./gradlew --version 2>&1 || true
+  echo
+  echo "Gradle daemons"
+  ./gradlew --status 2>&1 || true
+} > "$output_dir/gradle-status.txt"
+
+copy_file() {
+  local source="$1"
+  local relative="$2"
+  local destination="$output_dir/$relative"
+  mkdir -p "$(dirname "$destination")"
+  cp "$source" "$destination" 2>/dev/null || true
+}
+
+for report_root in build/reports app/build/reports app/build/outputs/logs; do
+  if [[ -d "$report_root" ]]; then
+    while IFS= read -r -d '' report; do
+      copy_file "$report" "$report"
+    done < <(find "$report_root" -type f -size -25M -print0 2>/dev/null)
+  fi
+done
+
+daemon_root="$gradle_user_home/daemon"
+if [[ -d "$daemon_root" ]]; then
+  while IFS= read -r -d '' daemon_log; do
+    relative="${daemon_log#"$gradle_user_home/"}"
+    copy_file "$daemon_log" "gradle/$relative"
+  done < <(
+    find "$daemon_root" -type f \
+      \( -name '*.log' -o -name '*.out.log' \) \
+      -size -25M -print0 2>/dev/null
+  )
+fi
+
+if [[ -d ci-logs ]]; then
+  find ci-logs -maxdepth 1 -type f -size -25M -print 2>/dev/null || true
+fi

--- a/.github/scripts/run-gradle-build.sh
+++ b/.github/scripts/run-gradle-build.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+if (( $# < 2 )); then
+  echo "Usage: $0 <label> <timeout-minutes> [Gradle arguments...]" >&2
+  exit 2
+fi
+
+label="$1"
+timeout_minutes="$2"
+shift 2
+
+if [[ ! "$timeout_minutes" =~ ^[1-9][0-9]*$ ]]; then
+  echo "timeout-minutes must be a positive integer: $timeout_minutes" >&2
+  exit 2
+fi
+
+safe_label="${label//[^a-zA-Z0-9_.-]/_}"
+log_dir="${CI_GRADLE_LOG_DIR:-ci-logs}"
+mkdir -p "$log_dir"
+log_file="$log_dir/$safe_label.log"
+workspace="${GITHUB_WORKSPACE:-$PWD}"
+jvm_args="${CI_GRADLE_JVM_ARGS:--Xmx6g -Dfile.encoding=UTF-8}"
+started_at="$(date +%s)"
+heartbeat_pid=""
+gradle_pid=""
+
+system_snapshot() {
+  echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $label system snapshot"
+  echo "Working directory: $workspace"
+  free -h 2>&1 || true
+  df -h "$workspace" 2>&1 || true
+  ps -eo pid,ppid,rss,%mem,etime,comm --sort=-rss 2>&1 | head -n 12 || true
+}
+
+cleanup() {
+  if [[ -n "$heartbeat_pid" ]] && kill -0 "$heartbeat_pid" 2>/dev/null; then
+    kill "$heartbeat_pid" 2>/dev/null || true
+  fi
+  if [[ -n "$heartbeat_pid" ]]; then
+    wait "$heartbeat_pid" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+gradle_command=(
+  ./gradlew
+  --no-daemon
+  --no-configuration-cache
+  --profile
+  --console=plain
+  --stacktrace
+  "-Dorg.gradle.jvmargs=$jvm_args"
+  "$@"
+)
+
+echo "Starting $label build with a ${timeout_minutes} minute timeout"
+echo "Gradle JVM arguments: $jvm_args"
+system_snapshot | tee "$log_file.system"
+
+heartbeat() {
+  while kill -0 "$gradle_pid" 2>/dev/null; do
+    sleep 60
+    if kill -0 "$gradle_pid" 2>/dev/null; then
+      {
+        echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $label is still running"
+        system_snapshot
+      } | tee -a "$log_file"
+    fi
+  done
+}
+
+set +e
+# Keep timeout's process-group handling enabled so a timed-out Gradle build
+# does not leave Kotlin, R8, or AGP child processes behind.
+timeout --signal=TERM --kill-after=30s "${timeout_minutes}m" \
+  "${gradle_command[@]}" > >(tee "$log_file") 2>&1 &
+gradle_pid=$!
+set -e
+
+heartbeat &
+heartbeat_pid=$!
+
+set +e
+wait "$gradle_pid"
+status=$?
+set -e
+
+system_snapshot | tee -a "$log_file.system"
+elapsed=$(( $(date +%s) - started_at ))
+if (( status == 124 )); then
+  echo "::error title=$label build timed out::$label exceeded ${timeout_minutes} minutes after ${elapsed} seconds"
+elif (( status == 137 )); then
+  echo "::error title=$label build was killed::$label was killed after ${elapsed} seconds"
+elif (( status != 0 )); then
+  echo "::error title=$label build failed::$label failed with exit code $status after ${elapsed} seconds"
+else
+  echo "Finished $label build successfully in ${elapsed} seconds"
+fi
+
+exit "$status"

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -57,7 +57,7 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 35
     outputs:
       version_name: ${{ steps.version.outputs.name }}
       version_code: ${{ steps.version.outputs.code }}
@@ -128,6 +128,7 @@ jobs:
       id: build
       env:
         TWITCH_PUBLIC_CLIENT_ID: ${{ vars.TWITCH_PUBLIC_CLIENT_ID }}
+        CI_GRADLE_JVM_ARGS: '-Xmx6g -Dfile.encoding=UTF-8'
       shell: bash
       run: |
         set -euo pipefail
@@ -139,24 +140,8 @@ jobs:
           "-PciVersionCode=${{ steps.version.outputs.code }}"
           "-PtwitchPublicClientId=${TWITCH_PUBLIC_CLIENT_ID}"
         )
-        # Release and perf share almost all sources. Build them in separate
-        # Gradle invocations so Kotlin does not compile both variants at the
-        # same time and exhaust the GitHub runner heap.
-        # AGP's incremental APK packaging can fail transiently after
-        # a packaging worker is interrupted. Avoid reusing a partial
-        # configuration-cache/package state and retry the complete variant
-        # once; real compilation failures still fail the job.
-        build_variant() {
-          local task="$1"
-          if ./gradlew --no-daemon --no-configuration-cache "$task" "${build_args[@]}"; then
-            return 0
-          fi
-          echo "${task} failed; retrying once after stopping Gradle daemons" >&2
-          ./gradlew --stop || true
-          ./gradlew --no-daemon --no-configuration-cache "$task" "${build_args[@]}"
-        }
-        build_variant :app:assembleRelease
-        build_variant :app:assemblePerf
+        bash .github/scripts/run-gradle-build.sh release 15 \
+          :app:assembleRelease "${build_args[@]}"
 
     - name: Inspect release APKs
       if: always()
@@ -364,18 +349,21 @@ jobs:
         done
         cp "$metadata_asset" release-package/xtra-release-metadata.json
 
-    - name: Upload a Build Artifact
-      if: >-
-        success() &&
-        steps.build.outcome == 'success' &&
-        steps.verify-release-apk.outcome == 'success' &&
-        (github.event_name == 'push' || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch')
+    - name: Collect build diagnostics
+      if: failure()
+      continue-on-error: true
+      env:
+        CI_GRADLE_JVM_ARGS: '-Xmx6g -Dfile.encoding=UTF-8'
+      run: bash .github/scripts/collect-gradle-diagnostics.sh
+
+    - name: Upload build diagnostics
+      if: failure()
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
-        name: xtra-${{ steps.version.outputs.name }}-build-${{ steps.version.outputs.code }}
+        name: xtra-build-diagnostics-${{ github.run_id }}
         path: |
-          app/build/outputs/apk/release/*.apk
-          app/build/outputs/apk/perf/*.apk
+          ci-diagnostics
+          ci-logs
         if-no-files-found: warn
         retention-days: 7
 
@@ -392,3 +380,57 @@ jobs:
         path: release-package
         if-no-files-found: error
         retention-days: 14
+
+  perf:
+    if: >-
+      (github.event_name == 'push' && github.ref == 'refs/heads/master') ||
+      github.event_name == 'workflow_dispatch'
+    needs: build
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+    - name: Checkout sources
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      with:
+        persist-credentials: false
+    - name: Setup Java
+      uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
+      with:
+        java-version: '21'
+        distribution: 'temurin'
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6
+      with:
+        cache-provider: 'basic'
+    - name: Build performance APK
+      env:
+        CI_GRADLE_JVM_ARGS: '-Xmx6g -Dfile.encoding=UTF-8'
+        TWITCH_PUBLIC_CLIENT_ID: ${{ vars.TWITCH_PUBLIC_CLIENT_ID }}
+      shell: bash
+      run: |
+        set -euo pipefail
+        if [[ -z "${TWITCH_PUBLIC_CLIENT_ID:-}" ]]; then
+          echo "Repository variable TWITCH_PUBLIC_CLIENT_ID is required for perf builds" >&2
+          exit 1
+        fi
+        bash .github/scripts/run-gradle-build.sh perf 15 \
+          :app:assemblePerf \
+          "-PciVersionCode=${{ needs.build.outputs.version_code }}" \
+          "-PtwitchPublicClientId=${TWITCH_PUBLIC_CLIENT_ID}"
+    - name: Collect perf diagnostics
+      if: failure()
+      continue-on-error: true
+      env:
+        CI_GRADLE_JVM_ARGS: '-Xmx6g -Dfile.encoding=UTF-8'
+      run: bash .github/scripts/collect-gradle-diagnostics.sh
+    - name: Upload perf diagnostics
+      if: failure()
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      with:
+        name: xtra-perf-diagnostics-${{ github.run_id }}
+        path: |
+          ci-diagnostics
+          ci-logs
+        if-no-files-found: warn
+        retention-days: 7

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -36,6 +36,7 @@ jobs:
   analyze-java-kotlin:
     name: Analyze (java-kotlin)
     runs-on: ubuntu-latest
+    timeout-minutes: 35
     permissions:
       actions: read
       contents: read
@@ -61,21 +62,31 @@ jobs:
       - name: Build for CodeQL
         # CodeQL only needs a compilable release graph; publishing validates the real ID.
         # CodeQL tracing increases packaging memory pressure, so keep the build single-worker.
+        env:
+          CI_GRADLE_JVM_ARGS: '-Xmx6g -Dfile.encoding=UTF-8'
         shell: bash
         run: |
           set -euo pipefail
-          build_args=(
-            "-PtwitchPublicClientId=codeql-placeholder"
-          )
-          # AGP can leave its incremental packaging worker in a bad state after
-          # CodeQL interrupts or traces a packaging task. Retry without daemon
-          # or configuration-cache state before treating the build as broken.
-          if ./gradlew --no-daemon --no-configuration-cache --max-workers=1 assembleRelease "${build_args[@]}"; then
-            exit 0
-          fi
-          ./gradlew --stop || true
-          ./gradlew --no-daemon --no-configuration-cache --max-workers=1 assembleRelease "${build_args[@]}"
+          bash .github/scripts/run-gradle-build.sh codeql 25 \
+            --max-workers=1 assembleRelease \
+            -PtwitchPublicClientId=codeql-placeholder
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@4c0873ef8656cb3c50b3f42fb63bc1ade0cfa827 # v4
         with:
           category: /language:java-kotlin
+      - name: Collect CodeQL diagnostics
+        if: failure()
+        continue-on-error: true
+        env:
+          CI_GRADLE_JVM_ARGS: '-Xmx6g -Dfile.encoding=UTF-8'
+        run: bash .github/scripts/collect-gradle-diagnostics.sh
+      - name: Upload CodeQL diagnostics
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: xtra-codeql-diagnostics-${{ github.run_id }}
+          path: |
+            ci-diagnostics
+            ci-logs
+          if-no-files-found: warn
+          retention-days: 7

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -38,6 +38,7 @@ jobs:
       (github.event.workflow_run.conclusion == 'success' &&
        github.event.workflow_run.event == 'push')
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     env:
       GH_REPO: ${{ github.repository }}
       GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Improves Android build reliability and PR feedback.\n\n- Keeps release verification on pull requests while moving perf builds to a non-blocking master/manual job.\n- Gives heavy Gradle builds more memory and hard per-build timeouts.\n- Adds heartbeats, build profiles, and failure diagnostics.\n- Removes large APK uploads from pull requests.