### PR TITLE
Redesign Browse category tiles

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/GameTags.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/GameTags.kt
@@ -1,17 +1,14 @@
 package com.github.andreyasadchy.xtra.ui.common
 
-import android.util.TypedValue
 import android.view.LayoutInflater
 import android.view.View
 import android.widget.TextView
 import androidx.constraintlayout.helper.widget.Flow
 import androidx.constraintlayout.widget.ConstraintLayout
-import androidx.core.content.res.use
-import androidx.core.widget.TextViewCompat
 import com.github.andreyasadchy.xtra.R
 import com.github.andreyasadchy.xtra.model.ui.Tag
 
-/** Reuses a fixed tag hierarchy so game row binding never creates or removes views. */
+/** Reuses a fixed tag hierarchy so category tile binding never creates or removes views. */
 internal class GameTagViews(
     private val tagsLayout: ConstraintLayout,
     private val tagViews: List<TextView>,
@@ -73,29 +70,20 @@ internal fun createGameTagViews(tagsLayout: ConstraintLayout): GameTagViews {
             endToEnd = tagsLayout.id
         }
         setWrapMode(Flow.WRAP_CHAIN)
+        setHorizontalStyle(Flow.CHAIN_PACKED)
+        setHorizontalBias(0f)
+        setHorizontalAlign(Flow.HORIZONTAL_ALIGN_START)
+        setVerticalAlign(Flow.VERTICAL_ALIGN_TOP)
     }
     tagsLayout.addView(flow)
 
