### PR TITLE
Improve live caption partial latency

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/captions/LiveCaptionManager.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/captions/LiveCaptionManager.kt
@@ -333,6 +333,8 @@ class LiveCaptionManager(
         var lastInferenceMs = 0L
         var maxInferenceMs = 0L
         var inferenceCalls = 0L
+        var partialResults = 0L
+        var finalResults = 0L
         var totalInferenceMs = 0L
         var acceptedAudioMs = 0L
         var nextMetricsLogMs = SystemClock.elapsedRealtime() + METRICS_LOG_INTERVAL_MS
@@ -398,6 +400,8 @@ class LiveCaptionManager(
             lastInferenceMs = 0L
             maxInferenceMs = 0L
             inferenceCalls = 0L
+            partialResults = 0L
+            finalResults = 0L
             totalInferenceMs = 0L
             acceptedAudioMs = 0L
             droppedBuffersBaseline.reset(droppedAudioBuffers.get())
@@ -563,6 +567,10 @@ class LiveCaptionManager(
                         if (event.generation != audioGeneration.get() || !enabled.get()) continue
                         invalidatePendingCaptionEventsIfNeeded()
                         events.forEach { recognition ->
+                            when (recognition) {
+                                is CaptionRecognitionEvent.Partial -> partialResults++
+                                is CaptionRecognitionEvent.Final -> finalResults++
+                            }
                             enqueueCaptionEvent(recognition)
                         }
 
@@ -575,6 +583,8 @@ class LiveCaptionManager(
                                 lastInferenceMs = lastInferenceMs,
                                 maxInferenceMs = maxInferenceMs,
                                 inferenceCalls = inferenceCalls,
+                                partialResults = partialResults,
+                                finalResults = finalResults,
                                 droppedAudioBuffers = droppedBuffersBaseline.delta(droppedAudioBuffers.get()),
                                 realTimeFactor = if (acceptedAudioMs == 0L) {
                                     0.0
@@ -592,6 +602,8 @@ class LiveCaptionManager(
                                     "firstOutput=${firstOutputAfterStartMs ?: "none"}ms " +
                                     "lastInfer=${lastInferenceMs}ms " +
                                     "maxInfer=${maxInferenceMs}ms " +
+                                    "partials=$partialResults " +
+                                    "finals=$finalResults " +
                                     "rtf=${"%.2f".format(java.util.Locale.US, totalInferenceMs.toDouble() / acceptedAudioMs.coerceAtLeast(1L))} " +
                                     "drops=${droppedBuffersBaseline.delta(droppedAudioBuffers.get())}",
                             )

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/captions/LiveCaptionMetrics.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/captions/LiveCaptionMetrics.kt
@@ -7,6 +7,8 @@ data class LiveCaptionMetrics(
     val lastInferenceMs: Long = 0,
     val maxInferenceMs: Long = 0,
     val inferenceCalls: Long = 0,
+    val partialResults: Long = 0,
+    val finalResults: Long = 0,
     val droppedAudioBuffers: Int = 0,
     val realTimeFactor: Double = 0.0,
     val pcmBuffersReceived: Long = 0,

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/captions/engine/SherpaMoonshineEngine.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/player/captions/engine/SherpaMoonshineEngine.kt
@@ -130,16 +130,26 @@ class SherpaMoonshineEngine(
             ) {
                 val decodeStartedAt = SystemClock.elapsedRealtime()
                 val partial = decode(utterance.toArray())
-                previousPartialDecodeDurationMs =
+                val partialDecodeDurationMs =
                     (SystemClock.elapsedRealtime() - decodeStartedAt).coerceAtLeast(0L)
+                previousPartialDecodeDurationMs = partialDecodeDurationMs
                 partial.takeIf(String::isNotEmpty)?.let {
                     events += CaptionRecognitionEvent.Partial(it)
                 }
-                nextPartialDecodeMs = audioPositionMs() + nextMoonshinePartialIntervalMs(
+                val nextPartialIntervalMs = nextMoonshinePartialIntervalMs(
                     configuredIntervalMs = partialDecodeIntervalMs,
-                    previousPartialDecodeDurationMs = previousPartialDecodeDurationMs,
+                    previousPartialDecodeDurationMs = partialDecodeDurationMs,
                     firstPartial = false,
                 )
+                nextPartialDecodeMs = audioPositionMs() + nextPartialIntervalMs
+                if (BuildConfig.DEBUG) {
+                    Log.d(
+                        TAG,
+                        "partial_decode durationMs=$partialDecodeDurationMs " +
+                            "nextIntervalMs=$nextPartialIntervalMs " +
+                            "utteranceMs=${utterance.size * 1_000L / TARGET_SAMPLE_RATE}",
+                    )
+                }
             }
         }
     }
@@ -259,7 +269,12 @@ internal fun nextMoonshinePartialIntervalMs(
 ): Long {
     val configured = configuredIntervalMs.coerceAtLeast(0L)
     if (firstPartial) return configured
-    return maxOf(configured, (previousPartialDecodeDurationMs ?: 0L) * 2L)
+    val measuredDecodeDuration = (previousPartialDecodeDurationMs ?: 0L)
+        .coerceAtMost(MAX_ADAPTIVE_PARTIAL_INTERVAL_MS)
+    // Leave proportional idle time for audio/VAD work instead of repeatedly
+    // re-decoding the growing utterance as soon as the previous decode ends.
+    val measuredIntervalWithHeadroom = (measuredDecodeDuration * 5L + 3L) / 4L
+    return maxOf(configured, measuredIntervalWithHeadroom)
         .coerceAtMost(MAX_ADAPTIVE_PARTIAL_INTERVAL_MS)
 }
 

--- a/app/src/test/java/com/github/andreyasadchy/xtra/ui/player/captions/engine/MoonshineCaptionPolicyTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/ui/player/captions/engine/MoonshineCaptionPolicyTest.kt
@@ -29,13 +29,18 @@ class MoonshineCaptionPolicyTest {
     }
 
     @Test
-    fun `slow partial inference backs off`() {
-        assertEquals(1_800L, nextMoonshinePartialIntervalMs(1_000L, 900L, false))
+    fun `slow partial inference keeps the configured latency target`() {
+        assertEquals(1_125L, nextMoonshinePartialIntervalMs(1_000L, 900L, false))
+    }
+
+    @Test
+    fun `slow partial inference keeps proportional headroom`() {
+        assertEquals(1_125L, nextMoonshinePartialIntervalMs(200L, 900L, false))
     }
 
     @Test
     fun `adaptive interval is capped`() {
-        assertEquals(2_500L, nextMoonshinePartialIntervalMs(1_000L, 2_000L, false))
+        assertEquals(2_500L, nextMoonshinePartialIntervalMs(1_000L, 3_000L, false))
     }
 
     @Test


### PR DESCRIPTION
Reduce unnecessary adaptive backoff between Moonshine partial captions while keeping proportional CPU headroom and a hard safety cap. Add partial/final output metrics for real-device validation.