### PR TITLE
Fix followage and emote rendering

### DIFF
--- a/app/src/main/graphql/UserMessageClicked.graphql
+++ b/app/src/main/graphql/UserMessageClicked.graphql
@@ -2,7 +2,7 @@ fragment UserMessageClickedUser on User {
     bannerImageURL
     createdAt
     displayName
-    follow(targetID: $targetId) {
+    follow(targetID: $targetId, targetLogin: $targetLogin) {
         followedAt
     }
     displayBadges(channelID: $targetId) {
@@ -49,7 +49,7 @@ query UserMessageClicked($id: ID, $login: String, $targetId: ID, $userLogin: Str
     }
 }
 
-query UserMessageClickedBasic($id: ID, $login: String, $targetId: ID) {
+query UserMessageClickedBasic($id: ID, $login: String, $targetId: ID, $targetLogin: String) {
     user(id: $id, login: $login, lookupType: ALL) {
         ...UserMessageClickedUser
     }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/model/misc/FFZResponse.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/model/misc/FFZResponse.kt
@@ -11,6 +11,8 @@ class FFZResponse(
     class Emote(
         val id: Int? = null,
         val name: String? = null,
+        val width: Int? = null,
+        val height: Int? = null,
         val animated: Urls? = null,
         val urls: Urls? = null,
     )

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/GraphQLRepository.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/GraphQLRepository.kt
@@ -850,11 +850,12 @@ class GraphQLRepository(
         sendQuery(networkLibrary, headers, query)
     }
 
-    suspend fun loadBasicQueryUserMessageClicked(networkLibrary: String?, headers: Map<String, String>, id: String? = null, login: String? = null, targetId: String?): ApolloResponse<UserMessageClickedBasicQuery.Data> = withContext(Dispatchers.IO) {
+    suspend fun loadBasicQueryUserMessageClicked(networkLibrary: String?, headers: Map<String, String>, id: String? = null, login: String? = null, targetId: String?, targetLogin: String? = null): ApolloResponse<UserMessageClickedBasicQuery.Data> = withContext(Dispatchers.IO) {
         val query = UserMessageClickedBasicQuery(
             id = if (!id.isNullOrBlank()) Optional.Present(id) else Optional.Absent,
             login = if (!login.isNullOrBlank()) Optional.Present(login) else Optional.Absent,
             targetId = Optional.Present(targetId),
+            targetLogin = if (!targetLogin.isNullOrBlank()) Optional.Present(targetLogin) else Optional.Absent,
         )
         sendQuery(networkLibrary, headers, query)
     }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/PlayerRepository.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/PlayerRepository.kt
@@ -140,6 +140,41 @@ internal fun parseBTTVEmotes(response: List<BTTVResponse>, useWebp: Boolean, sou
     }
 }
 
+internal fun parseFFZEmotes(response: List<FFZResponse.Emote>, useWebp: Boolean, source: Int): List<Emote> {
+    return response.mapNotNull { emote ->
+        emote.name?.takeIf { it.isNotBlank() }?.let { name ->
+            val isAnimated = emote.animated != null
+            if (isAnimated) {
+                if (useWebp) {
+                    emote.animated
+                } else {
+                    FFZResponse.Urls(
+                        url1x = emote.animated.url1x + ".gif",
+                        url2x = emote.animated.url2x + ".gif",
+                        url4x = emote.animated.url4x + ".gif",
+                    )
+                }
+            } else {
+                emote.urls
+            }?.let { urls ->
+                Emote(
+                    name = name,
+                    id = emote.id?.toString(),
+                    url1x = urls.url1x,
+                    url2x = urls.url2x,
+                    url3x = urls.url2x,
+                    url4x = urls.url4x,
+                    format = if (isAnimated && useWebp) "webp" else null,
+                    isAnimated = isAnimated,
+                    source = source,
+                    width = emote.width,
+                    height = emote.height,
+                )
+            }
+        }
+    }
+}
+
 @OptIn(UnstableApi::class)
 class PlayerRepository(
     private val httpEngine: Lazy<HttpEngine?>,
@@ -1728,39 +1763,6 @@ class PlayerRepository(
         val response = json.decodeFromString<FFZChannelResponse>(response)
         response.sets.entries.flatMap {
             it.value.emoticons?.let { emotes -> parseFFZEmotes(emotes, useWebp, Emote.CHANNEL_FFZ) } ?: emptyList()
-        }
-    }
-
-    private fun parseFFZEmotes(response: List<FFZResponse.Emote>, useWebp: Boolean, source: Int): List<Emote> {
-        return response.mapNotNull { emote ->
-            emote.name?.takeIf { it.isNotBlank() }?.let { name ->
-                val isAnimated = emote.animated != null
-                if (isAnimated) {
-                    if (useWebp) {
-                        emote.animated
-                    } else {
-                        FFZResponse.Urls(
-                            url1x = emote.animated.url1x + ".gif",
-                            url2x = emote.animated.url2x + ".gif",
-                            url4x = emote.animated.url4x + ".gif",
-                        )
-                    }
-                } else {
-                    emote.urls
-                }?.let { urls ->
-                    Emote(
-                        name = name,
-                        id = emote.id?.toString(),
-                        url1x = urls.url1x,
-                        url2x = urls.url2x,
-                        url3x = urls.url2x,
-                        url4x = urls.url4x,
-                        format = if (isAnimated && useWebp) "webp" else null,
-                        isAnimated = isAnimated,
-                        source = source,
-                    )
-                }
-            }
         }
     }
 

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/MessageClickedViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/MessageClickedViewModel.kt
@@ -71,6 +71,7 @@ class MessageClickedViewModel(
                             channelId,
                             channelLogin.takeIf { channelId.isNullOrBlank() },
                             targetId,
+                            targetLogin,
                         ).data
                         data?.user?.userMessageClickedUser?.let { clickedUser ->
                             mapUser(clickedUser, isSubscribedHint = isSubscribedHint)

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/recommendations/EmoteRecommendationEngine.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/recommendations/EmoteRecommendationEngine.kt
@@ -64,10 +64,11 @@ class EmoteRecommendationEngine(
         usage: List<EmoteUsage>,
         viewerId: String,
     ): List<EmoteRecommendation> {
-        if (query.isBlank()) return emptyList()
+        val normalizedQuery = query.trim().removePrefix(":").removeSuffix(":")
+        if (normalizedQuery.isBlank()) return emptyList()
         val usageByKey = usage.associateBy(EmoteUsage::usageKey)
         return catalog.emotes.mapNotNull { emote ->
-            val match = matcher.match(emote.name, query) ?: return@mapNotNull null
+            val match = matcher.match(emote.name, normalizedQuery) ?: return@mapNotNull null
             val record = usageByKey[EmoteUsageKeys.forEmote(emote, channelId, viewerId)]
             EmoteRecommendation(
                 emote = emote,

--- a/app/src/test/java/com/github/andreyasadchy/xtra/repository/PlayerRepositoryEmoteParserTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/repository/PlayerRepositoryEmoteParserTest.kt
@@ -2,6 +2,7 @@ package com.github.andreyasadchy.xtra.repository
 
 import com.github.andreyasadchy.xtra.model.chat.Emote
 import com.github.andreyasadchy.xtra.model.misc.BTTVResponse
+import com.github.andreyasadchy.xtra.model.misc.FFZResponse
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
@@ -68,5 +69,25 @@ class PlayerRepositoryEmoteParserTest {
         assertEquals(72, emote.width)
         assertEquals(24, emote.height)
         assertTrue(emote.isOverlayEmote)
+    }
+
+    @Test
+    fun ffzParserPreservesAspectRatioMetadata() {
+        val emote = FFZResponse.Emote(
+            id = 9,
+            name = "WideWave",
+            width = 90,
+            height = 30,
+            urls = FFZResponse.Urls(url4x = "https://cdn.example/wide"),
+        )
+
+        val parsed = parseFFZEmotes(
+            listOf(emote),
+            useWebp = true,
+            source = Emote.GLOBAL_FFZ,
+        ).single()
+
+        assertEquals(90, parsed.width)
+        assertEquals(30, parsed.height)
     }
 }

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/recommendations/EmoteRecommendationEngineTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/recommendations/EmoteRecommendationEngineTest.kt
@@ -94,6 +94,23 @@ class EmoteRecommendationEngineTest {
     }
 
     @Test
+    fun `recommendation query accepts colon-delimited emote syntax`() {
+        val kappa = emote("Kappa", "kappa")
+        val catalog = engine.catalog(ChatCatalogSnapshot(1, twitch = mapOf(kappa.name to kappa)))
+
+        assertEquals(
+            listOf("Kappa"),
+            engine.recommend(":kap", "channel", catalog, emptyList(), EmoteUsageKeys.ANONYMOUS_VIEWER_ID)
+                .map { it.emote.name },
+        )
+        assertEquals(
+            listOf("Kappa"),
+            engine.recommend(":kappa:", "channel", catalog, emptyList(), EmoteUsageKeys.ANONYMOUS_VIEWER_ID)
+                .map { it.emote.name },
+        )
+    }
+
+    @Test
     fun `other chatters personal sets are not recommendation or send candidates`() {
         val viewer = emote("ViewerOnly", "viewer", ChatEmoteScope.PERSONAL, ChatAssetProvider.SEVEN_TV)
         val chatter = emote("ChatterOnly", "chatter", ChatEmoteScope.PERSONAL, ChatAssetProvider.SEVEN_TV)


### PR DESCRIPTION
Restores channel followage in user cards, supports colon emote lookup, and preserves FFZ wide-emote dimensions so chat emotes render without distortion or clipping.