### PR TITLE
Fix chatter followed-since data

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/MessageClickedDialog.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/MessageClickedDialog.kt
@@ -63,7 +63,7 @@ class MessageClickedDialog : BottomSheetDialogFragment() {
         private const val KEY_CHANNEL_LOGIN = "channelLogin"
         private data class SavedUserCard(
             val user: User,
-            val targetId: String?,
+            val targetKey: String,
             val viewerId: String?,
         )
         private val savedUsers = mutableListOf<SavedUserCard>()
@@ -158,15 +158,19 @@ class MessageClickedDialog : BottomSheetDialogFragment() {
                     }
                     if (selectedMessage.userId != null || selectedMessage.userLogin != null) {
                         val targetId = requireArguments().getString(KEY_CHANNEL_ID)
+                        val targetLogin = requireArguments().getString(KEY_CHANNEL_LOGIN)
+                        val targetKey = messageClickedChannelCacheKey(targetId, targetLogin)
                         val viewerId = currentViewerId()
-                        val item = selectedMessage.userId?.let {
+                        val item = if (targetKey != null && selectedMessage.userId != null) {
                             synchronized(savedUsers) {
                                 savedUsers.find {
                                     it.user.id == selectedMessage.userId &&
-                                        it.targetId == targetId &&
+                                        it.targetKey == targetKey &&
                                         it.viewerId == viewerId
                                 }
                             }
+                        } else {
+                            null
                         }
                         if (item != null) {
                             userCardUser = item.user
@@ -214,7 +218,7 @@ class MessageClickedDialog : BottomSheetDialogFragment() {
                                             val error = pair.second
                                             if (user != null) {
                                                 userCardUser = user
-                                                replaceSavedUser(user, targetId, currentViewerId())
+                                                replaceSavedUser(user, targetId, targetLogin, currentViewerId())
                                                 updateUserLayout(user)
                                                 adapter.selectedMessage?.let { selectedMessage ->
                                                     if (requireArguments().getBoolean(KEY_MESSAGING) &&
@@ -507,7 +511,12 @@ class MessageClickedDialog : BottomSheetDialogFragment() {
             userCardUser?.let { currentUser ->
                 val updatedUser = currentUser.withViewerFollowState(result.isFollowing)
                 userCardUser = updatedUser
-                replaceSavedUser(updatedUser, requireArguments().getString(KEY_CHANNEL_ID), currentViewerId())
+                replaceSavedUser(
+                    updatedUser,
+                    requireArguments().getString(KEY_CHANNEL_ID),
+                    requireArguments().getString(KEY_CHANNEL_LOGIN),
+                    currentViewerId(),
+                )
                 renderUserActions(updatedUser)
             }
         }
@@ -542,12 +551,13 @@ class MessageClickedDialog : BottomSheetDialogFragment() {
         return requireContext().tokenPrefs().getString(C.USER_ID, null)
     }
 
-    private fun replaceSavedUser(user: User, targetId: String?, viewerId: String?) {
+    private fun replaceSavedUser(user: User, targetId: String?, targetLogin: String?, viewerId: String?) {
+        val targetKey = messageClickedChannelCacheKey(targetId, targetLogin) ?: return
         synchronized(savedUsers) {
             savedUsers.removeAll {
-                it.user.id == user.id && it.targetId == targetId && it.viewerId == viewerId
+                it.user.id == user.id && it.targetKey == targetKey && it.viewerId == viewerId
             }
-            savedUsers.add(SavedUserCard(user, targetId, viewerId))
+            savedUsers.add(SavedUserCard(user, targetKey, viewerId))
         }
     }
 
@@ -640,6 +650,11 @@ class MessageClickedDialog : BottomSheetDialogFragment() {
         super.onDestroyView()
         _binding = null
     }
+}
+
+internal fun messageClickedChannelCacheKey(targetId: String?, targetLogin: String?): String? {
+    return targetId?.trim()?.takeIf { it.isNotEmpty() }?.let { "id:$it" }
+        ?: targetLogin?.trim()?.takeIf { it.isNotEmpty() }?.let { "login:${it.lowercase(Locale.ROOT)}" }
 }
 
 

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/MessageClickedViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/MessageClickedViewModel.kt
@@ -56,7 +56,11 @@ class MessageClickedViewModel(
                                     imageUrl = badge.imageURL,
                                 )
                             }
-                            mapUser(user = clickedUser, earnedBadges = earnedBadges, isSubscribedHint = isSubscribedHint)
+                            mapUser(
+                                user = clickedUser,
+                                earnedBadges = earnedBadges,
+                                isSubscribedHint = isSubscribedHint,
+                            )
                         }
                     } catch (e: Exception) {
                         null
@@ -74,7 +78,10 @@ class MessageClickedViewModel(
                             targetLogin,
                         ).data
                         data?.user?.userMessageClickedUser?.let { clickedUser ->
-                            mapUser(clickedUser, isSubscribedHint = isSubscribedHint)
+                            mapUser(
+                                user = clickedUser,
+                                isSubscribedHint = isSubscribedHint,
+                            )
                         }
                     } catch (e: Exception) {
                         null
@@ -120,7 +127,7 @@ class MessageClickedViewModel(
             profileImageURL = user.profileImageURL,
             bannerImageURL = user.bannerImageURL,
             createdAt = user.createdAt,
-            followedAt = user.follow?.followedAt,
+            followedAt = messageClickedFollowedAt(user),
             displayBadges = earnedBadges.ifEmpty {
                 mapBadges(user.displayBadges) { badge ->
                     BadgeFields(badge?.id, badge?.setID, badge?.version, badge?.title, badge?.description, badge?.imageURL)
@@ -236,3 +243,7 @@ class MessageClickedViewModel(
         }
     }
 }
+
+internal fun messageClickedFollowedAt(
+    user: com.github.andreyasadchy.xtra.graphql.fragment.UserMessageClickedUser,
+): Any? = user.follow?.followedAt

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/MessageClickedFollowedAtTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/MessageClickedFollowedAtTest.kt
@@ -1,0 +1,71 @@
+package com.github.andreyasadchy.xtra.ui.chat
+
+import com.github.andreyasadchy.xtra.graphql.fragment.UserMessageClickedUser
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MessageClickedFollowedAtTest {
+    @Test
+    fun `uses clicked chatter to channel date rather than viewer to chatter date`() {
+        assertEquals(
+            "2025-02-03T04:05:06Z",
+            messageClickedFollowedAt(
+                user(
+                    clickedUserToChannelAt = "2025-02-03T04:05:06Z",
+                    viewerToClickedUserAt = "2024-01-02T03:04:05Z",
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `does not invent a channel follow date from the viewer relation`() {
+        assertNull(
+            messageClickedFollowedAt(
+                user(
+                    clickedUserToChannelAt = null,
+                    viewerToClickedUserAt = "2024-01-02T03:04:05Z",
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `viewer follow relation remains separate from chatter follow date`() {
+        val user = user(
+            clickedUserToChannelAt = "2020-01-02T03:04:05Z",
+            viewerToClickedUserAt = "2025-02-03T04:05:06Z",
+        )
+
+        assertEquals("2020-01-02T03:04:05Z", messageClickedFollowedAt(user))
+        assertTrue(user.self?.follower != null)
+    }
+
+    @Test
+    fun `cache key prefers channel id and falls back to normalized login`() {
+        assertEquals("id:123", messageClickedChannelCacheKey(" 123 ", "ChannelName"))
+        assertEquals("login:channelname", messageClickedChannelCacheKey(null, " ChannelName "))
+        assertNull(messageClickedChannelCacheKey(null, "  "))
+    }
+
+    private fun user(
+        clickedUserToChannelAt: String?,
+        viewerToClickedUserAt: String?,
+    ) = UserMessageClickedUser(
+        bannerImageURL = null,
+        createdAt = null,
+        displayName = "Chatter",
+        follow = clickedUserToChannelAt?.let(UserMessageClickedUser::Follow),
+        displayBadges = null,
+        relationship = null,
+        self = UserMessageClickedUser.Self(
+            canFollow = true,
+            follower = viewerToClickedUserAt?.let(UserMessageClickedUser::Follower),
+        ),
+        id = "chatter-id",
+        login = "chatter",
+        profileImageURL = null,
+    )
+}


### PR DESCRIPTION
Keeps the chatter follow date tied to the active channel and prevents cached chatter details from leaking between channels.