### PR TITLE
Make emote picker assets load faster

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/CompactEmojiAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/CompactEmojiAdapter.kt
@@ -26,6 +26,12 @@ internal class CompactEmojiAdapter(
     private var items: List<Item> = emptyList()
 
     fun submitSections(sections: List<Pair<EmojiPickerCategory, List<EmojiPickerItem>>>) {
+        emojiAdapter.prefetch(
+            sections.asSequence()
+                .flatMap { it.second.asSequence() }
+                .take(EmotePickerImageLoader.INITIAL_PREFETCH_LIMIT)
+                .asIterable(),
+        )
         items = sections.flatMap { (category, emojis) ->
             if (emojis.isEmpty()) emptyList()
             else listOf(Item.Header(category)) + emojis.map(Item::EmojiItem)
@@ -68,7 +74,16 @@ internal class CompactEmojiAdapter(
         when (val item = items[position]) {
             is Item.Header -> (holder as SectionHeaderViewHolder).title.text =
                 holder.itemView.context.getString(item.category.titleRes)
-            is Item.EmojiItem -> (holder as EmojiAdapter.ViewHolder).bind(item.emoji)
+            is Item.EmojiItem -> {
+                (holder as EmojiAdapter.ViewHolder).bind(item.emoji)
+                emojiAdapter.prefetch(
+                    items.asSequence()
+                        .drop(position + 1)
+                        .mapNotNull { (it as? Item.EmojiItem)?.emoji }
+                        .take(EmotePickerImageLoader.LOOKAHEAD_PREFETCH_LIMIT)
+                        .asIterable(),
+                )
+            }
         }
     }
 

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/EmojiAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/EmojiAdapter.kt
@@ -38,7 +38,21 @@ internal class EmojiAdapter(
     var itemTouchHelper: ItemTouchHelper? = null
     var accessibilityMoveListener: ((Int, Int) -> Boolean)? = null
 
-    fun submitList(items: List<EmojiPickerItem>) = differ.submitList(items.toList())
+    fun submitList(items: List<EmojiPickerItem>) {
+        val copy = items.toList()
+        prefetch(copy)
+        differ.submitList(copy)
+    }
+
+    fun prefetch(items: Iterable<EmojiPickerItem>) {
+        assets.prefetch(
+            items.asSequence()
+                .map { Twemoji.asset(it.value).key }
+                .distinct()
+                .take(EmotePickerImageLoader.INITIAL_PREFETCH_LIMIT)
+                .asIterable(),
+        )
+    }
 
     fun setFavoriteValues(values: Set<String>) {
         if (favoriteValues == values) return
@@ -83,6 +97,12 @@ internal class EmojiAdapter(
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
         holder.bind(differ.currentList[position])
+        prefetch(
+            differ.currentList.asSequence()
+                .drop(position + 1)
+                .take(EmotePickerImageLoader.LOOKAHEAD_PREFETCH_LIMIT)
+                .asIterable(),
+        )
     }
 
     inner class ViewHolder(

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/EmotePickerImageLoader.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/EmotePickerImageLoader.kt
@@ -1,0 +1,115 @@
+package com.github.andreyasadchy.xtra.ui.chat
+
+import android.content.Context
+import android.util.TypedValue
+import coil3.imageLoader
+import coil3.network.NetworkHeaders
+import coil3.network.httpHeaders
+import coil3.request.CachePolicy
+import coil3.request.Disposable
+import coil3.request.ImageRequest
+import coil3.request.crossfade
+import coil3.request.target
+import com.github.andreyasadchy.xtra.BuildConfig
+import com.github.andreyasadchy.xtra.model.chat.Emote
+import java.util.LinkedHashMap
+
+/** Shared, bounded image requests for the emote picker and its adapters. */
+internal object EmotePickerImageLoader {
+    const val INITIAL_PREFETCH_LIMIT = 64
+    const val LOOKAHEAD_PREFETCH_LIMIT = 24
+    private const val PREFETCH_TRACKER_LIMIT = 512
+    private const val PREFETCH_TRACKER_TTL_MS = 15_000L
+    private val prefetchedAt = LinkedHashMap<String, Long>(PREFETCH_TRACKER_LIMIT, .75f, true)
+    private val prefetchedRequests = LinkedHashMap<String, Disposable>(PREFETCH_TRACKER_LIMIT, .75f, true)
+
+    fun urlFor(item: Emote, quality: String): String? = when (quality) {
+        "4" -> item.url4x ?: item.url3x ?: item.url2x ?: item.url1x
+        "3" -> item.url3x ?: item.url2x ?: item.url1x
+        "2" -> item.url2x ?: item.url1x
+        else -> item.url1x
+    }
+
+    fun request(context: Context, item: Emote, quality: String): ImageRequest.Builder? {
+        val url = urlFor(item, quality) ?: return null
+        val sizePx = pickerRequestSizePx(context)
+        return ImageRequest.Builder(context)
+            .data(url)
+            .size(sizePx, sizePx)
+            .memoryCacheKey(memoryCacheKey(url, sizePx))
+            .diskCacheKey(url)
+            .memoryCachePolicy(CachePolicy.ENABLED)
+            .diskCachePolicy(CachePolicy.ENABLED)
+            .networkCachePolicy(CachePolicy.ENABLED)
+            .crossfade(false)
+            .apply {
+                if (item.thirdParty) {
+                    httpHeaders(NetworkHeaders.Builder().apply {
+                        add("User-Agent", "Xtra/${BuildConfig.VERSION_NAME}")
+                    }.build())
+                }
+            }
+    }
+
+    fun loadInto(context: Context, item: Emote, quality: String, target: android.widget.ImageView) {
+        prefetchKey(context, item, quality)?.let(::cancelPrefetch)
+        request(context, item, quality)
+            ?.target(target)
+            ?.build()
+            ?.let(context.imageLoader::enqueue)
+    }
+
+    fun prefetch(context: Context, items: Iterable<Emote>, quality: String) {
+        val appContext = context.applicationContext
+        items.asSequence()
+            .distinctBy { item -> urlFor(item, quality) }
+            .mapNotNull { item ->
+                val key = prefetchKey(appContext, item, quality) ?: return@mapNotNull null
+                if (!markForPrefetch(key)) return@mapNotNull null
+                cancelPrefetch(key)
+                request(appContext, item, quality)?.build()
+                    ?.also { request ->
+                        val disposable = appContext.imageLoader.enqueue(request)
+                        synchronized(prefetchedRequests) {
+                            prefetchedRequests[key] = disposable
+                            while (prefetchedRequests.size > PREFETCH_TRACKER_LIMIT) {
+                                prefetchedRequests.remove(prefetchedRequests.entries.first().key)?.dispose()
+                            }
+                        }
+                    }
+            }
+            .take(INITIAL_PREFETCH_LIMIT)
+            .count()
+    }
+
+    private fun markForPrefetch(key: String): Boolean {
+        val now = System.currentTimeMillis()
+        synchronized(prefetchedAt) {
+            val previous = prefetchedAt[key]
+            if (previous != null && now - previous < PREFETCH_TRACKER_TTL_MS) return false
+            prefetchedAt[key] = now
+            while (prefetchedAt.size > PREFETCH_TRACKER_LIMIT) {
+                prefetchedAt.remove(prefetchedAt.entries.first().key)
+            }
+            return true
+        }
+    }
+
+    private fun prefetchKey(context: Context, item: Emote, quality: String): String? =
+        urlFor(item, quality)?.let { "$it@${pickerRequestSizePx(context)}" }
+
+    private fun cancelPrefetch(key: String) {
+        synchronized(prefetchedRequests) {
+            prefetchedRequests.remove(key)?.dispose()
+        }
+    }
+
+    private fun pickerRequestSizePx(context: Context): Int = TypedValue.applyDimension(
+        TypedValue.COMPLEX_UNIT_DIP,
+        48f,
+        context.resources.displayMetrics,
+    ).toInt().coerceAtLeast(1)
+
+    private fun memoryCacheKey(url: String, sizePx: Int): String =
+        "xtra:emote-picker:$url:${sizePx}x$sizePx"
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/EmotesAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/EmotesAdapter.kt
@@ -17,16 +17,9 @@ import androidx.recyclerview.widget.AsyncListDiffer
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ItemTouchHelper
 import androidx.recyclerview.widget.RecyclerView
-import coil3.imageLoader
-import coil3.network.NetworkHeaders
-import coil3.network.httpHeaders
-import coil3.request.ImageRequest
-import coil3.request.crossfade
-import coil3.request.target
 import com.bumptech.glide.Glide
 import com.bumptech.glide.load.engine.DiskCacheStrategy
 import com.bumptech.glide.load.model.GlideUrl
-import com.bumptech.glide.load.resource.drawable.DrawableTransitionOptions
 import com.github.andreyasadchy.xtra.BuildConfig
 import com.github.andreyasadchy.xtra.R
 import com.github.andreyasadchy.xtra.databinding.FragmentEmotesListItemBinding
@@ -90,6 +83,7 @@ class EmotesAdapter(
      * mutating a list owned by a caller or by RecyclerView.
      */
     fun submitList(newItems: List<Emote>) {
+        fragment.context?.let { EmotePickerImageLoader.prefetch(it, newItems, emoteQuality) }
         if (reorderable) {
             // The favorites tab rebinds every item on notifyDataSetChanged,
             // which reloads all visible images. Skip redundant submissions
@@ -126,6 +120,10 @@ class EmotesAdapter(
 
     fun currentItems(): List<Emote> = if (reorderable) items.toList() else differ.currentList
 
+    fun prefetch(items: Iterable<Emote>) {
+        fragment.context?.let { EmotePickerImageLoader.prefetch(it, items, emoteQuality) }
+    }
+
     fun setFavoriteKeys(keys: Set<FavoriteEmoteKey>) {
         if (favoriteKeys != keys) {
             favoriteKeys = keys
@@ -158,6 +156,12 @@ class EmotesAdapter(
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
         val currentItems = if (reorderable) items else differ.currentList
         holder.bind(currentItems.getOrNull(position))
+        prefetch(
+            currentItems.asSequence()
+                .drop(position + 1)
+                .take(EmotePickerImageLoader.LOOKAHEAD_PREFETCH_LIMIT)
+                .asIterable(),
+        )
     }
 
     override fun onViewRecycled(holder: ViewHolder) {
@@ -234,34 +238,19 @@ class EmotesAdapter(
                         item.name,
                     )
                     emote.isFocusable = true
-                    val imageUrl = when (emoteQuality) {
-                        "4" -> item.url4x ?: item.url3x ?: item.url2x ?: item.url1x
-                        "3" -> item.url3x ?: item.url2x ?: item.url1x
-                        "2" -> item.url2x ?: item.url1x
-                        else -> item.url1x
-                    }
+                    val imageUrl = EmotePickerImageLoader.urlFor(item, emoteQuality)
                     // Rebinds (scroll, list resubmission) must not reload an
-                    // image that is already displayed: the crossfade would
-                    // blink even when fading from the image onto itself.
+                    // image that is already displayed.
                     val alreadyLoaded = emote.getTag(R.id.emote_image_url_key) == imageUrl && emote.drawable != null
                     if (alreadyLoaded) {
                         // Keep the current drawable; fall through to listeners.
-                    } else if (imageLibrary == "0" || (imageLibrary == "1" && !item.format.equals("webp", true))) {
+                    } else if (imageUrl != null && (imageLibrary == "0" || (imageLibrary == "1" && !item.format.equals("webp", true)))) {
                         emote.setTag(R.id.emote_image_url_key, imageUrl)
-                        fragment.requireContext().imageLoader.enqueue(
-                            ImageRequest.Builder(fragment.requireContext()).apply {
-                                data(imageUrl)
-                                if (item.thirdParty) {
-                                    httpHeaders(NetworkHeaders.Builder().apply {
-                                        add("User-Agent", "Xtra/" + BuildConfig.VERSION_NAME)
-                                    }.build())
-                                }
-                                crossfade(true)
-                                target(emote)
-                            }.build()
-                        )
+                        emote.setImageDrawable(null)
+                        EmotePickerImageLoader.loadInto(fragment.requireContext(), item, emoteQuality, emote)
                     } else {
                         emote.setTag(R.id.emote_image_url_key, imageUrl)
+                        emote.setImageDrawable(null)
                         Glide.with(fragment)
                             .load(
                                 imageUrl.let {
@@ -271,7 +260,7 @@ class EmotesAdapter(
                                 }
                             )
                             .diskCacheStrategy(DiskCacheStrategy.DATA)
-                            .transition(DrawableTransitionOptions.withCrossFade())
+                            .dontAnimate()
                             .into(emote)
                     }
                     if (!canReorder) {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/FavoritePickerAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/FavoritePickerAdapter.kt
@@ -55,6 +55,18 @@ internal class FavoritePickerAdapter(
     fun submitList(newItems: List<FavoritePickerItem>) {
         if (items.hasSameFavoritePickerBinding(newItems)) return
         items = newItems.toList()
+        emoteAdapter.prefetch(
+            items.asSequence()
+                .mapNotNull { (it as? FavoritePickerItem.EmoteItem)?.emote }
+                .take(EmotePickerImageLoader.INITIAL_PREFETCH_LIMIT)
+                .asIterable(),
+        )
+        emojiAdapter.prefetch(
+            items.asSequence()
+                .mapNotNull { (it as? FavoritePickerItem.EmojiItem)?.emoji }
+                .take(EmotePickerImageLoader.INITIAL_PREFETCH_LIMIT)
+                .asIterable(),
+        )
         notifyDataSetChanged()
     }
 
@@ -117,8 +129,26 @@ internal class FavoritePickerAdapter(
 
     override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
         when (val item = items[position]) {
-            is FavoritePickerItem.EmoteItem -> (holder as EmotesAdapter.ViewHolder).bind(item.emote)
-            is FavoritePickerItem.EmojiItem -> (holder as EmojiAdapter.ViewHolder).bind(item.emoji)
+            is FavoritePickerItem.EmoteItem -> {
+                (holder as EmotesAdapter.ViewHolder).bind(item.emote)
+                emoteAdapter.prefetch(
+                    items.asSequence()
+                        .drop(position + 1)
+                        .mapNotNull { (it as? FavoritePickerItem.EmoteItem)?.emote }
+                        .take(EmotePickerImageLoader.LOOKAHEAD_PREFETCH_LIMIT)
+                        .asIterable(),
+                )
+            }
+            is FavoritePickerItem.EmojiItem -> {
+                (holder as EmojiAdapter.ViewHolder).bind(item.emoji)
+                emojiAdapter.prefetch(
+                    items.asSequence()
+                        .drop(position + 1)
+                        .mapNotNull { (it as? FavoritePickerItem.EmojiItem)?.emoji }
+                        .take(EmotePickerImageLoader.LOOKAHEAD_PREFETCH_LIMIT)
+                        .asIterable(),
+                )
+            }
         }
     }
 

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/TwitchEmotesAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/TwitchEmotesAdapter.kt
@@ -36,6 +36,7 @@ internal class TwitchEmotesAdapter(
 
     fun submitList(newItems: List<Emote>) {
         emotes = newItems.toList()
+        emoteAdapter.prefetch(emotes)
         rebuildItems()
         notifyDataSetChanged()
     }
@@ -78,7 +79,16 @@ internal class TwitchEmotesAdapter(
         when (val item = items[position]) {
             is Item.Header -> (holder as SectionHeaderViewHolder).title.text =
                 holder.itemView.context.getString(item.group.titleRes)
-            is Item.EmoteItem -> (holder as EmotesAdapter.ViewHolder).bind(item.emote)
+            is Item.EmoteItem -> {
+                (holder as EmotesAdapter.ViewHolder).bind(item.emote)
+                emoteAdapter.prefetch(
+                    items.asSequence()
+                        .drop(position + 1)
+                        .mapNotNull { (it as? Item.EmoteItem)?.emote }
+                        .take(EmotePickerImageLoader.LOOKAHEAD_PREFETCH_LIMIT)
+                        .asIterable(),
+                )
+            }
         }
     }
 

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/assets/ChatAssetRepository.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/chat/v2/assets/ChatAssetRepository.kt
@@ -43,6 +43,23 @@ class ChatAssetRepository(
     @Synchronized internal fun cachedStateCount(): Int = states.size
     @Synchronized internal fun observerCount(key: ChatAssetKey): Int = listeners[key]?.size ?: 0
 
+    /** Warms shareable assets without attaching work to a transient RecyclerView row. */
+    fun prefetch(keys: Iterable<ChatAssetKey>) {
+        keys.asSequence().distinct().forEach { key ->
+            val shouldRequest = synchronized(this) {
+                if (states.containsKey(key)) {
+                    false
+                } else {
+                    states[key] = ChatAssetState.Missing
+                    trimCacheLocked()
+                    updateDiagnosticsLocked()
+                    true
+                }
+            }
+            if (shouldRequest) request(key)
+        }
+    }
+
     fun observe(key: ChatAssetKey, listener: () -> Unit) {
         val readyImage = synchronized(this) {
             listeners.getOrPut(key) { LinkedHashSet() }.add(listener)


### PR DESCRIPTION
Warm the first picker assets and a small scroll lookahead through the shared image caches. Use fixed-size, no-crossfade requests so cached emotes and Twemoji render without UI stalls, while keeping channel-specific loading bounded.