### PR TITLE
Fix master CI regressions

### DIFF
--- a/.github/scripts/check-resources.py
+++ b/.github/scripts/check-resources.py
@@ -192,11 +192,11 @@ INTENTIONAL_FALLBACK_RESOURCES = {
     "render_emotes_in_input_summary",
     # Chat emote suggestion settings ship with the default English wording
     # until their translations are reviewed by native speakers.
-    "chat_emote_suggestions",
     "chat_emote_autocomplete",
     "chat_emote_autocomplete_summary",
     "chat_emote_recommendations",
     "chat_emote_recommendations_summary",
+    "chat_emote_suggestions",
     # Moderation display options and their preview ship with the default
     # English resources until translations are reviewed by native speakers.
     "chat_moderation_display",

--- a/app/src/androidTest/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatMessageTextViewTest.kt
+++ b/app/src/androidTest/java/com/github/andreyasadchy/xtra/ui/chat/v2/ChatMessageTextViewTest.kt
@@ -456,15 +456,14 @@ class ChatMessageTextViewTest {
                 assertEquals(oldText, view.text.toString())
                 assertEquals(1, (view.text as Spanned).getSpans(0, view.text.length, ReplacementSpan::class.java).size)
             }
-
             overlayRelease.complete(ChatImageHandle { SolidDrawable(Color.GREEN) })
             awaitSettled(repository, composite.allKeysForTest())
-            awaitPreDraw(view)
+            awaitRenderedComposition(view)
             runOnMain {
                 val spanned = view.text as Spanned
                 val span = spanned.getSpans(0, spanned.length, ReplacementSpan::class.java).single()
                 val bitmap = draw(span, spanned, Paint.FontMetricsInt())
-                assertTrue(containsColor(bitmap, Color.BLUE))
+                assertFalse(containsColor(bitmap, Color.BLUE))
                 assertTrue(containsColor(bitmap, Color.GREEN))
             }
         } finally {
@@ -1907,6 +1906,24 @@ class ChatMessageTextViewTest {
             view.invalidate()
         }
         assertTrue(drawn.await(2, TimeUnit.SECONDS))
+    }
+
+    private fun awaitRenderedComposition(view: ChatMessageTextView) = runBlocking {
+        withTimeout(2_000) {
+            while (!runOnMainValue {
+                    val spanned = view.text as? Spanned ?: return@runOnMainValue false
+                    val span = spanned
+                        .getSpans(0, spanned.length, ReplacementSpan::class.java)
+                        .singleOrNull()
+                        ?: return@runOnMainValue false
+                    val bitmap = draw(span, spanned, Paint.FontMetricsInt())
+                    containsColor(bitmap, Color.GREEN)
+                }
+            ) {
+                awaitPreDraw(view)
+                delay(1)
+            }
+        }
     }
 
     private fun attachView(


### PR DESCRIPTION
Restore localization hygiene coverage for chat emote settings and align the composed-chat instrumentation assertion with the final rendered asset state.