### PR TITLE
Fix Drops filtered stream discovery

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/model/ui/DropStreamFilter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/model/ui/DropStreamFilter.kt
@@ -65,6 +65,12 @@ internal fun List<DropStreamFilter>.matchesDropStream(
         filter.matchesChannelCampaigns(campaigns)
 }
 
+/** Search each distinct selected Drop game once, in selection order. */
+internal fun List<DropStreamFilter>.searchQueries(): List<String> =
+    map { it.gameName.trim() }
+        .filter(String::isNotBlank)
+        .distinctBy { it.lowercase() }
+
 internal fun matchesDropCampaign(
     availableIds: Set<String>,
     campaignId: String,

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/datasource/SearchPageKey.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/datasource/SearchPageKey.kt
@@ -1,8 +1,17 @@
 package com.github.andreyasadchy.xtra.repository.datasource
 
+internal data class SearchQueryPageState(
+    val api: String? = null,
+    val cursor: String? = null,
+    val exhausted: Boolean = false,
+    val pagesLoaded: Int = 0,
+)
+
 internal data class SearchPageKey(
     val api: String,
     val cursor: String,
+    val queryIndex: Int = 0,
+    val queryStates: List<SearchQueryPageState> = emptyList(),
 )
 
 internal fun nextSearchPageKey(
@@ -13,3 +22,19 @@ internal fun nextSearchPageKey(
     val next = candidate?.takeIf { it.isNotBlank() && it != currentCursor } ?: return null
     return SearchPageKey(api, next)
 }
+
+internal fun nextSearchQueryIndex(
+    currentIndex: Int,
+    states: List<SearchQueryPageState>,
+): Int? {
+    if (states.isEmpty() || states.all(SearchQueryPageState::exhausted)) return null
+    return (1..states.size)
+        .map { offset -> (currentIndex + offset) % states.size }
+        .firstOrNull { index -> !states[index].exhausted }
+}
+
+internal fun isSearchQueryExhausted(
+    hasNextPage: Boolean,
+    pagesLoaded: Int,
+    pageBudget: Int?,
+): Boolean = !hasNextPage || pageBudget?.let { pagesLoaded >= it } == true

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/datasource/SearchStreamsDataSource.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/datasource/SearchStreamsDataSource.kt
@@ -18,7 +18,7 @@ import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 
 internal class SearchStreamsDataSource(
-    private val query: String,
+    private val queries: List<String>,
     private val gqlHeaders: Map<String, String>,
     private val graphQLRepository: GraphQLRepository,
     private val helixHeaders: Map<String, String>,
@@ -28,8 +28,15 @@ internal class SearchStreamsDataSource(
     private val dropsRepository: DropsRepository? = null,
 ) : PagingSource<SearchPageKey, Stream>() {
 
+    private companion object {
+        const val FIRST_PAGE = "first"
+        const val MAX_DROP_SEARCH_PAGES = 3
+    }
+
     override suspend fun load(params: LoadParams<SearchPageKey>): LoadResult<SearchPageKey, Stream> {
-        if (query.isBlank()) {
+        val queryIndex = params.key?.queryIndex ?: 0
+        val query = queries.getOrNull(queryIndex)?.takeIf { it.isNotBlank() }
+        if (query == null) {
             return LoadResult.Page(
                 data = emptyList(),
                 prevKey = null,
@@ -38,10 +45,16 @@ internal class SearchStreamsDataSource(
         }
 
         return try {
-            val page = params.key?.let { key ->
-                loadFromApi(params.loadSize, key)
-            } ?: loadFirstPage(params.loadSize)
-            if (dropsFilters.isEmpty()) page else filterDropPage(page)
+            val page = loadPage(
+                loadSize = params.loadSize,
+                query = query,
+                state = params.key?.queryStates?.getOrNull(queryIndex),
+            )
+            val pageWithNextQuery = page.withNextQuery(
+                currentKey = params.key,
+                queryIndex = queryIndex,
+            )
+            if (dropsFilters.isEmpty()) pageWithNextQuery else filterDropPage(pageWithNextQuery)
         } catch (error: CancellationException) {
             throw error
         } catch (error: Exception) {
@@ -83,26 +96,38 @@ internal class SearchStreamsDataSource(
         }
     }
 
-    private suspend fun loadFirstPage(loadSize: Int): LoadResult<SearchPageKey, Stream> {
-        return try {
-            loadGql(loadSize, cursor = null)
-        } catch (error: Exception) {
-            if (error is CancellationException) throw error
-            loadHelix(loadSize, cursor = null)
+    private suspend fun loadPage(
+        loadSize: Int,
+        query: String,
+        state: SearchQueryPageState?,
+    ): LoadedStreamPage {
+        val api = state?.api
+        if (api == null) {
+            return try {
+                LoadedStreamPage(loadGql(loadSize, query, cursor = null), C.GQL)
+            } catch (error: Exception) {
+                if (error is CancellationException) throw error
+                LoadedStreamPage(loadHelix(loadSize, query, cursor = null), C.HELIX)
+            }
         }
+        return LoadedStreamPage(
+            result = when (api) {
+                C.GQL -> loadGql(loadSize, query, state.cursor)
+                C.HELIX -> loadHelix(loadSize, query, state.cursor)
+                else -> throw IOException("Unknown search stream API: $api")
+            },
+            api = api,
+        )
     }
 
-    private suspend fun loadFromApi(
-        loadSize: Int,
-        key: SearchPageKey,
-    ): LoadResult<SearchPageKey, Stream> = when (key.api) {
-        C.GQL -> loadGql(loadSize, key.cursor)
-        C.HELIX -> loadHelix(loadSize, key.cursor)
-        else -> throw IOException("Unknown search stream API: ${key.api}")
-    }
+    private data class LoadedStreamPage(
+        val result: LoadResult<SearchPageKey, Stream>,
+        val api: String,
+    )
 
     private suspend fun loadGql(
         loadSize: Int,
+        query: String,
         cursor: String?,
     ): LoadResult<SearchPageKey, Stream> {
         val response = graphQLRepository.loadQuerySearchStreams(
@@ -159,6 +184,7 @@ internal class SearchStreamsDataSource(
 
     private suspend fun loadHelix(
         loadSize: Int,
+        query: String,
         cursor: String?,
     ): LoadResult<SearchPageKey, Stream> {
         val response = helixRepository.getSearchChannels(
@@ -194,4 +220,38 @@ internal class SearchStreamsDataSource(
     }
 
     override fun getRefreshKey(state: PagingState<SearchPageKey, Stream>): SearchPageKey? = null
+
+    private fun LoadedStreamPage.withNextQuery(
+        currentKey: SearchPageKey?,
+        queryIndex: Int,
+    ): LoadResult<SearchPageKey, Stream> {
+        val page = result as? LoadResult.Page ?: return result
+        val states = List(queries.size) { index ->
+            currentKey?.queryStates?.getOrNull(index) ?: SearchQueryPageState()
+        }
+        val pagesLoaded = states[queryIndex].pagesLoaded + 1
+        val updatedStates = states.toMutableList().apply {
+            this[queryIndex] = SearchQueryPageState(
+                api = api,
+                cursor = page.nextKey?.cursor,
+                exhausted = isSearchQueryExhausted(
+                    hasNextPage = page.nextKey != null,
+                    pagesLoaded = pagesLoaded,
+                    pageBudget = MAX_DROP_SEARCH_PAGES.takeIf { dropsFilters.isNotEmpty() },
+                ),
+                pagesLoaded = pagesLoaded,
+            )
+        }
+        val nextIndex = nextSearchQueryIndex(queryIndex, updatedStates)
+            ?: return page.copy(nextKey = null)
+        val nextState = updatedStates[nextIndex]
+        return page.copy(
+            nextKey = SearchPageKey(
+                api = nextState.api ?: FIRST_PAGE,
+                cursor = nextState.cursor.orEmpty(),
+                queryIndex = nextIndex,
+                queryStates = updatedStates,
+            ),
+        )
+    }
 }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/search/SearchPagerFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/search/SearchPagerFragment.kt
@@ -79,6 +79,8 @@ class SearchPagerFragment : BaseNetworkFragment(), FragmentHost {
     private var initialTab = -1
     private var streamTabPosition = -1
     private var initialQueryPending = false
+    private var queryBeforeDropsFilters: String? = null
+    private var suppressQuerySearch = false
 
     override val currentFragment: Fragment?
         get() = childFragmentManager.findFragmentByTag("f${binding.viewPager.currentItem}")
@@ -88,6 +90,7 @@ class SearchPagerFragment : BaseNetworkFragment(), FragmentHost {
         firstLaunch = savedInstanceState == null
         initialQuery = if (savedInstanceState == null) arguments?.getString(INITIAL_QUERY) else null
         initialTab = if (savedInstanceState == null) arguments?.getInt(INITIAL_TAB, -1) ?: -1 else -1
+        queryBeforeDropsFilters = savedInstanceState?.getString(DROPS_QUERY_BEFORE)
         dropsFilters = if (savedInstanceState?.getBoolean(DROPS_FILTER_ENABLED) == false) {
             emptyList()
         } else {
@@ -282,13 +285,21 @@ class SearchPagerFragment : BaseNetworkFragment(), FragmentHost {
             private var job: Job? = null
 
             override fun onQueryTextSubmit(query: String): Boolean {
+                if (suppressQuerySearch) return false
+                if (dropsFilters.isNotEmpty() && query.isNotBlank()) {
+                    clearDropsFiltersForTextSearch()
+                }
                 searchCurrent(query.trim())
                 return false
             }
 
             override fun onQueryTextChange(newText: String): Boolean {
+                if (suppressQuerySearch) return false
                 job?.cancel()
                 val query = newText.trim()
+                if (dropsFilters.isNotEmpty() && query.isNotBlank()) {
+                    clearDropsFiltersForTextSearch()
+                }
                 if (query.isNotEmpty()) {
                     job = lifecycleScope.launch {
                         delay(350L)
@@ -343,7 +354,25 @@ class SearchPagerFragment : BaseNetworkFragment(), FragmentHost {
     }
 
     private fun applyDropsFilters(filters: List<DropStreamFilter>) {
-        dropsFilters = filters.distinctBy { it.campaignId to it.dropIds }
+        applyDropsFilters(filters, restorePreviousQuery = true)
+    }
+
+    private fun clearDropsFiltersForTextSearch() {
+        queryBeforeDropsFilters = null
+        initialQueryPending = false
+        applyDropsFilters(emptyList(), restorePreviousQuery = false)
+    }
+
+    private fun applyDropsFilters(
+        filters: List<DropStreamFilter>,
+        restorePreviousQuery: Boolean,
+    ) {
+        val nextFilters = filters.distinctBy { it.campaignId to it.dropIds }
+        if (dropsFilters.isEmpty() && nextFilters.isNotEmpty()) {
+            queryBeforeDropsFilters = binding.searchView.query.toString().trim()
+        }
+        dropsFilters = nextFilters
+        if (nextFilters.isNotEmpty()) initialQueryPending = false
         renderDropsFilters()
         if (dropsFilters.isNotEmpty() && streamTabPosition >= 0 &&
             binding.viewPager.currentItem != streamTabPosition
@@ -353,6 +382,26 @@ class SearchPagerFragment : BaseNetworkFragment(), FragmentHost {
         childFragmentManager.fragments
             .filterIsInstance<StreamSearchFragment>()
             .forEach { it.applyDropsFilters(dropsFilters) }
+        if (dropsFilters.isEmpty() && restorePreviousQuery) {
+            queryBeforeDropsFilters?.let(::setSearchQueryWithoutSaving)
+            queryBeforeDropsFilters = null
+        } else if (dropsFilters.isNotEmpty()) {
+            // Drop mode discovers streams from the selected campaigns' games. The old text
+            // query would be misleading here, especially when the picker selection changes
+            // from one game to another, so the chips become the visible search context.
+            setSearchQueryWithoutSaving("")
+        }
+    }
+
+    private fun setSearchQueryWithoutSaving(query: String) {
+        if (binding.searchView.query.toString() != query) {
+            suppressQuerySearch = true
+            binding.searchView.setQuery(query, false)
+            suppressQuerySearch = false
+        }
+        childFragmentManager.fragments
+            .filterIsInstance<StreamSearchFragment>()
+            .forEach { it.searchWithoutSaving(query) }
     }
 
     private fun renderDropsFilters() {
@@ -417,6 +466,7 @@ class SearchPagerFragment : BaseNetworkFragment(), FragmentHost {
     override fun onSaveInstanceState(outState: Bundle) {
         outState.putBoolean(DROPS_FILTER_ENABLED, dropsFilters.isNotEmpty())
         outState.putParcelableArrayList(DROPS_FILTERS, ArrayList(dropsFilters))
+        queryBeforeDropsFilters?.let { outState.putString(DROPS_QUERY_BEFORE, it) }
         super.onSaveInstanceState(outState)
     }
 
@@ -431,6 +481,7 @@ class SearchPagerFragment : BaseNetworkFragment(), FragmentHost {
         const val INITIAL_TAB = "initial_search_tab"
         const val DROPS_FILTER_ENABLED = "drops_filter_enabled"
         const val DROPS_FILTERS = "drops_filters"
+        private const val DROPS_QUERY_BEFORE = "drops_query_before"
         const val DROPS_CAMPAIGN_ID = "drops_campaign_id"
         const val DROPS_CAMPAIGN_NAME = "drops_campaign_name"
         const val DROPS_GAME_ID = "drops_game_id"
@@ -462,7 +513,7 @@ class SearchPagerFragment : BaseNetworkFragment(), FragmentHost {
 
         fun dropsSearchArguments(filters: List<DropStreamFilter>) = Bundle().apply {
             val first = filters.firstOrNull() ?: return@apply
-            putString(INITIAL_QUERY, first.gameName)
+            putString(INITIAL_QUERY, "")
             putInt(INITIAL_TAB, 1)
             putParcelableArrayList(DROPS_FILTERS, ArrayList(filters))
         }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/search/streams/StreamSearchFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/search/streams/StreamSearchFragment.kt
@@ -94,8 +94,10 @@ class StreamSearchFragment : PagedListFragment(), Searchable {
             viewLifecycleOwner.lifecycleScope.launch {
                 repeatOnLifecycle(Lifecycle.State.STARTED) {
                     pagingAdapter.loadStateFlow.collectLatest { loadState ->
-                        updatePagingState(binding, pagingAdapter, loadState, showEmpty = viewModel.query.value.isNotBlank())
-                        if (viewModel.query.value.isBlank() && requireContext().prefs().getBoolean(C.UI_STORE_RECENT_SEARCHES, true)) {
+                        val hasActiveSearch = viewModel.query.value.isNotBlank() ||
+                            viewModel.dropsFilters.value.isNotEmpty()
+                        updatePagingState(binding, pagingAdapter, loadState, showEmpty = hasActiveSearch)
+                        if (!hasActiveSearch && requireContext().prefs().getBoolean(C.UI_STORE_RECENT_SEARCHES, true)) {
                             recyclerView.adapter = recentSearchAdapter
                         } else {
                             if (recyclerView.adapter is RecentSearchAdapter) {
@@ -139,10 +141,16 @@ class StreamSearchFragment : PagedListFragment(), Searchable {
 
     fun clearDropsFilter() {
         viewModel.setDropsFilters(emptyList())
+        if (_binding != null && viewModel.query.value.isBlank() && binding.recyclerView.adapter is RecentSearchAdapter) {
+            binding.recyclerView.adapter = pagingAdapter
+        }
     }
 
     fun applyDropsFilters(filters: List<DropStreamFilter>) {
         viewModel.setDropsFilters(filters)
+        if (_binding != null && filters.isNotEmpty() && binding.recyclerView.adapter is RecentSearchAdapter) {
+            binding.recyclerView.adapter = pagingAdapter
+        }
     }
 
     companion object {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/search/streams/StreamSearchViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/search/streams/StreamSearchViewModel.kt
@@ -11,6 +11,7 @@ import androidx.paging.PagingConfig
 import androidx.paging.cachedIn
 import com.github.andreyasadchy.xtra.XtraApp
 import com.github.andreyasadchy.xtra.model.ui.DropStreamFilter
+import com.github.andreyasadchy.xtra.model.ui.searchQueries
 import com.github.andreyasadchy.xtra.model.ui.RecentSearch
 import com.github.andreyasadchy.xtra.repository.DropsRepository
 import com.github.andreyasadchy.xtra.repository.GraphQLRepository
@@ -52,7 +53,7 @@ class StreamSearchViewModel(
             }
         ) {
             SearchStreamsDataSource(
-                query = query,
+                queries = dropsFilters.searchQueries().ifEmpty { listOf(query) },
                 helixHeaders = TwitchApiHelper.getHelixHeaders(applicationContext),
                 helixRepository = helixRepository,
                 gqlHeaders = TwitchApiHelper.getGQLHeaders(applicationContext, true),

--- a/app/src/test/java/com/github/andreyasadchy/xtra/model/ui/DropStreamFilterTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/model/ui/DropStreamFilterTest.kt
@@ -1,6 +1,7 @@
 package com.github.andreyasadchy.xtra.model.ui
 
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -81,6 +82,43 @@ class DropStreamFilterTest {
                 streamGameName = "Game A",
                 campaigns = listOf(campaignB),
             ),
+        )
+    }
+
+    @Test
+    fun `multiple filters match any selected drop`() {
+        val gameBFilter = filter.copy(
+            campaignId = "campaign-b",
+            campaignName = "Campaign B",
+            gameId = "game-2",
+            gameName = "Game B",
+            dropIds = setOf("drop-b"),
+        )
+
+        assertTrue(
+            listOf(filter, gameBFilter).matchesDropStream(
+                streamGameId = "game-1",
+                streamGameName = "Black Desert",
+                campaigns = listOf(channelCampaign(id = "campaign", dropId = "drop-1")),
+            ),
+        )
+        assertTrue(
+            listOf(filter, gameBFilter).matchesDropStream(
+                streamGameId = "game-2",
+                streamGameName = "Game B",
+                campaigns = listOf(channelCampaign(id = "campaign-b", dropId = "drop-b")),
+            ),
+        )
+    }
+
+    @Test
+    fun `drop search queries are unique game names in selection order`() {
+        val secondGame = filter.copy(gameId = "game-2", gameName = "Game B")
+        val duplicateGame = filter.copy(gameName = " black desert ")
+
+        assertEquals(
+            listOf("Black Desert", "Game B"),
+            listOf(filter, secondGame, duplicateGame).searchQueries(),
         )
     }
 

--- a/app/src/test/java/com/github/andreyasadchy/xtra/repository/datasource/SearchStreamsPagingTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/repository/datasource/SearchStreamsPagingTest.kt
@@ -1,0 +1,59 @@
+package com.github.andreyasadchy.xtra.repository.datasource
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SearchStreamsPagingTest {
+    @Test
+    fun `drop game searches advance round robin`() {
+        val active = listOf(
+            SearchQueryPageState(exhausted = false),
+            SearchQueryPageState(exhausted = false),
+        )
+
+        assertEquals(1, nextSearchQueryIndex(currentIndex = 0, states = active))
+        assertEquals(0, nextSearchQueryIndex(currentIndex = 1, states = active))
+    }
+
+    @Test
+    fun `exhausted game searches are skipped`() {
+        val active = listOf(
+            SearchQueryPageState(exhausted = true),
+            SearchQueryPageState(exhausted = false),
+            SearchQueryPageState(exhausted = false),
+        )
+
+        assertEquals(1, nextSearchQueryIndex(currentIndex = 0, states = active))
+        assertEquals(1, nextSearchQueryIndex(currentIndex = 2, states = active))
+    }
+
+    @Test
+    fun `no next query remains after all game searches are exhausted`() {
+        assertNull(
+            nextSearchQueryIndex(
+                currentIndex = 0,
+                states = listOf(
+                    SearchQueryPageState(exhausted = true),
+                    SearchQueryPageState(exhausted = true),
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `page budget can exhaust a game before its upstream cursor`() {
+        assertFalse(isSearchQueryExhausted(hasNextPage = true, pagesLoaded = 2, pageBudget = 3))
+        assertTrue(isSearchQueryExhausted(hasNextPage = true, pagesLoaded = 3, pageBudget = 3))
+        assertTrue(isSearchQueryExhausted(hasNextPage = false, pagesLoaded = 1, pageBudget = 3))
+        assertFalse(isSearchQueryExhausted(hasNextPage = true, pagesLoaded = 100, pageBudget = null))
+        assertNull(
+            nextSearchQueryIndex(
+                currentIndex = 0,
+                states = listOf(SearchQueryPageState(exhausted = true)),
+            ),
+        )
+    }
+}


### PR DESCRIPTION
Selecting a Drops filter now searches the selected campaign games and keeps multi-Drop results useful. The stale text query is cleared, filtered results stay visible, and normal typing exits Drops mode.