### PR TITLE
Rework player hover control layout

### DIFF
--- a/app/src/androidTest/java/com/github/andreyasadchy/xtra/ui/view/ControlEdgeLayoutInstrumentationTest.kt
+++ b/app/src/androidTest/java/com/github/andreyasadchy/xtra/ui/view/ControlEdgeLayoutInstrumentationTest.kt
@@ -1,0 +1,66 @@
+package com.github.andreyasadchy.xtra.ui.view
+
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ImageButton
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ControlEdgeLayoutInstrumentationTest {
+
+    @Test
+    fun crowdedOpposingRowsKeepTheirSharedWidth() {
+        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+        val edge = ControlEdgeLayout(context)
+        val start = row(context, 4)
+        val end = row(context, 4)
+        edge.addView(start)
+        edge.addView(end)
+
+        edge.measure(exactly(320), exactly(400))
+        edge.layout(0, 0, edge.measuredWidth, edge.measuredHeight)
+
+        assertTrue(start.right <= end.left)
+        assertTrue(start.left >= edge.paddingLeft)
+        assertTrue(end.right <= edge.width - edge.paddingRight)
+    }
+
+    @Test
+    fun invisibleControlsDoNotReserveRowWidth() {
+        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+        val edge = ControlEdgeLayout(context)
+        val start = ControlRowLayout(context).apply {
+            addView(ImageButton(context), ViewGroup.LayoutParams(48, 48))
+            addView(
+                ImageButton(context).apply { visibility = View.INVISIBLE },
+                ViewGroup.LayoutParams(48, 48),
+            )
+        }
+        val end = row(context, 1)
+        edge.addView(start)
+        edge.addView(end)
+
+        edge.measure(exactly(320), exactly(400))
+
+        assertEquals(48, start.measuredWidth)
+    }
+
+    private fun row(context: android.content.Context, count: Int) = ControlRowLayout(context).apply {
+        repeat(count) {
+            addView(
+                ImageButton(context),
+                ViewGroup.LayoutParams(48, 48),
+            )
+        }
+    }
+
+    private fun exactly(size: Int): Int = View.MeasureSpec.makeMeasureSpec(
+        size,
+        View.MeasureSpec.EXACTLY,
+    )
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/Media3PlayerFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/Media3PlayerFragment.kt
@@ -3160,10 +3160,8 @@ abstract class Media3PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFr
     private fun setLiveRewindTimelineLayout(enabled: Boolean) {
         val bottom = binding.playerControls.bottomLayout
         val bottomParams = bottom.layoutParams as? RelativeLayout.LayoutParams ?: return
-        val bottomLeft = binding.playerControls.bottomLeftLayout
-        val bottomLeftParams = bottomLeft.layoutParams as? RelativeLayout.LayoutParams ?: return
-        val bottomRight = binding.playerControls.bottomRightLayout
-        val bottomRightParams = bottomRight.layoutParams as? RelativeLayout.LayoutParams ?: return
+        val bottomControls = binding.playerControls.bottomControlLayout
+        val bottomControlsParams = bottomControls.layoutParams as? RelativeLayout.LayoutParams ?: return
         val position = binding.playerControls.position
         val positionParams = position.layoutParams as? RelativeLayout.LayoutParams ?: return
         val duration = binding.playerControls.duration
@@ -3183,10 +3181,8 @@ abstract class Media3PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFr
             durationParams.bottomMargin = 0
             bottomParams.removeRule(RelativeLayout.ALIGN_PARENT_BOTTOM)
             bottomParams.addRule(RelativeLayout.ABOVE, R.id.quickControlsBottomAnchor)
-            bottomLeftParams.removeRule(RelativeLayout.ABOVE)
-            bottomLeftParams.addRule(RelativeLayout.ALIGN_PARENT_BOTTOM)
-            bottomRightParams.removeRule(RelativeLayout.ABOVE)
-            bottomRightParams.addRule(RelativeLayout.ALIGN_PARENT_BOTTOM)
+            bottomControlsParams.removeRule(RelativeLayout.ABOVE)
+            bottomControlsParams.addRule(RelativeLayout.ALIGN_PARENT_BOTTOM)
             positionParams.removeRule(RelativeLayout.ALIGN_PARENT_BOTTOM)
             positionParams.addRule(RelativeLayout.ABOVE, R.id.quickControlsBottomAnchor)
             durationParams.removeRule(RelativeLayout.ALIGN_PARENT_BOTTOM)
@@ -3200,18 +3196,15 @@ abstract class Media3PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFr
             durationParams.bottomMargin = normalTimeLabelBottomMargin
             bottomParams.removeRule(RelativeLayout.ABOVE)
             bottomParams.addRule(RelativeLayout.ALIGN_PARENT_BOTTOM)
-            bottomLeftParams.removeRule(RelativeLayout.ALIGN_PARENT_BOTTOM)
-            bottomLeftParams.addRule(RelativeLayout.ABOVE, R.id.bottomLayout)
-            bottomRightParams.removeRule(RelativeLayout.ALIGN_PARENT_BOTTOM)
-            bottomRightParams.addRule(RelativeLayout.ABOVE, R.id.bottomLayout)
+            bottomControlsParams.removeRule(RelativeLayout.ALIGN_PARENT_BOTTOM)
+            bottomControlsParams.addRule(RelativeLayout.ABOVE, R.id.bottomLayout)
             positionParams.removeRule(RelativeLayout.ABOVE)
             positionParams.addRule(RelativeLayout.ALIGN_PARENT_BOTTOM)
             durationParams.removeRule(RelativeLayout.ABOVE)
             durationParams.addRule(RelativeLayout.ALIGN_PARENT_BOTTOM)
         }
         bottom.layoutParams = bottomParams
-        bottomLeft.layoutParams = bottomLeftParams
-        bottomRight.layoutParams = bottomRightParams
+        bottomControls.layoutParams = bottomControlsParams
         progress.layoutParams = progressParams
         position.layoutParams = positionParams
         duration.layoutParams = durationParams

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/PlayerFragment.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/PlayerFragment.kt
@@ -1372,10 +1372,8 @@ abstract class PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFragment
     private fun setLiveRewindTimelineLayout(enabled: Boolean) {
         val bottom = binding.playerControls.bottomLayout
         val bottomParams = bottom.layoutParams as? RelativeLayout.LayoutParams ?: return
-        val bottomLeft = binding.playerControls.bottomLeftLayout
-        val bottomLeftParams = bottomLeft.layoutParams as? RelativeLayout.LayoutParams ?: return
-        val bottomRight = binding.playerControls.bottomRightLayout
-        val bottomRightParams = bottomRight.layoutParams as? RelativeLayout.LayoutParams ?: return
+        val bottomControls = binding.playerControls.bottomControlLayout
+        val bottomControlsParams = bottomControls.layoutParams as? RelativeLayout.LayoutParams ?: return
         val position = binding.playerControls.position
         val positionParams = position.layoutParams as? RelativeLayout.LayoutParams ?: return
         val duration = binding.playerControls.duration
@@ -1395,10 +1393,8 @@ abstract class PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFragment
             durationParams.bottomMargin = 0
             bottomParams.removeRule(RelativeLayout.ALIGN_PARENT_BOTTOM)
             bottomParams.addRule(RelativeLayout.ABOVE, R.id.quickControlsBottomAnchor)
-            bottomLeftParams.removeRule(RelativeLayout.ABOVE)
-            bottomLeftParams.addRule(RelativeLayout.ALIGN_PARENT_BOTTOM)
-            bottomRightParams.removeRule(RelativeLayout.ABOVE)
-            bottomRightParams.addRule(RelativeLayout.ALIGN_PARENT_BOTTOM)
+            bottomControlsParams.removeRule(RelativeLayout.ABOVE)
+            bottomControlsParams.addRule(RelativeLayout.ALIGN_PARENT_BOTTOM)
             positionParams.removeRule(RelativeLayout.ALIGN_PARENT_BOTTOM)
             positionParams.addRule(RelativeLayout.ABOVE, R.id.quickControlsBottomAnchor)
             durationParams.removeRule(RelativeLayout.ALIGN_PARENT_BOTTOM)
@@ -1412,18 +1408,15 @@ abstract class PlayerFragment : BaseNetworkFragment(), RadioButtonDialogFragment
             durationParams.bottomMargin = normalTimeLabelBottomMargin
             bottomParams.removeRule(RelativeLayout.ABOVE)
             bottomParams.addRule(RelativeLayout.ALIGN_PARENT_BOTTOM)
-            bottomLeftParams.removeRule(RelativeLayout.ALIGN_PARENT_BOTTOM)
-            bottomLeftParams.addRule(RelativeLayout.ABOVE, R.id.bottomLayout)
-            bottomRightParams.removeRule(RelativeLayout.ALIGN_PARENT_BOTTOM)
-            bottomRightParams.addRule(RelativeLayout.ABOVE, R.id.bottomLayout)
+            bottomControlsParams.removeRule(RelativeLayout.ALIGN_PARENT_BOTTOM)
+            bottomControlsParams.addRule(RelativeLayout.ABOVE, R.id.bottomLayout)
             positionParams.removeRule(RelativeLayout.ABOVE)
             positionParams.addRule(RelativeLayout.ALIGN_PARENT_BOTTOM)
             durationParams.removeRule(RelativeLayout.ABOVE)
             durationParams.addRule(RelativeLayout.ALIGN_PARENT_BOTTOM)
         }
         bottom.layoutParams = bottomParams
-        bottomLeft.layoutParams = bottomLeftParams
-        bottomRight.layoutParams = bottomRightParams
+        bottomControls.layoutParams = bottomControlsParams
         progress.layoutParams = progressParams
         position.layoutParams = positionParams
         duration.layoutParams = durationParams

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/settings/PlayerControlLayoutEditor.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/settings/PlayerControlLayoutEditor.kt
@@ -24,6 +24,7 @@ import androidx.core.content.edit
 import androidx.core.widget.NestedScrollView
 import com.google.android.material.button.MaterialButton
 import com.github.andreyasadchy.xtra.R
+import com.github.andreyasadchy.xtra.ui.view.ControlRowPlanner
 import com.github.andreyasadchy.xtra.util.C
 import com.github.andreyasadchy.xtra.util.PlayerControlLayout
 import com.github.andreyasadchy.xtra.util.SettingsMigration
@@ -206,7 +207,9 @@ class PlayerControlLayoutEditor(
                 else -> PlayerControlLayout.GROUP_HIDDEN
             }
         }
