### PR TITLE
Make chat emote suggestions configurable

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatFragment.kt
@@ -471,6 +471,8 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
 
     private var autoCompleteAdapter: AutoCompleteAdapter<Any>? = null
     private var recommendationAdapter: EmoteRecommendationAdapter? = null
+    private var emoteAutocompleteEnabled = true
+    private var emoteRecommendationsEnabled = true
     private val recommendationEngine = EmoteRecommendationEngine()
     private val recommendationInput = MutableStateFlow(RecommendationInput())
     private var currentRecommendations = emptyList<EmoteRecommendation>()
@@ -893,6 +895,14 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
                     val enableMessaging = isLive && isLoggedIn &&
                             viewModel.activeChatMode is ChatViewModel.ActiveChatMode.Live
                     messagingEnabled = enableMessaging
+                    emoteAutocompleteEnabled = requireContext().prefs().getBoolean(
+                        C.CHAT_EMOTE_AUTOCOMPLETE,
+                        true,
+                    )
+                    emoteRecommendationsEnabled = requireContext().prefs().getBoolean(
+                        C.CHAT_EMOTE_RECOMMENDATIONS,
+                        true,
+                    )
                     val chatStyle = resolveChatRenderStyle(requireContext())
                     val profilePopoutGesture = ChatProfilePopoutGesture.fromPreference(
                         requireContext().prefs().getString(C.CHAT_PROFILE_POPOUT_GESTURE, "tap"),
@@ -1244,35 +1254,47 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
                                 }
                             }
                         }
