### PR TITLE
Fix automatic channel point bonus chests

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/model/gql/ClaimCommunityPointsResponse.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/model/gql/ClaimCommunityPointsResponse.kt
@@ -1,0 +1,18 @@
+package com.github.andreyasadchy.xtra.model.gql
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonElement
+
+@Serializable
+class ClaimCommunityPointsResponse(
+    val data: Data? = null,
+    val errors: List<Error>? = null,
+) {
+    @Serializable
+    class Data(
+        val claimCommunityPoints: JsonElement? = null,
+    )
+
+    val isSuccessful: Boolean
+        get() = errors.isNullOrEmpty() && data?.claimCommunityPoints != null
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/GraphQLRepository.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/GraphQLRepository.kt
@@ -65,6 +65,7 @@ import com.github.andreyasadchy.xtra.graphql.type.ClipsPeriod
 import com.github.andreyasadchy.xtra.graphql.type.Language
 import com.github.andreyasadchy.xtra.graphql.type.StreamSort
 import com.github.andreyasadchy.xtra.graphql.type.VideoSort
+import com.github.andreyasadchy.xtra.model.gql.ClaimCommunityPointsResponse
 import com.github.andreyasadchy.xtra.model.gql.ErrorResponse
 import com.github.andreyasadchy.xtra.model.gql.channel.ChannelClipsResponse
 import com.github.andreyasadchy.xtra.model.gql.channel.ChannelSuggestionsResponse
@@ -1982,7 +1983,7 @@ class GraphQLRepository(
         java.security.SecureRandom().nextBytes(it)
     }.joinToString("") { byte -> "%02x".format(byte.toInt() and 0xff) }
 
-    suspend fun loadClaimPoints(networkLibrary: String?, headers: Map<String, String>, channelId: String?, claimId: String?): ErrorResponse = withContext(Dispatchers.IO) {
+    suspend fun loadClaimPoints(networkLibrary: String?, headers: Map<String, String>, channelId: String?, claimId: String?): ClaimCommunityPointsResponse = withContext(Dispatchers.IO) {
         val body = buildJsonObject {
             putJsonObject("extensions") {
                 putJsonObject("persistedQuery") {
@@ -1998,7 +1999,7 @@ class GraphQLRepository(
                 }
             }
         }.toString()
-        json.decodeFromString<ErrorResponse>(sendPersistedQuery(networkLibrary, headers, body))
+        json.decodeFromString<ClaimCommunityPointsResponse>(sendPersistedQuery(networkLibrary, headers, body))
     }
 
     private companion object {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatViewModel.kt
@@ -79,6 +79,7 @@ import com.github.andreyasadchy.xtra.util.chat.ChatUtils
 import com.github.andreyasadchy.xtra.util.chat.ChatWriteIRCSocket
 import com.github.andreyasadchy.xtra.util.chat.ChatWriteWebSocket
 import com.github.andreyasadchy.xtra.util.chat.ChannelPointsBalanceEvent
+import com.github.andreyasadchy.xtra.util.chat.ChannelPointsBonusClaim
 import com.github.andreyasadchy.xtra.util.chat.EventSubConnectionAnnouncementState
 import com.github.andreyasadchy.xtra.util.chat.EventSubChatConnectionState
 import com.github.andreyasadchy.xtra.util.chat.EventSubChatConnectionStatus
@@ -161,6 +162,7 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.zip.DeflaterOutputStream
 import java.util.zip.InflaterOutputStream
 import javax.net.ssl.X509TrustManager
+import kotlin.coroutines.coroutineContext
 import kotlin.time.Instant
 
 internal fun resolveCurrentLiveStreamId(currentStreamId: String?, initialStreamId: String?): String? =
@@ -303,6 +305,10 @@ class ChatViewModel(
     private val trustManager: Lazy<X509TrustManager>,
     private val json: Json,
 ) : ViewModel() {
+
+    private data class PendingChannelPointsClaim(
+        val claim: ChannelPointsBonusClaim?,
+    )
 
     private val emoteRecommendationEngine = EmoteRecommendationEngine()
     private val emoteUsageViewerId = MutableStateFlow(currentEmoteUsageViewerId())
@@ -568,9 +574,15 @@ class ChatViewModel(
     private var hermesWebSocket: HermesWebSocket? = null
     private var pubSubJob: Job? = null
     private var channelPointsJob: Job? = null
+    private var channelPointsRefreshJob: Job? = null
     private var channelPointsReconciliationJob: Job? = null
     private var pinnedChatRefreshJob: Job? = null
     private var claimJob: Job? = null
+    private val claimQueueLock = Any()
+    private val pendingClaims = ArrayDeque<PendingChannelPointsClaim>()
+    private val pendingClaimIds = mutableSetOf<String>()
+    private val recentlyClaimedIds = LinkedHashSet<String>()
+    private var claimWorkerActive = false
     private var watchStreakWorkerJob: Job? = null
     private var watchStreakRefreshJob: Job? = null
     private var watchStreakSession = 0L
@@ -2623,6 +2635,47 @@ class ChatViewModel(
         }
     }
 
+    private fun startChannelPointsRefresh(
+        channelId: String?,
+        channelLogin: String,
+        listener: PubSubListener,
+        enabled: Boolean,
+    ) {
+        channelPointsRefreshJob?.cancel()
+        channelPointsRefreshJob = null
+        if (!enabled || channelId.isNullOrBlank()) return
+
+        val expectedSession = predictionSessionToken
+        val expectedChannelId = channelId
+        val expectedChannelLogin = channelLogin
+        lateinit var refreshJob: Job
+        refreshJob = viewModelScope.launch {
+            while (
+                isActive &&
+                predictionSessionToken == expectedSession &&
+                activeChannelId == expectedChannelId &&
+                activeChannelLogin.equals(expectedChannelLogin, ignoreCase = true)
+            ) {
+                delay(CHANNEL_POINTS_REFRESH_INTERVAL_MILLIS)
+                if (
+                    predictionSessionToken != expectedSession ||
+                    activeChannelId != expectedChannelId ||
+                    !activeChannelLogin.equals(expectedChannelLogin, ignoreCase = true)
+                ) {
+                    break
+                }
+                Log.d(WatchCreditTelemetry.LOG_TAG, "Channel Points fallback poll started")
+                listener.onClaimAvailable()
+            }
+        }
+        channelPointsRefreshJob = refreshJob
+        refreshJob.invokeOnCompletion {
+            if (channelPointsRefreshJob === refreshJob) {
+                channelPointsRefreshJob = null
+            }
+        }
+    }
+
     private fun startPinnedChatRefresh(
         networkLibrary: String?,
         gqlHeaders: Map<String, String>,
@@ -3243,6 +3296,7 @@ class ChatViewModel(
             val gqlWebClientId = applicationContext.prefs().getString(C.GQL_CLIENT_ID_WEB, C.DEFAULT_GQL_CLIENT_ID_WEB)
             val notifyPoints = applicationContext.prefs().getBoolean(C.CHAT_POINTS_NOTIFY, false)
             val showRaids = applicationContext.prefs().getBoolean(C.CHAT_RAIDS_SHOW, true)
+            val pubSubListener = PubSubListener(channelLogin, collectPoints, notifyPoints, showRaids, showPolls, showPredictions, networkLibrary, gqlHeaders, isLoggedIn, accountId, channelId, showWebSocketDebugInfo, sessionToken)
             hermesWebSocket = HermesWebSocket(
                 channelId = channelId,
                 userId = accountId,
@@ -3255,8 +3309,9 @@ class ChatViewModel(
                 showPredictions = showPredictions,
                 listenForDrops = hasHermesUserAuth,
                 trustManager = trustManager,
-                listener = PubSubListener(channelLogin, collectPoints, notifyPoints, showRaids, showPolls, showPredictions, networkLibrary, gqlHeaders, isLoggedIn, accountId, channelId, showWebSocketDebugInfo, sessionToken),
+                listener = pubSubListener,
             )
+            startChannelPointsRefresh(channelId, channelLogin, pubSubListener, collectPoints && hasHermesUserAuth)
             if (isLoggedIn && !hasHermesUserAuth) {
                 Log.w(
                     WatchCreditTelemetry.LOG_TAG,
@@ -3513,11 +3568,19 @@ class ChatViewModel(
         }
         channelPointsJob?.cancel()
         channelPointsJob = null
+        channelPointsRefreshJob?.cancel()
+        channelPointsRefreshJob = null
         channelPointsReconciliationJob?.cancel()
         channelPointsReconciliationJob = null
         highlightedMessageReward = null
-        claimJob?.cancel()
-        claimJob = null
+        synchronized(claimQueueLock) {
+            pendingClaims.clear()
+            pendingClaimIds.clear()
+            recentlyClaimedIds.clear()
+            claimWorkerActive = false
+            claimJob?.cancel()
+            claimJob = null
+        }
         watchStreakRefreshJob?.cancel()
         watchStreakRefreshJob = null
         watchStreakWorkerJob?.cancel()
@@ -4629,51 +4692,146 @@ class ChatViewModel(
             }
         }
 
-        override suspend fun onClaimAvailable() {
+        override suspend fun onClaimAvailable(message: JSONObject?) {
+            val eventClaim = message?.let(PubSubUtils::parseClaimAvailable)
+            val eventClaimId = eventClaim?.id
             Log.d(
                 WatchCreditTelemetry.LOG_TAG,
-                "claim-available handler invoked collectPoints=$collectPoints gqlTokenPresent=${!gqlHeaders[C.HEADER_TOKEN].isNullOrBlank()}",
+                "claim-available handler invoked source=${if (eventClaimId.isNullOrBlank()) "gql-poll" else "Hermes"} eventClaimPresent=${!eventClaimId.isNullOrBlank()} collectPoints=$collectPoints gqlTokenPresent=${!gqlHeaders[C.HEADER_TOKEN].isNullOrBlank()}",
             )
             if (!collectPoints || gqlHeaders[C.HEADER_TOKEN].isNullOrBlank()) {
                 return
             }
-            if (claimJob?.isActive == true) {
-                Log.d(WatchCreditTelemetry.LOG_TAG, "claim-available ignored while another claim is in flight")
+            if (eventClaim?.channelId != null && eventClaim.channelId != channelId) {
+                Log.w(
+                    WatchCreditTelemetry.LOG_TAG,
+                    "claim-available ignored for another channel eventChannelId=${eventClaim.channelId} sessionChannelId=$channelId",
+                )
                 return
             }
-            val job = viewModelScope.launch {
-                try {
-                    val contextResponse = graphQLRepository.loadChannelPointsContext(networkLibrary, gqlHeaders, channelLogin)
-                    val contextError = contextResponse.errors?.firstOrNull()?.message
-                    val claimId = contextResponse.data?.community?.channel?.self?.communityPoints?.availableClaim?.id
-                    Log.d(
-                        WatchCreditTelemetry.LOG_TAG,
-                        "ChannelPointsContext result dataPresent=${contextResponse.data != null} claimPresent=${!claimId.isNullOrBlank()} error=${contextError ?: "none"}",
-                    )
-                    updateChannelPoints(contextResponse)
-                    if (claimId.isNullOrBlank()) {
-                        return@launch
-                    }
+            if (eventClaim?.userId != null && eventClaim.userId != accountId) {
+                Log.w(
+                    WatchCreditTelemetry.LOG_TAG,
+                    "claim-available ignored for another user eventUserIdPresent=true sessionUserIdPresent=${!accountId.isNullOrBlank()}",
+                )
+                return
+            }
+            enqueueChannelPointsClaim(eventClaim)
+        }
 
-                    val claimResponse = graphQLRepository.loadClaimPoints(networkLibrary, gqlHeaders, channelId, claimId)
-                    val claimError = claimResponse.errors?.firstOrNull()?.message
-                    Log.d(
-                        WatchCreditTelemetry.LOG_TAG,
-                        "ClaimCommunityPoints result success=${claimError == null} error=${claimError ?: "none"}",
-                    )
-                    if (claimError == null) {
-                        loadChannelPoints(networkLibrary, gqlHeaders, channelLogin)
-                    }
-                } catch (e: CancellationException) {
-                    throw e
-                } catch (e: Exception) {
-                    Log.e(WatchCreditTelemetry.LOG_TAG, "Channel Points claim handling failed", e)
+        private fun enqueueChannelPointsClaim(claim: ChannelPointsBonusClaim?) {
+            val claimId = claim?.id
+            synchronized(claimQueueLock) {
+                if (claimId != null &&
+                    (pendingClaimIds.contains(claimId) || recentlyClaimedIds.contains(claimId))
+                ) {
+                    Log.d(WatchCreditTelemetry.LOG_TAG, "claim-available ignored duplicate claimIdPresent=true")
+                    return
+                }
+                pendingClaims.addLast(PendingChannelPointsClaim(claim))
+                if (claimId != null) {
+                    pendingClaimIds.add(claimId)
+                }
+                if (claimWorkerActive) return
+                claimWorkerActive = true
+                claimJob = viewModelScope.launch {
+                    processPendingChannelPointsClaims()
                 }
             }
-            claimJob = job
-            job.invokeOnCompletion {
-                if (claimJob === job) {
-                    claimJob = null
+        }
+
+        private suspend fun processPendingChannelPointsClaims() {
+            val currentJob = coroutineContext[Job]
+            try {
+                while (true) {
+                    val nextClaim = synchronized(claimQueueLock) {
+                        if (pendingClaims.isEmpty()) {
+                            if (claimJob === currentJob) {
+                                claimJob = null
+                                claimWorkerActive = false
+                            }
+                            null
+                        } else {
+                            pendingClaims.removeFirst()
+                        }
+                    } ?: break
+                    processChannelPointsClaim(nextClaim.claim)
+                }
+            } finally {
+                synchronized(claimQueueLock) {
+                    if (claimJob === currentJob) {
+                        claimJob = null
+                        claimWorkerActive = false
+                    }
+                }
+            }
+        }
+
+        private suspend fun processChannelPointsClaim(eventClaim: ChannelPointsBonusClaim?) {
+            val eventClaimId = eventClaim?.id
+            var resolvedClaimId: String? = null
+            val alreadyClaimed = eventClaimId != null && synchronized(claimQueueLock) {
+                recentlyClaimedIds.contains(eventClaimId)
+            }
+            val succeeded = if (alreadyClaimed) {
+                Log.d(WatchCreditTelemetry.LOG_TAG, "Channel Points claim skipped recently claimed chest")
+                true
+            } else try {
+                val contextResponse = if (eventClaimId.isNullOrBlank()) {
+                    graphQLRepository.loadChannelPointsContext(networkLibrary, gqlHeaders, channelLogin)
+                } else {
+                    null
+                }
+                val contextError = contextResponse?.errors?.firstOrNull()?.message
+                val contextClaimId = contextResponse?.data?.community?.channel?.self?.communityPoints?.availableClaim?.id
+                val claimId = eventClaimId ?: contextClaimId
+                resolvedClaimId = claimId
+                Log.d(
+                    WatchCreditTelemetry.LOG_TAG,
+                    "ChannelPointsContext result queried=${contextResponse != null} dataPresent=${contextResponse?.data != null} claimPresent=${!claimId.isNullOrBlank()} source=${if (eventClaimId.isNullOrBlank()) "gql-poll" else "Hermes"} error=${contextError ?: "none"}",
+                )
+                contextResponse?.let(::updateChannelPoints)
+                if (claimId.isNullOrBlank()) {
+                    false
+                } else if (eventClaimId.isNullOrBlank() && synchronized(claimQueueLock) { recentlyClaimedIds.contains(claimId) }) {
+                    Log.d(WatchCreditTelemetry.LOG_TAG, "Channel Points fallback skipped recently claimed chest")
+                    true
+                } else {
+                    val claimResponse = graphQLRepository.loadClaimPoints(
+                        networkLibrary,
+                        gqlHeaders,
+                        eventClaim?.channelId ?: channelId,
+                        claimId,
+                    )
+                    val claimError = claimResponse.errors?.firstOrNull()?.message
+                    val claimSucceeded = claimResponse.isSuccessful
+                    Log.d(
+                        WatchCreditTelemetry.LOG_TAG,
+                        "ClaimCommunityPoints result success=$claimSucceeded dataPresent=${claimResponse.data?.claimCommunityPoints != null} error=${claimError ?: "none"}",
+                    )
+                    if (claimSucceeded) {
+                        loadChannelPoints(networkLibrary, gqlHeaders, channelLogin)
+                    }
+                    claimSucceeded
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Log.e(WatchCreditTelemetry.LOG_TAG, "Channel Points claim handling failed", e)
+                false
+            }
+
+            val completedClaimId = resolvedClaimId ?: eventClaimId
+            if (completedClaimId != null) {
+                synchronized(claimQueueLock) {
+                    pendingClaimIds.remove(completedClaimId)
+                    if (succeeded) {
+                        recentlyClaimedIds.remove(completedClaimId)
+                        recentlyClaimedIds.add(completedClaimId)
+                        while (recentlyClaimedIds.size > MAX_RECENT_CLAIM_IDS) {
+                            recentlyClaimedIds.remove(recentlyClaimedIds.first())
+                        }
+                    }
                 }
             }
         }
@@ -7114,6 +7272,8 @@ class ChatViewModel(
         private const val WATCH_STREAK_RECONCILIATION_DELAY_MILLIS = 750L
         private val CHANNEL_POINTS_RECONCILIATION_DELAYS_MILLIS = listOf(750L, 3_000L, 10_000L, 20_000L)
         private const val PINNED_CHAT_REFRESH_INTERVAL_MILLIS = 30_000L
+        private const val CHANNEL_POINTS_REFRESH_INTERVAL_MILLIS = 60_000L
+        private const val MAX_RECENT_CLAIM_IDS = 64
         private const val METERED_CACHE_MAX_AGE_MS = 604_800_000L
         private const val MAX_BADGE_CACHE_FILES = 100
         private const val DEFAULT_REWARD_COLOR = "#9146FF"

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/chat/HermesWebSocket.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/chat/HermesWebSocket.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.json.JSONObject
+import java.util.Locale
 import java.util.Timer
 import javax.net.ssl.X509TrustManager
 import kotlin.concurrent.schedule
@@ -19,6 +20,13 @@ import kotlin.time.Clock
 import kotlin.uuid.Uuid
 
 private const val MINUTE_WATCHED_INTERVAL_MILLIS = 59_000L
+
+internal fun shouldStartMinuteWatchedTimer(
+    listenForDrops: Boolean,
+    userIdPresent: Boolean,
+    gqlTokenPresent: Boolean,
+    authenticationAccepted: Boolean,
+): Boolean = listenForDrops && userIdPresent && gqlTokenPresent && authenticationAccepted
 
 class HermesWebSocket(
     private val channelId: String,
@@ -40,12 +48,23 @@ class HermesWebSocket(
     private var timeout = 15000L
     private var minuteWatchedTimer: Timer? = null
     private var topics = emptyMap<String, String>()
+    private val subscriptionResponseTopics = mutableMapOf<String, String>()
+    private val acknowledgedPrivateTopics = mutableSetOf<String>()
     private val handledMessageIds = mutableListOf<String>()
     private var hasSubscribed = false
+    private var authenticationAccepted = false
+    private var privateSubscriptionsSent = false
+    private var subscriptionsSentNotified = false
+    private var subscriptionsReconnected = false
 
     fun connect(coroutineScope: CoroutineScope): Job {
         Log.d(WatchCreditTelemetry.LOG_TAG, "Hermes connect requested channelIdPresent=${channelId.isNotBlank()} userIdPresent=${!userId.isNullOrBlank()} collectPoints=$collectPoints listenForPoints=$listenForPoints listenForDrops=$listenForDrops")
         hasSubscribed = false
+        authenticationAccepted = false
+        subscriptionResponseTopics.clear()
+        acknowledgedPrivateTopics.clear()
+        privateSubscriptionsSent = false
+        subscriptionsSentNotified = false
         webSocket = WebSocket("wss://hermes.twitch.tv/v1?clientId=${gqlClientId}", trustManager, WebSocketListener())
         webSocket?.coroutineScope = coroutineScope
         return coroutineScope.launch(Dispatchers.IO) {
@@ -63,6 +82,16 @@ class HermesWebSocket(
     }
 
     private suspend fun subscribe() = withContext(Dispatchers.IO) {
+        authenticationAccepted = false
+        subscriptionResponseTopics.clear()
+        acknowledgedPrivateTopics.clear()
+        privateSubscriptionsSent = false
+        subscriptionsSentNotified = false
+        subscriptionsReconnected = hasSubscribed
+        if (listenForDrops) {
+            minuteWatchedTimer?.cancel()
+            minuteWatchedTimer = null
+        }
         if (!userId.isNullOrBlank() && !gqlToken.isNullOrBlank() && (listenForPoints || listenForDrops)) {
             val authenticate = JSONObject().apply {
                 put("id", Uuid.random().toHexString().substring(0, 21))
@@ -97,10 +126,32 @@ class HermesWebSocket(
                 }
             }
         }
-        topics.forEach {
+        val needsAuthentication = !userId.isNullOrBlank() && !gqlToken.isNullOrBlank() && (listenForPoints || listenForDrops)
+        sendTopicSubscriptions(
+            if (needsAuthentication) {
+                topics.filterValues { !isPrivateTopic(it) }
+            } else {
+                topics
+            },
+        )
+        if (!needsAuthentication) {
+            notifySubscriptionsSent()
+        }
+        Log.d(WatchCreditTelemetry.LOG_TAG, "Hermes subscriptions sent count=${if (needsAuthentication) topics.count { !isPrivateTopic(it.value) } else topics.size}")
+        hasSubscribed = true
+    }
+
+    private fun isPrivateTopic(topic: String): Boolean =
+        topic.startsWith("community-points-user") || topic.startsWith("user-drop-events")
+
+    private suspend fun sendTopicSubscriptions(topicEntries: Map<String, String>) {
+        topicEntries.forEach {
+            val requestId = Uuid.random().toHexString().substring(0, 21)
+            subscriptionResponseTopics[requestId] = it.value
+            subscriptionResponseTopics[it.key] = it.value
             val subscribe = JSONObject().apply {
                 put("type", "subscribe")
-                put("id", Uuid.random().toHexString().substring(0, 21))
+                put("id", requestId)
                 put("subscribe", JSONObject().apply {
                     put("id", it.key)
                     put("type", "pubsub")
@@ -118,10 +169,90 @@ class HermesWebSocket(
                 Log.d(WatchCreditTelemetry.LOG_TAG, "Hermes user-drop-events subscription sent")
             }
         }
-        Log.d(WatchCreditTelemetry.LOG_TAG, "Hermes subscriptions sent count=${topics.size}")
-        val reconnected = hasSubscribed
-        hasSubscribed = true
-        listener.onSubscriptionsSent(reconnected)
+    }
+
+    private suspend fun sendPrivateSubscriptions() {
+        if (privateSubscriptionsSent) return
+        privateSubscriptionsSent = true
+        sendTopicSubscriptions(topics.filterValues(::isPrivateTopic))
+        Log.d(WatchCreditTelemetry.LOG_TAG, "Hermes private subscriptions sent count=${topics.count { isPrivateTopic(it.value) }}")
+        notifySubscriptionsSent()
+    }
+
+    private suspend fun notifySubscriptionsSent() {
+        if (subscriptionsSentNotified) return
+        subscriptionsSentNotified = true
+        listener.onSubscriptionsSent(subscriptionsReconnected)
+    }
+
+    private suspend fun maybeStartMinuteWatchedTimer() {
+        if (!shouldStartMinuteWatchedTimer(
+                listenForDrops = listenForDrops,
+                userIdPresent = !userId.isNullOrBlank(),
+                gqlTokenPresent = !gqlToken.isNullOrBlank(),
+                authenticationAccepted = authenticationAccepted,
+            )
+        ) {
+            if (!listenForDrops || userId.isNullOrBlank() || gqlToken.isNullOrBlank()) {
+                Log.w(WatchCreditTelemetry.LOG_TAG, "Hermes minute-watched timer not started: missing userId or GQL token")
+            } else {
+                Log.w(
+                    WatchCreditTelemetry.LOG_TAG,
+                    "Hermes minute-watched timer waiting for authentication acknowledgement",
+                )
+            }
+            return
+        }
+        if (minuteWatchedTimer == null) {
+            Log.d(
+                WatchCreditTelemetry.LOG_TAG,
+                "Hermes minute-watched timer starting privateSubscriptionAcks=${acknowledgedPrivateTopics.size}",
+            )
+            startMinuteWatchedTimer()
+        }
+    }
+
+    private suspend fun handleAuthenticationResponse(json: JSONObject) {
+        val response = json.optJSONObject("authenticateResponse")
+        val result = response?.optString("result").orEmpty()
+        authenticationAccepted = result.equals("ok", ignoreCase = true)
+        if (authenticationAccepted) {
+            Log.d(WatchCreditTelemetry.LOG_TAG, "Hermes authentication accepted")
+            sendPrivateSubscriptions()
+        } else {
+            Log.w(
+                WatchCreditTelemetry.LOG_TAG,
+                "Hermes authentication rejected result=${result.ifBlank { "unknown" }} error=${response?.optString("error").orEmpty().ifBlank { "none" }} errorCode=${response?.optString("errorCode").orEmpty().ifBlank { "none" }}",
+            )
+            notifySubscriptionsSent()
+        }
+        maybeStartMinuteWatchedTimer()
+    }
+
+    private suspend fun handleSubscriptionResponse(json: JSONObject) {
+        val response = json.optJSONObject("subscribeResponse")
+        val result = response?.optString("result").orEmpty()
+        val subscriptionId = response?.optJSONObject("subscription")?.optString("id")
+            ?.takeIf { it.isNotBlank() }
+            ?: response?.optString("id")?.takeIf { it.isNotBlank() }
+            ?: json.optString("parentId").takeIf { it.isNotBlank() }
+            ?: json.optString("id").takeIf { it.isNotBlank() }
+        val topic = subscriptionId?.let(subscriptionResponseTopics::get)
+        if (result.equals("ok", ignoreCase = true)) {
+            topic?.takeIf {
+                it.startsWith("community-points-user") || it.startsWith("user-drop-events")
+            }?.let(acknowledgedPrivateTopics::add)
+            Log.d(
+                WatchCreditTelemetry.LOG_TAG,
+                "Hermes subscription accepted topic=${topic ?: "unknown"}",
+            )
+        } else {
+            Log.w(
+                WatchCreditTelemetry.LOG_TAG,
+                "Hermes subscription rejected topic=${topic ?: "unknown"} result=${result.ifBlank { "unknown" }} error=${response?.optString("error").orEmpty().ifBlank { "none" }} errorCode=${response?.optString("errorCode").orEmpty().ifBlank { "none" }}",
+            )
+        }
+        maybeStartMinuteWatchedTimer()
     }
 
     private suspend fun startPongTimer() = withContext(Dispatchers.IO) {
@@ -159,7 +290,7 @@ class HermesWebSocket(
         suspend fun onRewardMessage(message: JSONObject) {}
         suspend fun onPointsEarned(message: JSONObject) {}
         suspend fun onPointsSpent(message: JSONObject) {}
-        suspend fun onClaimAvailable() {}
+        suspend fun onClaimAvailable(message: JSONObject? = null) {}
         suspend fun onDropMessage(message: JSONObject) {}
         suspend fun onMinuteWatched() {}
         suspend fun onRaidUpdate(message: JSONObject, openStream: Boolean) {}
@@ -197,7 +328,7 @@ class HermesWebSocket(
                         val subscriptionId = subscription?.optString("id")
                         val topic = topics[subscriptionId]
                         val message = notification?.optString("pubsub")?.let { if (it.isNotBlank()) JSONObject(it) else null }
-                        val messageType = message?.optString("type")
+                        val messageType = message?.optString("type")?.lowercase(Locale.US)
                         if (topic != null && messageType != null) {
                             when {
                                 topic.startsWith("video-playback-by-id") -> listener.onPlaybackMessage(message)
@@ -223,7 +354,7 @@ class HermesWebSocket(
                                         }
                                         messageType.startsWith("claim-available") -> {
                                             Log.d(WatchCreditTelemetry.LOG_TAG, "Hermes claim-available received")
-                                            listener.onClaimAvailable()
+                                            listener.onClaimAvailable(message)
                                         }
                                         else -> {
                                             if (BuildConfig.DEBUG) {
@@ -249,7 +380,10 @@ class HermesWebSocket(
                         startPongTimer()
                     }
                     "authenticated" -> {
+                        authenticationAccepted = true
                         Log.d(WatchCreditTelemetry.LOG_TAG, "Hermes authentication accepted")
+                        sendPrivateSubscriptions()
+                        maybeStartMinuteWatchedTimer()
                     }
                     "reconnect" -> {
                         //val reconnect = json.optJSONObject("reconnect")
@@ -268,13 +402,10 @@ class HermesWebSocket(
                         startPongTimer()
                         Log.d(WatchCreditTelemetry.LOG_TAG, "Hermes welcome received collectPoints=$collectPoints listenForDrops=$listenForDrops userIdPresent=${!userId.isNullOrBlank()} gqlTokenPresent=${!gqlToken.isNullOrBlank()}")
                         subscribe()
-                        if (listenForDrops && !userId.isNullOrBlank() && !gqlToken.isNullOrBlank() && minuteWatchedTimer == null) {
-                            startMinuteWatchedTimer()
-                        } else if (listenForDrops && minuteWatchedTimer == null) {
-                            Log.w(WatchCreditTelemetry.LOG_TAG, "Hermes minute-watched timer not started: missing userId or GQL token")
-                        }
                     }
-                }
+                    "authenticateResponse" -> handleAuthenticationResponse(json)
+                    "subscribeResponse" -> handleSubscriptionResponse(json)
+                    }
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/chat/PubSubUtils.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/chat/PubSubUtils.kt
@@ -28,7 +28,25 @@ data class ChannelPointsBalanceEvent(
 
 typealias ChannelPointsBalanceEventType = ChannelPointsBalanceEvent.Type
 
+data class ChannelPointsBonusClaim(
+    val id: String,
+    val channelId: String? = null,
+    val userId: String? = null,
+)
+
 object PubSubUtils {
+    /** Returns the claim carried by a community-points bonus notification. */
+    fun parseClaimAvailable(message: JSONObject): ChannelPointsBonusClaim? {
+        val claim = message.optJSONObject("data")?.optJSONObject("claim")
+            ?: message.optJSONObject("claim")
+        val id = claim?.optString("id")?.takeIf { it.isNotBlank() } ?: return null
+        return ChannelPointsBonusClaim(
+            id = id,
+            channelId = claim.optString("channel_id").takeIf { it.isNotBlank() },
+            userId = claim.optString("user_id").takeIf { it.isNotBlank() },
+        )
+    }
+
     fun parsePlaybackMessage(message: JSONObject): PlaybackMessage? {
         val messageType = message.optString("type")
         return when {

--- a/app/src/test/java/com/github/andreyasadchy/xtra/repository/ClaimCommunityPointsResponseTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/repository/ClaimCommunityPointsResponseTest.kt
@@ -1,0 +1,29 @@
+package com.github.andreyasadchy.xtra.repository
+
+import com.github.andreyasadchy.xtra.model.gql.ClaimCommunityPointsResponse
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ClaimCommunityPointsResponseTest {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @Test
+    fun missingMutationResultIsNotSuccessful() {
+        val response = json.decodeFromString<ClaimCommunityPointsResponse>(
+            """{"data":{"claimCommunityPoints":null}}""",
+        )
+
+        assertFalse(response.isSuccessful)
+    }
+
+    @Test
+    fun mutationResultWithoutErrorsIsSuccessful() {
+        val response = json.decodeFromString<ClaimCommunityPointsResponse>(
+            """{"data":{"claimCommunityPoints":{"currentPoints":50}}}""",
+        )
+
+        assertTrue(response.isSuccessful)
+    }
+}

--- a/app/src/test/java/com/github/andreyasadchy/xtra/util/chat/HermesWebSocketTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/util/chat/HermesWebSocketTest.kt
@@ -2,6 +2,8 @@ package com.github.andreyasadchy.xtra.util.chat
 
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class HermesWebSocketTest {
@@ -31,5 +33,37 @@ class HermesWebSocketTest {
 
         assertEquals("Game", info.gameName)
         assertEquals("1234", info.gameId)
+    }
+
+    @Test
+    fun dropsTimerDoesNotDependOnChannelPointsSubscription() {
+        assertTrue(
+            shouldStartMinuteWatchedTimer(
+                listenForDrops = true,
+                userIdPresent = true,
+                gqlTokenPresent = true,
+                authenticationAccepted = true,
+            ),
+        )
+    }
+
+    @Test
+    fun dropsTimerRequiresAuthenticationAndCredentials() {
+        assertFalse(
+            shouldStartMinuteWatchedTimer(
+                listenForDrops = true,
+                userIdPresent = true,
+                gqlTokenPresent = true,
+                authenticationAccepted = false,
+            ),
+        )
+        assertFalse(
+            shouldStartMinuteWatchedTimer(
+                listenForDrops = true,
+                userIdPresent = false,
+                gqlTokenPresent = true,
+                authenticationAccepted = true,
+            ),
+        )
     }
 }

--- a/app/src/test/java/com/github/andreyasadchy/xtra/util/chat/PubSubUtilsTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/util/chat/PubSubUtilsTest.kt
@@ -8,6 +8,31 @@ import org.junit.Test
 
 class PubSubUtilsTest {
     @Test
+    fun parsesBonusClaimIdFromHermesEvent() {
+        val claim = PubSubUtils.parseClaimAvailable(
+            JSONObject(
+                """
+                {
+                  "type": "claim-available",
+                  "data": {
+                    "claim": {
+                      "id": "claim-123",
+                      "channel_id": "channel-456",
+                      "user_id": "user-789",
+                      "point_gain": {"total_points": 50}
+                    }
+                  }
+                }
+                """.trimIndent(),
+            ),
+        )
+
+        assertEquals("claim-123", claim?.id)
+        assertEquals("channel-456", claim?.channelId)
+        assertEquals("user-789", claim?.userId)
+    }
+
+    @Test
     fun parsesWatchStreakReasonCode() {
         val (points, channelId) = PubSubUtils.parsePointsEarned(
             JSONObject(


### PR DESCRIPTION
Users should now receive channel point bonus chests automatically while watching.\n\nThe app now uses the live chest notification directly, retries through a periodic refresh, avoids losing overlapping chests, and handles the current Hermes connection responses.\n\nVerified with the focused parser tests, a successful debug APK build, emulator install/launch, and no fatal app exception.