### PR TITLE
Warn when Twitch may be blocked by DNS

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/GraphQLRepository.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/GraphQLRepository.kt
@@ -114,6 +114,7 @@ import com.github.andreyasadchy.xtra.diagnostics.diagnosticsRequestSucceeded
 import com.github.andreyasadchy.xtra.diagnostics.DiagnosticsTransport
 import com.github.andreyasadchy.xtra.repository.auth.TwitchWebSessionManager
 import com.github.andreyasadchy.xtra.util.C
+import com.github.andreyasadchy.xtra.util.NetworkInterferenceReporter
 import com.github.andreyasadchy.xtra.util.NetworkUtils
 import com.github.andreyasadchy.xtra.util.NetworkUtils.executeAsync
 import kotlinx.coroutines.Dispatchers
@@ -395,6 +396,7 @@ class GraphQLRepository(
             logger?.failRequest(token, "cancelled")
             throw error
         } catch (error: Throwable) {
+            NetworkInterferenceReporter.report("gql.twitch.tv", error)
             logger?.failRequest(token, diagnosticsErrorCode(error))
             throw error
         }
@@ -504,9 +506,10 @@ class GraphQLRepository(
         true
     }.getOrDefault(false)
 
-    private fun diagnosticsErrorCode(error: Throwable): String = when (error) {
-        is MissingAuthenticationException -> "authentication_required"
-        is java.io.IOException -> "io_error"
+    private fun diagnosticsErrorCode(error: Throwable): String = when {
+        error is MissingAuthenticationException -> "authentication_required"
+        NetworkInterferenceReporter.isDnsResolutionFailure(error) -> "dns_resolution_failed"
+        error is java.io.IOException -> "io_error"
         else -> "request_failed"
     }
 

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/PlayerRepository.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/PlayerRepository.kt
@@ -48,6 +48,7 @@ import com.github.andreyasadchy.xtra.model.misc.STVChannelResponse
 import com.github.andreyasadchy.xtra.model.misc.STVEmoteSetResponse
 import com.github.andreyasadchy.xtra.model.ui.TranslatedChannel
 import com.github.andreyasadchy.xtra.util.C
+import com.github.andreyasadchy.xtra.util.NetworkInterferenceReporter
 import com.github.andreyasadchy.xtra.util.NetworkUtils
 import com.github.andreyasadchy.xtra.util.NetworkUtils.executeAsync
 import com.github.andreyasadchy.xtra.util.prefs
@@ -1067,7 +1068,12 @@ class PlayerRepository(
             logger?.finishRequest(token, successful = false, code = "cancelled")
             throw e
         } catch (e: Exception) {
-            logger?.finishRequest(token, successful = false, code = "request_failed")
+            NetworkInterferenceReporter.report(urlHost(url), e)
+            logger?.finishRequest(
+                token,
+                successful = false,
+                code = if (NetworkInterferenceReporter.isDnsResolutionFailure(e)) "dns_resolution_failed" else "request_failed",
+            )
             Log.e(WatchCreditTelemetry.LOG_TAG, "$label GET failed", e)
             null
         }
@@ -1156,7 +1162,12 @@ class PlayerRepository(
             logger?.finishRequest(token, successful = false, code = "cancelled")
             throw e
         } catch (e: Exception) {
-            logger?.finishRequest(token, successful = false, code = "request_failed")
+            NetworkInterferenceReporter.report(urlHost(spadeUrl), e)
+            logger?.finishRequest(
+                token,
+                successful = false,
+                code = if (NetworkInterferenceReporter.isDnsResolutionFailure(e)) "dns_resolution_failed" else "request_failed",
+            )
             Log.e(WatchCreditTelemetry.LOG_TAG, "Spade POST failed host=${urlHost(spadeUrl)}", e)
             false
         }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/TwitchPrivateGqlClient.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/TwitchPrivateGqlClient.kt
@@ -11,6 +11,7 @@ import com.github.andreyasadchy.xtra.model.twitchinbox.TwitchInboxError
 import com.github.andreyasadchy.xtra.model.twitchinbox.TwitchInboxException
 import com.github.andreyasadchy.xtra.repository.auth.TwitchWebSessionManager
 import com.github.andreyasadchy.xtra.util.C
+import com.github.andreyasadchy.xtra.util.NetworkInterferenceReporter
 import com.github.andreyasadchy.xtra.util.NetworkUtils
 import com.github.andreyasadchy.xtra.util.NetworkUtils.executeAsync
 import kotlinx.coroutines.Dispatchers
@@ -108,6 +109,7 @@ class TwitchPrivateGqlClient(
             logger?.failRequest(token, "cancelled")
             throw error
         } catch (error: Throwable) {
+            NetworkInterferenceReporter.report("gql.twitch.tv", error)
             logger?.failRequest(token, diagnosticsErrorCode(error))
             throw TwitchInboxException(TwitchInboxError.Network, error)
         }
@@ -131,8 +133,9 @@ class TwitchPrivateGqlClient(
         body
     }
 
-    private fun diagnosticsErrorCode(error: Throwable): String = when (error) {
-        is java.io.IOException -> "io_error"
+    private fun diagnosticsErrorCode(error: Throwable): String = when {
+        NetworkInterferenceReporter.isDnsResolutionFailure(error) -> "dns_resolution_failed"
+        error is java.io.IOException -> "io_error"
         else -> "request_failed"
     }
 

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/main/MainActivity.kt
@@ -102,6 +102,7 @@ import com.github.andreyasadchy.xtra.ui.tv.disableTvClippingUpTree
 import com.github.andreyasadchy.xtra.ui.team.TeamFragmentDirections
 import com.github.andreyasadchy.xtra.ui.top.TopStreamsFragmentDirections
 import com.github.andreyasadchy.xtra.util.C
+import com.github.andreyasadchy.xtra.util.NetworkInterferenceReporter
 import com.github.andreyasadchy.xtra.util.PlaybackBackend
 import com.github.andreyasadchy.xtra.util.resolvePlaybackBackend
 import com.github.andreyasadchy.xtra.util.SettingsUpdateIndicator
@@ -163,6 +164,7 @@ class MainActivity : AppCompatActivity() {
     private val updateRepository by lazy { (application as XtraApp).xtraModule.updateRepository }
     private val authSessionMaintainer by lazy { (application as XtraApp).xtraModule.authSessionMaintainer }
     private var networkSnackbar: Snackbar? = null
+    private var networkFilterSnackbar: Snackbar? = null
     private var updateNotificationSnackbar: Snackbar? = null
     private var updateNotificationPermissionLauncher: ActivityResultLauncher<String>? = null
     private var fragmentLifecycleCallbacks: FragmentManager.FragmentLifecycleCallbacks? = null
@@ -361,6 +363,25 @@ class MainActivity : AppCompatActivity() {
                             }
                         }
                         viewModel.checkCellularStatus.value = false
+                    }
+                }
+            }
+        }
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                NetworkInterferenceReporter.events.collectLatest {
+                    val connectivityManager = getSystemService(CONNECTIVITY_SERVICE) as ConnectivityManager
+                    val networkCapabilities = connectivityManager.getNetworkCapabilities(connectivityManager.activeNetwork)
+                    val isNetworkAvailable = networkCapabilities != null
+                            && networkCapabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+                            && networkCapabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
+                    if (isNetworkAvailable && !isFinishing && !isDestroyed && NetworkInterferenceReporter.tryAcquireWarningPermit()) {
+                        networkFilterSnackbar?.dismiss()
+                        networkFilterSnackbar = Snackbar.make(
+                            binding.root,
+                            R.string.network_filter_warning,
+                            Snackbar.LENGTH_LONG,
+                        ).also { it.show() }
                     }
                 }
             }