-                        autoCompleteAdapter = AutoCompleteAdapter(
-                            requireContext(),
-                            R.layout.auto_complete_emotes_list_item,
-                            R.id.name,
-                            viewModel.autoCompleteList,
-                        ).apply {
-                            setNotifyOnChange(false)
-                            editText.setAdapter(this)
+                        if (emoteAutocompleteEnabled) {
+                            autoCompleteAdapter = AutoCompleteAdapter(
+                                requireContext(),
+                                R.layout.auto_complete_emotes_list_item,
+                                R.id.name,
+                                viewModel.autoCompleteList,
+                            ).apply {
+                                setNotifyOnChange(false)
+                                editText.setAdapter(this)
 
-                            var previousSize = 0
-                            editText.setOnFocusChangeListener { _, hasFocus ->
-                                if (hasFocus && count != previousSize) {
-                                    previousSize = count
-                                    notifyDataSetChanged()
+                                var previousSize = 0
+                                editText.setOnFocusChangeListener { _, hasFocus ->
+                                    if (hasFocus && count != previousSize) {
+                                        previousSize = count
+                                        notifyDataSetChanged()
+                                    }
+                                    setNotifyOnChange(hasFocus)
                                 }
-                                setNotifyOnChange(hasFocus)
                             }
+                        } else {
+                            autoCompleteAdapter = null
+                            editText.setAdapter(null)
+                            editText.dismissDropDown()
                         }
-                        val app = requireContext().applicationContext as XtraApp
-                        recommendationAdapter = EmoteRecommendationAdapter(
-                            assets = app.xtraModule.chatAssetRepository,
-                            clickListener = ::insertRecommendedEmote,
-                        )
-                        recommendationStrip.layoutManager = LinearLayoutManager(
-                            requireContext(),
-                            LinearLayoutManager.HORIZONTAL,
-                            false,
-                        )
-                        recommendationStrip.adapter = recommendationAdapter
+                        if (emoteRecommendationsEnabled) {
+                            val app = requireContext().applicationContext as XtraApp
+                            recommendationAdapter = EmoteRecommendationAdapter(
+                                assets = app.xtraModule.chatAssetRepository,
+                                clickListener = ::insertRecommendedEmote,
+                            )
+                            recommendationStrip.layoutManager = LinearLayoutManager(
+                                requireContext(),
+                                LinearLayoutManager.HORIZONTAL,
+                                false,
+                            )
+                            recommendationStrip.adapter = recommendationAdapter
+                        } else {
+                            recommendationAdapter = null
+                            recommendationStrip.adapter = null
+                            recommendationStrip.isVisible = false
+                        }
                         if (useChatV2) {
                             viewLifecycleOwner.lifecycleScope.launch {
                                 repeatOnLifecycle(Lifecycle.State.STARTED) {
@@ -1285,51 +1307,55 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
                                     }
                                 }
                             }
-                            viewLifecycleOwner.lifecycleScope.launch {
-                                repeatOnLifecycle(Lifecycle.State.STARTED) {
-                                    combine(
-                                        recommendationInput,
-                                        viewModel.emoteRecommendationCatalogFor(channelId, channelLogin, useV2 = true),
-                                    ) { input, catalog ->
-                                        withContext(Dispatchers.Default) {
-                                            val token = ChatInputToken.aroundCursor(input.text, input.cursor)
-                                            if (token == null) {
-                                                RecommendationResult("", emptyList())
-                                            } else if (catalog == null) {
-                                                RecommendationResult(token.text, emptyList())
-                                            } else {
-                                                RecommendationResult(
-                                                    query = token.text,
-                                                    recommendations = recommendationEngine.recommend(
+                            if (emoteRecommendationsEnabled) {
+                                viewLifecycleOwner.lifecycleScope.launch {
+                                    repeatOnLifecycle(Lifecycle.State.STARTED) {
+                                        combine(
+                                            recommendationInput,
+                                            viewModel.emoteRecommendationCatalogFor(channelId, channelLogin, useV2 = true),
+                                        ) { input, catalog ->
+                                            withContext(Dispatchers.Default) {
+                                                val token = ChatInputToken.aroundCursor(input.text, input.cursor)
+                                                if (token == null) {
+                                                    RecommendationResult("", emptyList())
+                                                } else if (catalog == null) {
+                                                    RecommendationResult(token.text, emptyList())
+                                                } else {
+                                                    RecommendationResult(
                                                         query = token.text,
-                                                        channelId = channelId.orEmpty(),
-                                                        catalog = catalog.catalog,
-                                                        usage = catalog.usage,
-                                                        viewerId = catalog.viewerId,
-                                                    ),
-                                                )
+                                                        recommendations = recommendationEngine.recommend(
+                                                            query = token.text,
+                                                            channelId = channelId.orEmpty(),
+                                                            catalog = catalog.catalog,
+                                                            usage = catalog.usage,
+                                                            viewerId = catalog.viewerId,
+                                                        ),
+                                                    )
+                                                }
                                             }
+                                        }.collectLatest { result ->
+                                            val queryChanged = currentRecommendationQuery != result.query
+                                            currentRecommendationQuery = result.query
+                                            currentRecommendations = result.recommendations
+                                            if (queryChanged) {
+                                                recommendationStrip.stopScroll()
+                                                recommendationStrip.scrollToPosition(0)
+                                            }
+                                            recommendationAdapter?.submitList(result.recommendations)
+                                            updateRecommendationVisibility()
                                         }
-                                    }.collectLatest { result ->
-                                        val queryChanged = currentRecommendationQuery != result.query
-                                        currentRecommendationQuery = result.query
-                                        currentRecommendations = result.recommendations
-                                        if (queryChanged) {
-                                            recommendationStrip.stopScroll()
-                                            recommendationStrip.scrollToPosition(0)
-                                        }
-                                        recommendationAdapter?.submitList(result.recommendations)
-                                        updateRecommendationVisibility()
                                     }
                                 }
                             }
                         }
                         editText.addTextChangedListener(onTextChanged = { text, _, _, _ ->
-                            updateRecommendationInput()
+                            if (emoteRecommendationsEnabled) updateRecommendationInput()
                             updateComposerButtons()
                         })
-                        editText.onSelectionChangedListener = { _, _ -> updateRecommendationInput() }
-                        updateRecommendationInput()
+                        editText.onSelectionChangedListener = { _, _ ->
+                            if (emoteRecommendationsEnabled) updateRecommendationInput()
+                        }
+                        if (emoteRecommendationsEnabled) updateRecommendationInput()
                         editText.setTokenizer(SpaceTokenizer())
                         editText.setOnKeyListener { _, keyCode, event ->
                             if (event.action == KeyEvent.ACTION_DOWN && keyCode == KeyEvent.KEYCODE_ENTER) {
@@ -2462,6 +2488,7 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
     }
 
     private fun updateRecommendationInput() {
+        if (!emoteRecommendationsEnabled) return
         val current = _binding?.editText ?: return
         recommendationInput.value = RecommendationInput(
             text = current.text.toString(),
@@ -2471,7 +2498,8 @@ class ChatFragment : BaseNetworkFragment(), MessageClickedDialog.OnButtonClickLi
 
     private fun updateRecommendationVisibility() {
         val currentBinding = _binding ?: return
-        currentBinding.recommendationStrip.isVisible = currentRecommendations.isNotEmpty() &&
+        currentBinding.recommendationStrip.isVisible = emoteRecommendationsEnabled &&
+                currentRecommendations.isNotEmpty() &&
                 messagingEnabled && currentBinding.messageView.isVisible
     }
 

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/domain/ChatMessage.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/domain/ChatMessage.kt
@@ -79,7 +79,16 @@ data class ChatAssetSpec(
     val overlays: List<ChatAssetSpec> = emptyList(),
 ) {
     val computedWidth: Int
-        get() = (sourceWidth.toLong() * targetHeight / sourceHeight.coerceAtLeast(1)).toInt().coerceAtLeast(1)
+        get() {
+            val height = targetHeight.coerceAtLeast(1)
+            val proportionalWidth = sourceWidth.toLong().coerceAtLeast(1) * height / sourceHeight.coerceAtLeast(1)
+            // Provider metadata is untrusted. Keep an extreme aspect ratio from reserving a
+            // span wider than the chat viewport and destabilizing TextView line layout.
+            return proportionalWidth.coerceIn(
+                ((height.toLong() + 1) / 2).coerceAtLeast(1),
+                height.toLong() * 4,
+            ).toInt()
+        }
     val compositionKey: String
         get() = buildString {
             append(key.value).append(':').append(sourceWidth).append('x').append(sourceHeight).append('@').append(targetHeight)

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/C.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/C.kt
@@ -306,6 +306,8 @@ object C {
     const val CHAT_ENABLE_STV = "chat_enable_stv"
     const val CHAT_ENABLE_BTTV = "chat_enable_bttv"
     const val CHAT_ENABLE_FFZ = "chat_enable_ffz"
+    const val CHAT_EMOTE_AUTOCOMPLETE = "chat_emote_autocomplete"
+    const val CHAT_EMOTE_RECOMMENDATIONS = "chat_emote_recommendations"
     const val CHAT_DISABLE = "chat_disable"
     const val CHAT_POINTS_COLLECT = "chat_points_collect"
     const val CHAT_POINTS_NOTIFY = "chat_points_notify"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -491,6 +491,11 @@
     <string name="chat_moderation_display_hide">Hide message</string>
     <string name="chat_moderation_display_preview_title">Preview</string>
     <string name="chat_moderation_preview_summary">Preview of the selected deleted and moderated message style.</string>
+    <string name="chat_emote_suggestions">Emote suggestions</string>
+    <string name="chat_emote_autocomplete">Autocomplete dropdown</string>
+    <string name="chat_emote_autocomplete_summary">Show matching emotes while typing.</string>
+    <string name="chat_emote_recommendations">Recommendation strip</string>
+    <string name="chat_emote_recommendations_summary">Show ranked emotes above the chat input.</string>
     <string name="settings_username_appearance">Username appearance</string>
     <string name="settings_7tv_appearance">7TV appearance</string>
     <string name="settings_chat_size">Chat size</string>

--- a/app/src/main/res/xml/chat_emotes_preferences.xml
+++ b/app/src/main/res/xml/chat_emotes_preferences.xml
@@ -3,6 +3,11 @@
     <Preference android:key="chat_7tv_appearance" android:dependency="chat_enable_stv" android:title="@string/settings_7tv_appearance" app:iconSpaceReserved="false" />
     <SwitchPreferenceCompat android:defaultValue="true" android:key="chat_enable_bttv" android:title="@string/enable_bttv" app:iconSpaceReserved="false" />
     <SwitchPreferenceCompat android:defaultValue="true" android:key="chat_enable_ffz" android:title="@string/enable_ffz" app:iconSpaceReserved="false" />
+
+    <PreferenceCategory android:title="@string/chat_emote_suggestions" app:iconSpaceReserved="false" />
+    <SwitchPreferenceCompat android:defaultValue="true" android:key="chat_emote_autocomplete" android:summary="@string/chat_emote_autocomplete_summary" android:title="@string/chat_emote_autocomplete" app:iconSpaceReserved="false" />
+    <SwitchPreferenceCompat android:defaultValue="true" android:key="chat_emote_recommendations" android:summary="@string/chat_emote_recommendations_summary" android:title="@string/chat_emote_recommendations" app:iconSpaceReserved="false" />
+
     <SwitchPreferenceCompat android:defaultValue="true" android:key="animatedGifEmotes" android:title="@string/animated_emotes" app:iconSpaceReserved="false" />
     <SwitchPreferenceCompat android:defaultValue="true" android:key="chat_zerowidth" android:title="@string/overlay_emotes" app:iconSpaceReserved="false" />
 </androidx.preference.PreferenceScreen>

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/domain/ChatAssetSpecTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/domain/ChatAssetSpecTest.kt
@@ -1,0 +1,20 @@
+package com.github.andreyasadchy.xtra.ui.chat.v2.domain
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ChatAssetSpecTest {
+    @Test
+    fun `normal aspect ratio is preserved`() {
+        val spec = ChatAssetSpec(ChatAssetKey("normal"), sourceWidth = 200, sourceHeight = 100, targetHeight = 28)
+
+        assertEquals(56, spec.computedWidth)
+    }
+
+    @Test
+    fun `extreme provider aspect ratio is capped for inline layout`() {
+        val spec = ChatAssetSpec(ChatAssetKey("malformed"), sourceWidth = 9_000, sourceHeight = 1, targetHeight = 28)
+
+        assertEquals(112, spec.computedWidth)
+    }
+}


### PR DESCRIPTION
Keeps extreme emotes from breaking chat and lets users independently turn the autocomplete dropdown and recommendation strip on or off.