### PR TITLE
Fix Discover recommendation image races

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/model/ui/Stream.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/model/ui/Stream.kt
@@ -31,4 +31,23 @@ class Stream(
         get() = TwitchApiHelper.getProfileImage(channelImageURL)
     val thumbnail: String?
         get() = TwitchApiHelper.getStreamThumbnail(thumbnailURL)
+
+    /** Creates the same stream snapshot with a new live-preview refresh generation. */
+    fun withThumbnailGeneration(generation: Long): Stream = Stream(
+        id = id,
+        channelId = channelId,
+        channelLogin = channelLogin,
+        channelName = channelName,
+        channelImageURL = channelImageURL,
+        gameId = gameId,
+        gameSlug = gameSlug,
+        gameName = gameName,
+        title = title,
+        thumbnailURL = thumbnailURL,
+        createdAt = createdAt,
+        viewerCount = viewerCount,
+        tags = tags,
+        dropsAvailable = dropsAvailable,
+        thumbnailGeneration = generation,
+    )
 }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/RecommendationsRepository.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/RecommendationsRepository.kt
@@ -92,6 +92,7 @@ class RecommendationsRepository(
                 }
                 debug("PersonalSections sections=${sections?.size ?: 0} items=$itemCount")
                 parsePersonalSections(response)
+                    .filter(::hasRenderableFeedImages)
                     .filterNot { it.channelId in excludedChannelIds }
                     .also { debug("PersonalSections parsed count=${it.size}") }
             } catch (error: CancellationException) {
@@ -229,6 +230,7 @@ class RecommendationsRepository(
         )
         return response.data?.streams?.edges.orEmpty().mapNotNull { it.node.toStream() }
             .filterNot { it.channelId in followedIds }
+            .filter(::hasRenderableFeedImages)
             .take(limit)
     }
 
@@ -346,6 +348,9 @@ enum class RecommendationSource {
     FALLBACK,
     UNAVAILABLE,
 }
+
+private fun hasRenderableFeedImages(stream: Stream): Boolean =
+    !stream.channelImageURL.isNullOrBlank() && !stream.thumbnailURL.isNullOrBlank()
 
 internal fun recommendationSourceFor(
     personalized: List<Stream>?,

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/RecommendationsRepository.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/RecommendationsRepository.kt
@@ -61,6 +61,7 @@ class RecommendationsRepository(
                             .take(limit),
                         source = entry.source,
                         authMode = entry.authMode,
+                        isCacheHit = true,
                     )
                 }
         }
@@ -88,6 +89,7 @@ class RecommendationsRepository(
                     },
                     result = streams,
                 ),
+                isCacheHit = false,
             )
             lastSource = result.source
             debug("source=${result.source} auth=${result.authMode} cache-supplement count=${result.streams.size}")