@@ -905,6 +926,8 @@ class MainActivity : AppCompatActivity() {
         keepStateNavigator = null
         networkSnackbar?.dismiss()
         networkSnackbar = null
+        networkFilterSnackbar?.dismiss()
+        networkFilterSnackbar = null
         updateNotificationSnackbar?.dismiss()
         updateNotificationSnackbar = null
         networkCallback?.let {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/NetworkInterferenceReporter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/NetworkInterferenceReporter.kt
@@ -1,0 +1,89 @@
+package com.github.andreyasadchy.xtra.util
+
+import android.os.SystemClock
+import java.net.UnknownHostException
+import java.util.ArrayDeque
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+
+/**
+ * Reports repeated DNS failures for Twitch requests without claiming that a specific blocker was
+ * identified. A failed lookup can also be caused by a VPN, proxy, or an ordinary network outage.
+ */
+object NetworkInterferenceReporter {
+    data class PotentialDnsFailure(val host: String)
+
+    private val state = NetworkInterferenceState()
+    private val _events = MutableSharedFlow<PotentialDnsFailure>(
+        extraBufferCapacity = 1,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST,
+    )
+
+    val events = _events.asSharedFlow()
+
+    fun report(host: String?, error: Throwable) {
+        if (!isDnsResolutionFailure(error)) return
+
+        if (state.recordFailure(SystemClock.elapsedRealtime())) {
+            _events.tryEmit(PotentialDnsFailure(host.orEmpty()))
+        }
+    }
+
+    /** Returns true only when a warning may be shown to the user now. */
+    fun tryAcquireWarningPermit(): Boolean =
+        state.tryAcquireWarningPermit(SystemClock.elapsedRealtime())
+
+    internal fun isDnsResolutionFailure(error: Throwable): Boolean {
+        val seen = HashSet<Throwable>()
+        var current: Throwable? = error
+        while (current != null && seen.add(current)) {
+            if (current is UnknownHostException) return true
+
+            val message = current.message.orEmpty()
+            if (DNS_FAILURE_MARKERS.any { message.contains(it, ignoreCase = true) }) return true
+            current = current.cause
+        }
+        return false
+    }
+
+    private val DNS_FAILURE_MARKERS = arrayOf(
+        "ERR_DNS_TIMED_OUT",
+        "ERR_NAME_NOT_RESOLVED",
+        "NAME_NOT_RESOLVED",
+        "UNKNOWN_HOST",
+        "unable to resolve host",
+        "nodename nor servname provided",
+    )
+}
+
+internal class NetworkInterferenceState(
+    private val failureWindowMillis: Long = 90_000L,
+    private val warningCooldownMillis: Long = 15 * 60 * 1_000L,
+) {
+    private companion object {
+        const val MIN_FAILURES = 2
+    }
+
+    private val lock = Any()
+    private val recentFailures = ArrayDeque<Long>()
+    private var lastWarningElapsedMillis: Long? = null
+
+    fun recordFailure(nowElapsedMillis: Long): Boolean = synchronized(lock) {
+        while (recentFailures.peekFirst()?.let { nowElapsedMillis - it > failureWindowMillis } == true) {
+            recentFailures.removeFirst()
+        }
+        recentFailures.addLast(nowElapsedMillis)
+        recentFailures.size >= MIN_FAILURES
+    }
+
+    fun tryAcquireWarningPermit(nowElapsedMillis: Long): Boolean = synchronized(lock) {
+        val lastWarning = lastWarningElapsedMillis
+        if (lastWarning != null && nowElapsedMillis - lastWarning < warningCooldownMillis) {
+            false
+        } else {
+            lastWarningElapsedMillis = nowElapsedMillis
+            true
+        }
+    }
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/WebSocket.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/WebSocket.kt
@@ -148,7 +148,12 @@ class WebSocket(
                     }
                     is Event.Message -> listener.onMessage(this, event.text)
                     Event.Closed -> return ConnectionResult(connected = opened)
-                    is Event.Failed -> return ConnectionResult(opened, event.error, event.httpCode)
+                    is Event.Failed -> {
+                        if (!disconnectRequested) {
+                            NetworkInterferenceReporter.report(urlHost(), event.error)
+                        }
+                        return ConnectionResult(opened, event.error, event.httpCode)
+                    }
                 }
             }
         } finally {
@@ -185,6 +190,8 @@ class WebSocket(
     fun updateUrl(url: String) {
         this.url = url
     }
+
+    private fun urlHost(): String? = runCatching { java.net.URI(url).host }.getOrNull()
 
     interface Listener {
         suspend fun onConnect(webSocket: WebSocket) {}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -236,6 +236,7 @@
     <string name="settings_live_rewind_summary">Rewind live streams using their recording</string>
     <string name="player_live" translatable="false">LIVE</string>
     <string name="settings_player_behavior">Player behavior</string>
+    <string name="network_filter_warning" translatable="false">Some Twitch requests failed to resolve. A DNS filter, VPN, proxy, or network issue may be blocking Twitch.</string>
     <string name="settings_buffer_limits">Buffer limits</string>
     <string name="settings_buffer_live">Live latency</string>
     <string name="settings_playback_stream">Stream requests</string>

--- a/app/src/test/java/com/github/andreyasadchy/xtra/util/NetworkInterferenceReporterTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/util/NetworkInterferenceReporterTest.kt
@@ -1,0 +1,67 @@
+package com.github.andreyasadchy.xtra.util
+
+import java.io.IOException
+import java.net.UnknownHostException
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class NetworkInterferenceReporterTest {
+    private val state = NetworkInterferenceState()
+
+    @Test
+    fun `recognizes unknown host failures`() {
+        assertTrue(NetworkInterferenceReporter.isDnsResolutionFailure(UnknownHostException("gql.twitch.tv")))
+    }
+
+    @Test
+    fun `recognizes nested DNS transport failures`() {
+        val error = IOException("request failed", UnknownHostException("gql.twitch.tv"))
+
+        assertTrue(NetworkInterferenceReporter.isDnsResolutionFailure(error))
+    }
+
+    @Test
+    fun `recognizes Cronet name resolution failures`() {
+        assertTrue(NetworkInterferenceReporter.isDnsResolutionFailure(IOException("net::ERR_NAME_NOT_RESOLVED")))
+    }
+
+    @Test
+    fun `does not classify ordinary request failures as DNS failures`() {
+        assertFalse(NetworkInterferenceReporter.isDnsResolutionFailure(IOException("connection timed out")))
+    }
+
+    @Test
+    fun `one failure is not enough to produce a candidate`() {
+        assertFalse(state.recordFailure(1_000L))
+    }
+
+    @Test
+    fun `two failures within the window produce a candidate`() {
+        assertFalse(state.recordFailure(1_000L))
+
+        assertTrue(state.recordFailure(90_000L))
+    }
+
+    @Test
+    fun `failures outside the window do not produce a candidate`() {
+        assertFalse(state.recordFailure(1_000L))
+
+        assertFalse(state.recordFailure(91_001L))
+    }
+
+    @Test
+    fun `candidate detection does not consume the display cooldown`() {
+        assertFalse(state.recordFailure(1_000L))
+        assertTrue(state.recordFailure(2_000L))
+
+        assertTrue(state.tryAcquireWarningPermit(2_000L))
+    }
+
+    @Test
+    fun `display permit is suppressed for fifteen minutes`() {
+        assertTrue(state.tryAcquireWarningPermit(1_000L))
+        assertFalse(state.tryAcquireWarningPermit(900_999L))
+        assertTrue(state.tryAcquireWarningPermit(901_000L))
+    }
+}


### PR DESCRIPTION
Warn users when repeated Twitch DNS-resolution failures suggest a DNS filter, VPN, proxy, or network issue may be blocking Twitch.