### PR TITLE
Restore earned channel points notices in live chat

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/ChatViewModel.kt
@@ -4769,12 +4769,15 @@ class ChatViewModel(
             }
             if (notifyPoints) {
                 if (channelMatches) {
-                    onMessage(ChatMessage(
+                    val notice = ChatMessage(
+                        id = points.messageId,
                         type = ChatMessage.NOTICE_MESSAGE,
                         systemMsg = ContextCompat.getString(applicationContext, R.string.points_earned).format(points.pointsGained),
                         timestamp = points.timestamp,
                         fullMsg = points.fullMsg
-                    ))
+                    )
+                    forwardLegacyNoticeToV2(notice, channelId)
+                    onMessage(notice)
                 }
             }
         }
@@ -5557,6 +5560,24 @@ class ChatViewModel(
             active.session.submit(
                 active.key,
                 TwitchChatEventParser.fromPubSubReward(message, targetChannelId),
+            )
+        } catch (error: CancellationException) {
+            throw error
+        } catch (_: Throwable) {
+            // The legacy chat path remains authoritative if v2 is stopping concurrently.
+        }
+    }
+
+    /** Supplemental Hermes notices must enter the V2 timeline because live chat no longer reads
+     * the ViewModel's legacy mutation stream. */
+    private suspend fun forwardLegacyNoticeToV2(message: ChatMessage, channelId: String?) {
+        val targetChannelId = channelId ?: return
+        val active = v2ActiveSession.value ?: return
+        if (!active.spec.legacySupplementalSockets || active.spec.channelId != targetChannelId) return
+        try {
+            active.session.submit(
+                active.key,
+                TwitchChatEventParser.fromLegacyNotice(message, targetChannelId),
             )
         } catch (error: CancellationException) {
             throw error

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/transport/TwitchChatEventParser.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/transport/TwitchChatEventParser.kt
@@ -158,6 +158,16 @@ object TwitchChatEventParser {
         )
     }
 
+    /** Normalizes a legacy system notice emitted by a supplemental Hermes listener. */
+    fun fromLegacyNotice(message: LegacyChatMessage, channelId: String): ChatEvent.Notice {
+        val normalized = fromLegacy(message, channelId, forceNotice = true)
+        return ChatEvent.Notice(
+            message = normalized,
+            eventId = normalized.id.value,
+            receivedAtMs = normalized.timestampMs,
+        )
+    }
+
     fun fromEventSubClear(event: JSONObject, timestamp: String?, notificationId: String? = null): ChatEvent {
         val receivedAt = parseTimestamp(timestamp)
         val eventId = notificationId?.takeIf { it.isNotBlank() }

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/TwitchChatEventParserTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/chat/v2/TwitchChatEventParserTest.kt
@@ -15,6 +15,7 @@ import com.github.andreyasadchy.xtra.ui.chat.v2.presentation.ChatEventKind
 import com.github.andreyasadchy.xtra.ui.chat.v2.presentation.ChatPiece
 import com.github.andreyasadchy.xtra.ui.chat.v2.presentation.ChatRowCompiler
 import com.github.andreyasadchy.xtra.ui.chat.v2.transport.TwitchChatEventParser
+import com.github.andreyasadchy.xtra.model.chat.ChatMessage as LegacyChatMessage
 import com.github.andreyasadchy.xtra.util.chat.ChatUtils
 import com.github.andreyasadchy.xtra.util.chat.PubSubUtils
 import org.json.JSONObject
@@ -318,6 +319,24 @@ class TwitchChatEventParserTest {
         assertEquals("reward-1", message.rewardId)
         assertEquals("Sound Alert", message.rewardTitle)
         assertTrue(message.segments.isEmpty())
+    }
+
+    @Test
+    fun legacySystemNoticeIsNormalizedForTheV2Timeline() {
+        val event = TwitchChatEventParser.fromLegacyNotice(
+            LegacyChatMessage(
+                type = LegacyChatMessage.NOTICE_MESSAGE,
+                id = "points-earned-1",
+                systemMsg = "Received 50 channel points",
+                timestamp = 1234L,
+            ),
+            "broadcaster",
+        )
+
+        assertEquals(ChatMessageKind.NOTICE, event.message.kind)
+        assertEquals("Received 50 channel points", event.message.systemText)
+        assertEquals("points-earned-1", event.eventId)
+        assertEquals("broadcaster", event.message.channelId)
     }
 
     @Test


### PR DESCRIPTION
Restores the earned channel points notice in the live V2 chat timeline. Adds regression coverage for legacy notice conversion.