@@ -329,6 +331,7 @@ data class RecommendationResult(
     val streams: List<Stream>,
     val source: RecommendationSource,
     val authMode: RecommendationAuthMode,
+    val isCacheHit: Boolean = false,
 )
 
 enum class RecommendationAuthMode {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/RecommendationsRepository.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/RecommendationsRepository.kt
@@ -51,19 +51,47 @@ class RecommendationsRepository(
             ?.xtraModule?.twitchWebSessionManager
         val requestContext = recommendationRequestContext(now)
         val accountKey = requestContext.accountKey
-        cacheMutex.withLock {
+        val cachedResult = cacheMutex.withLock {
             cache
                 ?.takeIf { it.accountKey == accountKey && recommendationCacheIsFresh(now, it.expiresAt) }
                 ?.let { entry ->
-                    lastSource = entry.source
-                    return RecommendationResult(
+                    RecommendationResult(
                         streams = entry.recommendations
-                        .filterNot { it.channelId in excludedChannelIds }
-                        .take(limit),
+                            .filterNot { it.channelId in excludedChannelIds }
+                            .take(limit),
                         source = entry.source,
                         authMode = entry.authMode,
-                    ).also { debug("source=${it.source} auth=${it.authMode} cache-hit count=${it.streams.size}") }
+                    )
                 }
+        }
+        if (cachedResult != null && cachedResult.streams.size >= limit) {
+            lastSource = cachedResult.source
+            return cachedResult.also {
+                debug("source=${it.source} auth=${it.authMode} cache-hit count=${it.streams.size}")
+            }
+        }
+        if (cachedResult != null) {
+            val fallbackStreams = loadFallbackRecommendations(
+                requestContext = requestContext,
+                limit = limit,
+                excludedChannelIds = excludedChannelIds,
+            )
+            val streams = (cachedResult.streams + fallbackStreams)
+                .filterNot { it.channelId in excludedChannelIds }
+                .distinctBy { it.channelId ?: it.id }
+                .take(limit)
+            val result = cachedResult.copy(
+                streams = streams,
+                source = recommendationSourceFor(
+                    personalized = cachedResult.streams.takeIf {
+                        cachedResult.source == RecommendationSource.PERSONALIZED
+                    },
+                    result = streams,
+                ),
+            )
+            lastSource = result.source
+            debug("source=${result.source} auth=${result.authMode} cache-supplement count=${result.streams.size}")
+            return result
         }
         val auth = requestContext.auth
         debug("auth=${auth.mode} userBound=${auth.userId != null}")
@@ -102,33 +130,23 @@ class RecommendationsRepository(
                 null
             }
         }
-        val source = if (!personalized.isNullOrEmpty()) {
-            RecommendationSource.PERSONALIZED
+        val fallbackStreams = if (personalized == null || personalized.size < limit) {
+            debug(
+                if (personalized.isNullOrEmpty()) {
+                    "source=FALLBACK reason=${if (personalized == null) "personalized-error" else "personalized-empty"}"
+                } else {
+                    "source=FALLBACK reason=supplement-personalized count=${personalized.size}"
+                },
+            )
+            loadFallbackRecommendations(
+                requestContext = requestContext,
+                limit = limit,
+                excludedChannelIds = excludedChannelIds,
+            )
         } else {
-            RecommendationSource.FALLBACK
+            emptyList()
         }
-        lastSource = source
-        val streams = if (!personalized.isNullOrEmpty()) {
-            personalized
-        } else {
-            debug("source=FALLBACK reason=${if (personalized == null) "personalized-error" else "personalized-empty"}")
-            try {
-                fallback(
-                    networkLibrary = requestContext.networkLibrary,
-                    headers = TwitchApiHelper.getPublicRecommendationGQLHeaders(
-                        context = context,
-                        clientSessionId = recommendationClientSessionId,
-                    ),
-                    limit = limit,
-                    excludedChannelIds = excludedChannelIds,
-                )
-            } catch (error: CancellationException) {
-                throw error
-            } catch (error: Exception) {
-                debugFailure("Fallback recommendations failed", error)
-                emptyList()
-            }
-        }
+        val streams = (personalized.orEmpty() + fallbackStreams)
             .filterNot { it.channelId in excludedChannelIds }
             .distinctBy { it.channelId ?: it.id }
             .take(limit)
@@ -147,6 +165,27 @@ class RecommendationsRepository(
             )
         }
         return result
+    }
+
+    private suspend fun loadFallbackRecommendations(
+        requestContext: RecommendationRequestContext,
+        limit: Int,
+        excludedChannelIds: Set<String>,
+    ): List<Stream> = try {
+        fallback(
+            networkLibrary = requestContext.networkLibrary,
+            headers = TwitchApiHelper.getPublicRecommendationGQLHeaders(
+                context = context,
+                clientSessionId = recommendationClientSessionId,
+            ),
+            limit = limit,
+            excludedChannelIds = excludedChannelIds,
+        )
+    } catch (error: CancellationException) {
+        throw error
+    } catch (error: Exception) {
+        debugFailure("Fallback recommendations failed", error)
+        emptyList()
     }
 
     private suspend fun publishCacheIfCurrent(

--- a/app/src/main/java/com/github/andreyasadchy/xtra/repository/streamfeed/StreamFeedCache.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/repository/streamfeed/StreamFeedCache.kt
@@ -146,23 +146,6 @@ internal fun appendCachedPage(
     return activePrefix
 }
 
-private fun Stream.withThumbnailGeneration(generation: Long): Stream = Stream(
-    id = id,
-    channelId = channelId,
-    channelLogin = channelLogin,
-    channelName = channelName,
-    channelImageURL = channelImageURL,
-    gameId = gameId,
-    gameSlug = gameSlug,
-    gameName = gameName,
-    title = title,
-    thumbnailURL = thumbnailURL,
-    createdAt = createdAt,
-    viewerCount = viewerCount,
-    tags = tags,
-    thumbnailGeneration = generation,
-)
-
 private fun normalizedStreams(streams: List<Stream>, generation: Long): List<Stream> =
     streams.distinctBy { it.cacheItemKey() }
         .mapNotNull { stream ->

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/StreamsAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/StreamsAdapter.kt
@@ -87,7 +87,7 @@ class StreamsAdapter(
 
     override fun onBindViewHolder(holder: PagingViewHolder, position: Int, payloads: MutableList<Any>) {
         if (payloads.isNotEmpty() && payloads.all { it === StreamThumbnailChangedPayload }) {
-            holder.beginImageBind(getItem(position))
+            holder.beginThumbnailRefresh()
             holder.bindThumbnail(getItem(position))
         } else {
             super.onBindViewHolder(holder, position, payloads)
@@ -146,6 +146,11 @@ class StreamsAdapter(
             thumbnailLoadScheduler.clear(this)
             imageRequests.cancel()
             boundImageIdentity = item?.streamIdentity()
+            boundThumbnailKey = null
+        }
+
+        fun beginThumbnailRefresh() {
+            imageRequests.cancel(binding.thumbnail)
             boundThumbnailKey = null
         }
 

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/StreamsCompactAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/StreamsCompactAdapter.kt
@@ -95,7 +95,7 @@ class StreamsCompactAdapter(
 
     override fun onBindViewHolder(holder: PagingViewHolder, position: Int, payloads: MutableList<Any>) {
         if (payloads.isNotEmpty() && payloads.all { it === StreamThumbnailChangedPayload }) {
-            holder.beginImageBind(getItem(position))
+            holder.beginThumbnailRefresh()
             holder.bindThumbnail(getItem(position))
         } else {
             super.onBindViewHolder(holder, position, payloads)
@@ -152,6 +152,11 @@ class StreamsCompactAdapter(
             thumbnailLoadScheduler.clear(this)
             imageRequests.cancel()
             boundImageIdentity = item?.streamIdentity()
+            boundThumbnailKey = null
+        }
+
+        fun beginThumbnailRefresh() {
+            imageRequests.cancel(binding.thumbnail)
             boundThumbnailKey = null
         }
 

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/ThumbnailImageRequest.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/ThumbnailImageRequest.kt
@@ -31,6 +31,7 @@ import com.github.andreyasadchy.xtra.util.UiInteractionGovernor
 import java.util.Collections
 import java.util.concurrent.ConcurrentHashMap
 import java.util.IdentityHashMap
+import java.util.concurrent.atomic.AtomicLong
 
 internal interface FeedImageRequestOwner {
     /** Cancel optional work without invalidating an image that is already on screen. */
@@ -352,11 +353,13 @@ internal fun streamThumbnailOnlyChanged(oldItem: Stream, newItem: Stream): Boole
 /**
  * Coil normally sends a null onStart value to an ImageViewTarget when a new
  * request has no placeholder. Keep the existing successful image in that
- * case, and guard every callback against a recycled ViewHolder identity.
+ * case, and guard every callback against both a recycled ViewHolder identity
+ * and an older bind of the same identity.
  */
 private class StreamImageTarget(
     imageView: ImageView,
     private val identity: String,
+    private val bindToken: Long?,
     private val preserveCurrentImage: Boolean,
     private val requestKey: Any? = null,
     private val thumbnailRequestKey: Any? = null,
@@ -366,6 +369,7 @@ private class StreamImageTarget(
 
     private fun isCurrent(): Boolean =
         view.tag == identity &&
+            (bindToken == null || view.getTag(R.id.stream_image_bind_token) == bindToken) &&
             when {
                 requestKey != null -> view.getTag(R.id.stream_profile_request_key) == requestKey
                 thumbnailRequestKey != null -> view.getTag(R.id.stream_thumbnail_request_key) == thumbnailRequestKey
@@ -408,6 +412,7 @@ private class StreamImageTarget(
 private class StreamThumbnailCacheTarget(
     imageView: ImageView,
     private val identity: String,
+    private val bindToken: Long?,
     private val cacheKey: String,
 ) : ImageViewTarget(imageView) {
 
@@ -417,7 +422,9 @@ private class StreamThumbnailCacheTarget(
     }
 
     override fun onSuccess(result: Image) {
-        if (view.tag == identity) {
+        if (view.tag == identity &&
+            (bindToken == null || view.getTag(R.id.stream_image_bind_token) == bindToken)
+        ) {
             super.onSuccess(result)
             view.setTag(R.id.stream_thumbnail_display_state, StreamThumbnailDisplayState.IMAGE)
             rememberWarmStreamThumbnail(cacheKey, view)
@@ -425,7 +432,9 @@ private class StreamThumbnailCacheTarget(
     }
 
     override fun onError(error: Image?) {
-        if (view.tag == identity) {
+        if (view.tag == identity &&
+            (bindToken == null || view.getTag(R.id.stream_image_bind_token) == bindToken)
+        ) {
             // Preserve whatever was already displayed, including a previous
             // cached image. The request listener starts the fresh stage after
             // this target callback has completed.
@@ -449,6 +458,10 @@ private data class StreamThumbnailViewRequestKey(
 )
 
 private val warmStreamThumbnailCache = object : LruCache<String, Drawable.ConstantState>(16) {}
+
+private val streamImageBindTokens = AtomicLong()
+
+private fun nextStreamImageBindToken(): Long = streamImageBindTokens.incrementAndGet()
 
 private data class WarmThumbnailRequestKey(val memoryCacheKey: String)
 
@@ -668,6 +681,7 @@ internal fun streamThumbnailRequestPlan(stream: Stream, bucket: Long): StreamThu
 
 internal fun prepareStreamProfileImage(imageView: ImageView, stream: Stream) {
     val identity = stream.streamIdentity()
+    imageView.setTag(R.id.stream_image_bind_token, nextStreamImageBindToken())
     if (imageView.tag != identity) {
         imageView.setImageDrawable(null)
         imageView.setTag(R.id.stream_profile_request_key, null)
@@ -677,6 +691,7 @@ internal fun prepareStreamProfileImage(imageView: ImageView, stream: Stream) {
 
 internal fun prepareStreamThumbnailImage(imageView: ImageView, stream: Stream) {
     val identity = stream.thumbnailIdentity()
+    imageView.setTag(R.id.stream_image_bind_token, nextStreamImageBindToken())
     if (imageView.tag != identity) {
         imageView.setImageDrawable(null)
         imageView.setTag(R.id.stream_thumbnail_request_key, null)
@@ -706,6 +721,7 @@ internal fun loadStreamProfileImage(
     }
     val roundUserImage = FeedUiPreferencesStore.current(context).roundUserImage
     val requestKey = "$identity|$url|round=$roundUserImage"
+    val bindToken = imageView.getTag(R.id.stream_image_bind_token) as? Long
     if (sameIdentity &&
         imageView.drawable != null &&
         imageView.getTag(R.id.stream_profile_request_key) == requestKey
@@ -725,7 +741,15 @@ internal fun loadStreamProfileImage(
         }
         // Keep an already displayed image in place while a changed profile URL loads.
         crossfade(false)
-        target(StreamImageTarget(imageView, identity, preserveCurrentImage = sameIdentity, requestKey = requestKey))
+        target(
+            StreamImageTarget(
+                imageView = imageView,
+                identity = identity,
+                bindToken = bindToken,
+                preserveCurrentImage = sameIdentity,
+                requestKey = requestKey,
+            ),
+        )
     }.build())
 }
 
@@ -783,6 +807,7 @@ internal fun loadStreamThumbnail(
         imageView.setTag(R.id.stream_thumbnail_successful_fresh_key, null)
     }
     imageView.tag = identity
+    val bindToken = imageView.getTag(R.id.stream_image_bind_token) as? Long
     val bucket = StreamThumbnailPolicy.bucket(System.currentTimeMillis())
     val forceEpoch = StreamThumbnailRefreshSignal.currentForceEpoch()
     val plan = streamThumbnailRequestPlan(stream, bucket)
@@ -855,6 +880,7 @@ internal fun loadStreamThumbnail(
                 StreamImageTarget(
                     imageView = imageView,
                     identity = identity,
+                    bindToken = bindToken,
                     preserveCurrentImage = preserveCurrentImage,
                     thumbnailRequestKey = requestKey,
                     thumbnailCacheKey = plan.memoryCacheKey,
@@ -916,7 +942,7 @@ internal fun loadStreamThumbnail(
             },
             onError = { scheduleFreshRequest(::enqueueFreshRequest) },
         )
-        target(StreamThumbnailCacheTarget(imageView, identity, plan.memoryCacheKey))
+        target(StreamThumbnailCacheTarget(imageView, identity, bindToken, plan.memoryCacheKey))
     }.build()))
     return requestHandle
 }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/ThumbnailImageRequest.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/common/ThumbnailImageRequest.kt
@@ -244,6 +244,11 @@ internal class FeedImageRequestBag {
         cancellations.put(slot, handle::cancel)?.invoke()
     }
 
+    /** Cancel one image slot without disturbing the other image requests. */
+    fun cancel(slot: Any) {
+        cancellations.remove(slot)?.invoke()
+    }
+
     fun cancel(preserveRegistrations: Boolean = false) {
         cancellations.values.forEach { it() }
         if (!preserveRegistrations) cancellations.clear()
@@ -281,9 +286,8 @@ internal class StreamThumbnailRequestHandle(
     }
 
     @Synchronized
-    fun rearm() {
-        cancelled = false
-    }
+    fun isCancelled(): Boolean = cancelled
+
 }
 
 internal fun ImageRequest.Builder.thumbnailState(): ImageRequest.Builder = apply {
@@ -844,10 +848,14 @@ internal fun loadStreamThumbnail(
     }
 
     fun enqueueFreshRequest() {
+        if (requestHandle.isCancelled()) return
         val nowMs = System.currentTimeMillis()
         if (!streamThumbnailFetchGate.shouldFetch(identity, bucket, forceEpoch, nowMs)) return
         streamThumbnailFetchGate.markAttempt(identity, bucket, forceEpoch, nowMs)
-        requestHandle.rearm()
+        if (requestHandle.isCancelled()) {
+            streamThumbnailFetchGate.clearAttempt(identity, bucket, forceEpoch)
+            return
+        }
         val preserveCurrentImage = imageView.tag == identity &&
                 imageView.getTag(R.id.stream_thumbnail_display_state) == StreamThumbnailDisplayState.IMAGE
         val policies = thumbnailCachePolicies(fresh = true)
@@ -897,7 +905,9 @@ internal fun loadStreamThumbnail(
     // only revalidate when the fetch gate says the current bucket is due.
     if (warmImageRestored || restoreWarmStreamThumbnail(plan.memoryCacheKey, imageView)) {
         if (streamThumbnailFetchGate.shouldFetch(identity, bucket, forceEpoch, System.currentTimeMillis())) {
-            scheduleFreshRequest(::enqueueFreshRequest)
+            if (!requestHandle.isCancelled()) {
+                scheduleFreshRequest(::enqueueFreshRequest)
+            }
         }
         return requestHandle
     }
@@ -937,10 +947,16 @@ internal fun loadStreamThumbnail(
                         forceRefresh = forceRefresh || retryFreshRequest,
                     )
                 ) {
+                    if (!requestHandle.isCancelled()) {
+                        scheduleFreshRequest(::enqueueFreshRequest)
+                    }
+                }
+            },
+            onError = {
+                if (!requestHandle.isCancelled()) {
                     scheduleFreshRequest(::enqueueFreshRequest)
                 }
             },
-            onError = { scheduleFreshRequest(::enqueueFreshRequest) },
         )
         target(StreamThumbnailCacheTarget(imageView, identity, bindToken, plan.memoryCacheKey))
     }.build()))

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/discover/DiscoverViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/discover/DiscoverViewModel.kt
@@ -98,6 +98,7 @@ class DiscoverViewModel(
     private val recommendationsMutex = Mutex()
     private var currentTrendingSpec: StreamFeedSpec? = null
     private var lastVisibleRefreshAt = 0L
+    private var recommendationsRefreshGeneration = 0L
 
     @OptIn(ExperimentalCoroutinesApi::class)
     val state: StateFlow<DiscoverState> = combine(
@@ -234,7 +235,15 @@ class DiscoverViewModel(
                         if (result.source == RecommendationSource.UNAVAILABLE && current.data.isNotEmpty()) {
                             current.copy(refreshing = false, hasLoadedOnce = true, error = null)
                         } else {
-                            current.copy(data = result.streams, refreshing = false, hasLoadedOnce = true, error = null)
+                            val generation = ++recommendationsRefreshGeneration
+                            current.copy(
+                                data = result.streams.map { stream ->
+                                    stream.withThumbnailGeneration(generation)
+                                },
+                                refreshing = false,
+                                hasLoadedOnce = true,
+                                error = null,
+                            )
                         }
                     }
                 } catch (error: CancellationException) {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/discover/DiscoverViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/discover/DiscoverViewModel.kt
@@ -235,7 +235,8 @@ class DiscoverViewModel(
                         if (result.source == RecommendationSource.UNAVAILABLE && current.data.isNotEmpty()) {
                             current.copy(refreshing = false, hasLoadedOnce = true, error = null)
                         } else {
-                            val recommendationsChanged = !recommendationStreamsSame(current.data, result.streams)
+                            val recommendationsChanged = !result.isCacheHit ||
+                                !recommendationStreamsSame(current.data, result.streams)
                             val generation = if (recommendationsChanged) {
                                 ++recommendationsRefreshGeneration
                             } else {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/discover/DiscoverViewModel.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/discover/DiscoverViewModel.kt
@@ -235,10 +235,20 @@ class DiscoverViewModel(
                         if (result.source == RecommendationSource.UNAVAILABLE && current.data.isNotEmpty()) {
                             current.copy(refreshing = false, hasLoadedOnce = true, error = null)
                         } else {
-                            val generation = ++recommendationsRefreshGeneration
+                            val recommendationsChanged = !recommendationStreamsSame(current.data, result.streams)
+                            val generation = if (recommendationsChanged) {
+                                ++recommendationsRefreshGeneration
+                            } else {
+                                current.data.firstOrNull()?.thumbnailGeneration
+                                    ?: recommendationsRefreshGeneration
+                            }
                             current.copy(
-                                data = result.streams.map { stream ->
-                                    stream.withThumbnailGeneration(generation)
+                                data = if (recommendationsChanged) {
+                                    result.streams.map { stream ->
+                                        stream.withThumbnailGeneration(generation)
+                                    }
+                                } else {
+                                    current.data
                                 },
                                 refreshing = false,
                                 hasLoadedOnce = true,
@@ -379,4 +389,24 @@ class DiscoverViewModel(
             }
         }
     }
+}
+
+private fun recommendationStreamsSame(
+    first: List<Stream>,
+    second: List<Stream>,
+): Boolean = first.size == second.size && first.zip(second).all { (old, new) ->
+    old.id == new.id &&
+        old.channelId == new.channelId &&
+        old.channelLogin == new.channelLogin &&
+        old.channelName == new.channelName &&
+        old.channelImageURL == new.channelImageURL &&
+        old.gameId == new.gameId &&
+        old.gameSlug == new.gameSlug &&
+        old.gameName == new.gameName &&
+        old.title == new.title &&
+        old.thumbnailURL == new.thumbnailURL &&
+        old.createdAt == new.createdAt &&
+        old.viewerCount == new.viewerCount &&
+        old.tags == new.tags &&
+        old.dropsAvailable == new.dropsAvailable
 }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/overview/FeaturedStreamShelfAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/overview/FeaturedStreamShelfAdapter.kt
@@ -76,8 +76,9 @@ class FeaturedStreamShelfAdapter(
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int, payloads: MutableList<Any>) {
         if (payloads.isNotEmpty() && payloads.all { it === StreamThumbnailChangedPayload }) {
-            holder.beginThumbnailRefresh()
-            holder.bindThumbnail(getItem(position))
+            val stream = getItem(position)
+            holder.beginThumbnailRefresh(stream)
+            holder.bindThumbnail(stream)
         } else {
             super.onBindViewHolder(holder, position, payloads)
         }
@@ -252,7 +253,9 @@ class FeaturedStreamShelfAdapter(
             boundThumbnailKey = null
         }
 
-        fun beginThumbnailRefresh() {
+        fun beginThumbnailRefresh(stream: Stream?) {
+            boundImageStream = stream
+            boundImageIdentity = stream?.streamIdentity()
             imageRequests.cancel(binding.thumbnail)
             boundThumbnailKey = null
         }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/overview/FeaturedStreamShelfAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/overview/FeaturedStreamShelfAdapter.kt
@@ -76,7 +76,7 @@ class FeaturedStreamShelfAdapter(
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int, payloads: MutableList<Any>) {
         if (payloads.isNotEmpty() && payloads.all { it === StreamThumbnailChangedPayload }) {
-            holder.beginImageBind(getItem(position))
+            holder.beginThumbnailRefresh()
             holder.bindThumbnail(getItem(position))
         } else {
             super.onBindViewHolder(holder, position, payloads)
@@ -249,6 +249,11 @@ class FeaturedStreamShelfAdapter(
             imageRequests.cancel()
             boundImageStream = stream
             boundImageIdentity = stream?.streamIdentity()
+            boundThumbnailKey = null
+        }
+
+        fun beginThumbnailRefresh() {
+            imageRequests.cancel(binding.thumbnail)
             boundThumbnailKey = null
         }
 

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/overview/StreamShelfAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/overview/StreamShelfAdapter.kt
@@ -65,7 +65,7 @@ class StreamShelfAdapter(
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int, payloads: MutableList<Any>) {
         if (payloads.isNotEmpty() && payloads.all { it === StreamThumbnailChangedPayload }) {
-            holder.beginImageBind(getItem(position))
+            holder.beginThumbnailRefresh()
             holder.bindThumbnail(getItem(position))
         } else {
             super.onBindViewHolder(holder, position, payloads)
@@ -146,6 +146,11 @@ class StreamShelfAdapter(
             imageRequests.cancel()
             boundImageStream = stream
             boundImageIdentity = stream?.streamIdentity()
+            boundThumbnailKey = null
+        }
+
+        fun beginThumbnailRefresh() {
+            imageRequests.cancel(binding.thumbnail)
             boundThumbnailKey = null
         }
 

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/overview/StreamShelfAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/overview/StreamShelfAdapter.kt
@@ -65,8 +65,9 @@ class StreamShelfAdapter(
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int, payloads: MutableList<Any>) {
         if (payloads.isNotEmpty() && payloads.all { it === StreamThumbnailChangedPayload }) {
-            holder.beginThumbnailRefresh()
-            holder.bindThumbnail(getItem(position))
+            val stream = getItem(position)
+            holder.beginThumbnailRefresh(stream)
+            holder.bindThumbnail(stream)
         } else {
             super.onBindViewHolder(holder, position, payloads)
         }
@@ -149,7 +150,9 @@ class StreamShelfAdapter(
             boundThumbnailKey = null
         }
 
-        fun beginThumbnailRefresh() {
+        fun beginThumbnailRefresh(stream: Stream?) {
+            boundImageStream = stream
+            boundImageIdentity = stream?.streamIdentity()
             imageRequests.cancel(binding.thumbnail)
             boundThumbnailKey = null
         }

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/streams/FollowingStreamsListAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/streams/FollowingStreamsListAdapter.kt
@@ -72,11 +72,11 @@ class FollowingStreamsListAdapter(
         if (payloads.isNotEmpty() && payloads.all { it === StreamThumbnailChangedPayload }) {
             when (holder) {
                 is StreamsCompactAdapter.PagingViewHolder -> {
-                    holder.beginImageBind(item)
+                    holder.beginThumbnailRefresh()
                     holder.bindThumbnail(item)
                 }
                 is StreamsShelfPagingAdapter.ViewHolder -> {
-                    holder.beginImageBind(item)
+                    holder.beginThumbnailRefresh()
                     holder.bindThumbnail(item)
                 }
                 else -> bindItem(holder, item)

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/streams/StreamsShelfPagingAdapter.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/following/streams/StreamsShelfPagingAdapter.kt
@@ -78,7 +78,7 @@ class StreamsShelfPagingAdapter(
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int, payloads: MutableList<Any>) {
         if (payloads.isNotEmpty() && payloads.all { it === StreamThumbnailChangedPayload }) {
-            holder.beginImageBind(getItem(position))
+            holder.beginThumbnailRefresh()
             holder.bindThumbnail(getItem(position))
         } else {
             super.onBindViewHolder(holder, position, payloads)
@@ -131,6 +131,11 @@ class StreamsShelfPagingAdapter(
             thumbnailLoadScheduler.clear(this)
             imageRequests.cancel()
             boundImageIdentity = item?.streamIdentity()
+            boundThumbnailKey = null
+        }
+
+        fun beginThumbnailRefresh() {
+            imageRequests.cancel(binding.thumbnail)
             boundThumbnailKey = null
         }
 

--- a/app/src/main/res/values/ids.xml
+++ b/app/src/main/res/values/ids.xml
@@ -5,6 +5,7 @@
     <item name="stream_thumbnail_successful_fresh_key" type="id" />
     <item name="stream_thumbnail_display_state" type="id" />
     <item name="stream_profile_request_key" type="id" />
+    <item name="stream_image_bind_token" type="id" />
     <item name="tv_focus_helper_installed" type="id" />
     <item name="emote_image_url_key" type="id" />
     <item name="autocomplete_image_request" type="id" />

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/common/ThumbnailImageRequestTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/common/ThumbnailImageRequestTest.kt
@@ -197,4 +197,32 @@ class ThumbnailImageRequestTest {
     fun missingThumbnailHasNoTwoStageRequest() {
         assertNull(streamThumbnailRequestPlan(Stream(channelId = "channel-42"), bucket = 10L))
     }
+
+    @Test
+    fun thumbnailRefreshCancelsOnlyThumbnailWork() {
+        val requests = FeedImageRequestBag()
+        var avatarCancellations = 0
+        var thumbnailCancellations = 0
+        val avatarSlot = Any()
+        val thumbnailSlot = Any()
+
+        requests.replace(
+            avatarSlot,
+            StreamThumbnailRequestHandle { avatarCancellations++ },
+        )
+        requests.replace(
+            thumbnailSlot,
+            StreamThumbnailRequestHandle { thumbnailCancellations++ },
+        )
+
+        requests.cancel(thumbnailSlot)
+
+        assertEquals(0, avatarCancellations)
+        assertEquals(1, thumbnailCancellations)
+
+        requests.cancel()
+
+        assertEquals(1, avatarCancellations)
+        assertEquals(1, thumbnailCancellations)
+    }
 }


### PR DESCRIPTION
Prevents recycled recommendation cards from accepting stale avatar or thumbnail callbacks. Recommendation refreshes now participate in live thumbnail generations, and incomplete recommendation records are skipped before reaching the shelf.