### PR TITLE
Fix Browse category pagination

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/gamefeed/GameFeedSpecs.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/gamefeed/GameFeedSpecs.kt
@@ -20,7 +20,7 @@ object GameFeedSpecs {
         val normalizedTags = tags?.map { it.trim() }?.filter { it.isNotEmpty() }?.distinct()
         val loader: GameFeedPageLoader = TwitchGameFeedPageLoader(
             tags = normalizedTags?.takeIf { it.isNotEmpty() },
-            gqlHeaders = { TwitchApiHelper.getGQLHeaders(context) },
+            gqlHeaders = { TwitchApiHelper.getGQLHeaders(context, true) },
             graphQLRepository = graphQLRepository,
             helixHeaders = { TwitchApiHelper.getHelixHeaders(context) },
             helixRepository = helixRepository,


### PR DESCRIPTION
Pass the authenticated Twitch GQL headers to the category feed so cursor pagination can refresh integrity and continue loading categories past the first page.