-        if (item.group == PlayerControlLayout.GROUP_QUICK && item.anchor !in PlayerControlLayout.anchors) {
+        if (item.group == PlayerControlLayout.GROUP_QUICK &&
+            item.anchor !in PlayerControlLayout.validAnchors(action)
+        ) {
             item.anchor = PlayerControlLayout.defaultAnchor(action)
         }
         selectedAction = action
@@ -435,7 +438,7 @@ class PlayerControlLayoutEditor(
                 paint.strokeWidth = dp(1).toFloat()
                 paint.color = themeColor(androidx.appcompat.R.attr.colorPrimary, Color.WHITE)
                 paint.alpha = 180
-                PlayerControlLayout.anchors.forEach { anchor ->
+                PlayerControlLayout.validAnchors(draggingAction.orEmpty()).forEach { anchor ->
                     val point = anchorPoint(anchor)
                     canvas.drawCircle(point.x, point.y, dp(8).toFloat(), paint)
                 }
@@ -556,19 +559,20 @@ class PlayerControlLayoutEditor(
 
         private fun snapChip(action: String, centerX: Float, centerY: Float) {
             val item = items.firstOrNull { it.action == action } ?: return
-            val anchor = PlayerControlLayout.anchors.minByOrNull { candidate ->
+            val anchor = PlayerControlLayout.validAnchors(action).minByOrNull { candidate ->
                 val point = anchorPoint(candidate)
                 hypot((point.x - centerX).toDouble(), (point.y - centerY).toDouble())
             } ?: PlayerControlLayout.defaultAnchor(action)
             items.remove(item)
             item.anchor = anchor
+            val targetAnchor = anchor
             val sameAnchor = items.filter {
-                it.group == PlayerControlLayout.GROUP_QUICK && it.anchor == anchor
+                it.group == PlayerControlLayout.GROUP_QUICK && it.anchor == targetAnchor
             }
-            val crossCoordinate = if (anchor.startsWith("middle")) centerY else centerX
+            val crossCoordinate = if (targetAnchor.startsWith("middle")) centerY else centerX
             val insertBefore = sameAnchor.firstOrNull { other ->
                 val index = sameAnchor.indexOf(other)
-                crossCoordinateFor(anchor, index, sameAnchor.size) > crossCoordinate
+                crossCoordinateFor(targetAnchor, index, sameAnchor.size) > crossCoordinate
             }
             val targetIndex = insertBefore?.let { items.indexOf(it) } ?: items.size
             items.add(targetIndex, item)
@@ -579,9 +583,9 @@ class PlayerControlLayoutEditor(
         private fun positionChildren() {
             val grouped = items.filter { it.group == PlayerControlLayout.GROUP_QUICK }.groupBy { it.anchor }
             grouped.forEach { (anchor, group) ->
-                group.forEachIndexed { index, item ->
+                wrappedControlPoints(anchor, group.size).forEachIndexed { index, point ->
+                    val item = group[index]
                     chips[item.action]?.let { chip ->
-                        val point = controlPoint(anchor, index, group.size)
                         chip.x = point.x - chip.width / 2f
                         chip.y = point.y - chip.height / 2f
                     }
@@ -593,27 +597,40 @@ class PlayerControlLayoutEditor(
             play.y = (height - play.height) / 2f
         }
 
-        private fun controlPoint(anchor: String, index: Int, count: Int): PointF {
+        private fun wrappedControlPoints(anchor: String, count: Int): List<PointF> {
             val size = dp(44)
             val spacing = dp(6)
             val padding = dp(9)
             val menuReserve = if (menu.visibility == View.VISIBLE && anchor == PlayerControlLayout.ANCHOR_TOP_END) dp(48) else 0
-            val total = count * size + (count - 1).coerceAtLeast(0) * spacing
-            val x = when (anchor) {
-                PlayerControlLayout.ANCHOR_TOP_START, PlayerControlLayout.ANCHOR_BOTTOM_START -> padding + size / 2f + index * (size + spacing)
-                PlayerControlLayout.ANCHOR_TOP_CENTER, PlayerControlLayout.ANCHOR_BOTTOM_CENTER -> (width - total) / 2f + size / 2f + index * (size + spacing)
-                PlayerControlLayout.ANCHOR_TOP_END, PlayerControlLayout.ANCHOR_BOTTOM_END -> width - padding - menuReserve - total + size / 2f + index * (size + spacing)
-                PlayerControlLayout.ANCHOR_MIDDLE_START, PlayerControlLayout.ANCHOR_MIDDLE_END -> if (anchor.endsWith("start")) padding + size / 2f else width - padding - size / 2f
-                else -> width / 2f
+            val edgeWidth = ((width - padding * 2) / 2).coerceAtLeast(size)
+            val lines = ControlRowPlanner.lineBreak(edgeWidth, List(count) { size }, spacing)
+            val rowHeight = lines.size * size
+            val rightEdge = width - padding - menuReserve
+            val top = if (anchor.startsWith("top")) {
+                padding.toFloat()
+            } else {
+                (height - padding - dp(13) - rowHeight).toFloat()
             }
-            val y = when (anchor) {
-                PlayerControlLayout.ANCHOR_TOP_START, PlayerControlLayout.ANCHOR_TOP_CENTER, PlayerControlLayout.ANCHOR_TOP_END -> padding + size / 2f
-                PlayerControlLayout.ANCHOR_BOTTOM_START, PlayerControlLayout.ANCHOR_BOTTOM_CENTER, PlayerControlLayout.ANCHOR_BOTTOM_END -> height - padding - size / 2f - dp(13)
-                PlayerControlLayout.ANCHOR_MIDDLE_START, PlayerControlLayout.ANCHOR_MIDDLE_END -> (height - total) / 2f + size / 2f + index * (size + spacing)
-                else -> height / 2f
+            return lines.flatMapIndexed { lineIndex, line ->
+                val lineWidth = line.size * size + (line.size - 1).coerceAtLeast(0) * spacing
+                val lineLeft = when {
+                    anchor.endsWith("start") -> padding
+                    anchor.endsWith("end") -> rightEdge - lineWidth
+                    else -> (width - lineWidth) / 2
+                }
+                line.mapIndexed { childIndex, _ ->
+                    PointF(
+                        (lineLeft.toFloat() + size / 2f + childIndex * (size + spacing))
+                            .coerceIn(size / 2f, (width - size / 2f).coerceAtLeast(size / 2f)),
+                        (top + size / 2f + lineIndex * size)
+                            .coerceIn(size / 2f, (height - size / 2f).coerceAtLeast(size / 2f)),
+                    )
+                }
             }
-            return PointF(x.coerceIn(size / 2f, (width - size / 2f).coerceAtLeast(size / 2f)), y.coerceIn(size / 2f, (height - size / 2f).coerceAtLeast(size / 2f)))
         }
+
+        private fun controlPoint(anchor: String, index: Int, count: Int): PointF =
+            wrappedControlPoints(anchor, count).getOrElse(index) { wrappedControlPoints(anchor, 1).first() }
 
         private fun crossCoordinateFor(anchor: String, index: Int, count: Int): Float {
             val point = controlPoint(anchor, index, count)

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/settings/PlayerControlScalePreview.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/settings/PlayerControlScalePreview.kt
@@ -16,6 +16,7 @@ import android.widget.ImageView
 import androidx.preference.Preference
 import androidx.preference.PreferenceViewHolder
 import com.github.andreyasadchy.xtra.R
+import com.github.andreyasadchy.xtra.ui.view.ControlRowPlanner
 import com.github.andreyasadchy.xtra.util.C
 import com.github.andreyasadchy.xtra.util.PlayerControlLayout
 import com.github.andreyasadchy.xtra.util.PortraitPlayerControls
@@ -398,9 +399,10 @@ class PlayerControlScalePreviewView @JvmOverloads constructor(
             if (width <= 0 || height <= 0) return
             val grouped = items.filter { it.group == PlayerControlLayout.GROUP_QUICK }.groupBy { it.anchor }
             grouped.forEach { (anchor, group) ->
-                group.forEachIndexed { index, item ->
+                wrappedControlPoints(anchor, group.size).forEachIndexed { index, point ->
+                    val item = group[index]
                     chips[item.action]?.let { chip ->
-                        placeScaled(chip, controlPoint(anchor, index, group.size), anchor)
+                        placeScaled(chip, point, anchor)
                     }
                 }
             }
@@ -470,51 +472,36 @@ class PlayerControlScalePreviewView @JvmOverloads constructor(
             view.translationY = boundedY - viewCenterY
         }
 
-        private fun controlPoint(anchor: String, index: Int, count: Int): PointF {
+        private fun wrappedControlPoints(anchor: String, count: Int): List<PointF> {
             val size = previewDp(44).toFloat()
             val spacing = previewDp(6).toFloat()
             val padding = previewDp(9).toFloat()
             val menuReserve = if (anchor == PlayerControlLayout.ANCHOR_TOP_END) previewDp(48) else 0
-            val total = count * size + (count - 1).coerceAtLeast(0) * spacing
-            val x = when (anchor) {
-                PlayerControlLayout.ANCHOR_TOP_START,
-                PlayerControlLayout.ANCHOR_BOTTOM_START -> padding + size / 2f + index * (size + spacing)
-                PlayerControlLayout.ANCHOR_TOP_CENTER,
-                PlayerControlLayout.ANCHOR_BOTTOM_CENTER -> (width - total) / 2f + size / 2f + index * (size + spacing)
-                PlayerControlLayout.ANCHOR_TOP_END,
-                PlayerControlLayout.ANCHOR_BOTTOM_END -> width - padding - menuReserve - total + size / 2f + index * (size + spacing)
-                PlayerControlLayout.ANCHOR_MIDDLE_START,
-                PlayerControlLayout.ANCHOR_MIDDLE_END -> if (anchor.endsWith("start")) padding + size / 2f else width - padding - size / 2f
-                else -> width / 2f
-            }
-            val bottomEndRowOffset = if (
-                anchor == PlayerControlLayout.ANCHOR_BOTTOM_END &&
-                items.any {
-                    it.group == PlayerControlLayout.GROUP_QUICK &&
-                        it.anchor == PlayerControlLayout.ANCHOR_BOTTOM_START
-                }
-            ) {
-                size + spacing
+            val edgeWidth = ((width - padding * 2f) / 2f).roundToInt().coerceAtLeast(size.roundToInt())
+            val lines = ControlRowPlanner.lineBreak(edgeWidth, List(count) { size.toInt() }, spacing.toInt())
+            val rowHeight = lines.size * size
+            val rightEdge = width - padding - menuReserve
+            val top = if (anchor.startsWith("top")) {
+                padding
             } else {
-                0f
+                height - padding - previewDp(13) - rowHeight
             }
-            val y = when (anchor) {
-                PlayerControlLayout.ANCHOR_TOP_CENTER,
-                PlayerControlLayout.ANCHOR_TOP_END -> padding + size / 2f
-                PlayerControlLayout.ANCHOR_TOP_START ->
-                    padding + size / 2f + previewDp(64)
-                PlayerControlLayout.ANCHOR_BOTTOM_START,
-                PlayerControlLayout.ANCHOR_BOTTOM_CENTER -> height - padding - size / 2f - previewDp(13)
-                PlayerControlLayout.ANCHOR_BOTTOM_END ->
-                    height - padding - size / 2f - previewDp(13) - bottomEndRowOffset
-                PlayerControlLayout.ANCHOR_MIDDLE_START,
-                PlayerControlLayout.ANCHOR_MIDDLE_END -> (height - total) / 2f + size / 2f + index * (size + spacing)
-                else -> height / 2f
+            return lines.flatMapIndexed { lineIndex, line ->
+                val lineWidth = line.size * size + (line.size - 1).coerceAtLeast(0) * spacing
+                val lineLeft = when {
+                    anchor.endsWith("start") -> padding
+                    anchor.endsWith("end") -> rightEdge - lineWidth
+                    else -> (width - lineWidth) / 2
+                }
+                line.mapIndexed { childIndex, _ ->
+                    PointF(
+                        (lineLeft + size / 2 + childIndex * (size + spacing))
+                            .coerceIn(size / 2f, (width - size / 2f).coerceAtLeast(size / 2f)),
+                        (top + size / 2 + lineIndex * size)
+                            .coerceIn(size / 2f, (height - size / 2f).coerceAtLeast(size / 2f)),
+                    )
+                }
             }
-            return PointF(
-                x.coerceIn(size / 2f, (width - size / 2f).coerceAtLeast(size / 2f)),
-                y.coerceIn(size / 2f, (height - size / 2f).coerceAtLeast(size / 2f)),
-            )
         }
 
         private fun previewUnit(): Float = if (width == 0) 0f else width / (360f * resources.displayMetrics.density)

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/view/ControlEdgeLayout.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/view/ControlEdgeLayout.kt
@@ -1,0 +1,140 @@
+package com.github.andreyasadchy.xtra.ui.view
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.View
+import android.view.ViewGroup
+import kotlin.math.max
+
+/**
+ * Lays out the start and end control rows against one shared width budget.
+ *
+ * The top edge also contains the metadata view as its first child. The rows
+ * receive half of the available width each, while metadata uses the space
+ * that remains between them. This keeps custom layouts predictable when a
+ * user enables many actions or uses a narrow player.
+ */
+class ControlEdgeLayout @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0,
+) : ViewGroup(context, attrs, defStyleAttr) {
+
+    private val hasMetadata: Boolean
+        get() = childCount >= 3
+
+    init {
+        clipChildren = true
+        clipToPadding = false
+    }
+
+    override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
+        val widthMode = MeasureSpec.getMode(widthMeasureSpec)
+        val widthSize = MeasureSpec.getSize(widthMeasureSpec)
+        val availableWidth = when (widthMode) {
+            MeasureSpec.UNSPECIFIED -> Int.MAX_VALUE
+            else -> (widthSize - paddingLeft - paddingRight).coerceAtLeast(1)
+        }
+        val availableHeight = when (MeasureSpec.getMode(heightMeasureSpec)) {
+            MeasureSpec.UNSPECIFIED -> Int.MAX_VALUE
+            else -> (MeasureSpec.getSize(heightMeasureSpec) - paddingTop - paddingBottom)
+                .coerceAtLeast(1)
+        }
+        // Wrapped rows need the full available height. A smaller artificial
+        // cap would measure only part of a custom layout, after which the
+        // edge's clipping boundary would cut off its remaining controls.
+        val edgeHeight = availableHeight
+        val start = startRow()
+        val end = endRow()
+        val metadata = metadataView()
+        val rowBudget = (availableWidth / 2).coerceAtLeast(1)
+
+        measureChildAtMost(start, availableWidth, edgeHeight)
+        measureChildAtMost(end, availableWidth, edgeHeight)
+
+        // Re-measuring both rows with the same budget is what makes the
+        // non-overlap guarantee hold. ControlRowLayout will wrap inside it.
+        measureChildAtMost(start, rowBudget, edgeHeight)
+        measureChildAtMost(end, rowBudget, edgeHeight)
+
+        val metadataWidth = (availableWidth - start.measuredWidth - end.measuredWidth)
+            .coerceAtLeast(0)
+        metadata?.let { measureChildExactly(it, metadataWidth, edgeHeight) }
+
+        val contentHeight = max(
+            max(start.measuredHeight, end.measuredHeight),
+            metadata?.measuredHeight ?: 0,
+        )
+        val desiredWidth = paddingLeft + paddingRight + start.measuredWidth +
+            end.measuredWidth + (metadata?.measuredWidth ?: 0)
+        val desiredHeight = paddingTop + paddingBottom + contentHeight
+        setMeasuredDimension(
+            resolveSize(desiredWidth, widthMeasureSpec),
+            resolveSize(desiredHeight, heightMeasureSpec),
+        )
+    }
+
+    override fun onLayout(changed: Boolean, left: Int, top: Int, right: Int, bottom: Int) {
+        val contentLeft = paddingLeft
+        val contentRight = width - paddingRight
+        val contentTop = paddingTop
+        val start = startRow()
+        val end = endRow()
+        val metadata = metadataView()
+        val startRight = contentLeft + start.measuredWidth
+        val endLeft = contentRight - end.measuredWidth
+
+        layoutChild(start, contentLeft, contentTop)
+        layoutChild(end, endLeft, contentTop)
+        metadata?.let {
+            layoutChild(it, startRight, contentTop, (endLeft - startRight).coerceAtLeast(0))
+        }
+    }
+
+    override fun generateDefaultLayoutParams(): LayoutParams =
+        MarginLayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT)
+
+    override fun generateLayoutParams(attrs: AttributeSet): LayoutParams =
+        MarginLayoutParams(context, attrs)
+
+    override fun generateLayoutParams(params: ViewGroup.LayoutParams): LayoutParams =
+        MarginLayoutParams(params)
+
+    override fun checkLayoutParams(params: ViewGroup.LayoutParams): Boolean =
+        params is MarginLayoutParams
+
+    private fun startRow(): View = getChildAt(if (hasMetadata) 1 else 0)
+
+    private fun endRow(): View = getChildAt(if (hasMetadata) 2 else 1)
+
+    private fun metadataView(): View? = if (hasMetadata) getChildAt(0) else null
+
+    private fun measureChildAtMost(child: View, width: Int, height: Int) {
+        val parentWidth = (width + paddingLeft + paddingRight).coerceAtLeast(1)
+        val parentHeight = (height + paddingTop + paddingBottom).coerceAtLeast(1)
+        measureChildWithMargins(
+            child,
+            MeasureSpec.makeMeasureSpec(parentWidth, MeasureSpec.AT_MOST),
+            0,
+            MeasureSpec.makeMeasureSpec(parentHeight, MeasureSpec.AT_MOST),
+            0,
+        )
+    }
+
+    private fun measureChildExactly(child: View, width: Int, height: Int) {
+        val parentWidth = (width + paddingLeft + paddingRight).coerceAtLeast(0)
+        val parentHeight = (height + paddingTop + paddingBottom).coerceAtLeast(1)
+        measureChildWithMargins(
+            child,
+            MeasureSpec.makeMeasureSpec(parentWidth, MeasureSpec.EXACTLY),
+            0,
+            MeasureSpec.makeMeasureSpec(parentHeight, MeasureSpec.AT_MOST),
+            0,
+        )
+    }
+
+    private fun layoutChild(child: View, left: Int, top: Int, forcedWidth: Int? = null) {
+        val width = forcedWidth ?: child.measuredWidth
+        child.layout(left, top, left + width, top + child.measuredHeight)
+    }
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/view/ControlRowLayout.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/view/ControlRowLayout.kt
@@ -1,0 +1,145 @@
+package com.github.andreyasadchy.xtra.ui.view
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.Gravity
+import android.view.View
+import android.view.ViewGroup
+import android.widget.LinearLayout
+
+internal object ControlRowPlanner {
+
+    /** Returns child indexes grouped into horizontal lines for a bounded row. */
+    fun lineBreak(availableWidth: Int, itemWidths: List<Int>, spacing: Int = 0): List<List<Int>> {
+        if (itemWidths.isEmpty()) return emptyList()
+        val lines = mutableListOf<MutableList<Int>>()
+        var line = mutableListOf<Int>()
+        var lineWidth = 0
+        itemWidths.forEachIndexed { index, itemWidth ->
+            val requiredWidth = if (line.isEmpty()) itemWidth else lineWidth + spacing + itemWidth
+            if (line.isNotEmpty() && requiredWidth > availableWidth) {
+                lines += line
+                line = mutableListOf()
+                lineWidth = 0
+            }
+            line += index
+            lineWidth += if (line.size == 1) itemWidth else spacing + itemWidth
+        }
+        lines += line
+        return lines
+    }
+}
+
+/**
+ * A compact control row that wraps instead of letting buttons run underneath
+ * another overlay group. It keeps the existing ViewGroup contract used by the
+ * player control layout editor while making a crowded custom layout safe.
+ */
+class ControlRowLayout @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0,
+) : LinearLayout(context, attrs, defStyleAttr) {
+
+    private data class Line(
+        val children: MutableList<View> = mutableListOf(),
+        var width: Int = 0,
+        var height: Int = 0,
+    )
+
+    init {
+        orientation = HORIZONTAL
+        clipChildren = false
+    }
+
+    override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
+        val availableWidth = when (MeasureSpec.getMode(widthMeasureSpec)) {
+            MeasureSpec.UNSPECIFIED -> Int.MAX_VALUE
+            else -> (MeasureSpec.getSize(widthMeasureSpec) - paddingLeft - paddingRight).coerceAtLeast(1)
+        }
+        val lines = measureLines(widthMeasureSpec, heightMeasureSpec, availableWidth)
+        val desiredWidth = (lines.maxOfOrNull { it.width } ?: 0) + paddingLeft + paddingRight
+        val desiredHeight = lines.sumOf { it.height } + paddingTop + paddingBottom
+        setMeasuredDimension(
+            resolveSize(desiredWidth, widthMeasureSpec),
+            resolveSize(desiredHeight, heightMeasureSpec),
+        )
+    }
+
+    override fun onLayout(changed: Boolean, left: Int, top: Int, right: Int, bottom: Int) {
+        val availableWidth = (width - paddingLeft - paddingRight).coerceAtLeast(1)
+        val lines = layoutLines(availableWidth)
+        var lineTop = paddingTop
+        val horizontalGravity = gravity and Gravity.HORIZONTAL_GRAVITY_MASK
+        lines.forEach { line ->
+            val lineLeft = when (horizontalGravity) {
+                Gravity.RIGHT, Gravity.END -> width - paddingRight - line.width
+                Gravity.CENTER_HORIZONTAL -> paddingLeft + (availableWidth - line.width) / 2
+                else -> paddingLeft
+            }
+            var childLeft = lineLeft
+            line.children.forEach { child ->
+                val params = child.layoutParams as MarginLayoutParams
+                childLeft += params.leftMargin
+                val childTop = lineTop + params.topMargin +
+                    ((line.height - params.topMargin - params.bottomMargin - child.measuredHeight) / 2)
+                child.layout(
+                    childLeft,
+                    childTop,
+                    childLeft + child.measuredWidth,
+                    childTop + child.measuredHeight,
+                )
+                childLeft += child.measuredWidth + params.rightMargin
+            }
+            lineTop += line.height
+        }
+    }
+
+    override fun generateDefaultLayoutParams(): LayoutParams =
+        LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT)
+
+    override fun generateLayoutParams(attrs: AttributeSet): LayoutParams =
+        LayoutParams(context, attrs)
+
+    override fun generateLayoutParams(params: ViewGroup.LayoutParams): LayoutParams =
+        LayoutParams(params)
+
+    override fun checkLayoutParams(params: ViewGroup.LayoutParams): Boolean =
+        params is LayoutParams
+
+    private fun measureLines(
+        widthMeasureSpec: Int,
+        heightMeasureSpec: Int,
+        availableWidth: Int,
+    ): List<Line> {
+        val children = visibleChildren()
+        children.forEach { child ->
+            measureChildWithMargins(child, widthMeasureSpec, 0, heightMeasureSpec, 0)
+        }
+        return buildLines(availableWidth, children)
+    }
+
+    private fun layoutLines(availableWidth: Int): List<Line> = buildLines(availableWidth, visibleChildren())
+
+    private fun buildLines(availableWidth: Int, children: List<View>): List<Line> {
+        val widths = children.map { child ->
+            val params = child.layoutParams as MarginLayoutParams
+            params.leftMargin + child.measuredWidth + params.rightMargin
+        }
+        return ControlRowPlanner.lineBreak(availableWidth, widths).map { indexes ->
+            Line(
+                children = indexes.mapTo(mutableListOf(), children::get),
+                width = indexes.sumOf { widths[it] },
+                height = indexes.maxOf { index ->
+                    val child = children[index]
+                    val params = child.layoutParams as MarginLayoutParams
+                    params.topMargin + child.measuredHeight + params.bottomMargin
+                },
+            )
+        }
+    }
+
+    private fun visibleChildren(): List<View> = (0 until childCount)
+        .map(::getChildAt)
+        .filter { it.visibility == View.VISIBLE }
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/PlayerControlLayout.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/PlayerControlLayout.kt
@@ -12,6 +12,8 @@ object PlayerControlLayout {
     const val GROUP_HIDDEN = "hidden"
 
     const val ANCHOR_TOP_START = "top_start"
+    // Kept for source compatibility with the preview renderer and old saved layouts.
+    // They are intentionally no longer valid placement destinations.
     const val ANCHOR_TOP_CENTER = "top_center"
     const val ANCHOR_TOP_END = "top_end"
     const val ANCHOR_MIDDLE_START = "middle_start"
@@ -22,12 +24,8 @@ object PlayerControlLayout {
 
     val anchors = setOf(
         ANCHOR_TOP_START,
-        ANCHOR_TOP_CENTER,
         ANCHOR_TOP_END,
-        ANCHOR_MIDDLE_START,
-        ANCHOR_MIDDLE_END,
         ANCHOR_BOTTOM_START,
-        ANCHOR_BOTTOM_CENTER,
         ANCHOR_BOTTOM_END,
     )
 
@@ -147,6 +145,7 @@ object PlayerControlLayout {
                     bottomRightLayout.addView(liveCaptions)
                 }
             }
+
         }
 
         hideSecondaryActionsOnTelevision(context, binding)
@@ -183,7 +182,7 @@ object PlayerControlLayout {
         .distinctBy { it.action }
         .joinToString(",") { item ->
             val group = normalizedGroup(item.action, item.group)
-            val anchor = item.anchor.takeIf { it in anchors } ?: defaultAnchor(item.action)
+            val anchor = normalizedAnchor(item.action, item.anchor)
             "${item.action}:$group:$anchor"
         }
 
@@ -325,8 +324,27 @@ object PlayerControlLayout {
         val group = parts.getOrNull(1)?.trim()?.takeIf {
             it in setOf(GROUP_QUICK, GROUP_MENU, GROUP_HIDDEN)
         } ?: GROUP_HIDDEN
-        val anchor = parts.getOrNull(2)?.trim()?.takeIf { it in anchors } ?: defaultAnchor(action)
+        val anchor = normalizedAnchor(action, parts.getOrNull(2)?.trim().orEmpty())
         return ControlPlacement(action, normalizedGroup(action, group), anchor)
+    }
+
+    /**
+     * Keep the top-left slot clear for the minimize affordance. The other three
+     * slots are the actual quick-control rows and cannot collide with transport
+     * controls or the metadata block.
+     *
+     * Older serialized layouts may contain the removed center/middle anchors.
+     * Normalizing them here makes those layouts safe without a separate migration.
+     */
+    internal fun validAnchors(action: String): Set<String> = if (action == "minimize") {
+        anchors
+    } else {
+        anchors - ANCHOR_TOP_START
+    }
+
+    private fun normalizedAnchor(action: String, anchor: String): String = when {
+        anchor in validAnchors(action) -> anchor
+        else -> defaultAnchor(action)
     }
 
     private fun normalizedGroup(action: String, group: String): String = when {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/PortraitPlayerControls.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/PortraitPlayerControls.kt
@@ -25,10 +25,6 @@ object PortraitPlayerControls {
     private const val MIDDLE_QUICK_OFFSET_DP = 56f
     /** The metadata pivot sits just inside the text block, after its layout start. */
     const val METADATA_PIVOT_AFTER_INFO_START_DP = 6f
-    // The anchor layouts already provide the landscape-safe margins. Adding a
-    // second portrait inset leaves a visible gap beside the outer controls.
-    private const val EDGE_INSET_DP = 0f
-
     private data class MetadataWidthState(
         val availableWidth: Float,
         val scale: Float,
@@ -155,10 +151,13 @@ object PortraitPlayerControls {
         view.scaleX = scale
         view.scaleY = scale
 
-        val viewCenterX = view.left + view.width / 2f
-        val viewCenterY = view.top + view.height / 2f
+        val viewOffset = layoutOffsetInAncestor(view, root)
+        val viewCenterX = viewOffset.first + view.width / 2f
+        val viewCenterY = viewOffset.second + view.height / 2f
         val rootCenterX = root.width / 2f
         val rootCenterY = root.height / 2f
+        val parent = view.parent as? ViewGroup
+        val parentOffset = parent?.let { layoutOffsetInAncestor(it, root) } ?: Pair(0f, 0f)
         if (keepLandscapeLayout) {
             view.translationX = 0f
         } else {
@@ -166,7 +165,7 @@ object PortraitPlayerControls {
                 HorizontalAnchor.START -> {
                     val contentEdge = contentEdge(view, isStart = true)
                     if (contentEdge != null) {
-                        root.paddingLeft - scaledChildEdge(view, contentEdge, scale) + viewCenterX
+                        root.paddingLeft - scaledChildEdge(root, view, contentEdge, scale) + viewCenterX
                     } else {
                         root.paddingLeft + view.width * scale / 2f
                     }
@@ -175,16 +174,13 @@ object PortraitPlayerControls {
                 HorizontalAnchor.END -> {
                     val contentEdge = contentEdge(view, isStart = false)
                     if (contentEdge != null) {
-                        root.width - root.paddingRight - scaledChildEdge(view, contentEdge, scale) + viewCenterX
+                        root.width - root.paddingRight - scaledChildEdge(root, view, contentEdge, scale) + viewCenterX
                     } else {
                         root.width - root.paddingRight - view.width * scale / 2f
                     }
                 }
             }
-            view.translationX = scaledCenterX - viewCenterX
-            if (scale != 1f && horizontalAnchor != HorizontalAnchor.CENTER && view is ViewGroup) {
-                alignVisibleChildToEdge(root, view, horizontalAnchor)
-            }
+            view.translationX = scaledCenterX - parentOffset.first - view.width / 2f
         }
         val scaledCenterY = when (verticalAnchor) {
             VerticalAnchor.TOP -> viewCenterY * scale
@@ -192,7 +188,7 @@ object PortraitPlayerControls {
             VerticalAnchor.MIDDLE_QUICK -> rootCenterY - MIDDLE_QUICK_OFFSET_DP * root.resources.displayMetrics.density * scale
             VerticalAnchor.BOTTOM -> root.height - (root.height - viewCenterY) * scale
         }
-        view.translationY = scaledCenterY - viewCenterY
+        view.translationY = scaledCenterY - parentOffset.second - view.height / 2f
     }
 
     private fun contentEdge(view: View, isStart: Boolean): Float? {
@@ -207,8 +203,10 @@ object PortraitPlayerControls {
         }
     }
 
-    private fun scaledChildEdge(view: View, childEdge: Float, scale: Float): Float =
-        view.left + (childEdge - view.width / 2f) * scale + view.width / 2f
+    private fun scaledChildEdge(root: View, view: View, childEdge: Float, scale: Float): Float {
+        val viewOffset = layoutOffsetInAncestor(view, root)
+        return viewOffset.first + (childEdge - view.width / 2f) * scale + view.width / 2f
+    }
 
     private fun controlScale(binding: FragmentPlayerBinding, isPortrait: Boolean): Float {
         val density = binding.root.resources.displayMetrics.density
@@ -412,7 +410,10 @@ object PortraitPlayerControls {
         )
     ) {
         C.PLAYER_CONTROL_POSITION_BELOW -> QuickControlPosition.BELOW
-        C.PLAYER_CONTROL_POSITION_MIDDLE -> QuickControlPosition.MIDDLE
+        // The old middle position shared the transport-control area and could
+        // hide play/seek controls. Treat old saved values as the safe below-row
+        // placement; the setting no longer offers a collision-prone middle mode.
+        C.PLAYER_CONTROL_POSITION_MIDDLE -> QuickControlPosition.BELOW
         else -> QuickControlPosition.ABOVE
     }
 
@@ -422,10 +423,8 @@ object PortraitPlayerControls {
     ) {
         val bottom = binding.playerControls.bottomLayout
         val bottomParams = bottom.layoutParams as? RelativeLayout.LayoutParams ?: return
-        val bottomLeft = binding.playerControls.bottomLeftLayout
-        val bottomLeftParams = bottomLeft.layoutParams as? RelativeLayout.LayoutParams ?: return
-        val bottomRight = binding.playerControls.bottomRightLayout
-        val bottomRightParams = bottomRight.layoutParams as? RelativeLayout.LayoutParams ?: return
+        val bottomControls = binding.playerControls.bottomControlLayout
+        val bottomControlsParams = bottomControls.layoutParams as? RelativeLayout.LayoutParams ?: return
         val bottomCenter = binding.playerControls.bottomCenterLayout
         val bottomCenterParams = bottomCenter.layoutParams as? RelativeLayout.LayoutParams ?: return
         val positionView = binding.playerControls.position
@@ -457,28 +456,24 @@ object PortraitPlayerControls {
                 durationParams.bottomMargin = 0
                 durationParams.removeRule(RelativeLayout.ALIGN_PARENT_BOTTOM)
                 durationParams.addRule(RelativeLayout.ABOVE, R.id.quickControlsBottomAnchor)
-                setQuickControlRule(bottomLeftParams, QuickControlRule.BELOW)
-                setQuickControlRule(bottomRightParams, QuickControlRule.BELOW)
+                setQuickControlRule(bottomControlsParams, QuickControlRule.BELOW)
                 setQuickControlRule(bottomCenterParams, QuickControlRule.BELOW)
             }
             QuickControlPosition.MIDDLE -> {
                 restoreTimelineLayout(bottomParams, progressParams, positionParams, durationParams, density)
-                setQuickControlRule(bottomLeftParams, QuickControlRule.MIDDLE)
-                setQuickControlRule(bottomRightParams, QuickControlRule.MIDDLE)
+                setQuickControlRule(bottomControlsParams, QuickControlRule.MIDDLE)
                 setQuickControlRule(bottomCenterParams, QuickControlRule.MIDDLE)
             }
             QuickControlPosition.ABOVE -> {
                 restoreTimelineLayout(bottomParams, progressParams, positionParams, durationParams, density)
-                setQuickControlRule(bottomLeftParams, QuickControlRule.ABOVE)
-                setQuickControlRule(bottomRightParams, QuickControlRule.ABOVE)
+                setQuickControlRule(bottomControlsParams, QuickControlRule.ABOVE)
                 bottomCenterParams.removeRule(RelativeLayout.ALIGN_PARENT_BOTTOM)
                 bottomCenterParams.removeRule(RelativeLayout.CENTER_VERTICAL)
                 bottomCenterParams.addRule(RelativeLayout.ABOVE, R.id.streamInfoLayout)
             }
         }
         bottom.layoutParams = bottomParams
-        bottomLeft.layoutParams = bottomLeftParams
-        bottomRight.layoutParams = bottomRightParams
+        bottomControls.layoutParams = bottomControlsParams
         bottomCenter.layoutParams = bottomCenterParams
         progress.layoutParams = progressParams
         positionView.layoutParams = positionParams
@@ -521,44 +516,6 @@ object PortraitPlayerControls {
         durationParams.bottomMargin = (10 * density).toInt()
         durationParams.removeRule(RelativeLayout.ABOVE)
         durationParams.addRule(RelativeLayout.ALIGN_PARENT_BOTTOM)
-    }
-
-    private fun alignVisibleChildToEdge(
-        root: View,
-        container: ViewGroup,
-        horizontalAnchor: HorizontalAnchor,
-    ) {
-        val childBounds = Rect()
-        val rootLocation = IntArray(2)
-        root.getLocationOnScreen(rootLocation)
-        val visibleChildren = (0 until container.childCount)
-            .map(container::getChildAt)
-            .filter { child ->
-                child.visibility == View.VISIBLE && child.width > 0 && child.height > 0 &&
-                    child.getGlobalVisibleRect(childBounds)
-            }
-        if (visibleChildren.isEmpty()) return
-
-        val visibleEdge = if (horizontalAnchor == HorizontalAnchor.START) {
-            visibleChildren.minOf { child ->
-                val bounds = Rect()
-                child.getGlobalVisibleRect(bounds)
-                bounds.left - rootLocation[0].toFloat()
-            }
-        } else {
-            visibleChildren.maxOf { child ->
-                val bounds = Rect()
-                child.getGlobalVisibleRect(bounds)
-                bounds.right - rootLocation[0].toFloat()
-            }
-        }
-        val inset = EDGE_INSET_DP * root.resources.displayMetrics.density
-        val targetEdge = if (horizontalAnchor == HorizontalAnchor.START) {
-            root.paddingLeft + inset
-        } else {
-            root.width - root.paddingRight - inset
-        }
-        container.translationX += targetEdge - visibleEdge
     }
 
     private fun resetDescendantTransforms(view: ViewGroup) {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/util/SettingsMigration.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/util/SettingsMigration.kt
@@ -389,6 +389,7 @@ object SettingsMigration {
         // marker already says current; AndroidX ListPreference requires a
         // String and reads the raw SharedPreferences value directly.
         normalizeCaptionIntervalPreference(preferences)
+        normalizeQuickControlPositionPreference(preferences)
         if (!preferences.contains(C.CHAT_RECENT)) {
             // chat_history_preferences.xml enables recent history by default. Seed the
             // key here because this app does not initialize PreferenceManager defaults.
@@ -565,6 +566,14 @@ object SettingsMigration {
                     C.PLAYER_LIVE_CAPTION_PARTIAL_INTERVAL_MS,
                     storedValue.toInt().toString(),
                 )
+            }
+        }
+    }
+
+    private fun normalizeQuickControlPositionPreference(preferences: SharedPreferences) {
+        if (preferences.getString(C.PLAYER_CONTROL_POSITION, null) == C.PLAYER_CONTROL_POSITION_MIDDLE) {
+            preferences.edit {
+                putString(C.PLAYER_CONTROL_POSITION, C.PLAYER_CONTROL_POSITION_BELOW)
             }
         }
     }

--- a/app/src/main/res/layout-television/player_layout.xml
+++ b/app/src/main/res/layout-television/player_layout.xml
@@ -84,15 +84,19 @@
             tools:text="10" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 
-    <LinearLayout
-        android:id="@+id/topLeftLayout"
+    <com.github.andreyasadchy.xtra.ui.view.ControlEdgeLayout
+        android:id="@+id/topControlLayout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_alignParentStart="true"
-        android:layout_marginStart="@dimen/tv_safe_horizontal"
+        android:layout_alignParentTop="true"
         android:layout_marginTop="@dimen/tv_safe_vertical"
-        android:layout_marginEnd="@dimen/tv_safe_horizontal"
-        android:layout_toStartOf="@id/topRightLayout"
+        android:paddingStart="@dimen/tv_safe_horizontal"
+        android:paddingEnd="@dimen/tv_safe_horizontal">
+
+    <LinearLayout
+        android:id="@+id/topLeftLayout"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
         android:gravity="center_vertical"
         android:orientation="horizontal">
 
@@ -212,13 +216,10 @@
 
     </LinearLayout>
 
-    <LinearLayout
+    <com.github.andreyasadchy.xtra.ui.view.ControlRowLayout
         android:id="@+id/topStartLayout"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_alignParentStart="true"
-        android:layout_below="@id/topLeftLayout"
-        android:layout_marginTop="8dp"
         android:orientation="horizontal">
 
         <ImageButton
@@ -234,15 +235,13 @@
             app:tint="@android:color/white"
             tools:visibility="visible" />
 
-    </LinearLayout>
+    </com.github.andreyasadchy.xtra.ui.view.ControlRowLayout>
 
-    <LinearLayout
+    <com.github.andreyasadchy.xtra.ui.view.ControlRowLayout
         android:id="@+id/topRightLayout"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_alignParentEnd="true"
-        android:layout_marginTop="@dimen/tv_safe_vertical"
-        android:layout_marginEnd="@dimen/tv_safe_horizontal">
+        android:gravity="end">
 
         <ImageButton
             android:id="@+id/download"
@@ -351,7 +350,9 @@
             app:tint="@android:color/white"
             tools:visibility="visible" />
 
-    </LinearLayout>
+    </com.github.andreyasadchy.xtra.ui.view.ControlRowLayout>
+
+    </com.github.andreyasadchy.xtra.ui.view.ControlEdgeLayout>
 
     <LinearLayout
         android:id="@+id/topCenterLayout"
@@ -400,14 +401,19 @@
         android:importantForAccessibility="no"
         android:visibility="invisible" />
 
-    <LinearLayout
-        android:id="@+id/bottomLeftLayout"
-        android:layout_width="wrap_content"
+    <com.github.andreyasadchy.xtra.ui.view.ControlEdgeLayout
+        android:id="@+id/bottomControlLayout"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_above="@id/bottomLayout"
-        android:layout_alignParentStart="true"
-        android:layout_marginStart="@dimen/tv_safe_horizontal"
-        android:layout_marginBottom="@dimen/tv_player_bottom_spacing">
+        android:layout_marginBottom="@dimen/tv_player_bottom_spacing"
+        android:paddingStart="@dimen/tv_safe_horizontal"
+        android:paddingEnd="@dimen/tv_safe_horizontal">
+
+    <com.github.andreyasadchy.xtra.ui.view.ControlRowLayout
+        android:id="@+id/bottomLeftLayout"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content">
 
         <ImageButton
             android:id="@+id/restart"
@@ -501,16 +507,12 @@
             app:tint="@android:color/white"
             tools:visibility="visible" />
 
-    </LinearLayout>
+    </com.github.andreyasadchy.xtra.ui.view.ControlRowLayout>
 
-    <LinearLayout
+    <com.github.andreyasadchy.xtra.ui.view.ControlRowLayout
         android:id="@+id/bottomRightLayout"
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_above="@id/bottomLayout"
-        android:layout_alignParentEnd="true"
-        android:layout_marginEnd="@dimen/tv_safe_horizontal"
-        android:layout_marginBottom="@dimen/tv_player_bottom_spacing">
+        android:layout_height="wrap_content">
 
         <ImageButton
             android:id="@+id/liveCaptions"
@@ -577,7 +579,9 @@
             app:tint="@android:color/white"
             tools:visibility="visible" />
 
-    </LinearLayout>
+    </com.github.andreyasadchy.xtra.ui.view.ControlRowLayout>
+
+    </com.github.andreyasadchy.xtra.ui.view.ControlEdgeLayout>
 
     <LinearLayout
         android:id="@+id/bottomCenterLayout"

--- a/app/src/main/res/layout/player_layout.xml
+++ b/app/src/main/res/layout/player_layout.xml
@@ -80,15 +80,19 @@
             tools:text="10" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 
-    <LinearLayout
-        android:id="@+id/topLeftLayout"
+    <com.github.andreyasadchy.xtra.ui.view.ControlEdgeLayout
+        android:id="@+id/topControlLayout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_alignParentStart="true"
-        android:layout_marginStart="10dp"
-        android:layout_marginTop="8dp"
-        android:layout_marginEnd="8dp"
-        android:layout_toStartOf="@id/topRightLayout"
+        android:layout_alignParentTop="true"
+        android:layout_marginTop="5dp"
+        android:paddingStart="10dp"
+        android:paddingEnd="10dp">
+
+    <LinearLayout
+        android:id="@+id/topLeftLayout"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
         android:gravity="center_vertical"
         android:orientation="horizontal">
 
@@ -208,13 +212,10 @@
 
     </LinearLayout>
 
-    <LinearLayout
+    <com.github.andreyasadchy.xtra.ui.view.ControlRowLayout
         android:id="@+id/topStartLayout"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_alignParentStart="true"
-        android:layout_below="@id/topLeftLayout"
-        android:layout_marginTop="8dp"
         android:orientation="horizontal">
 
         <ImageButton
@@ -230,15 +231,13 @@
             app:tint="@android:color/white"
             tools:visibility="visible" />
 
-    </LinearLayout>
+    </com.github.andreyasadchy.xtra.ui.view.ControlRowLayout>
 
-    <LinearLayout
+    <com.github.andreyasadchy.xtra.ui.view.ControlRowLayout
         android:id="@+id/topRightLayout"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_alignParentEnd="true"
-        android:layout_marginTop="5dp"
-        android:layout_marginEnd="10dp">
+        android:gravity="end">
 
         <ImageButton
             android:id="@+id/download"
@@ -347,7 +346,9 @@
             app:tint="@android:color/white"
             tools:visibility="visible" />
 
-    </LinearLayout>
+    </com.github.andreyasadchy.xtra.ui.view.ControlRowLayout>
+
+    </com.github.andreyasadchy.xtra.ui.view.ControlEdgeLayout>
 
     <LinearLayout
         android:id="@+id/topCenterLayout"
@@ -396,14 +397,19 @@
         android:importantForAccessibility="no"
         android:visibility="invisible" />
 
-    <LinearLayout
-        android:id="@+id/bottomLeftLayout"
-        android:layout_width="wrap_content"
+    <com.github.andreyasadchy.xtra.ui.view.ControlEdgeLayout
+        android:id="@+id/bottomControlLayout"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_above="@id/bottomLayout"
-        android:layout_alignParentStart="true"
-        android:layout_marginStart="10dp"
-        android:layout_marginBottom="5dp">
+        android:layout_marginBottom="5dp"
+        android:paddingStart="10dp"
+        android:paddingEnd="10dp">
+
+    <com.github.andreyasadchy.xtra.ui.view.ControlRowLayout
+        android:id="@+id/bottomLeftLayout"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content">
 
         <ImageButton
             android:id="@+id/restart"
@@ -497,16 +503,13 @@
             app:tint="@android:color/white"
             tools:visibility="visible" />
 
-    </LinearLayout>
+    </com.github.andreyasadchy.xtra.ui.view.ControlRowLayout>
 
-    <LinearLayout
+    <com.github.andreyasadchy.xtra.ui.view.ControlRowLayout
         android:id="@+id/bottomRightLayout"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_above="@id/bottomLayout"
-        android:layout_alignParentEnd="true"
-        android:layout_marginEnd="10dp"
-        android:layout_marginBottom="5dp">
+        android:gravity="end">
 
         <ImageButton
             android:id="@+id/liveCaptions"
@@ -573,7 +576,9 @@
             app:tint="@android:color/white"
             tools:visibility="visible" />
 
-    </LinearLayout>
+    </com.github.andreyasadchy.xtra.ui.view.ControlRowLayout>
+
+    </com.github.andreyasadchy.xtra.ui.view.ControlEdgeLayout>
 
     <LinearLayout
         android:id="@+id/bottomCenterLayout"

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -234,13 +234,11 @@
     <string-array name="playerControlPositionEntries">
         <item>@string/player_control_position_above</item>
         <item>@string/player_control_position_below</item>
-        <item>@string/player_control_position_middle</item>
     </string-array>
 
     <string-array name="playerControlPositionValues" translatable="false">
         <item>above</item>
         <item>below</item>
-        <item>middle</item>
     </string-array>
 
     <string-array name="nameDisplayEntries" translatable="false">

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/view/ControlRowPlannerTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/view/ControlRowPlannerTest.kt
@@ -1,0 +1,22 @@
+package com.github.andreyasadchy.xtra.ui.view
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ControlRowPlannerTest {
+
+    @Test
+    fun `crowded controls wrap without exceeding the shared row budget`() {
+        val lines = ControlRowPlanner.lineBreak(
+            availableWidth = 100,
+            itemWidths = listOf(40, 40, 40, 40),
+            spacing = 8,
+        )
+
+        assertEquals(listOf(listOf(0, 1), listOf(2, 3)), lines)
+        assertTrue(lines.all { line ->
+            line.sumOf { index -> 40 } + (line.size - 1).coerceAtLeast(0) * 8 <= 100
+        })
+    }
+}

--- a/app/src/test/java/com/github/andreyasadchy/xtra/util/PlayerControlLayoutTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/util/PlayerControlLayoutTest.kt
@@ -40,7 +40,7 @@ class PlayerControlLayoutTest {
         assertEquals(PlayerControlLayout.GROUP_MENU, placements.first { it.action == "bookmark" }.group)
         assertEquals(PlayerControlLayout.GROUP_MENU, placements.first { it.action == "viewers" }.group)
         assertEquals(
-            "bookmark:menu:top_center,viewers:menu:top_center",
+            "bookmark:menu:top_end,viewers:menu:top_end",
             PlayerControlLayout.serializeControlLayout(placements),
         )
     }
@@ -53,5 +53,21 @@ class PlayerControlLayoutTest {
         assertEquals(false, PlayerControlLayout.isTvPrimaryAction("speed"))
         assertEquals(false, PlayerControlLayout.isTvPrimaryAction("clip"))
         assertEquals(false, PlayerControlLayout.isTvPrimaryAction("fullscreen"))
+    }
+
+    @Test
+    fun `top start is reserved for minimize in the editor policy`() {
+        assertEquals(
+            PlayerControlLayout.anchors,
+            PlayerControlLayout.validAnchors("minimize"),
+        )
+        assertEquals(
+            setOf(
+                PlayerControlLayout.ANCHOR_TOP_END,
+                PlayerControlLayout.ANCHOR_BOTTOM_START,
+                PlayerControlLayout.ANCHOR_BOTTOM_END,
+            ),
+            PlayerControlLayout.validAnchors("quality"),
+        )
     }
 }

--- a/app/src/test/java/com/github/andreyasadchy/xtra/util/SettingsMigrationTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/util/SettingsMigrationTest.kt
@@ -167,6 +167,23 @@ class SettingsMigrationTest {
     }
 
     @Test
+    fun `current schema migrates the removed middle quick control position`() {
+        val preferences = MemoryPreferences(
+            mutableMapOf(
+                C.SETTINGS_VERSION to C.SETTINGS_SCHEMA_VERSION,
+                C.PLAYER_CONTROL_POSITION to C.PLAYER_CONTROL_POSITION_MIDDLE,
+            ),
+        )
+
+        SettingsMigration.migratePreferences(preferences, freshInstall = false)
+
+        assertEquals(
+            C.PLAYER_CONTROL_POSITION_BELOW,
+            preferences.getString(C.PLAYER_CONTROL_POSITION, null),
+        )
+    }
+
+    @Test
     fun `schema 25 migration keeps moved following content reachable`() {
         val preferences = MemoryPreferences(
             mutableMapOf(


### PR DESCRIPTION
Reworks the player controls overlay with safe, aligned default regions. Keeps ordering and show/hide customization while moving controls into wrapping rows and preserving older saved layouts.