-    val minHeight = TypedValue.applyDimension(
-        TypedValue.COMPLEX_UNIT_DIP,
-        48f,
-        context.resources.displayMetrics,
-    ).toInt()
-    val padding = TypedValue.applyDimension(
-        TypedValue.COMPLEX_UNIT_DIP,
-        5f,
-        context.resources.displayMetrics,
-    ).toInt()
+    flow.setHorizontalGap(context.resources.getDimensionPixelSize(R.dimen.stream_tag_gap))
+    flow.setVerticalGap(context.resources.getDimensionPixelSize(R.dimen.stream_tag_gap))
+
+    val inflater = LayoutInflater.from(context)
     val tagViews = List(10) {
-        TextView(context).apply {
+        (inflater.inflate(R.layout.item_stream_tag, tagsLayout, false) as TextView).apply {
             id = View.generateViewId()
-            setMinHeight(minHeight)
-            isFocusable = false
-            isClickable = false
-            context.obtainStyledAttributes(intArrayOf(com.google.android.material.R.attr.textAppearanceBodyMedium)).use {
-                TextViewCompat.setTextAppearance(this, it.getResourceId(0, 0))
-            }
-            setPadding(padding, 0, padding, 0)
             tagsLayout.addView(this)
         }
     }

--- a/app/src/main/res/drawable/bg_game_viewer_dot.xml
+++ b/app/src/main/res/drawable/bg_game_viewer_dot.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+    <size
+        android:width="6dp"
+        android:height="6dp" />
+    <solid android:color="@color/liveStreamRed" />
+</shape>

--- a/app/src/main/res/layout/fragment_games_list_item.xml
+++ b/app/src/main/res/layout/fragment_games_list_item.xml
@@ -1,95 +1,79 @@
 <?xml version="1.0" encoding="utf-8"?>
-<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    style="?attr/cardStyle"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content">
+    android:layout_height="wrap_content"
+    android:layout_marginStart="4dp"
+    android:layout_marginTop="4dp"
+    android:layout_marginEnd="4dp"
+    android:layout_marginBottom="8dp"
+    android:background="?android:attr/colorBackground"
+    android:clickable="true"
+    android:focusable="true"
+    android:foreground="?attr/selectableItemBackground"
+    android:orientation="vertical">
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
 
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/topLayout"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            app:layout_constraintTop_toTopOf="parent">
-
-            <ImageView
-                android:id="@+id/gameImage"
-                android:layout_width="49dp"
-                android:layout_height="65dp"
-                android:importantForAccessibility="no"
-                android:layout_marginStart="10dp"
-                android:layout_marginTop="10dp"
-                android:layout_marginBottom="10dp"
-                android:visibility="gone"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
-                app:layout_constraintVertical_bias="0.0"
-                tools:src="@tools:sample/backgrounds/scenic"
-                tools:visibility="visible" />
-
-            <LinearLayout
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="10dp"
-                android:layout_marginEnd="10dp"
-                android:layout_marginTop="7dp"
-                android:layout_marginBottom="7dp"
-                android:orientation="vertical"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toEndOf="@id/gameImage"
-                app:layout_constraintTop_toTopOf="parent">
-
-                <TextView
-                    android:id="@+id/gameName"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:textAppearance="?attr/textAppearanceTitleMedium"
-                    android:visibility="gone"
-                    tools:text="@sample/games.json/top/game/name"
-                    tools:visibility="visible" />
-
-                <TextView
-                    android:id="@+id/viewers"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:textAppearance="?attr/textAppearanceBodyMedium"
-                    android:textColor="?android:attr/textColorSecondary"
-                    android:visibility="gone"
-                    tools:text="123456 viewers"
-                    tools:visibility="visible" />
-
-                <TextView
-                    android:id="@+id/broadcastersCount"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:textAppearance="?attr/textAppearanceBodyMedium"
-                    android:textColor="?android:attr/textColorSecondary"
-                    android:visibility="gone"
-                    tools:text="123456 broadcasters"
-                    tools:visibility="visible" />
-            </LinearLayout>
-
-        </androidx.constraintlayout.widget.ConstraintLayout>
-
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/tagsLayout"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="10dp"
-            android:layout_marginTop="7dp"
-            android:layout_marginEnd="10dp"
-            android:layout_marginBottom="7dp"
-            android:visibility="gone"
-            app:layout_constraintBottom_toBottomOf="parent"
+        <ImageView
+            android:id="@+id/gameImage"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:background="@drawable/bg_thumbnail_placeholder"
+            android:clipToOutline="true"
+            android:importantForAccessibility="no"
+            android:scaleType="centerCrop"
+            app:layout_constraintDimensionRatio="H,3:4"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/topLayout" />
-
+            app:layout_constraintTop_toTopOf="parent"
+            tools:src="@tools:sample/backgrounds/scenic" />
     </androidx.constraintlayout.widget.ConstraintLayout>
-</com.google.android.material.card.MaterialCardView>
+
+    <TextView
+        android:id="@+id/gameName"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="6dp"
+        android:ellipsize="end"
+        android:maxLines="2"
+        android:textAppearance="?attr/textAppearanceTitleSmall"
+        android:textStyle="bold"
+        tools:text="League of Legends" />
+
+    <TextView
+        android:id="@+id/viewers"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="2dp"
+        android:drawableStart="@drawable/bg_game_viewer_dot"
+        android:drawablePadding="4dp"
+        android:ellipsize="end"
+        android:gravity="center_vertical"
+        android:maxLines="1"
+        android:textAppearance="?attr/textAppearanceBodySmall"
+        android:textColor="?android:attr/textColorSecondary"
+        tools:text="1.2M viewers" />
+
+    <TextView
+        android:id="@+id/broadcastersCount"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:ellipsize="end"
+        android:maxLines="1"
+        android:textAppearance="?attr/textAppearanceBodySmall"
+        android:textColor="?android:attr/textColorSecondary"
+        tools:text="123456 broadcasters" />
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/tagsLayout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="4dp"
+        android:visibility="gone"
+        tools:visibility="visible" />
+
+</LinearLayout>


### PR DESCRIPTION
Replace bulky category cards with compact, cardless box-art tiles that match the video-style Browse presentation. Add live viewer markers and compact left-aligned tags.