### PR TITLE
Show complete updater changelog history

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/settings/SettingsActivity.kt
@@ -113,7 +113,6 @@ import com.github.andreyasadchy.xtra.ui.update.UpdateUiModel
 import com.github.andreyasadchy.xtra.ui.update.UpdateUiStatus
 import com.github.andreyasadchy.xtra.ui.update.toUiModel
 import com.github.andreyasadchy.xtra.util.updater.UpdateDiagnostics
-import com.github.andreyasadchy.xtra.util.updater.ChangeKind
 import com.github.andreyasadchy.xtra.util.updater.UpdateReleaseHistory
 import com.github.andreyasadchy.xtra.util.C
 import com.github.andreyasadchy.xtra.util.SettingsMigration
@@ -1727,12 +1726,15 @@ class SettingsActivity : AppCompatActivity() {
         private var _binding: FragmentUpdateSettingsBinding? = null
         private val binding get() = _binding!!
         private var technicalDetailsExpanded = false
+        private var visibleHistoryCount = INITIAL_HISTORY_COUNT
         private lateinit var updateNotificationPermissionLauncher: ActivityResultLauncher<String>
         private val repository
             get() = (requireContext().applicationContext as XtraApp).xtraModule.updateRepository
 
         override fun onCreate(savedInstanceState: Bundle?) {
             super.onCreate(savedInstanceState)
+            visibleHistoryCount = savedInstanceState?.getInt(KEY_VISIBLE_HISTORY_COUNT, INITIAL_HISTORY_COUNT)
+                ?: INITIAL_HISTORY_COUNT
             updateNotificationPermissionLauncher = registerForActivityResult(
                 ActivityResultContracts.RequestPermission(),
             ) {
@@ -1793,6 +1795,10 @@ class SettingsActivity : AppCompatActivity() {
                 performUpdateAction(UpdateUiMapper.map(repository.state.value, repository.selectedAssetInfo()).secondaryAction)
             }
             binding.updateOverflowButton.setOnClickListener { showUpdateOverflowMenu() }
+            binding.earlierChangesButton.setOnClickListener {
+                visibleHistoryCount += HISTORY_PAGE_SIZE
+                render(repository.state.value)
+            }
             binding.technicalDetailsToggle.setOnClickListener {
                 technicalDetailsExpanded = !technicalDetailsExpanded
                 render(repository.state.value)
@@ -1959,19 +1965,20 @@ class SettingsActivity : AppCompatActivity() {
             val showNotes = model.showReleaseNotes && release != null
             binding.whatsNewTitle.visibility = if (showNotes) View.VISIBLE else View.GONE
             binding.notesContainer.visibility = if (showNotes) View.VISIBLE else View.GONE
-            if (showNotes) {
-                val notes = UpdateReleaseHistory.notesForUpdate(
+            val currentNotes = if (showNotes) {
+                UpdateReleaseHistory.notesForUpdate(
                     historyComplete = repository.releaseHistoryComplete.value,
                     cumulativeReleases = repository.releasesSinceInstalled(release),
                     latestRelease = release,
                 )
-                UpdateNotesBinder.bindHistory(binding.notesContainer, notes)
+            } else {
+                emptyList()
+            }
+            if (showNotes) {
+                UpdateNotesBinder.bindHistory(binding.notesContainer, currentNotes)
             } else {
                 binding.notesContainer.removeAllViews()
             }
-            binding.earlierChangesButton.visibility = View.GONE
-            binding.earlierChangesContainer.visibility = View.GONE
-            binding.earlierChangesContainer.removeAllViews()
             binding.lastCheckedText.text = getString(
                 R.string.last_successful_update_check,
                 UpdateTimeFormatter.format(requireContext(), repository.lastSuccessfulCheck),
@@ -1984,27 +1991,19 @@ class SettingsActivity : AppCompatActivity() {
             binding.technicalDetailsToggle.text = getString(
                 if (technicalDetailsExpanded) R.string.hide_technical_details else R.string.update_diagnostics,
             )
-            val recent = repository.recentReleases(release)
+            val currentNoteIds = currentNotes.mapTo(hashSetOf()) { it.id }
+            val recent = repository.recentReleases(release).filterNot { it.id in currentNoteIds }
             binding.recentUpdatesCard.visibility = if (recent.isEmpty()) View.GONE else View.VISIBLE
-            binding.recentUpdatesContainer.removeAllViews()
-            recent.forEach { recentRelease ->
-                val row = TextView(requireContext()).apply {
-                    val date = recentRelease.publishedAt?.substringBefore('T')
-                    val counts = recentRelease.structuredReleaseNotes.items.groupingBy { it.kind }.eachCount()
-                    text = buildString {
-                        append(recentRelease.displayVersion)
-                        date?.let { append(getString(R.string.update_meta_separator)).append(it) }
-                        if (counts.isNotEmpty()) append("\n").append(
-                            counts.entries.joinToString(getString(R.string.update_meta_separator)) {
-                                getString(changeKindLabel(it.key), it.value)
-                            },
-                        )
-                    }
-                    setTextAppearance(com.google.android.material.R.style.TextAppearance_Material3_BodyMedium)
-                    setPadding(0, dp(8), 0, dp(8))
-                }
-                binding.recentUpdatesContainer.addView(row)
-            }
+            UpdateNotesBinder.bindHistory(
+                binding.recentUpdatesContainer,
+                recent.take(visibleHistoryCount),
+            )
+            val hasMoreHistory = recent.size > visibleHistoryCount
+            binding.earlierChangesButton.visibility = if (hasMoreHistory) View.VISIBLE else View.GONE
+            binding.earlierChangesButton.text = getString(
+                if (hasMoreHistory) R.string.update_release_notes_earlier
+                else R.string.update_release_notes_earlier_expanded,
+            )
         }
 
         private fun showUpdateOverflowMenu() {
@@ -2016,15 +2015,6 @@ class SettingsActivity : AppCompatActivity() {
                 }
             }
             menu.show()
-        }
-
-        @StringRes
-        private fun changeKindLabel(kind: ChangeKind): Int = when (kind) {
-            ChangeKind.NEW -> R.string.update_count_new
-            ChangeKind.IMPROVED -> R.string.update_count_improved
-            ChangeKind.FIXED -> R.string.update_count_fixed
-            ChangeKind.SECURITY -> R.string.update_count_security
-            ChangeKind.OTHER -> R.string.update_count_other
         }
 
         private fun actionText(action: UpdateUiAction?): String = getString(
@@ -2049,6 +2039,17 @@ class SettingsActivity : AppCompatActivity() {
         override fun onDestroyView() {
             _binding = null
             super.onDestroyView()
+        }
+
+        override fun onSaveInstanceState(outState: Bundle) {
+            outState.putInt(KEY_VISIBLE_HISTORY_COUNT, visibleHistoryCount)
+            super.onSaveInstanceState(outState)
+        }
+
+        private companion object {
+            const val INITIAL_HISTORY_COUNT = 5
+            const val HISTORY_PAGE_SIZE = 5
+            const val KEY_VISIBLE_HISTORY_COUNT = "visible_update_history_count"
         }
     }
 

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/update/UpdateNotesBinder.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/update/UpdateNotesBinder.kt
@@ -44,7 +44,13 @@ object UpdateNotesBinder {
 
     private fun addReleaseTitle(container: LinearLayout, release: UpdateRelease, addTopMargin: Boolean) {
         container.addView(TextView(container.context).apply {
-            text = release.displayVersion
+            text = buildString {
+                append(release.displayVersion)
+                release.publishedAt?.substringBefore('T')?.takeIf { it.isNotBlank() }?.let {
+                    append(container.context.getString(R.string.update_meta_separator))
+                    append(it)
+                }
+            }
             setTextAppearance(com.google.android.material.R.style.TextAppearance_Material3_TitleSmall)
             if (addTopMargin) {
                 layoutParams = LinearLayout.LayoutParams(

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/updater/ReleaseNotes.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/updater/ReleaseNotes.kt
@@ -1,6 +1,7 @@
 package com.github.andreyasadchy.xtra.util.updater
 
 import kotlinx.serialization.Serializable
+import java.util.Locale
 
 @Serializable
 enum class ChangeKind { NEW, IMPROVED, FIXED, SECURITY, OTHER }
@@ -27,6 +28,11 @@ object ReleaseNotes {
     private val markdownLink = Regex("\\[([^]]+)]\\(([^()]*(?:\\([^()]*\\)[^()]*)*)\\)")
     private val asteriskEmphasis = Regex("(\\*{1,3})([^*\\n]+)\\1")
     private val underscoreEmphasis = Regex("(?<![\\p{L}\\p{N}_])(_{1,3})([^_\\n]+)\\1(?![\\p{L}\\p{N}_])")
+    private val issueReference = Regex("\\s*\\(?#\\d+\\)?")
+    private val changePrefix = Regex(
+        "^(?:add|added|new|fix|fixed|improve|improved|update|updated|feature|performance|refactor)\\s+",
+        RegexOption.IGNORE_CASE,
+    )
 
     fun structured(body: String?, commits: List<String> = emptyList()): StructuredReleaseNotes {
         val lines = body.orEmpty().lineSequence().toList()
@@ -56,12 +62,19 @@ object ReleaseNotes {
             kind = ChangeKind.OTHER
             parseLines(commits)
         }
-        return StructuredReleaseNotes(
-            items.asSequence()
-                .filterNot { isNoise(it.text) }
-                .distinctBy { it.text.lowercase() }
-                .toList(),
-        )
+        val merged = mutableListOf<ChangeItem>()
+        items.asSequence()
+            .filterNot { isNoise(it.text) }
+            .forEach { item ->
+                val duplicate = merged.firstOrNull { existing -> areDuplicates(existing, item) }
+                if (duplicate == null) {
+                    merged += item
+                } else if (duplicate.kind == ChangeKind.OTHER && item.kind != ChangeKind.OTHER) {
+                    val index = merged.indexOf(duplicate)
+                    merged[index] = duplicate.copy(kind = item.kind)
+                }
+            }
+        return StructuredReleaseNotes(merged)
     }
 
     fun kindFor(text: String): ChangeKind {
@@ -96,6 +109,7 @@ object ReleaseNotes {
         val explicitKind = conventional?.groupValues?.getOrNull(1)?.let(::kindForPrefix)
         val cleaned = description
             .replace(commitHash, "")
+            .replace(issueReference, " ")
             .replace(Regex("\\s+by\\s+@[\\w-]+.*$", RegexOption.IGNORE_CASE), "")
             .replace(markdownLink) { it.groupValues[1] }
             .replace(asteriskEmphasis, "$2")
@@ -136,10 +150,28 @@ object ReleaseNotes {
             text.equals("what's changed", ignoreCase = true) ||
             text.matches(Regex("(?i)(chore|ci|build)?\\s*[:\\-]?\\s*(release automation|automate master build releases|bump version).*"))
     }
+
+    private fun areDuplicates(left: ChangeItem, right: ChangeItem): Boolean {
+        val leftText = duplicateText(left.text)
+        val rightText = duplicateText(right.text)
+        if (leftText.isBlank() || rightText.isBlank()) return false
+        if (left.kind != right.kind && left.kind != ChangeKind.OTHER && right.kind != ChangeKind.OTHER) return false
+        if (leftText == rightText) return true
+        return withoutChangePrefix(leftText) == withoutChangePrefix(rightText)
+    }
+
+    private fun duplicateText(value: String): String = value
+        .replace(issueReference, " ")
+        .lowercase(Locale.ROOT)
+        .replace(Regex("[^\\p{L}\\p{N}]+"), " ")
+        .trim()
+        .replace(whitespace, " ")
+
+    private fun withoutChangePrefix(value: String): String = value.replace(changePrefix, "").trim()
 }
 
 object UpdateReleaseHistory {
-    const val RECENT_RELEASE_COUNT = 5
+    const val RECENT_RELEASE_COUNT = 20
 
     fun merge(releases: List<UpdateRelease>): List<UpdateRelease> = releases.asSequence()
         .filter { !it.draft && !it.prerelease }
@@ -150,8 +182,17 @@ object UpdateReleaseHistory {
     fun sinceInstalled(releases: List<UpdateRelease>, installedVersionName: String, installedBuildNumber: Long?, fallbackRelease: UpdateRelease? = null): List<UpdateRelease> =
         merge(releases + listOfNotNull(fallbackRelease)).filter { UpdatePolicy.isNewer(installedVersionName, installedBuildNumber, it) }
 
-    fun recent(releases: List<UpdateRelease>, fallbackRelease: UpdateRelease? = null): List<UpdateRelease> =
-        merge(releases + listOfNotNull(fallbackRelease)).take(RECENT_RELEASE_COUNT)
+    fun recent(
+        releases: List<UpdateRelease>,
+        installedVersionName: String,
+        installedBuildNumber: Long?,
+        fallbackRelease: UpdateRelease? = null,
+    ): List<UpdateRelease> {
+        val merged = merge(releases + listOfNotNull(fallbackRelease))
+        val pending = merged.filter { UpdatePolicy.isNewer(installedVersionName, installedBuildNumber, it) }
+        val installedOrOlder = merged.filterNot { UpdatePolicy.isNewer(installedVersionName, installedBuildNumber, it) }
+        return merge(pending + installedOrOlder.take(RECENT_RELEASE_COUNT))
+    }
 
     fun notesForUpdate(
         historyComplete: Boolean,
@@ -166,7 +207,8 @@ object UpdateReleaseHistory {
     fun retainForInstalled(releases: List<UpdateRelease>, installedVersionName: String, installedBuildNumber: Long?): List<UpdateRelease> {
         val merged = merge(releases)
         val pending = merged.filter { UpdatePolicy.isNewer(installedVersionName, installedBuildNumber, it) }
-        return merge(merged.take(RECENT_RELEASE_COUNT) + pending)
+        val installedOrOlder = merged.filterNot { UpdatePolicy.isNewer(installedVersionName, installedBuildNumber, it) }
+        return merge(pending + installedOrOlder.take(RECENT_RELEASE_COUNT))
     }
 
     fun formatGrouped(releases: List<UpdateRelease>, noReleaseNotes: String): String = releases.joinToString("\n\n") { release ->

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/updater/UpdateModels.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/updater/UpdateModels.kt
@@ -55,6 +55,7 @@ data class CachedUpdateRelease(
     val buildNumber: Long?,
     val releaseNotes: List<String>,
     val releaseNoteKinds: List<ChangeKind> = emptyList(),
+    val publishedAt: String? = null,
 )
 
 fun UpdateRelease.toCachedHistory(): CachedUpdateRelease = CachedUpdateRelease(
@@ -63,6 +64,7 @@ fun UpdateRelease.toCachedHistory(): CachedUpdateRelease = CachedUpdateRelease(
     buildNumber = buildNumber,
     releaseNotes = releaseNotes,
     releaseNoteKinds = releaseNoteKinds,
+    publishedAt = publishedAt,
 )
 
 fun CachedUpdateRelease.toUpdateRelease(): UpdateRelease = UpdateRelease(
@@ -72,9 +74,9 @@ fun CachedUpdateRelease.toUpdateRelease(): UpdateRelease = UpdateRelease(
     title = "",
     releaseNotes = releaseNotes,
     releaseNoteKinds = releaseNoteKinds,
+    publishedAt = publishedAt,
     rawBody = "",
     releaseUrl = "",
-    publishedAt = null,
     assets = emptyList(),
     prerelease = false,
     draft = false,

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/updater/UpdateRepository.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/updater/UpdateRepository.kt
@@ -182,8 +182,14 @@ class UpdateRepository(
                         val release = (parsed as? ReleaseParseResult.Success)?.release
                             ?: throw UpdateException((parsed as ReleaseParseResult.Failure).error, stage = UpdateStage.PARSE)
                         when (val history = fetchReleaseHistory(url, networkLibrary, generation)) {
-                            is ReleaseHistoryResult.Complete -> updateReleaseHistory(listOf(release) + history.releases)
-                            is ReleaseHistoryResult.Partial,
+                            is ReleaseHistoryResult.Complete -> updateReleaseHistory(
+                                releases = listOf(release) + history.releases,
+                                complete = true,
+                            )
+                            is ReleaseHistoryResult.Partial -> updateReleaseHistory(
+                                releases = listOf(release) + history.releases,
+                                complete = false,
+                            )
                             ReleaseHistoryResult.Unavailable -> markReleaseHistoryIncomplete()
                         }
                         ensureCurrentCheck(generation)
@@ -864,7 +870,12 @@ class UpdateRepository(
         }
 
     fun recentReleases(fallbackRelease: UpdateRelease? = null): List<UpdateRelease> =
-        UpdateReleaseHistory.recent(_releaseHistory.value, fallbackRelease)
+        UpdateReleaseHistory.recent(
+            releases = _releaseHistory.value,
+            installedVersionName = BuildConfig.VERSION_NAME,
+            installedBuildNumber = installedBuildNumber,
+            fallbackRelease = fallbackRelease,
+        )
 
     private val installedBuildNumber: Long?
         get() = UpdateVersionDisplay.installedBuildNumber(
@@ -955,13 +966,13 @@ class UpdateRepository(
                 ?.let(ReleaseHistoryResult::Partial)
                 ?: ReleaseHistoryResult.Unavailable
             val pageReleases = ReleaseParser.parseHistory(response, url)
-            releases += pageReleases.filter { release ->
-                UpdatePolicy.isNewer(BuildConfig.VERSION_NAME, installedBuildNumber, release)
-            }
-            val reachedInstalledBuild = pageReleases.any { release ->
+            releases += pageReleases
+            val installedOrOlderCount = UpdateReleaseHistory.merge(releases).count { release ->
                 !UpdatePolicy.isNewer(BuildConfig.VERSION_NAME, installedBuildNumber, release)
             }
-            if (response.size < RELEASE_HISTORY_PAGE_SIZE || reachedInstalledBuild) {
+            if (response.size < RELEASE_HISTORY_PAGE_SIZE ||
+                installedOrOlderCount >= UpdateReleaseHistory.RECENT_RELEASE_COUNT
+            ) {
                 return ReleaseHistoryResult.Complete(releases)
             }
             page += 1
@@ -971,7 +982,7 @@ class UpdateRepository(
             ?: ReleaseHistoryResult.Unavailable
     }
 
-    private fun updateReleaseHistory(releases: List<UpdateRelease>) {
+    private fun updateReleaseHistory(releases: List<UpdateRelease>, complete: Boolean) {
         val merged = UpdateReleaseHistory.retainForInstalled(
             releases = releases + _releaseHistory.value,
             installedVersionName = BuildConfig.VERSION_NAME,
@@ -981,13 +992,13 @@ class UpdateRepository(
             .map(UpdateRelease::toCachedHistory)
             .map(CachedUpdateRelease::toUpdateRelease)
         _releaseHistory.value = compacted
-        _releaseHistoryComplete.value = true
+        _releaseHistoryComplete.value = complete
         preferences.edit {
             putString(
                 C.UPDATE_RELEASE_HISTORY,
                 historyJson.encodeToString(compacted.map(UpdateRelease::toCachedHistory)),
             )
-            putBoolean(C.UPDATE_RELEASE_HISTORY_COMPLETE, true)
+            putBoolean(C.UPDATE_RELEASE_HISTORY_COMPLETE, complete)
         }
     }
 

--- a/app/src/main/res/layout/fragment_update_settings.xml
+++ b/app/src/main/res/layout/fragment_update_settings.xml
@@ -140,22 +140,6 @@
             android:layout_marginTop="8dp"
             android:orientation="vertical" />
 
-        <com.google.android.material.button.MaterialButton
-            android:id="@+id/earlierChangesButton"
-            style="@style/Widget.Material3.Button.TextButton"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="4dp"
-            android:text="@string/update_release_notes_earlier"
-            android:visibility="gone" />
-
-        <LinearLayout
-            android:id="@+id/earlierChangesContainer"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="vertical"
-            android:visibility="gone" />
-
         <TextView
             android:id="@+id/lastCheckedText"
             android:layout_width="match_parent"
@@ -261,6 +245,15 @@
                     android:layout_height="wrap_content"
                     android:layout_marginTop="8dp"
                     android:orientation="vertical" />
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/earlierChangesButton"
+                    style="@style/Widget.Material3.Button.TextButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="6dp"
+                    android:text="@string/update_release_notes_earlier"
+                    android:visibility="gone" />
             </LinearLayout>
         </com.google.android.material.card.MaterialCardView>
     </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1285,8 +1285,8 @@
     <string name="update_install_permission_title">Installation permission required</string>
     <string name="update_install_cancelled_message">The installation was cancelled. You can try again.</string>
     <string name="update_install_failed_message">Xtra could not install this update. Try again.</string>
-    <string name="update_release_notes_earlier">Earlier changes included</string>
-    <string name="update_release_notes_earlier_expanded">Earlier changes included</string>
+    <string name="update_release_notes_earlier">Show older updates</string>
+    <string name="update_release_notes_earlier_expanded">Show fewer updates</string>
     <string name="update_full_release_notes">Full release notes</string>
     <string name="update_checked_recently">Checked %s</string>
     <string name="update_error_message">Something went wrong. See diagnostics for details.</string>

--- a/app/src/test/java/com/github/andreyasadchy/xtra/util/updater/StructuredReleaseNotesTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/util/updater/StructuredReleaseNotesTest.kt
@@ -127,4 +127,33 @@ class StructuredReleaseNotesTest {
 
         assertEquals(listOf("Read the docs"), notes.items.map(ChangeItem::text))
     }
+
+    @Test
+    fun bodyAndCommitVariantsOfTheSameChangeAreShownOnce() {
+        val notes = ReleaseNotes.structured(
+            "## Fixed\n- Player crash (#123)",
+            commits = listOf("fix: player crash", "Improve chat rendering"),
+        )
+
+        assertEquals(
+            listOf("Player crash", "Improved chat rendering"),
+            notes.items.map(ChangeItem::text),
+        )
+        assertEquals(listOf(ChangeKind.FIXED, ChangeKind.IMPROVED), notes.items.map(ChangeItem::kind))
+    }
+
+    @Test
+    fun identicalTextWithDifferentKindsRemainsVisible() {
+        val notes = ReleaseNotes.structured(
+            "## New\n- Shared wording\n## Fixed\n- Shared wording",
+        )
+
+        assertEquals(
+            listOf(
+                ChangeItem("Shared wording", ChangeKind.NEW),
+                ChangeItem("Shared wording", ChangeKind.FIXED),
+            ),
+            notes.items,
+        )
+    }
 }

--- a/app/src/test/java/com/github/andreyasadchy/xtra/util/updater/UpdateDomainTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/util/updater/UpdateDomainTest.kt
@@ -657,14 +657,36 @@ class UpdateDomainTest {
     }
 
     @Test
-    fun releaseHistoryRetentionKeepsRecentAndPendingEntriesOnly() {
+    fun releaseHistoryRetentionKeepsTwentyRecentEntries() {
         val retained = UpdateReleaseHistory.retainForInstalled(
             releases = (20 downTo 1).map { build -> parse("v2.58.5-build.$build") },
             installedVersionName = "2.58.5",
             installedBuildNumber = 10,
         )
 
-        assertEquals((20 downTo 11).map(Int::toLong), retained.mapNotNull(UpdateRelease::buildNumber))
+        assertEquals((20 downTo 1).map(Int::toLong), retained.mapNotNull(UpdateRelease::buildNumber))
+    }
+
+    @Test
+    fun releaseHistoryRetentionKeepsOlderEntriesWhenPendingBacklogIsLarge() {
+        val retained = UpdateReleaseHistory.retainForInstalled(
+            releases = (40 downTo 1).map { build -> parse("v2.58.5-build.$build") },
+            installedVersionName = "2.58.5",
+            installedBuildNumber = 10,
+        )
+
+        assertEquals((40 downTo 1).map(Int::toLong), retained.mapNotNull(UpdateRelease::buildNumber))
+    }
+
+    @Test
+    fun recentHistoryKeepsHistoricalEntriesAlongsidePendingBacklog() {
+        val recent = UpdateReleaseHistory.recent(
+            releases = (40 downTo 1).map { build -> parse("v2.58.5-build.$build") },
+            installedVersionName = "2.58.5",
+            installedBuildNumber = 10,
+        )
+
+        assertEquals((40 downTo 1).map(Int::toLong), recent.mapNotNull(UpdateRelease::buildNumber))
     }
 
     @Test

--- a/app/src/test/java/com/github/andreyasadchy/xtra/util/updater/UpdateRepositoryTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/util/updater/UpdateRepositoryTest.kt
@@ -65,7 +65,7 @@ class UpdateRepositoryTest {
         assertEquals(2, source.historyCalls)
         assertTrue(repository.releaseHistoryComplete.value)
         assertEquals(179, repository.releasesSinceInstalled(available.release).size)
-        assertEquals(5, repository.recentReleases().size)
+        assertEquals(199, repository.recentReleases().size)
 
         val persisted = preferences.getString(C.UPDATE_RELEASE_HISTORY, null).orEmpty()
         assertFalse(persisted.contains("rawBody"))
@@ -101,7 +101,10 @@ class UpdateRepositoryTest {
         assertEquals(2, source.historyCalls)
         assertFalse(repository.releaseHistoryComplete.value)
         assertTrue(repository.releasesSinceInstalled(available.release).isEmpty())
-        assertEquals(listOf("v2.58.6-build.300"), repository.recentReleases(available.release).map { it.id })
+        assertEquals(
+            (300 downTo 201).map(::buildTag),
+            repository.recentReleases(available.release).map { it.id },
+        )
     }
 
     @Test


### PR DESCRIPTION
Show full patch notes for recent updates, retain more history, and remove duplicate changelog entries.